### PR TITLE
Port missing Path changes from old shared source mirror

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -910,29 +910,21 @@ namespace System.IO
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.
         /// </summary>
-        public static string TrimEndingDirectorySeparator(string path) =>
-            EndsInDirectorySeparator(path) && !PathInternal.IsRoot(path.AsSpan()) ?
-                path.Substring(0, path.Length - 1) :
-                path;
+        public static string TrimEndingDirectorySeparator(string path) => PathInternal.TrimEndingDirectorySeparator(path);
 
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.
         /// </summary>
-        public static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) =>
-            EndsInDirectorySeparator(path) && !PathInternal.IsRoot(path) ?
-                path.Slice(0, path.Length - 1) :
-                path;
+        public static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) => PathInternal.TrimEndingDirectorySeparator(path);
 
         /// <summary>
         /// Returns true if the path ends in a directory separator.
         /// </summary>
-        public static bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
-            => path.Length > 0 && PathInternal.IsDirectorySeparator(path[path.Length - 1]);
+        public static bool EndsInDirectorySeparator(ReadOnlySpan<char> path) => PathInternal.EndsInDirectorySeparator(path);
 
         /// <summary>
         /// Returns true if the path ends in a directory separator.
         /// </summary>
-        public static bool EndsInDirectorySeparator(string path)
-              => !string.IsNullOrEmpty(path) && PathInternal.IsDirectorySeparator(path[path.Length - 1]);
+        public static bool EndsInDirectorySeparator(string path) => PathInternal.EndsInDirectorySeparator(path);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/PathInternal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/PathInternal.cs
@@ -18,12 +18,9 @@ namespace System.IO
 #if MS_IO_REDIST
         internal static string EnsureTrailingSeparator(string path)
             => EndsInDirectorySeparator(path) ? path : path + DirectorySeparatorCharAsString;
-
-        internal static bool EndsInDirectorySeparator(string path)
-            => !string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]);
 #else
         internal static string EnsureTrailingSeparator(string path)
-            => Path.EndsInDirectorySeparator(path.AsSpan()) ? path : path + DirectorySeparatorCharAsString;
+            => EndsInDirectorySeparator(path.AsSpan()) ? path : path + DirectorySeparatorCharAsString;
 #endif
 
         internal static bool IsRoot(ReadOnlySpan<char> path)
@@ -219,5 +216,33 @@ namespace System.IO
 
             return true;
         }
+
+        /// <summary>
+        /// Trims one trailing directory separator beyond the root of the path.
+        /// </summary>
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            EndsInDirectorySeparator(path) && !IsRoot(path.AsSpan()) ?
+                path.Substring(0, path.Length - 1) :
+                path;
+
+        /// <summary>
+        /// Returns true if the path ends in a directory separator.
+        /// </summary>
+        internal static bool EndsInDirectorySeparator(string path) =>
+              !string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]);
+
+        /// <summary>
+        /// Trims one trailing directory separator beyond the root of the path.
+        /// </summary>
+        internal static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) =>
+            EndsInDirectorySeparator(path) && !IsRoot(path) ?
+                path.Slice(0, path.Length - 1) :
+                path;
+
+        /// <summary>
+        /// Returns true if the path ends in a directory separator.
+        /// </summary>
+        internal static bool EndsInDirectorySeparator(ReadOnlySpan<char> path) =>
+            path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
     }
 }


### PR DESCRIPTION
It looks like the mirror didn't fully quiesce prior to snapping coreclr/corefx for the runtime consolidation.  As a result the libraries build is breaking.

cc: @ViktorHofer, @safern 