### PR TITLE
WIP: repo consolidation scouting kick-off - make clr build locally on Windows

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,7 +55,7 @@
     <!-- Corefx dependencies -->
     <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19466.8</MicrosoftNETCorePlatformsPackageVersion>
     <runtimenativeSystemIOPortsPackageVersion>5.0.0-alpha1.19466.8</runtimenativeSystemIOPortsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19477.7</MicrosoftPrivateCoreFxNETCoreAppVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha1.19508.1</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftNETCorePlatformsVersion>5.0.0-alpha1.19508.1</MicrosoftNETCorePlatformsVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.0.0-preview7.19326.2</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19501.13</MicrosoftNETCoreTargetsPackageVersion>

--- a/src/clr/tests/Directory.Build.props
+++ b/src/clr/tests/Directory.Build.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
-    <PackagesDir>$(ProjectDir)..\.packages\</PackagesDir>
+    <PackagesDir>$(ProjectDir)..\..\..\.packages\</PackagesDir>
   </PropertyGroup>
 
   <!-- Common properties -->


### PR DESCRIPTION
This is my first contribution to the scouting to let other people
see the first problems I'm hitting as I believe them to be mostly
general. With this small change I now have at least the native part
of CoreCLR build running - I'm not yet past that so then I'll see
what other problems I hit when building the managed components,
building and running tests.

As you can easily see, the first (and so far the only) problem is
the split of the two roots (subrepo root vs. repo root) making the
build script fail when trying to locate "msbuild.ps1" which is now
under a repo-global eng folder. I can imagine it may be undesirable
to query GIT in the build script; in this particular case we have
multiple alternate ways to proceed (keep the duplicates of
msbuild.ps1? autodetecting the root based on some well-known file?).

Thanks

Tomas