### PR TITLE
Avoid importing an Arcade extension point

### DIFF
--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -20,7 +20,7 @@
     Get ProjectToBuild and '<subset>ProjectToBuild' items. Using the items lets projects handle
     $(Subset) automatically when creating project-to-project dependencies.
   -->
-  <Import Project="$(RepositoryEngineeringDir)Build.props" />
+  <Import Project="$(RepositoryEngineeringDir)Subsets.props" />
 
   <!--
     Before Microsoft.Common.targets, set the extensions path to match the restore dir as Arcade


### PR DESCRIPTION
This is the backport of https://github.com/dotnet/core-setup/pull/8823.