### PR TITLE
Update paths, fix toolset install, update versions

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -47,6 +47,10 @@
       artifacts to the test layout, then running the test subset.
   -->
 
+  <PropertyGroup>
+    <SkipImportArcadeSdkFromRoot>true</SkipImportArcadeSdkFromRoot>
+  </PropertyGroup>
+
   <!-- Import only when imported by Arcade's Build.proj as we import Directory.Build.props ourselves. -->
   <Import Project="$(RepoRoot)Directory.Build.props" Condition="'$(MSBuildProjectFile)' == 'Build.proj'" />
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,132 +1,132 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19466.8">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4aea703673e942756c02b222e6b5babaf8612a25</Sha>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19477.7">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>7e9a177824cbefaee8985a9b517ebb0ea2e17a81</Sha>
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19466.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9042fe6c81aa3b47f58ccd94ff02e42f9f7a4e46</Sha>
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.19531.9">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>12fcf91ea6493c2d970188ca6884b2bc6e804986</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha1.19466.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9042fe6c81aa3b47f58ccd94ff02e42f9f7a4e46</Sha>
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.19531.9">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>12fcf91ea6493c2d970188ca6884b2bc6e804986</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha1.19466.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>9042fe6c81aa3b47f58ccd94ff02e42f9f7a4e46</Sha>
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.19531.9">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>12fcf91ea6493c2d970188ca6884b2bc6e804986</Sha>
     </Dependency>
-    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha1.19466.8">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4aea703673e942756c02b222e6b5babaf8612a25</Sha>
+    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19466.3">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f5437ac095272f1ab5e8ca79960add974fa96f2d</Sha>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19525.1">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>cea2bba3c295c5280d01900f7ae5492951ad8995</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-alpha1.19466.3">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f5437ac095272f1ab5e8ca79960add974fa96f2d</Sha>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-alpha1.19525.1">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>cea2bba3c295c5280d01900f7ae5492951ad8995</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-alpha1.19466.3">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f5437ac095272f1ab5e8ca79960add974fa96f2d</Sha>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-alpha1.19525.1">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>cea2bba3c295c5280d01900f7ae5492951ad8995</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19501.13">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dcc9f626eeb0751d4ba4499f623aac42d2e95c10</Sha>
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19531.5">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>898d47b4df506e30e54605a3a5c9fdec44f74916</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19531.1">
       <Uri>https://github.com/dotnet/standard</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,59 +33,58 @@
   <PropertyGroup>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>$(MicrosoftDotNetApiCompatPackageVersion)</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19463.3</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetCodeAnalysisPackageVersion>
     <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetGenAPIPackageVersion>
     <MicrosoftDotNetGenFacadesPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19531.4</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19463.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>1.0.0-beta.19463.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>$(MicrosoftDotNetBuildTasksPackagingPackageVersion)</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetVersionToolsTasksPackageVersion>5.0.0-beta.19531.4</MicrosoftDotNetVersionToolsTasksPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>1.0.0-beta.19463.3</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>$(MicrosoftDotNetVersionToolsTasksPackageVersion)</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
-    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha1.19466.2</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftNETCoreAppVersion>5.0.0-alpha1.19466.2</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostPackageVersion>5.0.0-alpha1.19466.2</MicrosoftNETCoreDotNetHostPackageVersion>
-    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>5.0.0-alpha1.19466.2</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha.1.19531.9</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostPackageVersion>5.0.0-alpha.1.19531.9</MicrosoftNETCoreDotNetHostPackageVersion>
+    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>5.0.0-alpha.1.19531.9</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <!-- CoreClr dependencies -->
-    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-alpha1.19466.3</MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-alpha1.19466.3</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftNETSdkILPackageVersion>5.0.0-alpha1.19472.2</MicrosoftNETSdkILPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETSdkILPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETSdkILPackageVersion>
     <!-- Libraries dependencies -->
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19466.8</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha1.19466.8</MicrosoftNETCorePlatformsVersion>
-    <runtimenativeSystemIOPortsPackageVersion>5.0.0-alpha1.19466.8</runtimenativeSystemIOPortsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha1.19477.7</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftBclAsyncInterfacesVersion>1.0.0-preview7.19326.2</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19501.13</MicrosoftNETCoreTargetsPackageVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-alpha1.19501.13</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha1.19501.13</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha1.19501.13</MicrosoftWindowsCompatibilityPackageVersion>
-    <SystemCodeDomVersion>5.0.0-alpha1.19501.13</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha1.19501.13</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-alpha1.19501.13</SystemDiagnosticsEventLogVersion>
-    <SystemDirectoryServicesVersion>5.0.0-alpha1.19501.13</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-alpha1.19501.13</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha1.19501.13</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-alpha1.19501.13</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19501.13</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-alpha1.19501.13</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-alpha1.19501.13</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha1.19501.13</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha1.19501.13</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha1.19501.13</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-alpha1.19501.13</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha1.19501.13</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextJsonVersion>5.0.0-alpha1.19501.13</SystemTextJsonVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-alpha1.19501.13</SystemTextEncodingsWebVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-alpha1.19501.13</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha1.19501.13</SystemWindowsExtensionsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha.1.19531.5</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsVersion>$(MicrosoftNETCorePlatformsPackageVersion)</MicrosoftNETCorePlatformsVersion>
+    <runtimenativeSystemIOPortsPackageVersion>5.0.0-alpha.1.19531.5</runtimenativeSystemIOPortsPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha.1.19531.5</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha.1.19531.5</MicrosoftNETCoreTargetsPackageVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19531.5</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19531.5</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha.1.19531.5</MicrosoftWindowsCompatibilityPackageVersion>
+    <SystemCodeDomVersion>5.0.0-alpha.1.19531.5</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19531.5</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19531.5</SystemDiagnosticsEventLogVersion>
+    <SystemDirectoryServicesVersion>5.0.0-alpha.1.19531.5</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-alpha.1.19531.5</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19531.5</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-alpha.1.19531.5</SystemIOPackagingVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha.1.19531.5</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19531.5</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19531.5</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha.1.19531.5</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha.1.19531.5</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19531.5</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19531.5</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19531.5</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextJsonVersion>5.0.0-alpha.1.19531.5</SystemTextJsonVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19531.5</SystemTextEncodingsWebVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19531.5</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha.1.19531.5</SystemWindowsExtensionsPackageVersion>
     <!-- Standard dependencies -->
     <NETStandardLibraryPackageVersion>2.2.0-prerelease.19531.1</NETStandardLibraryPackageVersion>
     <!-- dotnet-optimization dependencies -->
@@ -109,7 +108,7 @@
     <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
     <!-- Testing -->
-    <MicrosoftNETTestSdkPackageVersion>16.4.0-preview-20191007-01</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.3.0</MicrosoftNETTestSdkPackageVersion>
     <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -446,10 +446,7 @@ function GetSdkTaskProject([string]$taskName) {
 }
 
 function InitializeNativeTools() {
-  if ($env:DisableNativeToolsetInstalls) {
-    return
-  }
-  if (Get-Member -InputObject $GlobalJson -Name "native-tools") {
+  if (-Not (Test-Path variable:DisableNativeToolsetInstalls) -And (Get-Member -InputObject $GlobalJson -Name "native-tools")) {
     $nativeArgs= @{}
     if ($ci) {
       $nativeArgs = @{

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -4,7 +4,7 @@
 
 # CI mode - set to true on CI server for PR validation build or official build.
 ci=${ci:-false}
-disable_configure_toolset_import=${disable_configure_toolset_import:-null}
+disable_configure_toolset_import=${disable_configure_toolset_import:-}
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -273,7 +273,7 @@ function GetNuGetPackageCachePath {
 }
 
 function InitializeNativeTools() {
-  if [[ -z "${DisableNativeToolsetInstalls:-}" ]]; then
+  if [[ -n "${DisableNativeToolsetInstalls:-}" ]]; then
     return
   fi
   if grep -Fq "native-tools" $global_json_file
@@ -437,7 +437,7 @@ Write-PipelineSetVariable -name "Temp" -value "$temp_dir"
 Write-PipelineSetVariable -name "TMP" -value "$temp_dir"
 
 # Import custom tools configuration, if present in the repo.
-if [[ "$disable_configure_toolset_import" != null ]]; then
+if [[ -z "$disable_configure_toolset_import" ]]; then
   configure_toolset_script="$eng_root/configure-toolset.sh"
   if [[ -a "$configure_toolset_script" ]]; then
     . "$configure_toolset_script"

--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
     "Microsoft.DotNet.Build.Tasks.Configuration": "5.0.0-beta.19531.4",
     "Microsoft.DotNet.CoreFxTesting": "5.0.0-beta.19531.4",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "5.0.0-alpha1.19472.2",
+    "Microsoft.NET.Sdk.IL": "5.0.0-alpha1.19525.1",
     "Microsoft.Build.NoTargets": "1.0.53",
     "Microsoft.Build.Traversal": "2.0.2"
   }

--- a/src/libraries/Native/Unix/gen-buildsys-clang.sh
+++ b/src/libraries/Native/Unix/gen-buildsys-clang.sh
@@ -16,7 +16,7 @@ then
 fi
 
 #Set the root directory of the project
-project_root="$1"/../../..
+project_root="$1"/../../../..
 
 # Set up the environment to be used for building with clang.
 if which "clang-$2.$3" > /dev/null 2>&1

--- a/src/libraries/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/libraries/Native/Windows/clrcompression/CMakeLists.txt
@@ -84,7 +84,7 @@ add_library(clrcompression
     SHARED
     ${NATIVECOMPRESSION_SOURCES}
     # This will add versioning to the library
-    ${CMAKE_SOURCE_DIR}/../../../artifacts/obj/NativeVersion.rc
+    ${CMAKE_SOURCE_DIR}/../../../../artifacts/obj/NativeVersion.rc
 )
 
 # Allow specification of arguments that should be passed to the linker

--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -4,7 +4,7 @@ setlocal
 :SetupArgs
 :: Initialize the args that will be passed to cmake
 set __nativeWindowsDir=%~dp0\Windows
-set __artifactsDir=%~dp0..\..\artifacts
+set __artifactsDir=%~dp0..\..\..\artifacts
 set __rootDir=%~dp0..\..
 set __CMakeBinDir=""
 set __IntermediatesDir=""

--- a/src/libraries/Native/build-native.sh
+++ b/src/libraries/Native/build-native.sh
@@ -174,7 +174,7 @@ build_native()
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __nativeroot=$__scriptpath/Unix
-__rootRepo="$__scriptpath/../.."
+__rootRepo="$__scriptpath/../../.."
 __artifactsDir="$__rootRepo/artifacts"
 
 # Set the various build properties here so that CMake and MSBuild can pick them up

--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(RunningOnUnix)' != 'true'">$(TargetFrameworks);net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net46</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 


### PR DESCRIPTION
Submitted the following upstream changes:
- Core-Setup's condition in installer.tasks was relying on a core-setup property `RunningOnUnix`: https://github.com/dotnet/core-setup/pull/8723
- Native toolset bootstrapping is broken in Arcade: https://github.com/dotnet/arcade/pull/4265 (Chris and me working on that)
- CoreClr is using different Versions.props version property suffixes: https://github.com/dotnet/coreclr/pull/27606
- CoreFx is using a different PackageId suffix: https://github.com/dotnet/corefx/pull/42289
- Core-Setup has a lot unused dependencies and also different version suffixes: https://github.com/dotnet/core-setup/pull/8724

Remaining issues:
- CoreFx hardcodes paths in the Native scripts.
- Darc removes the `TEST_RESTORE_SOURCES_INSERTION_LINE` placeholder line in NuGet.config.

cc @jkoritzinsky @trylek @jaredpar @jashook 