### PR TITLE
Fix test build of test project that referenced corefx shared corelib directly and cleanup common path usages

### DIFF
--- a/src/libraries/Common/tests/Common.Tests.csproj
+++ b/src/libraries/Common/tests/Common.Tests.csproj
@@ -6,103 +6,103 @@
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>Common\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Linux\cgroups\Interop.cgroups.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\cgroups\Interop.cgroups.cs">
       <Link>Common\Interop\Linux\cgroups\Interop.cgroups.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Linux\procfs\Interop.ProcFsStat.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\procfs\Interop.ProcFsStat.cs">
       <Link>Common\Interop\Linux\procfs\Interop.ProcFsStat.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\CharArrayHelpers.cs">
+    <Compile Include="$(CommonPath)System\CharArrayHelpers.cs">
       <Link>Common\System\CharArrayHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Marvin.cs">
+    <Compile Include="$(CommonPath)System\Marvin.cs">
       <Link>Common\System\Marvin.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LargeArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\LargeArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\LargeArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs">
       <Link>Common\System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\RowConfigReader.cs">
+    <Compile Include="$(CommonPath)System\IO\RowConfigReader.cs">
       <Link>Common\System\IO\RowConfigReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+    <Compile Include="$(CommonPath)System\IO\StringParser.cs">
       <Link>Common\System\IO\StringParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpDateParser.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpDateParser.cs">
       <Link>Common\System\Net\HttpDateParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\IHttpHeadersHandler.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\IHttpHeadersHandler.cs">
       <Link>Common\System\Net\Http\Http2\IHttpHeadersHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\DynamicTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\DynamicTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\DynamicTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HeaderField.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HeaderField.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HeaderField.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\Huffman.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\Huffman.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\Huffman.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StaticTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StatusCodes.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\ReusableTextReader.cs">
+    <Compile Include="$(CommonPath)System\Text\ReusableTextReader.cs">
       <Link>Common\System\Text\ReusableTextReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\SimpleRegex.cs">
+    <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs">
       <Link>Common\System\Text\SimpleRegex.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">
       <Link>System\Text\ValueStringBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.cs">
@@ -150,14 +150,14 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Windows.cs">
       <Link>System\IO\PathInternal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="Tests\System\IO\PathInternal.Windows.Tests.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
@@ -176,7 +176,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.PathConf.cs">
       <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.Unix.cs">

--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.csproj
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.csproj
@@ -35,28 +35,28 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RtlGetVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetTokenInformation_void.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetTokenInformation_void.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.GetTokenInformation_void.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.TOKEN_ELEVATION.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.TOKEN_ELEVATION.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.TOKEN_ELEVATION.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
@@ -65,7 +65,7 @@
   </ItemGroup>
   <!-- Unix imports -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -258,8 +258,9 @@
 
   <!-- Set up some common paths -->
   <PropertyGroup>
-    <CommonPath>$(LibrariesProjectRoot)Common\src</CommonPath>
-    <CommonTestPath>$(LibrariesProjectRoot)Common\tests</CommonTestPath>
+    <CommonPathRoot>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'Common'))</CommonPathRoot>
+    <CommonPath>$([MSBuild]::NormalizeDirectory('$(CommonPathRoot)', 'src'))</CommonPath>
+    <CommonTestPath>$([MSBuild]::NormalizeDirectory('$(CommonPathRoot)', 'tests'))</CommonTestPath>
   </PropertyGroup>
 
   <!-- Set up the default output and intermediate paths -->

--- a/src/libraries/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/libraries/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -65,41 +65,41 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Windows.cs" Link="System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs" Link="System\IO\Win32Marshal.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs" Link="System\Text\ValueStringBuilder.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs" Link="Common\Interop\Windows\Interop.EncryptDecrypt.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" Link="Common\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs" Link="Common\Interop\Windows\Interop.UNICODE_STRING.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CopyFile.cs" Link="Common\Interop\Windows\Interop.CopyFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CopyFileEx.cs" Link="Common\Interop\Windows\Interop.CopyFileEx.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\Interop\Windows\Interop.CreateFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DeleteFile.cs" Link="Common\Interop\Windows\Interop.DeleteFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DeleteVolumeMountPoint.cs" Link="Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Interop.FileOperations.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FindNextFile.cs" Link="Common\Interop\Windows\Interop.FindNextFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs" Link="Common\Interop\Windows\Interop.GetVolumeInformation.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MoveFileEx.cs" Link="Common\Interop\Windows\Interop.MoveFileEx.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.RemoveDirectory.cs" Link="Common\Interop\Windows\Interop.RemoveDirectory.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReplaceFile.cs" Link="Common\Interop\Windows\Interop.ReplaceFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileAttributes.cs" Link="Common\Interop\Windows\Interop.SetFileAttributes.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileInformationByHandle.cs" Link="Common\Interop\Windows\Interop.SetFileInformationByHandle.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.FILE_FULL_DIR_INFORMATION.cs" Link="Common\Interop\Windows\Interop.FILE_FULL_DIR_INFORMATION.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.FILE_INFORMATION_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFORMATION_CLASS.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs" Link="Common\Interop\Windows\Interop.IO_STATUS_BLOCK.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtCreateFile.cs" Link="Common\Interop\Windows\Interop.NtCreateFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQueryDirectoryFile.cs" Link="Common\Interop\Windows\Interop.NtQueryDirectoryFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtStatus.cs" Link="Common\Interop\Windows\Interop.NtStatus.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs" Link="Common\Interop\Windows\Interop.RtlNtStatusToDosError.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs" Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
-    <Compile Include="$(CommonPath)\System\Memory\FixedBufferExtensions.cs" Link="Common\System\Memory\FixedBufferExtensions.cs" />
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs" Link="Common\Interop\Windows\Interop.EncryptDecrypt.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" Link="Common\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.UNICODE_STRING.cs" Link="Common\Interop\Windows\Interop.UNICODE_STRING.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CopyFile.cs" Link="Common\Interop\Windows\Interop.CopyFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CopyFileEx.cs" Link="Common\Interop\Windows\Interop.CopyFileEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\Interop\Windows\Interop.CreateFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DeleteFile.cs" Link="Common\Interop\Windows\Interop.DeleteFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DeleteVolumeMountPoint.cs" Link="Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Interop.FileOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FindNextFile.cs" Link="Common\Interop\Windows\Interop.FindNextFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs" Link="Common\Interop\Windows\Interop.GetVolumeInformation.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MoveFileEx.cs" Link="Common\Interop\Windows\Interop.MoveFileEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.RemoveDirectory.cs" Link="Common\Interop\Windows\Interop.RemoveDirectory.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReplaceFile.cs" Link="Common\Interop\Windows\Interop.ReplaceFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileAttributes.cs" Link="Common\Interop\Windows\Interop.SetFileAttributes.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileInformationByHandle.cs" Link="Common\Interop\Windows\Interop.SetFileInformationByHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.FILE_FULL_DIR_INFORMATION.cs" Link="Common\Interop\Windows\Interop.FILE_FULL_DIR_INFORMATION.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.FILE_INFORMATION_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFORMATION_CLASS.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs" Link="Common\Interop\Windows\Interop.IO_STATUS_BLOCK.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtCreateFile.cs" Link="Common\Interop\Windows\Interop.NtCreateFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtQueryDirectoryFile.cs" Link="Common\Interop\Windows\Interop.NtQueryDirectoryFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtStatus.cs" Link="Common\Interop\Windows\Interop.NtStatus.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs" Link="Common\Interop\Windows\Interop.RtlNtStatusToDosError.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs" Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
+    <Compile Include="$(CommonPath)System\Memory\FixedBufferExtensions.cs" Link="Common\System\Memory\FixedBufferExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" />
     <Compile Include="Microsoft\IO\StringExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">

--- a/src/libraries/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
+++ b/src/libraries/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.csproj
@@ -8,7 +8,7 @@
     <Compile Include="System\ComponentModel\Win32Exception.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
     <Compile Include="System\ComponentModel\Win32Exception.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -27,10 +27,10 @@
     <Compile Include="System\Security\AccessControl\RegistrySecurity.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -39,7 +39,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Advapi32\Interop.RegCloseKey.cs">
       <Link>Interop\Windows\Interop.RegCloseKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RegConnectRegistry.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RegConnectRegistry.cs">
       <Link>Common\Interop\Windows\Interop.RegConnectRegistry.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Advapi32\Interop.RegCreateKeyEx.cs">

--- a/src/libraries/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Advapi32\Interop.RegSetValueEx.cs">

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
@@ -6,121 +6,121 @@
     <Configurations>net461-Debug;net461-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netcoreapp3.0-Windows_NT-Debug;netcoreapp3.0-Windows_NT-Release;netfx-Debug;netfx-Release;netstandard2.0-Debug;netstandard2.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\User32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.CreateWindowEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.CreateWindowEx.cs">
       <Link>Common\Interop\Windows\User32\Interop.CreateWindowEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.DefWindowProc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.DefWindowProc.cs">
       <Link>Common\Interop\Windows\User32\Interop.DefWindowProc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.DestroyWindow.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.DestroyWindow.cs">
       <Link>Common\Interop\Windows\User32\Interop.DestroyWindow.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.DispatchMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.DispatchMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.DispatchMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetClassInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetClassInfo.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetClassInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetProcessWindowStation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetProcessWindowStation.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetProcessWindowStation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetUserObjectInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetUserObjectInformation.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetUserObjectInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.IsWindow.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.IsWindow.cs">
       <Link>Common\Interop\Windows\User32\Interop.IsWindow.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.KillTimer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.KillTimer.cs">
       <Link>Common\Interop\Windows\User32\Interop.KillTimer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.MSG.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.MSG.cs">
       <Link>Common\Interop\Windows\User32\Interop.MSG.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.MsgWaitForMultipleObjectsEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.MsgWaitForMultipleObjectsEx.cs">
       <Link>Common\Interop\Windows\User32\Interop.MsgWaitForMultipleObjectsEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.PeekMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PeekMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.PeekMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.PostMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PostMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.PostMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.RegisterClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.RegisterClass.cs">
       <Link>Common\Interop\Windows\User32\Interop.RegisterClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.RegisterWindowMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.RegisterWindowMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.RegisterWindowMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SendMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SendMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.SendMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SetClassLong.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SetClassLong.cs">
       <Link>Common\Interop\Windows\User32\Interop.SetClassLong.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SetClassLongPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SetClassLongPtr.cs">
       <Link>Common\Interop\Windows\User32\Interop.SetClassLongPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SetTimer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SetTimer.cs">
       <Link>Common\Interop\Windows\User32\Interop.SetTimer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SetWindowLong.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SetWindowLong.cs">
       <Link>Common\Interop\Windows\User32\Interop.SetWindowLong.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SetWindowLongPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SetWindowLongPtr.cs">
       <Link>Common\Interop\Windows\User32\Interop.SetWindowLongPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.TranslateMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.TranslateMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.TranslateMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.UnregisterClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.UnregisterClass.cs">
       <Link>Common\Interop\Windows\User32\Interop.UnregisterClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.USEROBJECTFLAGS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.USEROBJECTFLAGS.cs">
       <Link>Common\Interop\Windows\User32\Interop.USEROBJECTFLAGS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.WNDCLASS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.WNDCLASS.cs">
       <Link>Common\Interop\Windows\User32\Interop.WNDCLASS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.WndProc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.WndProc.cs">
       <Link>Common\Interop\Windows\User32\Interop.WndProc.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs">
       <Link>Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WtsApi32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WtsApi32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\WtsApi32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WtsApi32\Interop.WTSRegisterSessionNotification.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WtsApi32\Interop.WTSRegisterSessionNotification.cs">
       <Link>Common\Interop\Windows\WtsApi32\Interop.WTSRegisterSessionNotification.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WtsApi32\Interop.WTSUnRegisterSessionNotification.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WtsApi32\Interop.WTSUnRegisterSessionNotification.cs">
       <Link>Common\Interop\Windows\WtsApi32\Interop.WTSUnRegisterSessionNotification.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
@@ -147,7 +147,7 @@
     <Compile Include="Microsoft\Win32\UserPreferenceChangingEventHandler.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netcoreapp'">
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs">
       <Link>Common\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/Microsoft.Win32.SystemEvents.Tests.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/Microsoft.Win32.SystemEvents.Tests.csproj
@@ -3,16 +3,16 @@
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\User32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.FindWindow.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.FindWindow.cs">
       <Link>Common\Interop\Windows\User32\Interop.FindWindow.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SendMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SendMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.SendMessage.cs</Link>
     </Compile>
     <Compile Include="GenericEventTests.cs" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <Compile Include=".\SGenTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Private.Xml\tests\XmlSerializer\XmlSerializerTests.cs" />
   </ItemGroup>

--- a/src/libraries/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/libraries/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -9,6 +9,6 @@
     <Compile Include="ArrayPool\ArrayPoolTest.cs" />
     <Compile Include="ArrayPool\CollectionTests.cs" />
     <Compile Include="ArrayPool\UnitTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs" />
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.CodeDom/src/System.CodeDom.csproj
+++ b/src/libraries/System.CodeDom/src/System.CodeDom.csproj
@@ -68,7 +68,7 @@
     <Compile Include="System\CodeDom\CodeNamespaceCollection.cs" />
     <Compile Include="System\CodeDom\CodeNamespaceImport.cs" />
     <Compile Include="System\CodeDom\CodeNamespaceImportCollection.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeObject.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeObject.cs" />
     <Compile Include="System\CodeDom\CodeObjectCreateExpression.cs" />
     <Compile Include="System\CodeDom\CodeParameterDeclarationExpression.cs" />
     <Compile Include="System\CodeDom\CodeParameterDeclarationExpressionCollection.cs" />
@@ -96,8 +96,8 @@
     <Compile Include="System\CodeDom\CodeTypeOfExpression.cs" />
     <Compile Include="System\CodeDom\CodeTypeParameter.cs" />
     <Compile Include="System\CodeDom\CodeTypeParameterCollection.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReference.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReferenceCollection.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeTypeReference.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeTypeReferenceCollection.cs" />
     <Compile Include="System\CodeDom\CodeTypeReferenceExpression.cs" />
     <Compile Include="System\CodeDom\CodeVariableDeclarationStatement.cs" />
     <Compile Include="System\CodeDom\CodeVariableReferenceExpression.cs" />
@@ -119,11 +119,11 @@
     <Compile Include="System\CodeDom\Compiler\ICodeParser.cs" />
     <Compile Include="System\CodeDom\Compiler\ExposedTabStringIndentedTextWriter.cs" />
     <Compile Include="System\CodeDom\Compiler\LanguageOptions.cs" />
-    <Compile Include="$(CommonPath)\System\IO\TempFileCollection.cs" />
+    <Compile Include="$(CommonPath)System\IO\TempFileCollection.cs" />
     <Compile Include="System\CodeDom\FieldDirection.cs" />
     <Compile Include="System\CodeDom\MemberAttributes.cs" />
     <Compile Include="System\Collections\Specialized\FixedStringLookup.cs" />
-    <Compile Include="$(CommonPath)\System\CSharpHelpers.cs" />
+    <Compile Include="$(CommonPath)System\CSharpHelpers.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />

--- a/src/libraries/System.CodeDom/tests/System.CodeDom.Tests.csproj
+++ b/src/libraries/System.CodeDom/tests/System.CodeDom.Tests.csproj
@@ -97,22 +97,22 @@
     <Compile Include="System\CodeDom\CodeAttributeArgumentTests.cs" />
     <Compile Include="System\CodeDom\Compiler\VBCodeGenerationTests.cs" />
     <Compile Include="System\CodeDom\Compiler\CSharpCodeGenerationTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/libraries/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -9,58 +9,58 @@
       <Link>System\Collections\Concurrent\IProducerConsumerCollectionDebugView.cs</Link>
     </Compile>
     <!-- Common Collections tests -->
-    <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.Generic.Tests.cs">
       <Link>Common\System\Collections\ICollection.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.Generic.Tests.cs">
       <Link>Common\System\Collections\IDictionary.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.Generic.Tests.cs">
       <Link>Common\System\Collections\IList.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IGenericSharedAPI.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IGenericSharedAPI.Tests.cs">
       <Link>Common\System\Collections\IGenericSharedAPI.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ISet.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ISet.Generic.Tests.cs">
       <Link>Common\System\Collections\ISet.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.Generic.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.Generic.cs">
       <Link>Common\System\Collections\TestBase.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\DebugView.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DebugView.Tests.cs">
       <Link>Common\System\Collections\DebugView.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
+    <Compile Include="$(CommonTestPath)System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="BlockingCollectionCancellationTests.cs" />
@@ -80,15 +80,15 @@
     <Compile Include="PartitionerTests.cs" />
     <Compile Include="ProducerConsumerCollectionTests.cs" />
     <Compile Include="RangePartitionerNegativeTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -89,7 +89,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' or '$(TargetFramework)' == 'netstandard1.3'">
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs" Condition="'$(TargetsNetFx)' == 'true'">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs" Condition="'$(TargetsNetFx)' == 'true'">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="BadHasher.cs" />
@@ -32,62 +32,62 @@
     <Compile Include="IndexOfTests.cs" />
     <Compile Include="SimpleElementImmutablesTestBase.cs" />
     <Compile Include="TestExtensionsMethods.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <!-- Common Collections tests -->
-    <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\DelegateEqualityComparer.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DelegateEqualityComparer.cs">
       <Link>Common\System\Collections\DelegateEqualityComparer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.Generic.Tests.cs">
       <Link>Common\System\Collections\ICollection.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.Generic.Tests.cs">
       <Link>Common\System\Collections\IDictionary.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.Generic.Tests.cs">
       <Link>Common\System\Collections\IList.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IGenericSharedAPI.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IGenericSharedAPI.Tests.cs">
       <Link>Common\System\Collections\IGenericSharedAPI.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ISet.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ISet.Generic.Tests.cs">
       <Link>Common\System\Collections\ISet.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.Generic.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.Generic.cs">
       <Link>Common\System\Collections\TestBase.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\DebugView.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DebugView.Tests.cs">
       <Link>Common\System\Collections\DebugView.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\SerializableAttribute.cs">
+    <Compile Include="$(CommonPath)System\SerializableAttribute.cs">
       <Link>Common\System\SerializableAttribute.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/libraries/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -5,25 +5,25 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Common Collections tests -->
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="ArrayListTests.cs" />
@@ -42,11 +42,11 @@
     <Compile Include="ReadOnlyCollectionBaseTests.cs" />
     <Compile Include="SortedListTests.cs" />
     <Compile Include="StackTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
     <Compile Include="CaseInsensitiveHashCodeProviderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/libraries/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -4,28 +4,28 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Common Collections tests -->
-    <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <Compile Include="BitVector32Tests.cs" />
@@ -81,7 +81,7 @@
     <Compile Include="StringDictionary\StringDictionary.SyncRootTests.cs" />
     <Compile Include="StringDictionary\StringDictionary.ValuesTests.cs" />
     <Compile Include="StringDictionary\StringDictionaryClearTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
     <Compile Include="NameObjectCollectionBase\NameObjectCollectionBase.ConstructorTests.cs" />

--- a/src/libraries/System.Collections/src/System.Collections.csproj
+++ b/src/libraries/System.Collections/src/System.Collections.csproj
@@ -38,7 +38,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Collections\HashHelpers.cs">
       <Link>Common\System\Collections\HashHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\EnumerableHelpers.cs">
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -5,61 +5,61 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Common Collections tests -->
-    <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.Generic.Tests.cs">
       <Link>Common\System\Collections\ICollection.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.Generic.Tests.cs">
       <Link>Common\System\Collections\IDictionary.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.Generic.Tests.cs">
       <Link>Common\System\Collections\IList.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IGenericSharedAPI.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IGenericSharedAPI.Tests.cs">
       <Link>Common\System\Collections\IGenericSharedAPI.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ISet.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ISet.Generic.Tests.cs">
       <Link>Common\System\Collections\ISet.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.Generic.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.Generic.cs">
       <Link>Common\System\Collections\TestBase.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\DebugView.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DebugView.Tests.cs">
       <Link>Common\System\Collections\DebugView.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestingTypes.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestingTypes.cs">
       <Link>Common\System\Collections\TestingTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
+    <Compile Include="$(CommonTestPath)System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ObjectCloner.cs">
+    <Compile Include="$(CommonTestPath)System\ObjectCloner.cs">
       <Link>Common\System\ObjectCloner.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\RandomExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\RandomExtensions.cs">
       <Link>Common\System\RandomExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
     <!-- Generic tests -->
@@ -132,20 +132,20 @@
     <Compile Include="Generic\Stack\Stack.Tests.cs" />
     <Compile Include="Generic\Stack\Stack.Generic.cs" />
     <Compile Include="Generic\Stack\Stack.Generic.Tests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
     <Compile Include="Generic\Comparers\EqualityComparer.Generic.Serialization.Tests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Serialization.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.Generic.Tests.netcoreapp.cs">
       <Link>Common\System\Collections\IDictionary.Generic.Tests.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.netcoreapp.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -50,7 +50,7 @@
     <Compile Include="System\ComponentModel\DataAnnotations\ValidationException.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\ValidationResult.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\Validator.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
+++ b/src/libraries/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
@@ -13,19 +13,19 @@
     <Compile Include="System\Threading\Lock.cs" />
     <Compile Include="System\Threading\ReadLock.cs" />
     <Compile Include="System\Threading\WriteLock.cs" />
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTrace.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTrace.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTrace.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceId.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceId.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceSource.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceSource.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\DebuggerTraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\DebuggerTraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\DebuggerTraceWriter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\TraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\TraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\TraceWriter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
+++ b/src/libraries/System.ComponentModel.Composition/src/System.ComponentModel.Composition.csproj
@@ -173,16 +173,16 @@
     <Compile Include="System\ComponentModel\Composition\ReflectionModel\ReflectionProperty.cs" />
     <Compile Include="System\ComponentModel\Composition\ReflectionModel\ReflectionType.cs" />
     <Compile Include="System\ComponentModel\Composition\ReflectionModel\ReflectionWritableMember.cs" />
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceId.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceId.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceSource.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceSource.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\DebuggerTraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\DebuggerTraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\DebuggerTraceWriter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\TraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\TraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\TraceWriter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
@@ -10,10 +10,10 @@
     <ReferenceFromRuntime Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="IMetadataView.cs" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -81,10 +81,10 @@
     <Compile Include="System\ComponentModel\Design\IDictionaryService.cs" />
     <Compile Include="System\ComponentModel\Design\IExtenderListService.cs" />
     <Compile Include="System\ComponentModel\Design\ITypeDescriptorFilterService.cs" />
-    <Compile Include="$(CommonPath)\System\Drawing\ColorConverterCommon.cs">
+    <Compile Include="$(CommonPath)System\Drawing\ColorConverterCommon.cs">
       <Link>System\Drawing\ColorConverterCommon.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\ColorTable.cs">
+    <Compile Include="$(CommonPath)System\Drawing\ColorTable.cs">
       <Link>System\Drawing\ColorTable.cs</Link>
     </Compile>
     <Compile Include="System\Drawing\ColorConverter.cs" />

--- a/src/libraries/System.Composition.Convention/src/System.Composition.Convention.csproj
+++ b/src/libraries/System.Composition.Convention/src/System.Composition.Convention.csproj
@@ -13,19 +13,19 @@
     <Compile Include="System\Composition\Convention\ParameterImportConventionBuilder.cs" />
     <Compile Include="System\Composition\Convention\PartConventionBuilder.cs" />
     <Compile Include="System\Composition\Convention\PartConventionBuilderOfT.cs" />
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTrace.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTrace.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTrace.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceId.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceId.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\CompositionTraceSource.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\CompositionTraceSource.cs">
       <Link>Common\System\Composition\Diagnostics\CompositionTraceSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\DebuggerTraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\DebuggerTraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\DebuggerTraceWriter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Composition\Diagnostics\TraceWriter.cs">
+    <Compile Include="$(CommonPath)System\Composition\Diagnostics\TraceWriter.cs">
       <Link>Common\System\Composition\Diagnostics\TraceWriter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Composition.TypedParts/tests/System.Composition.TypedParts.Tests.csproj
+++ b/src/libraries/System.Composition.TypedParts/tests/System.Composition.TypedParts.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ContainerConfigurationTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
     <Compile Include="ReflectionTests.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -236,7 +236,7 @@
     <Compile Include="System\Configuration\XmlUtil.cs" />
     <Compile Include="System\Configuration\XmlUtilWriter.cs" />
     <Compile Include="System\Drawing\Configuration\SystemDrawingSection.cs" />
-    <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
     <Compile Include="System\Configuration\SettingsProperty.cs" />
@@ -244,7 +244,7 @@
     <Compile Include="System\Configuration\SettingsSerializeAs.cs" />
     <Compile Include="System\Configuration\NoSettingsVersionUpgradeAttribute.cs" />
     <Compile Include="System\UriIdnScope.cs" />
-    <Compile Include="$(CommonPath)\System\IO\TempFileCollection.cs">
+    <Compile Include="$(CommonPath)System\IO\TempFileCollection.cs">
       <Link>Common\System\IO\TempFileCollection.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="..\src\System\Configuration\ConfigPathUtility.cs">

--- a/src/libraries/System.Console/src/System.Console.csproj
+++ b/src/libraries/System.Console/src/System.Console.csproj
@@ -20,80 +20,80 @@
     <Compile Include="System\IO\ConsoleStream.cs" />
     <Compile Include="System\IO\SyncTextReader.cs" />
     <Compile Include="System\IO\Error.cs" />
-    <Compile Include="$(CommonPath)\System\Text\ConsoleEncoding.cs">
+    <Compile Include="$(CommonPath)System\Text\ConsoleEncoding.cs">
       <Link>Common\System\Text\ConsoleEncoding.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\ConsolePal.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Text\OSEncoding.Windows.cs">
+    <Compile Include="$(CommonPath)System\Text\OSEncoding.Windows.cs">
       <Link>Common\System\Text\OSEncoding.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\OSEncoder.cs">
+    <Compile Include="$(CommonPath)System\Text\OSEncoder.cs">
       <Link>Common\System\Text\OSEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\DBCSDecoder.cs">
+    <Compile Include="$(CommonPath)System\Text\DBCSDecoder.cs">
       <Link>Common\System\Text\DBCSDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
       <Link>Common\Interop\Windows\Interop.GetCPInfoEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs">
       <Link>Interop\Windows\Interop.MAX_PATH.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
       <Link>Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Beep.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Beep.cs">
       <Link>Common\Interop\Windows\Interop.Beep.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ConsoleCursorInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ConsoleCursorInfo.cs">
       <Link>Common\Interop\Windows\Interop.ConsoleCursorInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ConsoleScreenBufferInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ConsoleScreenBufferInfo.cs">
       <Link>Common\Interop\Windows\Interop.ConsoleScreenBufferInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FillConsoleOutputAttribute.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FillConsoleOutputAttribute.cs">
       <Link>Common\Interop\Windows\Interop.FillConsoleOutputAttribute.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FillConsoleOutputCharacter.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FillConsoleOutputCharacter.cs">
       <Link>Common\Interop\Windows\Interop.FillConsoleOutputCharacter.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs">
       <Link>Interop\Windows\Interop.FileTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleScreenBufferInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleScreenBufferInfo.cs">
       <Link>Common\Interop\Windows\Interop.GetConsoleScreenBufferInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleCP.cs">
       <Link>Common\Interop\Windows\Interop.GetConsoleCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleTitle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleTitle.cs">
       <Link>Common\Interop\Windows\Interop.GetConsoleTitle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleMode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleMode.cs">
       <Link>Common\Interop\Windows\Interop.GetConsoleMode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleOutputCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleOutputCP.cs">
       <Link>Common\Interop\Windows\Interop.GetConsoleOutputCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetLargestConsoleWindowSize.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetLargestConsoleWindowSize.cs">
       <Link>Common\Interop\Windows\Interop.GetLargestConsoleWindowSize.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetFileType_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetFileType_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.GetFileType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetKeyState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetKeyState.cs">
       <Link>Common\Interop\Windows\Interop.GetKeyState.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetStdHandle.cs">
@@ -105,58 +105,58 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MultiByteToWideChar.cs">
       <Link>Interop\Windows\Interop.MultiByteToWideChar.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.PeekConsoleInput.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PeekConsoleInput.cs">
       <Link>Common\Interop\Windows\Interop.PeekConsoleInput.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReadFile_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadFile_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.ReadFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReadConsole.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadConsole.cs">
       <Link>Common\Interop\Windows\Interop.ReadConsole.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReadConsoleInput.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadConsoleInput.cs">
       <Link>Common\Interop\Windows\Interop.ReadConsoleInput.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReadConsoleOutput.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadConsoleOutput.cs">
       <Link>Common\Interop\Windows\Interop.ReadConsoleOutput.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleCP.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleCtrlHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleCursorPosition.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleCursorPosition.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleCursorPosition.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleOutputCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleOutputCP.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleOutputCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleScreenBufferSize.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleScreenBufferSize.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleScreenBufferSize.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleTextAttribute.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleTextAttribute.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleTextAttribute.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleTitle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleTitle.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleTitle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleWindowInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetConsoleWindowInfo.cs">
       <Link>Common\Interop\Windows\Interop.SetConsoleWindowInfo.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs">
       <Link>Interop\Windows\Interop.WideCharToMultiByte.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WriteFile_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WriteFile_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.WriteFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WriteConsole.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WriteConsole.cs">
       <Link>Common\Interop\Windows\Interop.WriteConsole.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WriteConsoleOutput.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WriteConsoleOutput.cs">
       <Link>Common\Interop\Windows\Interop.WriteConsoleOutput.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\EncodingHelper.Windows.cs">
+    <Compile Include="$(CommonPath)System\Text\EncodingHelper.Windows.cs">
       <Link>Common\System\IO\EncodingHelper.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
@@ -172,7 +172,7 @@
     <Compile Include="System\TermInfo.cs" />
     <Compile Include="System\IO\StdInReader.cs" />
     <Compile Include="System\IO\SyncTextReader.Unix.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\PersistedFiles.Unix.cs">
@@ -184,13 +184,13 @@
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
       <Link>Common\System\Text\StringBuilderCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\EncodingHelper.Unix.cs">
+    <Compile Include="$(CommonPath)System\Text\EncodingHelper.Unix.cs">
       <Link>Common\System\Text\EncodingHelper.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\StringOrCharArray.cs">
+    <Compile Include="$(CommonPath)System\Text\StringOrCharArray.cs">
       <Link>Common\System\Text\StringOrCharArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -202,19 +202,19 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Dup.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Dup.cs">
       <Link>Common\Interop\Unix\Interop.Dup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FileDescriptors.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.FileDescriptors.cs">
       <Link>Common\Interop\Unix\Interop.FileDescriptors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.FLock.cs">
       <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetControlCharacters.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetControlCharacters.cs">
       <Link>Common\Interop\Unix\Interop.GetControlCharacters.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IsATty.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsATty.cs">
       <Link>Common\Interop\Unix\Interop.IsATty.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.LSeek.cs">
@@ -226,7 +226,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs">
@@ -235,19 +235,19 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetPwUid.cs">
       <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RegisterForCtrlC.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.RegisterForCtrlC.cs">
       <Link>Common\Interop\Unix\Interop.RegisterForCtrlC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RestoreAndHandleCtrl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.RestoreAndHandleCtrl.cs">
       <Link>Common\Interop\Unix\Interop.RestoreAndHandleCtrl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetTerminalInvalidationHandler.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetTerminalInvalidationHandler.cs">
       <Link>Common\Interop\Unix\Interop.SetTerminalInvalidationHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSignalForBreak.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetSignalForBreak.cs">
       <Link>Common\Interop\Unix\Interop.SetSignalForBreak.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SNPrintF.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SNPrintF.cs">
       <Link>Common\Interop\Unix\Interop.SNPrintF.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
@@ -259,16 +259,16 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Write.cs">
       <Link>Common\Interop\Unix\Interop.Write.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetWindowWidth.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetWindowWidth.cs">
       <Link>Common\Interop\Unix\Interop.GetWindowWidth.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.InitializeTerminalAndSignalHandling.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InitializeTerminalAndSignalHandling.cs">
       <Link>Common\Interop\Unix\Interop.InitializeTerminalAndSignalHandling.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ReadStdinUnbuffered.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ReadStdinUnbuffered.cs">
       <Link>Common\Interop\Unix\Interop.ReadStdinUnbuffered.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.StdinReady.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.StdinReady.cs">
       <Link>Common\Interop\Unix\Interop.StdinReady.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Console/tests/System.Console.Tests.csproj
+++ b/src/libraries/System.Console/tests/System.Console.Tests.csproj
@@ -23,10 +23,10 @@
     <Compile Include="TermInfo.cs" />
     <Compile Include="RedirectedStream.cs" />
     <Compile Include="ReadKey.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\InterceptStreamWriter.cs">
+    <Compile Include="$(CommonTestPath)System\IO\InterceptStreamWriter.cs">
       <Link>Common\System\IO\InterceptStreamWriter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="WindowAndCursorProps.cs" />
@@ -42,10 +42,10 @@
   <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
     <Compile Include="CancelKeyPress.Unix.cs" />
     <Compile Include="NonStandardConfiguration.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Interop\Unix\System.Native\Interop.Fcntl.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/libraries/System.Data.Common/src/System.Data.Common.csproj
@@ -162,7 +162,7 @@
     <Compile Include="System\Data\UpdateRowSource.cs" />
     <Compile Include="System\Data\Common\UInt64Storage.cs" />
     <Compile Include="System\Data\Common\AdapterUtil.Common.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\AdapterUtil.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\AdapterUtil.cs">
       <Link>System\Data\Common\AdapterUtil.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\BigIntegerStorage.cs" />
@@ -192,10 +192,10 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="System\Data\Common\DbConnectionOptions.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionOptions.Common.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionOptions.Common.cs">
       <Link>System\Data\Common\DbConnectionOptions.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionPoolKey.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionPoolKey.cs">
       <Link>System\Data\Common\DbConnectionPoolKey.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\DbConnectionStringBuilder.cs" />
@@ -229,10 +229,10 @@
     <Compile Include="System\Data\Common\Int16Storage.cs" />
     <Compile Include="System\Data\Common\Int32Storage.cs" />
     <Compile Include="System\Data\Common\Int64Storage.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\MultipartIdentifier.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\MultipartIdentifier.cs">
       <Link>System\Data\Common\MultipartIdentifier.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\NameValuePair.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\NameValuePair.cs">
       <Link>System\Data\Common\NameValuePair.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\ObjectStorage.cs" />
@@ -287,7 +287,7 @@
     <Compile Include="System\Data\SQLTypes\SQLInt32.cs" />
     <Compile Include="System\Data\SQLTypes\SQLInt64.cs" />
     <Compile Include="System\Data\SQLTypes\SQLMoney.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\SQLResource.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\SQLResource.cs">
       <Link>System\Data\SQLTypes\SQLResource.cs</Link>
     </Compile>
     <Compile Include="System\Data\SQLTypes\SQLSingle.cs" />

--- a/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -112,10 +112,10 @@
     <Compile Include="System\Data\XmlDataLoaderTest.cs" />
     <Compile Include="System\Data\XmlDataReaderTest.cs" />
     <Compile Include="System\Xml\XmlDataDocumentTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -7,54 +7,54 @@
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-FreeBSD-Debug;netcoreapp2.0-FreeBSD-Release;netcoreapp2.0-Linux-Debug;netcoreapp2.0-Linux-Release;netcoreapp2.0-OSX-Debug;netcoreapp2.0-OSX-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Data\Common\AdapterUtil.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\AdapterUtil.cs">
       <Link>Common\System\Data\Common\AdapterUtil.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\AdapterUtil.Drivers.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\AdapterUtil.Drivers.cs">
       <Link>System\Data\Common\AdapterUtil.Drivers.cs</Link>
     </Compile>
     <Compile Include="Common\System\Data\Common\AdapterUtil.Odbc.cs" />
     <Compile Include="Common\System\Data\Common\DbConnectionOptions.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionOptions.Common.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionOptions.Common.cs">
       <Link>Common\System\Data\Common\DbConnectionOptions.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionPoolKey.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionPoolKey.cs">
       <Link>System\Data\Common\DbConnectionPoolKey.cs</Link>
     </Compile>
     <Compile Include="Common\System\Data\Common\DBConnectionString.cs" />
     <Compile Include="Common\System\Data\Common\DbConnectionStringCommon.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\NameValuePair.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\NameValuePair.cs">
       <Link>Common\System\Data\Common\NameValuePair.cs</Link>
     </Compile>
     <Compile Include="Common\System\Data\Common\NameValuePermission.cs" />
     <Compile Include="Common\System\Data\Common\SafeNativeMethods.cs" />
     <Compile Include="Common\System\Data\DataStorage.cs" />
     <Compile Include="Common\System\Data\ProviderBase\DbBuffer.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\FieldNameLookup.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\FieldNameLookup.cs">
       <Link>Common\System\Data\ProviderBase\FieldNameLookup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\BasicFieldNameLookup.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\BasicFieldNameLookup.cs">
       <Link>Common\System\Data\ProviderBase\BasicFieldNameLookup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionInternal.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionInternal.cs">
       <Link>System\Data\ProviderBase\DbConnectionInternal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionFactory.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionFactory.cs">
       <Link>System\Data\ProviderBase\DbConnectionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionPoolGroup.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionPoolGroup.cs">
       <Link>System\Data\ProviderBase\DbConnectionPoolGroup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\TimeoutTimer.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\TimeoutTimer.cs">
       <Link>System\Data\ProviderBase\TimeoutTimer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbReferenceCollection.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbReferenceCollection.cs">
       <Link>System\Data\ProviderBase\DbReferenceCollection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbMetaDataFactory.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbMetaDataFactory.cs">
       <Link>System\Data\ProviderBase\DbMetaDataFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionClosed.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionClosed.cs">
       <Link>System\Data\ProviderBase\DbConnectionClosed.cs</Link>
     </Compile>
     <Compile Include="Common\System\Data\ProviderBase\DbConnectionClosed.cs" />
@@ -110,29 +110,29 @@
     <Compile Include="System\Data\Odbc\OdbcTransaction.cs" />
     <Compile Include="System\Data\Odbc\OdbcType.cs" />
     <Compile Include="System\Data\Odbc\OdbcUtils.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="Common\System\HResults.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\MultipartIdentifier.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\MultipartIdentifier.cs">
       <Link>Common\System\Data\Common\MultipartIdentifier.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.Odbc.cs">
+    <Compile Include="$(CommonPath)Interop\Interop.Odbc.cs">
       <Link>Common\Interop\Interop.Odbc.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsLinux)' == 'true' or '$(TargetsFreeBSD)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs">
       <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetsNetCoreApp)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/libraries/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -16,30 +16,30 @@
     <Compile Include="OdbcParameterTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libdl\Interop.dlopen.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <Compile Include="$(CommonPath)Interop\Unix\libdl\Interop.dlopen.cs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
       <Link>Common\Interop\Unix\libdl\Interop.dlopen.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs">
       <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\FreeBSD\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs">
       <Link>Common\Interop\FreeBSD\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="ConnectionStrings.Windows.cs" />

--- a/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
+++ b/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
@@ -9,10 +9,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\MultipartIdentifier.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\MultipartIdentifier.cs">
       <Link>Common\System\Data\Common\MultipartIdentifier.cs</Link>
     </Compile>
     <Compile Include="AdapterSwitches.cs" />

--- a/src/libraries/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/libraries/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -43,53 +43,53 @@
     <Compile Include="System\Data\OperationAbortedException.cs" />
     <Compile Include="System\Data\SqlClient\SqlDbColumn.cs" />
     <Compile Include="System\Data\Common\ActivityCorrelator.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\AdapterUtil.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\AdapterUtil.cs">
       <Link>System\Data\Common\AdapterUtil.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\AdapterUtil.Drivers.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\AdapterUtil.Drivers.cs">
       <Link>System\Data\Common\AdapterUtil.Drivers.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\AdapterUtil.SqlClient.cs" />
     <Compile Include="System\Data\Common\SR.cs" />
     <Compile Include="System\Data\Common\DbConnectionOptions.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionOptions.Common.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionOptions.Common.cs">
       <Link>System\Data\Common\DbConnectionOptions.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\DbConnectionPoolKey.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\DbConnectionPoolKey.cs">
       <Link>System\Data\Common\DbConnectionPoolKey.cs</Link>
     </Compile>
     <Compile Include="System\Data\Common\DbConnectionStringCommon.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\FieldNameLookup.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\FieldNameLookup.cs">
       <Link>System\Data\Common\FieldNameLookup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\BasicFieldNameLookup.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\BasicFieldNameLookup.cs">
       <Link>System\Data\Common\BasicFieldNameLookup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\MultipartIdentifier.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\MultipartIdentifier.cs">
       <Link>System\Data\Common\MultipartIdentifier.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\Common\NameValuePair.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\NameValuePair.cs">
       <Link>System\Data\Common\NameValuePair.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionInternal.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionInternal.cs">
       <Link>Common\System\Data\ProviderBase\DbConnectionInternal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionFactory.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionFactory.cs">
       <Link>Common\System\Data\ProviderBase\DbConnectionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionPoolGroup.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionPoolGroup.cs">
       <Link>Common\System\Data\ProviderBase\DbConnectionPoolGroup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\TimeoutTimer.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\TimeoutTimer.cs">
       <Link>Common\System\Data\ProviderBase\TimeoutTimer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbReferenceCollection.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbReferenceCollection.cs">
       <Link>Common\System\Data\ProviderBase\DbReferenceCollection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbMetaDataFactory.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbMetaDataFactory.cs">
       <Link>Common\System\Data\ProviderBase\DbMetaDataFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Data\ProviderBase\DbConnectionClosed.cs">
+    <Compile Include="$(CommonPath)System\Data\ProviderBase\DbConnectionClosed.cs">
       <Link>Common\System\Data\ProviderBase\DbConnectionClosed.cs</Link>
     </Compile>
     <Compile Include="System\Data\ProviderBase\DbConnectionClosed.cs" />
@@ -186,10 +186,10 @@
     <Compile Include="System\Data\SqlClient\TdsRecordBufferSetter.cs" />
     <Compile Include="System\Data\SqlClient\TdsValueSetter.cs" />
     <Compile Include="System\Data\SqlTypes\SqlTypeWorkarounds.cs" />
-    <Compile Include="$(CommonPath)\System\Data\Common\SQLResource.cs">
+    <Compile Include="$(CommonPath)System\Data\Common\SQLResource.cs">
       <Link>System\Data\SQLTypes\SQLResource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)System\NotImplemented.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
@@ -229,46 +229,46 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Windows.cs">
       <Link>System\IO\PathInternal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" Condition="'$(TargetGroup)' != 'netcoreapp'">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" Condition="'$(TargetGroup)' != 'netcoreapp'">
       <Link>Common\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">
       <Link>CoreLib\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.UNICODE_STRING.cs">
       <Link>Common\Interop\Windows\Interop.UNICODE_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs">
       <Link>Common\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.IoControlCodeAccess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.IoControlCodeAccess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.IoControlCodeAccess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CTL_CODE.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CTL_CODE.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CTL_CODE.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DeviceIoControl.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DeviceIoControl.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.DeviceIoControl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FileOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.IoControlTransferType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.IoControlTransferType.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.IoControlTransferType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.FILE_FULL_EA_INFORMATION.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.FILE_FULL_EA_INFORMATION.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.FILE_FULL_EA_INFORMATION.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtCreateFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtCreateFile.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.NtCreateFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs">
       <Link>Common\Interop\Windows\Interop.RtlNtStatusToDosError.cs</Link>
     </Compile>
     <Compile Include="System\Data\SqlClient\SqlFileStream.Windows.cs" />
@@ -304,16 +304,16 @@
     <Compile Include="System\Data\SqlClient\SNI\LocalDB.Windows.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
     <Compile Include="System\Data\SqlClient\TdsParser.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Data\SqlClient\LocalDBAPI.Common.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
@@ -322,174 +322,174 @@
   </ItemGroup>
   <!-- Windows dependencies for Integrated Authentication for MANAGED_SNI build -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true' ">
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\sspicliSafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.Windows.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Common (Windows and Unix) dependencies for MANAGED_SNI build -->
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(OSGroup)' != 'AnyOS'">
     <Reference Include="System.Memory" />
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' And '$(IsPartialFacadeAssembly)' != 'true' and '$(OSGroup)' != 'AnyOS'">
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Unix.cs" />
     <Compile Include="Interop\SNINativeMethodWrapper.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeNegoCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SecChannelBindings.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs">
       <Link>Common\System\Net\Security\Unix\SecChannelBindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteNegoContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteNegoContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteNegoContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
     <Compile Include="System\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />

--- a/src/libraries/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/libraries/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -3,7 +3,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="ProviderAgnostic\ReaderTest\ConcurrentLoadContext.cs" />

--- a/src/libraries/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
+++ b/src/libraries/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
@@ -38,7 +38,7 @@
     <Compile Include="TDSServerParser.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="SSPI\SSPIContext.Windows.cs" />

--- a/src/libraries/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Contracts/tests/System.Diagnostics.Contracts.Tests.csproj
@@ -11,7 +11,7 @@
     <Compile Include="ForAllTests.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="ValueTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -13,10 +13,10 @@
   <ItemGroup Condition=" '$(TargetsNetFx)' == 'true'">
     <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />
     <Compile Include="ActivityDateTimeTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -57,61 +57,61 @@
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ClearEventLog.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ClearEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ClearEventLog.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CloseEventLog.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CloseEventLog.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.DeregisterEventSource.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DeregisterEventSource.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.DeregisterEventSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetNumberOfEventLogRecords.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetNumberOfEventLogRecords.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.GetNumberOfEventLogRecords.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetOldestEventLogRecord.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetOldestEventLogRecord.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.GetOldestEventLogRecord.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LookupAccountSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LookupAccountSid.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LookupAccountSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.NotifyChangeEventLog.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.NotifyChangeEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.NotifyChangeEventLog.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenEventLog.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.OpenEventLog.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ReadEventLog.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ReadEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ReadEventLog.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RegisterEventSource.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RegisterEventSource.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.RegisterEventSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ReportEvent.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ReportEvent.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ReportEvent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FormatMessage_SafeLibraryHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FormatMessage_SafeLibraryHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FormatMessage_SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Diagnostics\NetFrameworkUtils.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\NetFrameworkUtils.cs">
       <Link>Common\System\Diagnostics\NetFrameworkUtils.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.csproj
@@ -10,34 +10,34 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Diagnostics\FileVersionInfo.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.FileVersionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.FileVersionInfo.cs">
       <Link>Common\Interop\Windows\Interop.FileVersionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.FileVersionInfoType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.FileVersionInfoType.cs">
       <Link>Common\Interop\Windows\Interop.FileVersionInfoType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.GetFileVersionInfoEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.GetFileVersionInfoEx.cs">
       <Link>Common\Interop\Windows\Interop.GetFileVersionInfoEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.GetFileVersionInfoSizeEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.GetFileVersionInfoSizeEx.cs">
       <Link>Common\Interop\Windows\Interop.GetFileVersionInfoSizeEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.VerLanguageName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.VerLanguageName.cs">
       <Link>Common\Interop\Windows\Interop.VerLanguageName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.VerQueryValue.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.VerQueryValue.cs">
       <Link>Common\Interop\Windows\Interop.VerQueryValue.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Version\Interop.VSFixedFileInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Version\Interop.VSFixedFileInfo.cs">
       <Link>Common\Interop\Windows\Interop.VSFixedFileInfo.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Diagnostics\FileVersionInfo.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">

--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="FileVersionInfoTest.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.VerLanguageName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.VerLanguageName.cs">
       <Link>ProductionCode\Common\Interop\Windows\Kernel32\Interop.VerLanguageName.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -55,118 +55,118 @@
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetTokenInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetTokenInformation.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.GetTokenInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.PERF_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.PERF_INFO.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.PERF_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RegConnectRegistry.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RegConnectRegistry.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.RegConnectRegistry.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.TOKEN_INFORMATION_CLASS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFileMapping.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFileMapping.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CreateFileMapping.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.DuplicateHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetComputerName.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetComputerName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcess_SafeProcessHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcess_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessTimes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessTimes.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessTimes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.HandleOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.HandleOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MapViewOfFile.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MemOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MemOptions.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.MemOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenFileMapping.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OpenFileMapping.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.OpenFileMapping.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OpenProcess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.OpenProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.PerformanceCounterOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PerformanceCounterOptions.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.PerformanceCounterOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.UnmapViewOfFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.UnmapViewOfFile.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.UnmapViewOfFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.VirtualQuery.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.VirtualQuery.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.VirtualQuery.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\PerfCounter\Interop.FormatFromRawValue.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\PerfCounter\Interop.FormatFromRawValue.cs">
       <Link>Common\Interop\Windows\PerfCounter\Interop.FormatFromRawValue.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\PerfCounter\Interop.PerformanceData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\PerfCounter\Interop.PerformanceData.cs">
       <Link>Common\Interop\Windows\PerfCounter\Interop.PerformanceData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalMemHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalMemHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalMemHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePerfProviderHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafePerfProviderHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePerfProviderHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Diagnostics\NetFrameworkUtils.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\NetFrameworkUtils.cs">
       <Link>Common\System\Diagnostics\NetFrameworkUtils.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/System.Diagnostics.PerformanceCounter.Tests.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/System.Diagnostics.PerformanceCounter.Tests.csproj
@@ -13,7 +13,7 @@
     <Compile Include="CounterCreationDataCollectionTests.cs" />
     <Compile Include="InstanceDataTests.cs" />
     <Compile Include="Helpers.cs" />
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="PerformanceDataTests.cs" />

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -35,185 +35,185 @@
     <Compile Include="System\Diagnostics\ThreadWaitReason.cs" />
     <Compile Include="System\Diagnostics\MonitoringDescriptionAttribute.cs" />
     <Compile Include="System\Collections\Specialized\StringDictionaryWrapper.cs" />
-    <Compile Include="$(CommonPath)\System\Runtime\Serialization\SerializationGuard.cs">
+    <Compile Include="$(CommonPath)System\Runtime\Serialization\SerializationGuard.cs">
       <Link>Common\System\Runtime\Serialization\SerializationGuard.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.cs">
       <Link>System\PasteArguments.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.EnumProcessModules.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcessModules.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.EnumProcessModules.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.NtQueryInformationProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.NtQuerySystemInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.EnumWindows.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.EnumWindows.cs">
       <Link>Common\Interop\Windows\User32\Interop.EnumWindows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindow.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindow.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindow.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindowLong.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindowLong.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindowLong.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindowTextLengthW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindowTextLengthW.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindowTextLengthW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindowTextW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindowTextW.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindowTextW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetWindowThreadProcessId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.PostMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.PostMessage.cs">
       <Link>Common\Interop\Windows\User32\Interop.PostMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.IsWindowVisible.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.IsWindowVisible.cs">
       <Link>Common\Interop\Windows\User32\Interop.IsWindowVisible.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SendMessageTimeout.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SendMessageTimeout.cs">
       <Link>Common\Interop\Windows\User32\Interop.SendMessageTimeout.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.WaitForInputIdle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.WaitForInputIdle.cs">
       <Link>Common\Interop\Windows\User32\Interop.WaitForInputIdle.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeTokenHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeTokenHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.PERF_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.PERF_INFO.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.PERF_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.IsWow64Process_SafeProcessHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.IsWow64Process_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.IsWow64Process_SafeProcessHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetExitCodeProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetExitCodeProcess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetExitCodeProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessTimes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessTimes.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessTimes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetThreadTimes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetThreadTimes.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetThreadTimes.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetStdHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.GetStdHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateProcess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CreateProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.TerminateProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.TerminateProcess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.TerminateProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcess_SafeProcessHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcess_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.GetCurrentProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OpenProcess.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.OpenProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.EnumProcesses.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcesses.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.EnumProcesses.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleInformation.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleBaseName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleBaseName.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleBaseName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleFileNameEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleFileNameEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleFileNameEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetProcessWorkingSetSizeEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetProcessWorkingSetSizeEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetProcessWorkingSetSizeEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessWorkingSetSizeEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessWorkingSetSizeEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessWorkingSetSizeEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetProcessAffinityMask.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetProcessAffinityMask.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetProcessAffinityMask.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessAffinityMask.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessAffinityMask.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessAffinityMask.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessId.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetThreadPriorityBoost.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetThreadPriorityBoost.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetThreadPriorityBoost.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetThreadPriorityBoost.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetThreadPriorityBoost.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetThreadPriorityBoost.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcessPriorityBoost.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessPriorityBoost.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcessPriorityBoost.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetProcessPriorityBoost.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetProcessPriorityBoost.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetProcessPriorityBoost.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenThread.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OpenThread.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.OpenThread.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetThreadPriority.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetThreadPriority.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetThreadPriority.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetThreadPriority.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetThreadPriority.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetThreadPriority.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetThreadAffinityMask.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetThreadAffinityMask.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetThreadAffinityMask.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetThreadIdealProcessor.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetThreadIdealProcessor.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetThreadIdealProcessor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetPriorityClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetPriorityClass.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetPriorityClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetPriorityClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetPriorityClass.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetPriorityClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.DuplicateHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ProcessWaitHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenProcessToken.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenProcessToken.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.OpenProcessToken.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LookupPrivilegeValue.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LookupPrivilegeValue.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LookupPrivilegeValue.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.AdjustTokenPrivileges.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.AdjustTokenPrivileges.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.AdjustTokenPrivileges.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetComputerName.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetComputerName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleCP.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetConsoleCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetConsoleOutputCP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetConsoleOutputCP.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetConsoleOutputCP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CreateProcessWithLogon.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CreateProcessWithLogon.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CreateProcessWithLogon.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
@@ -222,58 +222,58 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LUID.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LUID.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LUID.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LUID_AND_ATTRIBUTES.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LUID_AND_ATTRIBUTES.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LUID_AND_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.TOKEN_PRIVILEGE.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.TOKEN_PRIVILEGE.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.TOKEN_PRIVILEGE.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreatePipe_SafeFileHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreatePipe_SafeFileHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.CreatePipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ThreadOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ThreadOptions.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ThreadOptions.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.HandleTypes.cs">
       <Link>Interop\Windows\Kernel32\Interop.HandleTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.HandleOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.ProcessOptions.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MultiByteToWideChar.cs">
       <Link>Interop\Windows\Kernel32\Interop.MultiByteToWideChar.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.UNICODE_STRING.cs">
       <Link>Common\Interop\Interop.UNICODE_STRING.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs">
       <Link>Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\ConsoleEncoding.cs">
+    <Compile Include="$(CommonPath)System\Text\ConsoleEncoding.cs">
       <Link>Common\System\Text\ConsoleEncoding.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\EncodingHelper.Windows.cs">
+    <Compile Include="$(CommonPath)System\Text\EncodingHelper.Windows.cs">
       <Link>Common\System\Text\EncodingHelper.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\OSEncoding.Windows.cs">
+    <Compile Include="$(CommonPath)System\Text\OSEncoding.Windows.cs">
       <Link>Common\System\Text\OSEncoding.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\OSEncoder.cs">
+    <Compile Include="$(CommonPath)System\Text\OSEncoder.cs">
       <Link>Common\System\Text\OSEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\DBCSDecoder.cs">
+    <Compile Include="$(CommonPath)System\Text\DBCSDecoder.cs">
       <Link>Common\System\Text\DBCSDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs">
@@ -299,10 +299,10 @@
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">
       <Link>Common\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+    <Compile Include="$(CommonPath)System\IO\StringParser.cs">
       <Link>Common\System\IO\StringParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -317,58 +317,58 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.SysConf.cs">
       <Link>Common\Interop\Unix\Interop.SysConf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ConfigureTerminalForChildProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ConfigureTerminalForChildProcess.cs">
       <Link>Common\Interop\Unix\Interop.ConfigureTerminalForChildProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ForkAndExecProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ForkAndExecProcess.cs">
       <Link>Common\Interop\Unix\Interop.ForkAndExecProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetGroupList.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetGroupList.cs">
       <Link>Common\Interop\Unix\Interop.GetGroupList.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetLine.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetLine.cs">
       <Link>Common\Interop\Unix\Interop.GetLine.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\Interop.GetPid.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetPwUid.cs">
       <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSetPriority.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetSetPriority.cs">
       <Link>Common\Interop\Unix\Interop.GetSetPriority.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetSid.cs">
       <Link>Common\Interop\Unix\Interop.GetSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetUid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetUid.cs">
       <Link>Common\Interop\Unix\Interop.GetUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.InitializeTerminalAndSignalHandling.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InitializeTerminalAndSignalHandling.cs">
       <Link>Common\Interop\Unix\Interop.InitializeTerminalAndSignalHandling.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Kill.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Kill.cs">
       <Link>Common\Interop\Unix\Interop.Kill.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.ReadLink.cs">
       <Link>Common\Interop\Unix\Interop.ReadLink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RegisterForSigChld.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.RegisterForSigChld.cs">
       <Link>Common\Interop\Unix\Interop.RegisterForRegisterForSigChld.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ResourceLimits.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ResourceLimits.cs">
       <Link>Common\Interop\Unix\Interop.ResourceLimits.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.PathConf.cs">
       <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.POpen.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.POpen.cs">
       <Link>Common\Interop\Unix\Interop.POpen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.WaitId.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.WaitId.cs">
       <Link>Common\Interop\Unix\Interop.WaitId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.WaitPid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.WaitPid.cs">
       <Link>Common\Interop\Unix\Interop.WaitPid.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Access.cs">
@@ -379,16 +379,16 @@
     <Compile Include="System\Diagnostics\Process.Linux.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.Linux.cs" />
     <Compile Include="System\Diagnostics\ProcessThread.Linux.cs" />
-    <Compile Include="$(CommonPath)\Interop\Linux\cgroups\Interop.cgroups.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\cgroups\Interop.cgroups.cs">
       <Link>Common\Interop\Linux\Interop.cgroups.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Linux\procfs\Interop.ProcFsStat.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\procfs\Interop.ProcFsStat.cs">
       <Link>Common\Interop\Linux\Interop.ProcFsStat.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SchedGetSetAffinity.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SchedGetSetAffinity.cs">
       <Link>Common\Interop\Linux\Interop.SchedGetSetAffinity.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\ReusableTextReader.cs">
+    <Compile Include="$(CommonPath)System\Text\ReusableTextReader.cs">
       <Link>Common\System\Text\ReusableTextReader.cs</Link>
     </Compile>
   </ItemGroup>
@@ -398,15 +398,15 @@
     <Compile Include="System\Diagnostics\ProcessManager.BSD.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.OSX.cs" />
     <Compile Include="System\Diagnostics\ProcessThread.OSX.cs" />
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.libproc.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.libproc.cs">
       <Link>Common\Interop\OSX\Interop.libproc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Shell32\Interop.ShellExecuteExW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Shell32\Interop.ShellExecuteExW.cs">
       <Link>Common\Interop\Windows\Shell32\Interop.ShellExecuteExW.cs</Link>
     </Compile>
     <Compile Include="System\Diagnostics\Process.Win32.cs" />
@@ -422,10 +422,10 @@
     <Compile Include="System\Diagnostics\ProcessManager.BSD.cs" />
     <Compile Include="System\Diagnostics\ProcessManager.FreeBSD.cs" />
     <Compile Include="System\Diagnostics\ProcessThread.FreeBSD.cs" />
-    <Compile Include="$(CommonPath)\Interop\BSD\System.Native\Interop.Sysctl.cs">
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.Sysctl.cs">
       <Link>Common\Interop\BSD\System.Native\Interop.Sysctl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\FreeBSD\Interop.Process.cs">
+    <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Process.cs">
       <Link>Common\Interop\FreeBSD\Interop.Process.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -9,13 +9,13 @@
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.cs">
       <Link>System\PasteArguments.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+    <Compile Include="$(CommonPath)System\IO\StringParser.cs">
       <Link>Common\System\IO\StringParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\Microsoft\Win32\TempRegistryKey.cs">
+    <Compile Include="$(CommonTestPath)Microsoft\Win32\TempRegistryKey.cs">
       <Link>Common\Microsoft\Win32\TempRegistryKey.cs</Link>
     </Compile>
     <Compile Include="Helpers.cs" />

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -12,29 +12,29 @@
     <Compile Include="System\Diagnostics\DelimitedListTraceListener.cs" />
     <Compile Include="System\Diagnostics\TextWriterTraceListener.cs" />
     <Compile Include="System\Diagnostics\XmlWriterTraceListener.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.Windows.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.Windows.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\Interop.GetPid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.Unix.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.Unix.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.Unix.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\CodeDom\Compiler\GeneratedCodeAttribute.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -31,29 +31,29 @@
     <Compile Include="System\Diagnostics\TraceSwitch.cs" />
     <Compile Include="System\Diagnostics\SwitchAttribute.cs" />
     <Compile Include="System\Diagnostics\SwitchLevelAttribute.cs" />
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.Windows.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.Windows.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\Interop.GetPid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Diagnostics\TraceListenerHelpers.Unix.cs">
+    <Compile Include="$(CommonPath)System\Diagnostics\TraceListenerHelpers.Unix.cs">
       <Link>Common\System\Diagnostics\TraceListenerHelpers.Unix.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -82,10 +82,10 @@
     <Compile Include="System\DirectoryServices\AccountManagement\IdentityClaim.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\IdentityReference.cs" />
     <Compile Include="System\DirectoryServices\AccountManagement\UnknownPrincipal.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LookupAccountSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LookupAccountSid.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LookupAccountSid.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
@@ -10,7 +10,7 @@
     <Compile Include="PrincipalContextTests.cs" />
     <Compile Include="UserPrincipalTest.cs" />
     <Compile Include="AccountManagementTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\DirectoryServices\LdapConfiguration.cs">
+    <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs">
       <Link>Common\DirectoryServices\LdapConfiguration.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
@@ -47,7 +47,7 @@
     <Compile Include="AsqRequestControlTests.cs" />
     <Compile Include="AddRequestTests.cs" />
     <Compile Include="DirectoryServicesProtocolsTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\DirectoryServices\LdapConfiguration.cs">
+    <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs">
       <Link>Common\DirectoryServices\LdapConfiguration.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -18,7 +18,7 @@
     <Compile Include="System\DirectoryServices\ActiveDirectory\DirectoryContextTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\ForestTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\ActiveDirectoryTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\DirectoryServices\LdapConfiguration.cs">
+    <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs">
       <Link>Common\DirectoryServices\LdapConfiguration.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -149,10 +149,10 @@
     <Compile Include="System\Drawing\Imaging\ImageCodecInfo.cs" />
     <Compile Include="System\Drawing\Imaging\ImageCodecInfoPrivate.cs" />
     <Compile Include="System\Drawing\Imaging\MetafileFrameUnit.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.LOGFONT.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.LOGFONT.cs">
       <Link>Common\Interop\Windows\User32\Interop.LOGFONT.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.RasterOp.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.RasterOp.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.RasterOp.cs</Link>
     </Compile>
     <EmbeddedResource Include="Resources\System\Drawing\DefaultComponent.bmp">
@@ -222,124 +222,124 @@
     <Compile Include="$(CoreLibSharedDir)System\LocalAppContextSwitches.Common.cs">
       <Link>System\LocalAppContextSwitches.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CombineRgn.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CombineRgn.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CombineRgn.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CreateCompatibleDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CreateCompatibleDC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CreateCompatibleDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CreateDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CreateDC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CreateDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CreateIC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CreateIC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CreateIC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CreateFontIndirect.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CreateFontIndirect.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CreateFontIndirect.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.CreateRectRgn.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.CreateRectRgn.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.CreateRectRgn.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.DeleteDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.DeleteDC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.DeleteDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.DeleteObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.DeleteObject.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.DeleteObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetClipRgn.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetClipRgn.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetClipRgn.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetCurrentObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetCurrentObject.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetCurrentObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetDeviceCaps.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetDeviceCaps.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetDeviceCaps.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetObjectType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetObjectType.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetObjectType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetRgnBox.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetRgnBox.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetRgnBox.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.GetStockObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.GetStockObject.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.GetStockObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.ObjectType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.ObjectType.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.ObjectType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.OffsetViewportOrgEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.OffsetViewportOrgEx.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.OffsetViewportOrgEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.RECT.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.RECT.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.RECT.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.RegionType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.RegionType.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.RegionType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.RestoreDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.RestoreDC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.RestoreDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.SaveDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.SaveDC.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.SaveDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.SelectClipRgn.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.SelectClipRgn.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.SelectClipRgn.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GlobalFree.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GlobalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalLock.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GlobalLock.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GlobalLock.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Gdi32\Interop.BitBlt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Gdi32\Interop.BitBlt.cs">
       <Link>Common\Interop\Windows\Gdi32\Interop.BitBlt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.IStream.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.IStream.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.IStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.STATSTG.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.STATSTG.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.STATSTG.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.STGTY.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.STGTY.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.STGTY.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.STATFLAG.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.STATFLAG.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.STATFLAG.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.STGM.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.STGM.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.STGM.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetDC.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.ReleaseDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.ReleaseDC.cs">
       <Link>Common\Interop\Windows\User32\Interop.ReleaseDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.SystemParametersInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.SystemParametersInfo.cs">
       <Link>Common\Interop\Windows\User32\Interop.SystemParametersInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.NONCLIENTMETRICS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.NONCLIENTMETRICS.cs">
       <Link>Common\Interop\Windows\User32\Interop.NONCLIENTMETRICS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.WindowFromDC.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.WindowFromDC.cs">
       <Link>Common\Interop\Windows\User32\Interop.WindowFromDC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.HRESULT.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.HRESULT.cs">
       <Link>Common\Interop\Windows\Interop.HRESULT.cs</Link>
     </Compile>
   </ItemGroup>
@@ -387,7 +387,7 @@
     <Compile Include="System\Drawing\Text\PrivateFontCollection.Unix.cs" />
     <Compile Include="System\Drawing\LibraryResolver.cs" />
     <Compile Include="misc\ExternDll.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <EmbeddedResource Include="Resources\System\Drawing\Error.ico">

--- a/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -78,13 +78,13 @@
     <Compile Include="Printing\PaperSizeTests.cs" />
     <Compile Include="Printing\PaperSourceTests.cs" />
     <Compile Include="Printing\PrinterUnitConvertTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">
+    <Compile Include="$(CommonTestPath)System\Drawing\Helpers.cs">
       <Link>Common\System\Drawing\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -28,33 +28,33 @@
     <Compile Include="System\Drawing\Size.cs" />
     <Compile Include="System\Drawing\SizeF.cs" />
     <Compile Include="System\Drawing\Color.cs" />
-    <Compile Include="$(CommonPath)\System\Drawing\ColorConverterCommon.cs">
+    <Compile Include="$(CommonPath)System\Drawing\ColorConverterCommon.cs">
       <Link>System\Drawing\ColorConverterCommon.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\ColorTable.cs">
+    <Compile Include="$(CommonPath)System\Drawing\ColorTable.cs">
       <Link>System\Drawing\ColorTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\ColorTranslator.cs">
+    <Compile Include="$(CommonPath)System\Drawing\ColorTranslator.cs">
       <Link>System\Drawing\ColorTranslator.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\KnownColor.cs">
+    <Compile Include="$(CommonPath)System\Drawing\KnownColor.cs">
       <Link>System\Drawing\KnownColor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\KnownColorTable.cs">
+    <Compile Include="$(CommonPath)System\Drawing\KnownColorTable.cs">
       <Link>System\Drawing\KnownColorTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Drawing\SystemColors.cs">
+    <Compile Include="$(CommonPath)System\Drawing\SystemColors.cs">
       <Link>System\Drawing\SystemColors.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetSysColor.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.GetSysColor.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetSysColor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.Win32SystemColors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.Win32SystemColors.cs">
       <Link>Common\Interop\Windows\User32\Interop.Win32SystemColors.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
+++ b/src/libraries/System.Drawing.Primitives/tests/System.Drawing.Primitives.Tests.csproj
@@ -13,13 +13,13 @@
     <Compile Include="SizeFTests.cs" />
     <Compile Include="SizeTests.cs" />
     <Compile Include="ColorTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\DataContractSerializerHelper.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\DataContractSerializerHelper.cs">
       <Link>Common\System\Runtime\Serialization\DataContractSerializerHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs">
       <Link>Common\System\Runtime\Serialization\Utils.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/libraries/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -101,7 +101,7 @@
     <Compile Include="ThaiBuddhistCalendar\ThaiBuddhistCalendarToDateTime.cs" />
     <Compile Include="ThaiBuddhistCalendar\ThaiBuddhistCalendarToFourDigitYear.cs" />
     <Compile Include="ThaiBuddhistCalendar\ThaiBuddhistCalendarTwoDigitYearMax.cs" />
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
+    <Compile Include="$(CommonTestPath)System\RandomDataGenerator.cs" />
     <!-- Helpers -->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">

--- a/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -108,20 +108,20 @@
     <Compile Include="System\Globalization\TextElementEnumeratorTests.cs" />
     <Compile Include="System\Globalization\UnicodeCategoryTests.cs" />
     <!-- Helpers -->
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+    <Compile Include="$(CommonTestPath)System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.11.0.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\UnicodeData.11.0.txt">
       <Link>CharUnicodeInfo\UnicodeData.11.0.txt</Link>
       <LogicalName>UnicodeData.11.0.txt</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.8.0.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\UnicodeData.8.0.txt">
       <Link>CharUnicodeInfo\UnicodeData8.0.txt</Link>
       <LogicalName>UnicodeData.8.0.txt</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData63.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\UnicodeData63.txt">
       <Link>CharUnicodeInfo\UnicodeData6.3.txt</Link>
       <LogicalName>UnicodeData6.3.txt</LogicalName>
     </EmbeddedResource>

--- a/src/libraries/System.IO.Compression.Brotli/src/System.IO.Compression.Brotli.csproj
+++ b/src/libraries/System.IO.Compression.Brotli/src/System.IO.Compression.Brotli.csproj
@@ -8,7 +8,7 @@
   <!-- Default configurations to help VS understand the options -->
   <!-- Platform agnostic files -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Interop.Brotli.cs" />
+    <Compile Include="$(CommonPath)Interop\Interop.Brotli.cs" />
     <Compile Include="System\IO\Compression\enc\BrotliStream.Compress.cs" />
     <Compile Include="System\IO\Compression\dec\BrotliStream.Decompress.cs" />
     <Compile Include="System\IO\Compression\BrotliUtils.cs" />
@@ -20,19 +20,19 @@
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBrotliHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBrotliHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBrotliHandle.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/libraries/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -7,19 +7,19 @@
     <Compile Include="BrotliEncoderTests.cs" />
     <Compile Include="BrotliGoogleTestData.cs" />
     <Compile Include="CompressionStreamUnitTests.Brotli.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CompressionStreamTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamUnitTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CompressionStreamUnitTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamUnitTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\LocalMemoryStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\LocalMemoryStream.cs">
       <Link>Common\System\IO\Compression\LocalMemoryStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\StreamHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\StreamHelpers.cs">
       <Link>Common\System\IO\Compression\StreamHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -13,7 +13,7 @@
     <Compile Include="System\IO\Compression\ZipFileExtensions.ZipArchive.Create.cs" />
     <Compile Include="System\IO\Compression\ZipFileExtensions.ZipArchive.Extract.cs" />
     <Compile Include="System\IO\Compression\ZipFileExtensions.ZipArchiveEntry.Extract.cs" />
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -8,25 +8,25 @@
     <Compile Include="ZipFileExtensions.ZipArchive.Create.cs" />
     <Compile Include="ZipFileExtensions.ZipArchiveEntry.Extract.cs" />
     <Compile Include="ZipFileExtensions.ZipArchive.Extract.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CRC.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CRC.cs">
       <Link>Common\System\IO\Compression\CRC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\FileData.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\FileData.cs">
       <Link>Common\System\IO\Compression\FileData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\LocalMemoryStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\LocalMemoryStream.cs">
       <Link>Common\System\IO\Compression\LocalMemoryStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\StreamHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\StreamHelpers.cs">
       <Link>Common\System\IO\Compression\StreamHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\ZipTestHelper.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\ZipTestHelper.cs">
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Interop.zlib.cs" />
+    <Compile Include="$(CommonPath)Interop\Interop.zlib.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\ZipArchive.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\ZipArchiveEntry.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\ZipArchiveMode.cs" />
@@ -46,20 +46,20 @@
   <!-- Windows specific files -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Compression\ZipArchiveEntry.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\IO\Compression\ZipArchiveEntry.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.PathConf.cs">

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -16,31 +16,31 @@
     <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
     <Compile Include="ZipArchive\zip_ReadTests.cs" />
     <Compile Include="ZipArchive\zip_UpdateTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\PathFeatures.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PathFeatures.cs">
       <Link>Common\System\IO\PathFeatures.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CRC.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CRC.cs">
       <Link>Common\System\IO\Compression\CRC.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CompressionStreamTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\CompressionStreamUnitTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\CompressionStreamUnitTestBase.cs">
       <Link>Common\System\IO\Compression\CompressionStreamUnitTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\FileData.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\FileData.cs">
       <Link>Common\System\IO\Compression\FileData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\LocalMemoryStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\LocalMemoryStream.cs">
       <Link>Common\System\IO\Compression\LocalMemoryStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\StreamHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\StreamHelpers.cs">
       <Link>Common\System\IO\Compression\StreamHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\Compression\ZipTestHelper.cs">
+    <Compile Include="$(CommonTestPath)System\IO\Compression\ZipTestHelper.cs">
       <Link>Common\System\IO\Compression\ZipTestHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -7,12 +7,12 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' != 'true'">
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" />
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\SuppressGCTransitionAttribute.internal.cs" />
   </ItemGroup>
   <!-- Source includes -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetsNetFx)' != 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs" Link="Common\System\NotImplemented.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)System\NotImplemented.cs" Link="Common\System\NotImplemented.cs" />
     <Compile Include="System\IO\FileSystemAclExtensions.cs" />
     <Compile Include="System\Security\AccessControl\DirectoryObjectSecurity.cs" />
     <Compile Include="System\Security\AccessControl\DirectorySecurity.cs" />
@@ -47,14 +47,14 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Windows.cs" Link="System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs" Link="System\IO\Win32Marshal.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs" Link="System\Text\ValueStringBuilder.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Compile Include="System\IO\FileSystemAclExtensions.net46.cs" />

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -6,10 +6,10 @@
     <Compile Include="DirectoryObjectSecurityTests.cs" />
     <Compile Include="FileSystemAccessRuleTests.cs" />
     <Compile Include="FileSystemAclExtensionsTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
     <Compile Include="FileSystemAuditRuleTests.cs" />

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -9,35 +9,35 @@
     <Compile Include="System\IO\DriveInfo.cs" />
     <Compile Include="System\IO\DriveNotFoundException.cs" />
     <Compile Include="System\IO\DriveType.cs" />
-    <Compile Include="$(CommonPath)\System\HResults.cs">
+    <Compile Include="$(CommonPath)System\HResults.cs">
       <Link>Common\System\HResults.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Error.cs" />
     <Compile Include="System\IO\DriveInfo.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetDriveType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetDriveType.cs">
       <Link>Common\Interop\Windows\Interop.GetDriveType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs">
       <Link>Common\Interop\Windows\Interop.GetVolumeInformation.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetLogicalDrives.cs">
       <Link>Common\Interop\Windows\Interop.GetLogicalDrives.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetDiskFreeSpaceEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetDiskFreeSpaceEx.cs">
       <Link>Common\Interop\Windows\Interop.GetDiskFreeSpaceEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs">
       <Link>Interop\Windows\Interop.MAX_PATH.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetVolumeLabel.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetVolumeLabel.cs">
       <Link>Common\Interop\Windows\Interop.SetVolumeLabel.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs">
@@ -46,10 +46,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs">
       <Link>Common\Interop\Windows\Interop.SecurityOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Interop.FileOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -64,13 +64,13 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\DriveInfoInternal.Windows.cs">
       <Link>Common\System\IO\DriveInfoInternal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp' ">
     <Compile Include="System\IO\DriveInfo.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -79,7 +79,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
       <Link>Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.PathConf.cs">
@@ -88,7 +88,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.MountPoints.cs">
       <Link>Common\Interop\Unix\Interop.MountPoints.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MountPoints.FormatInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MountPoints.FormatInfo.cs">
       <Link>Common\Interop\Unix\Interop.MountPoints.FormatInfo.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -18,15 +18,15 @@
     <Compile Include="System\IO\RenamedEventHandler.cs" />
     <Compile Include="System\IO\WatcherChangeTypes.cs" />
     <Compile Include="System\IO\WaitForChangedResult.cs" />
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs">
       <Link>Common\System\IO\PathInternal.CaseSensitivity.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
@@ -35,10 +35,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FileOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReadDirectoryChangesW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReadDirectoryChangesW.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ReadDirectoryChangesW.cs</Link>
     </Compile>
     <Compile Include="System\IO\FileSystemWatcher.Win32.cs">
@@ -50,12 +50,12 @@
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFile.cs">
       <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Read.cs">
@@ -67,7 +67,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
       <Link>Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.PathConf.cs">
@@ -76,10 +76,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' or '$(TargetsFreeBSD)' == 'true'">
     <Compile Include="System\IO\FileSystemWatcher.Linux.cs" />
-    <Compile Include="$(CommonPath)\Interop\Linux\System.Native\Interop.INotify.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\System.Native\Interop.INotify.cs">
       <Link>Common\Interop\Linux\Interop.inotify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
@@ -91,37 +91,37 @@
     <Compile Include="$(LibrariesProjectRoot)System.IO.FileSystem\src\System\IO\FileSystem.Exists.Unix.cs">
       <Link>System.IO.FileSystem\src\System\IO\FileSystem.Exists.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.EventStream.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.EventStream.cs">
       <Link>Common\Interop\OSX\Interop.EventStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.RunLoop.cs">
       <Link>Common\Interop\OSX\Interop.RunLoop.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RealPath.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.RealPath.cs">
       <Link>Common\Interop\Unix\Interop.RealPath.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Span.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.Span.cs">
       <Link>Common\Interop\Unix\Interop.Stat.Span.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Sync.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Sync.cs">
       <Link>Common\Interop\Unix\Interop.Sync.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\ValueUtf8Converter.cs">
+    <Compile Include="$(CommonPath)System\Text\ValueUtf8Converter.cs">
       <Link>Common\System\Text\ValueUtf8Converter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -25,19 +25,19 @@
     <!-- Helpers -->
     <Compile Include="Utility\TestFileSystemWatcher.cs" />
     <Compile Include="Utility\FileSystemWatcherTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' ">
     <Compile Include="FileSystemWatcher.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ResourceLimits.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ResourceLimits.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.ResourceLimits.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/libraries/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -18,7 +18,7 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.cs" Link="System\IO\PathInternal.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs" Link="System\IO\StreamHelpers.CopyValidation.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs" Link="System\Text\ValueStringBuilder.cs" />
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.CaseSensitivity.cs" Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs" Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
     <Compile Include="System\IO\Directory.cs" />
     <Compile Include="System\IO\DirectoryInfo.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEntry.cs" />
@@ -77,41 +77,41 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\DriveInfoInternal.Windows.cs" Link="Common\System\IO\DriveInfoInternal.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Windows.cs" Link="System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs" Link="System\IO\Win32Marshal.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs" Link="Common\Interop\Windows\Interop.EncryptDecrypt.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" Link="Common\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs" Link="Common\Interop\Windows\Interop.UNICODE_STRING.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CompareStringOrdinal.cs" Link="Common\Interop\Windows\Interop.CompareStringOrdinal.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CopyFile.cs" Link="Common\Interop\Windows\Interop.CopyFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CopyFileEx.cs" Link="Common\Interop\Windows\Interop.CopyFileEx.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\Interop\Windows\Interop.CreateFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DeleteFile.cs" Link="Common\Interop\Windows\Interop.DeleteFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DeleteVolumeMountPoint.cs" Link="Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Interop.FileOperations.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FindNextFile.cs" Link="Common\Interop\Windows\Interop.FindNextFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs" Link="Common\Interop\Windows\Interop.GetVolumeInformation.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MoveFileEx.cs" Link="Common\Interop\Windows\Interop.MoveFileEx.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.RemoveDirectory.cs" Link="Common\Interop\Windows\Interop.RemoveDirectory.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ReplaceFile.cs" Link="Common\Interop\Windows\Interop.ReplaceFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileAttributes.cs" Link="Common\Interop\Windows\Interop.SetFileAttributes.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileInformationByHandle.cs" Link="Common\Interop\Windows\Interop.SetFileInformationByHandle.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.FILE_FULL_DIR_INFORMATION.cs" Link="Common\Interop\Windows\Interop.FILE_FULL_DIR_INFORMATION.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.FILE_INFORMATION_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFORMATION_CLASS.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs" Link="Common\Interop\Windows\Interop.IO_STATUS_BLOCK.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtCreateFile.cs" Link="Common\Interop\Windows\Interop.NtCreateFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtQueryDirectoryFile.cs" Link="Common\Interop\Windows\Interop.NtQueryDirectoryFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtStatus.cs" Link="Common\Interop\Windows\Interop.NtStatus.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs" Link="Common\Interop\Windows\Interop.RtlNtStatusToDosError.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\HResults.cs" Link="Common\System\HResults.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Memory\FixedBufferExtensions.cs" Link="Common\System\Memory\FixedBufferExtensions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs" Link="Common\Interop\Windows\Interop.EncryptDecrypt.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" Link="Common\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.UNICODE_STRING.cs" Link="Common\Interop\Windows\Interop.UNICODE_STRING.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CompareStringOrdinal.cs" Link="Common\Interop\Windows\Interop.CompareStringOrdinal.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CopyFile.cs" Link="Common\Interop\Windows\Interop.CopyFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CopyFileEx.cs" Link="Common\Interop\Windows\Interop.CopyFileEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\Interop\Windows\Interop.CreateFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DeleteFile.cs" Link="Common\Interop\Windows\Interop.DeleteFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DeleteVolumeMountPoint.cs" Link="Common\Interop\Windows\Interop.DeleteVolumeMountPoint.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Interop.FileOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FindNextFile.cs" Link="Common\Interop\Windows\Interop.FindNextFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs" Link="Common\Interop\Windows\Interop.GetVolumeInformation.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MoveFileEx.cs" Link="Common\Interop\Windows\Interop.MoveFileEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.RemoveDirectory.cs" Link="Common\Interop\Windows\Interop.RemoveDirectory.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ReplaceFile.cs" Link="Common\Interop\Windows\Interop.ReplaceFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileAttributes.cs" Link="Common\Interop\Windows\Interop.SetFileAttributes.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileInformationByHandle.cs" Link="Common\Interop\Windows\Interop.SetFileInformationByHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.FILE_FULL_DIR_INFORMATION.cs" Link="Common\Interop\Windows\Interop.FILE_FULL_DIR_INFORMATION.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.FILE_INFORMATION_CLASS.cs" Link="Common\Interop\Windows\Interop.FILE_INFORMATION_CLASS.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.IO_STATUS_BLOCK.cs" Link="Common\Interop\Windows\Interop.IO_STATUS_BLOCK.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtCreateFile.cs" Link="Common\Interop\Windows\Interop.NtCreateFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtQueryDirectoryFile.cs" Link="Common\Interop\Windows\Interop.NtQueryDirectoryFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtStatus.cs" Link="Common\Interop\Windows\Interop.NtStatus.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RtlNtStatusToDosError.cs" Link="Common\Interop\Windows\Interop.RtlNtStatusToDosError.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
+    <Compile Include="$(CommonPath)System\HResults.cs" Link="Common\System\HResults.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.Attributes.Windows.cs" Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
+    <Compile Include="$(CommonPath)System\IO\FileSystem.DirectoryCreation.Windows.cs" Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
+    <Compile Include="$(CommonPath)System\Memory\FixedBufferExtensions.cs" Link="Common\System\Memory\FixedBufferExtensions.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEntry.Windows.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.Win32.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.Windows.cs" />
@@ -132,18 +132,18 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Unlink.cs" Link="Common\Interop\Unix\Interop.Unlink.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\DriveInfoInternal.Unix.cs" Link="Common\System\IO\DriveInfoInternal.Unix.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.Unix.cs" Link="System\IO\PathInternal.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" Link="Common\Interop\Unix\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ChMod.cs" Link="Common\Interop\Unix\Interop.ChMod.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.CopyFile.cs" Link="Common\Interop\Unix\Interop.CopyFile.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetEGid.cs" Link="Common\Interop\Unix\Interop.GetEGid.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.LChflags.cs" Link="Common\Interop\Unix\Interop.LChflags.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Link.cs" Link="Common\Interop\Unix\Interop.Link.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MkDir.cs" Link="Common\Interop\Unix\Interop.MkDir.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Rename.cs" Link="Common\Interop\Unix\Interop.Rename.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RmDir.cs" Link="Common\Interop\Unix\Interop.RmDir.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Span.cs" Link="Common\Interop\Unix\Interop.Stat.Span.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.UTimensat.cs" Link="Common\Interop\Unix\Interop.UTimensat.cs" />
-    <Compile Include="$(CommonPath)\System\Text\ValueUtf8Converter.cs" Link="Common\System\Text\ValueUtf8Converter.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs" Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ChMod.cs" Link="Common\Interop\Unix\Interop.ChMod.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.CopyFile.cs" Link="Common\Interop\Unix\Interop.CopyFile.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEGid.cs" Link="Common\Interop\Unix\Interop.GetEGid.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.LChflags.cs" Link="Common\Interop\Unix\Interop.LChflags.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Link.cs" Link="Common\Interop\Unix\Interop.Link.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs" Link="Common\Interop\Unix\Interop.MkDir.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Rename.cs" Link="Common\Interop\Unix\Interop.Rename.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.RmDir.cs" Link="Common\Interop\Unix\Interop.RmDir.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.Span.cs" Link="Common\Interop\Unix\Interop.Stat.Span.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.UTimensat.cs" Link="Common\Interop\Unix\Interop.UTimensat.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueUtf8Converter.cs" Link="Common\System\Text\ValueUtf8Converter.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEntry.Unix.cs" />
     <Compile Include="System\IO\Enumeration\FileSystemEnumerator.Unix.cs" />
     <Compile Include="System\IO\FileStatus.Unix.cs" />

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -161,14 +161,14 @@
     <Compile Include="FileInfo\AppendText.cs" />
     <Compile Include="FileInfo\CopyTo.cs" />
     <!-- Helpers -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\PathFeatures.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PathFeatures.cs">
       <Link>Common\System\IO\PathFeatures.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -11,7 +11,7 @@
     <Compile Include="System\IO\IsolatedStorage\Helper.cs" />
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32Unix.cs" />
     <Compile Include="System\IO\IsolatedStorage\INormalizeForIsolatedStorage.cs" />
-    <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -24,16 +24,16 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.cs">
       <Link>Internals\Helper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\IdentityHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\IdentityHelper.cs">
       <Link>Common\System\Security\IdentityHelper.cs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -17,31 +17,31 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\MemoryMappedFiles\Interop.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFileMapping.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFileMapping.cs">
       <Link>Common\Interop\Windows\Interop.CreateFileMapping.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MapViewOfFile.cs">
       <Link>Common\Interop\Windows\Interop.MapViewOfFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenFileMapping.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OpenFileMapping.cs">
       <Link>Common\Interop\Windows\Interop.OpenFileMapping.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.VirtualAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.VirtualAlloc.cs">
       <Link>Common\Interop\Windows\Interop.VirtualAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalMemoryStatusEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GlobalMemoryStatusEx.cs">
       <Link>Common\Interop\Windows\Interop.GlobalMemoryStatusEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -50,13 +50,13 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileAttributes.cs">
       <Link>Common\Interop\Windows\Interop.FileAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Interop.FileOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FlushViewOfFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FlushViewOfFile.cs">
       <Link>Common\Interop\Windows\Interop.FlushViewOfFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs">
       <Link>Common\Interop\Windows\Interop.GenericOperations.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetSystemInfo.cs">
@@ -65,16 +65,16 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SYSTEM_INFO.cs">
       <Link>Common\Interop\Windows\Interop.SYSTEM_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.HandleOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs">
       <Link>Common\Interop\Windows\Interop.HandleOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
       <Link>Common\Interop\Windows\Interop.MEMORY_BASIC_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MemOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MemOptions.cs">
       <Link>Common\Interop\Windows\Interop.MemOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.PipeOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PipeOptions.cs">
       <Link>Common\Interop\Windows\Interop.PipeOptions.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
@@ -83,10 +83,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs">
       <Link>Common\Interop\Windows\Interop.SecurityOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.UnmapViewOfFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.UnmapViewOfFile.cs">
       <Link>Common\Interop\Windows\Interop.UnmapViewOfFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.VirtualQuery.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.VirtualQuery.cs">
       <Link>Common\Interop\Windows\Interop.VirtualQuery.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
@@ -98,25 +98,25 @@
     <Compile Include="System\IO\MemoryMappedFiles\MemoryMappedView.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Common\Interop\Unix\Interop.Fcntl.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
       <Link>Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MMap.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MMap.cs">
       <Link>Common\Interop\Unix\Interop.MMap.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MUnmap.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MUnmap.cs">
       <Link>Common\Interop\Unix\Interop.MUnmap.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MSync.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MSync.cs">
       <Link>Common\Interop\Unix\Interop.MSync.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Open.cs">
@@ -138,10 +138,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.FTruncate.cs">
       <Link>Common\Interop\Unix\Interop.FTruncate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MAdvise.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MAdvise.cs">
       <Link>Common\Interop\Unix\Interop.MAdvise.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ShmOpen.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ShmOpen.cs">
       <Link>Common\Interop\Unix\Interop.ShmOpen.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Unlink.cs">

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -15,7 +15,7 @@
     <Compile Include="MemoryMappedFilesTestsBase.cs" />
     <Compile Include="MemoryMappedFilesTestsBase.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <Compile Include="MemoryMappedFilesTestsBase.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="XunitAssemblyAttributes.cs" />

--- a/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -26,13 +26,13 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -53,16 +53,16 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs">
       <Link>Common\Interop\Windows\Interop.GenericOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.HandleOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs">
       <Link>Common\Interop\Windows\Interop.HandleOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.PipeOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PipeOptions.cs">
       <Link>Common\Interop\Windows\Interop.PipeOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Interop.FileOperations.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs">
@@ -71,28 +71,28 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.GetCurrentProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DuplicateHandle_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle_IntPtr.cs">
       <Link>Common\Interop\Windows\Interop.DuplicateHandle_IntPtr.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs">
       <Link>Interop\Windows\Interop.GetFileType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreatePipe_SafePipeHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreatePipe_SafePipeHandle.cs">
       <Link>Common\Interop\Windows\Interop.CreatePipe_SafePipeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ConnectNamedPipe.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ConnectNamedPipe.cs">
       <Link>Common\Interop\Windows\Interop.ConnectNamedPipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WaitNamedPipe.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitNamedPipe.cs">
       <Link>Common\Interop\Windows\Interop.WaitNamedPipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs">
       <Link>Common\Interop\Windows\Interop.GetNamedPipeHandleState.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetNamedPipeInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeInfo.cs">
       <Link>Common\Interop\Windows\Interop.GetNamedPipeInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetNamedPipeHandleState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetNamedPipeHandleState.cs">
       <Link>Common\Interop\Windows\Interop.SetNamedPipeHandleState.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
@@ -113,19 +113,19 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs">
       <Link>Common\Interop\Windows\Interop.WriteFile_NativeOverlapped.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DisconnectNamedPipe.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DisconnectNamedPipe.cs">
       <Link>Common\Interop\Windows\Interop.DisconnectNamedPipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateNamedPipe.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipe.cs">
       <Link>Common\Interop\Windows\Interop.CreateNamedPipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MaxLengths.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MaxLengths.cs">
       <Link>Common\Interop\Windows\Interop.MaxLengths.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
       <Link>Common\Interop\Windows\Interop.RevertToSelf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ImpersonateNamedPipeClient.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ImpersonateNamedPipeClient.cs">
       <Link>Common\Interop\Windows\Interop.ImpersonateNamedPipeClient.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
@@ -147,7 +147,7 @@
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateNamedPipeClient.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipeClient.cs">
       <Link>Common\Interop\Windows\Interop.CreateNamedPipeClient.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
@@ -161,10 +161,10 @@
     <Compile Include="System\IO\Pipes\NamedPipeClientStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.Unix.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -176,10 +176,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Fcntl.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Common\Interop\Unix\Interop.Fcntl.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.FLock.cs">
@@ -188,10 +188,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>Common\Interop\Unix\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPeerUserName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerUserName.cs">
       <Link>Common\Interop\Unix\Interop.GetPeerUserName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MkDir.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs">
       <Link>Common\Interop\Unix\Interop.MkDir.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Open.cs">
@@ -203,37 +203,37 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Read.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Read.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Read.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Unlink.cs">
       <Link>Common\Interop\Unix\Interop.Unlink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Write.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Write.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Write.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Stat.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPeerID.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerID.cs">
       <Link>Common\Interop\Unix\Interop.GetPeerID.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs">
       <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetEUid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetEUid.cs">
       <Link>Common\Interop\Unix\Interop.SetEUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\ForceAsyncAwaiter.cs">
+    <Compile Include="$(CommonPath)System\Threading\Tasks\ForceAsyncAwaiter.cs">
       <Link>Common\System\Threading\Tasks\ForceAsyncAwaiter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -26,7 +26,7 @@
     <Compile Include="PipeTest.Read.cs" />
     <Compile Include="PipeTest.Write.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>
@@ -43,16 +43,16 @@
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs">
       <Link>Common\Interop\Windows\Interop.GetNamedPipeHandleState.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MaxLengths.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MaxLengths.cs">
       <Link>Common\Interop\Windows\Interop.MaxLengths.cs</Link>
     </Compile>
     <Compile Include="NamedPipeTests\NamedPipeTest.CurrentUserOnly.cs" />

--- a/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
@@ -26,55 +26,55 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Ports\SerialStream.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DCB.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DCB.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.DCB.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.COMMPROP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.COMMPROP.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.COMMPROP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.COMMTIMEOUTS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.COMMTIMEOUTS.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.COMMTIMEOUTS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.COMSTAT.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.COMSTAT.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.COMSTAT.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetCommState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetCommState.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetCommState.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetCommBreak.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetCommBreak.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetCommBreak.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ClearCommBreak.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ClearCommBreak.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ClearCommBreak.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.EscapeCommFunction.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EscapeCommFunction.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.EscapeCommFunction.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetCommTimeouts.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetCommTimeouts.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetCommTimeouts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCommModemStatus.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCommModemStatus.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCommModemStatus.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.ClearCommError.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ClearCommError.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.ClearCommError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCommProperties.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCommProperties.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCommProperties.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetCommMask.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetCommMask.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetCommMask.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.PurgeComm.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PurgeComm.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.PurgeComm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetupComm.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetupComm.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetupComm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCommState.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCommState.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCommState.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WaitCommEvent.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitCommEvent.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.WaitCommEvent.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">
@@ -89,13 +89,13 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs">
       <Link>Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FlushFileBuffers.cs">
       <Link>Interop\Windows\Kernel32\Interop.FlushFileBuffers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GenericOperations.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
@@ -104,16 +104,16 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs">
       <Link>Interop\Windows\Interop.FileTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
@@ -132,10 +132,10 @@
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Ports\SerialPort.Win32.cs" />
     <Compile Include="System\IO\Ports\SerialStream.Win32.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateFile.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CreateFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FileOperations.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FileOperations.cs</Link>
     </Compile>
   </ItemGroup>
@@ -153,7 +153,7 @@
     <Compile Include="System\IO\Ports\SerialStream.Unix.cs" />
     <Compile Include="Interop\Unix\Interop.Termios.cs" />
     <Compile Include="Interop\Unix\Interop.Serial.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -168,10 +168,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Write.cs">
       <Link>Interop\Unix\System.Native\Interop.Write.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Interop\Unix\System.Native\Interop.Poll.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Shutdown.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Shutdown.cs">
       <Link>Interop\Unix\System.Native\Interop.Shutdown.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.IO/tests/System.IO.Tests.csproj
+++ b/src/libraries/System.IO/tests/System.IO.Tests.csproj
@@ -45,16 +45,16 @@
     <Compile Include="Stream\Stream.TimeoutTests.cs" />
     <Compile Include="StringReader\StringReader.CtorTests.cs" />
     <Compile Include="StringWriter\StringWriterTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
+    <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\CallTrackingStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs">
       <Link>Common\System\IO\CallTrackingStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\WrappedMemoryStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\WrappedMemoryStream.cs">
       <Link>Common\System\IO\WrappedMemoryStream.cs</Link>
     </Compile>
     <Compile Include="TestDataProvider\TestDataProvider.cs" />

--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -13,7 +13,7 @@
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\PreserveDependencyAttribute.cs">
@@ -131,7 +131,7 @@
     <Compile Include="System\Dynamic\IInvokeOnGetBinder.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsInterpreting)' != 'true'">
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ReferenceEqualityComparer.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ReferenceEqualityComparer.cs">
       <Link>Common\System\Collections\Generic\ReferenceEqualityComparer.cs</Link>
     </Compile>
     <Compile Include="System\Linq\Expressions\Compiler\AssemblyGen.cs" />

--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -224,7 +224,7 @@
     <Compile Include="Visitor\VisitorTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsInterpreting)' != 'true' ">
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="ILReader\DynamicMethodILProvider.cs" />

--- a/src/libraries/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/libraries/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -4,13 +4,13 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadPoolHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
     <Compile Include="Combinatorial\CancellationParallelQueryCombinationTests.cs" />

--- a/src/libraries/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.csproj
+++ b/src/libraries/System.Linq.Queryable/tests/System.Linq.Queryable.Tests.csproj
@@ -56,7 +56,7 @@
     <Compile Include="UnionTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="ZipTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Linq\SkipTakeData.cs">
+    <Compile Include="$(CommonTestPath)System\Linq\SkipTakeData.cs">
       <Link>Common\System\Linq\SkipTakeData.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -29,24 +29,24 @@
     <Compile Include="System\Linq\Take.SpeedOpt.cs" />
     <Compile Include="System\Linq\Union.SpeedOpt.cs" />
     <Compile Include="System\Linq\Where.SpeedOpt.cs" />
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs">
       <Link>System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">
       <Link>System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\EnumerableHelpers.cs">
       <Link>System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.Linq.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\EnumerableHelpers.Linq.cs">
       <Link>System\Collections\Generic\EnumerableHelpers.Linq.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LargeArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\LargeArrayBuilder.cs">
       <Link>System\Collections\Generic\LargeArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\SparseArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\SparseArrayBuilder.cs">
       <Link>System\Collections\Generic\SparseArrayBuilder.cs</Link>
     </Compile>
     <Compile Include="System\Linq\Aggregate.cs" />

--- a/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
@@ -68,10 +68,10 @@
     <Compile Include="WhereTests.cs" />
     <Compile Include="ZipTests.cs" />
     <Compile Include="ZipTests.netcoreapp.cs" />
-    <Compile Include="$(CommonTestPath)\System\Linq\SkipTakeData.cs">
+    <Compile Include="$(CommonTestPath)System\Linq\SkipTakeData.cs">
       <Link>Common\System\Linq\SkipTakeData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
     <Compile Include="GroupByTests.DebuggerAttributes.cs" />

--- a/src/libraries/System.Management/src/System.Management.csproj
+++ b/src/libraries/System.Management/src/System.Management.csproj
@@ -7,34 +7,34 @@
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetStandard)' != 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalLock.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GlobalLock.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GlobalLock.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoGetObjectContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.CoGetObjectContext.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CoGetObjectContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoMarshalInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.CoMarshalInterface.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CoMarshalInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoUnmarshalInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.CoUnmarshalInterface.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CoUnmarshalInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CreateStreamOnHGlobal.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.CreateStreamOnHGlobal.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CreateStreamOnHGlobal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.GetHGlobalFromStream.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.GetHGlobalFromStream.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.GetHGlobalFromStream.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">

--- a/src/libraries/System.Memory/src/System.Memory.csproj
+++ b/src/libraries/System.Memory/src/System.Memory.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Common or Common-branched source files -->
-    <Compile Include="$(CommonPath)\System\Buffers\ArrayBufferWriter.cs">
+    <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs">
       <Link>Common\System\Buffers\ArrayBufferWriter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -15,9 +15,9 @@
     <Compile Include="MemoryMarshal\AsReadOnlyRef.cs" />
     <Compile Include="MemoryMarshal\CreateSpan.cs" />
     <Compile Include="MemoryMarshal\CreateReadOnlySpan.cs" />
-    <Compile Include="$(CommonPath)\..\tests\System\RealFormatterTestsBase.netcoreapp.cs" Link="ParsersAndFormatters\Formatter\RealFormatterTestsBase.netcoreapp.cs" />
+    <Compile Include="$(CommonPath)..\tests\System\RealFormatterTestsBase.netcoreapp.cs" Link="ParsersAndFormatters\Formatter\RealFormatterTestsBase.netcoreapp.cs" />
     <Compile Include="ParsersAndFormatters\Formatter\RealFormatterTests.netcoreapp.cs" />
-    <Compile Include="$(CommonPath)\..\tests\System\RealParserTestsBase.netcoreapp.cs" Link="ParsersAndFormatters\Parser\RealParserTestsBase.netcoreapp.cs" />
+    <Compile Include="$(CommonPath)..\tests\System\RealParserTestsBase.netcoreapp.cs" Link="ParsersAndFormatters\Parser\RealParserTestsBase.netcoreapp.cs" />
     <Compile Include="ParsersAndFormatters\Parser\RealParserTests.netcoreapp.cs" />
     <Compile Include="ReadOnlySpan\Contains.byte.cs" />
     <Compile Include="ReadOnlySpan\Contains.T.cs" />
@@ -169,7 +169,7 @@
     <Compile Include="ReadOnlySpan\ToArray.cs" />
     <Compile Include="ReadOnlySpan\ToString.cs" />
     <Compile Include="ReadOnlySpan\ToUpperLower.cs" />
-    <Compile Include="$(CommonTestPath)\Tests\System\StringTests.cs">
+    <Compile Include="$(CommonTestPath)Tests\System\StringTests.cs">
       <Link>ReadOnlySpan\StringTests.cs</Link>
     </Compile>
   </ItemGroup>
@@ -259,10 +259,10 @@
     <Compile Include="Base64\Base64TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
+    <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\MutableDecimal.cs">
+    <Compile Include="$(CommonPath)System\MutableDecimal.cs">
       <Link>Common\System\MutableDecimal.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -10,7 +10,7 @@
     <!-- Need to compile it here since the NET46 target here is building against System.Runtime whereas the
          the list of other files in System.Net.Http.WinHttpHandler.msbuild is also used by System.Net.Http
          library and the NET46 target there uses framework assembly references instead. -->
-    <CompileItem Include="$(CommonPath)\System\Net\HttpStatusDescription.cs" />
+    <CompileItem Include="$(CommonPath)System\Net\HttpStatusDescription.cs" />
   </ItemGroup>
   <!--  For source files to be shown within the visual tree in Solution Explorer, the items must be
          included directly in the project file. We have the *.msbuild define the Compile items in a made
@@ -21,7 +21,7 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs">
       <Link>System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -3,10 +3,10 @@
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
     <Compile Include="ServerCertificateTest.cs" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -9,76 +9,76 @@
     <DefaultReferenceExclusions Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonTestPath)\System\Net\SslProtocolSupport.cs">
+    <Compile Include="$(CommonTestPath)System\Net\SslProtocolSupport.cs">
       <Link>CommonTest\System\Net\SslProtocolSupport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.HRESULT_FROM_WIN32.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.HRESULT_FROM_WIN32.cs">
       <Link>Common\Interop\Windows\Interop.HRESULT_FROM_WIN32.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs">
       <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs">
       <Link>Common\Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinHttp\Interop.winhttp_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinHttp\Interop.winhttp_types.cs">
       <Link>Common\Interop\Windows\WinHttp\Interop.winhttp_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\CharArrayHelpers.cs">
+    <Compile Include="$(CommonPath)System\CharArrayHelpers.cs">
       <Link>Common\System\CharArrayHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs">
       <Link>System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpStatusDescription.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpStatusDescription.cs">
       <Link>Common\System\Net\HttpStatusDescription.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\NoWriteNoSeekStreamContent.cs">
       <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateHelper.cs">
       <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateHelper.Windows.cs">
       <Link>Common\System\Net\Security\CertificateHelper.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
+    <Compile Include="$(CommonPath)System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
       <Link>Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\SimpleRegex.cs">
+    <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs">
       <Link>Common\System\Text\SimpleRegex.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs">
+    <Compile Include="$(CommonPath)System\Threading\Tasks\RendezvousAwaitable.cs">
       <Link>Common\System\Threading\Tasks\RendezvousAwaitable.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -90,25 +90,25 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs">
       <Link>System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SslClientAuthenticationOptionsExtensions.cs">
       <Link>Common\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
+    <Compile Include="$(CommonPath)System\IO\DelegatingStream.cs">
       <Link>Common\System\IO\DelegatingStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\ReadOnlyMemoryStream.cs">
+    <Compile Include="$(CommonPath)System\IO\ReadOnlyMemoryStream.cs">
       <Link>Common\System\IO\ReadOnlyMemoryStream.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
       <Link>Common\System\Text\StringBuilderCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpDateParser.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpDateParser.cs">
       <Link>Common\System\Net\HttpDateParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\SimpleRegex.cs">
+    <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs">
       <Link>Common\System\Text\SimpleRegex.cs</Link>
     </Compile>
   </ItemGroup>
@@ -157,85 +157,85 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\FailedProxyCache.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IMultiWebProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\MultiProxy.cs" />
-    <Compile Include="$(CommonPath)\System\Net\NTAuthentication.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\IHttpHeadersHandler.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\IHttpHeadersHandler.cs">
       <Link>Common\System\Net\Http\Http2\IHttpHeadersHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\DynamicTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\DynamicTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\DynamicTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HeaderField.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HeaderField.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HeaderField.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\Huffman.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\Huffman.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\Huffman.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StaticTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StatusCodes.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SSPIHandleCache.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs">
       <Link>Common\System\Net\Security\SSPIHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
   </ItemGroup>
@@ -243,40 +243,40 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeNegoCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SecChannelBindings.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs">
       <Link>Common\System\Net\Security\Unix\SecChannelBindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteNegoContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteNegoContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteNegoContext.cs</Link>
     </Compile>
   </ItemGroup>
@@ -287,40 +287,40 @@
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\MacProxy.cs" />
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFArray.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFData.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFDictionary.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFDictionary.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFProxy.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFProxy.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFProxy.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFUrl.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFUrl.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFUrl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFString.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFNumber.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFNumber.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFError.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.RunLoop.cs">
       <Link>Common\Interop\OSX\Interop.RunLoop.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
   </ItemGroup>
@@ -330,85 +330,85 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpWindowsProxy.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.Windows.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\SspiCli\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
   </ItemGroup>
@@ -416,28 +416,28 @@
   <ItemGroup>
     <Compile Include="System\Net\Http\DiagnosticsHandler.cs" />
     <Compile Include="System\Net\Http\DiagnosticsHandlerLoggingStrings.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Mail\DomainLiteralReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DomainLiteralReader.cs">
       <Link>Common\System\Net\Mail\DomainLiteralReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DotAtomReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DotAtomReader.cs">
       <Link>Common\System\Net\Mail\DotAtomReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddress.cs">
       <Link>Common\System\Net\Mail\MailAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddressParser.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddressParser.cs">
       <Link>Common\System\Net\Mail\MailAddressParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailBnfHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailBnfHelper.cs">
       <Link>Common\System\Net\Mail\MailBnfHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedPairReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedPairReader.cs">
       <Link>Common\System\Net\Mail\QuotedPairReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedStringFormatReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedStringFormatReader.cs">
       <Link>Common\System\Net\Mail\QuotedStringFormatReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\WhitespaceReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\WhitespaceReader.cs">
       <Link>Common\System\Net\Mail\WhitespaceReader.cs</Link>
     </Compile>
   </ItemGroup>
@@ -469,13 +469,13 @@
     <Compile Include="System\Net\Http\HttpClientHandler.Core.cs" />
     <Compile Include="System\Net\Http\HttpClientHandler.netcoreapp.cs" />
     <Compile Include="System\Net\Http\HttpClientHandler.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\StrongToWeakReference.cs">
+    <Compile Include="$(CommonPath)System\StrongToWeakReference.cs">
       <Link>Common\Interop\Unix\StrongToWeakReference.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -484,7 +484,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
       <Link>Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
@@ -496,10 +496,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Interop\Unix\System.Native\Interop.OpenFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\libc\Interop.Poll.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Read.cs">
@@ -508,34 +508,34 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Write.cs">
       <Link>Common\Interop\Unix\libc\Interop.Write.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\CharArrayHelpers.cs">
+    <Compile Include="$(CommonPath)System\CharArrayHelpers.cs">
       <Link>Common\System\CharArrayHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpStatusDescription.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpStatusDescription.cs">
       <Link>Common\System\Net\HttpStatusDescription.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\NoWriteNoSeekStreamContent.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\NoWriteNoSeekStreamContent.cs">
       <Link>Common\System\Net\Http\NoWriteNoSeekStreamContent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\TlsCertificateExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\TlsCertificateExtensions.cs">
       <Link>Common\System\Net\Http\TlsCertificateExtensions</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateHelper.cs">
       <Link>Common\System\Net\Security\CertificateHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateHelper.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateHelper.Unix.cs">
       <Link>Common\System\Net\Security\CertificateHelper.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
@@ -543,70 +543,70 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' and '$(TargetsOSX)' != 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateValidation.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs">
       <Link>Common\System\Net\Security\CertificateValidation.Unix.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -7,82 +7,82 @@
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs" Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs" Condition="'$(TargetsUnix)' == 'true'">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs" Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs" Condition="'$(TargetsUnix)' == 'true'">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
+    <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\ConsoleEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\ConsoleEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\ConsoleEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\DelegateStream.cs">
       <Link>Common\System\IO\DelegateStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\RemoteServerQuery.cs">
+    <Compile Include="$(CommonTestPath)System\Net\RemoteServerQuery.cs">
       <Link>Common\System\Net\RemoteServerQuery.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\HttpsTestServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\HttpsTestServer.cs">
       <Link>Common\System\Net\HttpsTestServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Windows.cs" Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Windows.cs" Condition="'$(TargetsWindows)' == 'true'">
       <Link>Common\System\Net\Capability.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Unix.cs" Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Unix.cs" Condition="'$(TargetsUnix)' == 'true'">
       <Link>Common\System\Net\Capability.Security.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs">
       <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Sockets.cs">
       <Link>Common\System\Net\Configuration.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\TestWebProxies.cs">
+    <Compile Include="$(CommonTestPath)System\Net\TestWebProxies.cs">
       <Link>Common\System\Net\TestWebProxies.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackProxyServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackProxyServer.cs">
       <Link>Common\System\Net\Http\LoopbackProxyServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
       <Link>Common\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs">
       <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\TrackingSynchronizationContext.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\TrackingSynchronizationContext.cs">
       <Link>Common\System\Threading\TrackingSynchronizationContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\GetStateMachineData.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\GetStateMachineData.cs">
       <Link>Common\System\Threading\Tasks\GetStateMachineData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
     <Compile Include="ByteArrayContentTest.cs" />
@@ -151,22 +151,22 @@
     <Compile Include="NtAuthTests.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
     <Compile Include="SocketsHttpHandlerTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Http\Http2Frames.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http2Frames.cs">
       <Link>Common\System\Net\Http\Http2Frames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\HPackEncoder.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\HPackEncoder.cs">
       <Link>Common\System\Net\Http\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\Http2LoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackServer.cs">
       <Link>Common\System\Net\Http\Http2LoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\Http2LoopbackConnection.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackConnection.cs">
       <Link>Common\System\Net\Http\Http2LoopbackConnection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanDecoder.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\HuffmanDecoder.cs">
       <Link>Common\System\Net\Http\HuffmanDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanEncoder.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\HuffmanEncoder.cs">
       <Link>Common\System\Net\Http\HuffmanEncoder.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -11,13 +11,13 @@
     <DefaultReferenceExclusions Include="System.Net.Mail" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>ProductionCode\Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\CharArrayHelpers.cs">
+    <Compile Include="$(CommonPath)System\CharArrayHelpers.cs">
       <Link>ProductionCode\Common\System\CharArrayHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>ProductionCode\Common\System\StringExtensions.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
@@ -26,64 +26,64 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs">
       <Link>ProductionCode\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>ProductionCode\Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpDateParser.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpDateParser.cs">
       <Link>ProductionCode\Common\System\Net\HttpDateParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>ProductionCode\Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
       <Link>ProductionCode\Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpStatusDescription.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpStatusDescription.cs">
       <Link>ProductionCode\Common\System\Net\HttpStatusDescription.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>ProductionCode\Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>ProductionCode\Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Text\SimpleRegex.cs">
+    <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs">
       <Link>Common\System\Text\SimpleRegex.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\HPackEncoder.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\HPackEncoder.cs">
       <Link>Common\System\Net\Http\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanEncoder.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\HuffmanEncoder.cs">
       <Link>Common\System\Net\Http\HuffmanEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddress.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\MailAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DomainLiteralReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DomainLiteralReader.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\DomainLiteralReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DotAtomReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DotAtomReader.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\DotAtomReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddressParser.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddressParser.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\MailAddressParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailBnfHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailBnfHelper.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\MailBnfHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedPairReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedPairReader.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\QuotedPairReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedStringFormatReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedStringFormatReader.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\QuotedStringFormatReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\WhitespaceReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\WhitespaceReader.cs">
       <Link>ProductionCode\Common\src\System\Net\Mail\WhitespaceReader.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
@@ -101,7 +101,7 @@
     <Compile Include="..\..\src\System\Net\Http\DelegatingHandler.cs">
       <Link>ProductionCode\System\Net\Http\DelegatingHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
+    <Compile Include="$(CommonPath)System\IO\DelegatingStream.cs">
       <Link>ProductionCode\System\IO\DelegatingStream.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\ByteArrayHelpers.cs">
@@ -329,7 +329,7 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs">
       <Link>ProductionCode\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
     <Compile Include="DigestAuthenticationTests.cs" />
@@ -388,16 +388,16 @@
     <Compile Include="Headers\ViaHeaderValueTest.cs" />
     <Compile Include="Headers\WarningHeaderValueTest.cs" />
     <Compile Include="HPack\HPackRoundtripTests.cs" />
-    <Compile Include="$(CommonPath)\..\tests\Tests\System\Net\Http2\DynamicTableTest.cs">
+    <Compile Include="$(CommonPath)..\tests\Tests\System\Net\Http2\DynamicTableTest.cs">
       <Link>HPack\DynamicTableTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\..\tests\Tests\System\Net\Http2\HPackDecoderTest.cs">
+    <Compile Include="$(CommonPath)..\tests\Tests\System\Net\Http2\HPackDecoderTest.cs">
       <Link>HPack\HPackDecoderTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\..\tests\Tests\System\Net\Http2\HPackIntegerTest.cs">
+    <Compile Include="$(CommonPath)..\tests\Tests\System\Net\Http2\HPackIntegerTest.cs">
       <Link>HPack\HPackIntegerTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\..\tests\Tests\System\Net\Http2\HuffmanDecodingTests.cs">
+    <Compile Include="$(CommonPath)..\tests\Tests\System\Net\Http2\HuffmanDecodingTests.cs">
       <Link>HPack\HuffmanDecodingTests.cs</Link>
     </Compile>
     <Compile Include="HttpContentTest.cs" />
@@ -431,64 +431,64 @@
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpTraceHelper.cs">
       <Link>ProductionCode\System\Net\Http\WinHttpTraceHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
       <Link>ProductionCode\Common\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>ProductionCode\Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.HRESULT_FROM_WIN32.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.HRESULT_FROM_WIN32.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.HRESULT_FROM_WIN32.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs">
       <Link>ProductionCode\Common\Interop\Windows\WinHttp\Interop.SafeWinHttpHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
+    <Compile Include="$(CommonPath)System\Runtime\ExceptionServices\ExceptionStackTrace.cs">
       <Link>ProductionCode\Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinHttp\Interop.winhttp_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinHttp\Interop.winhttp_types.cs">
       <Link>ProductionCode\Common\Interop\Windows\WinHttp\Interop.winhttp_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\IHttpHeadersHandler.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\IHttpHeadersHandler.cs">
       <Link>Common\System\Net\Http\Http2\IHttpHeadersHandler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\DynamicTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\DynamicTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\DynamicTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HeaderField.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HeaderField.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HeaderField.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HPackEncodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HPackEncodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\Huffman.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\Huffman.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\Huffman.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\HuffmanDecodingException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerDecoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StaticTable.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\Http2\Hpack\StatusCodes.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeInterop.cs">

--- a/src/libraries/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/libraries/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -60,43 +60,43 @@
     <Compile Include="System\Net\NetEventSource.HttpListener.cs" />
     <Compile Include="System\Net\WebSockets\HttpListenerWebSocketContext.cs" />
     <Compile Include="System\Net\WebSockets\HttpWebSocket.cs" />
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieComparer.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieComparer.cs">
       <Link>Common\System\Net\CookieComparer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieFields.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieFields.cs">
       <Link>Common\System\Net\CookieFields.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieParser.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieParser.cs">
       <Link>Common\System\Net\CookieParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CaseInsensitiveAscii.cs">
+    <Compile Include="$(CommonPath)System\Net\CaseInsensitiveAscii.cs">
       <Link>Common\System\Net\CaseInsensitiveAscii.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpStatusDescription.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpStatusDescription.cs">
       <Link>Common\System\Net\HttpStatusDescription.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebHeaderEncoding.cs">
+    <Compile Include="$(CommonPath)System\Net\WebHeaderEncoding.cs">
       <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
     <Compile Include="System\Net\Windows\CookieExtensions.cs" />
@@ -118,10 +118,10 @@
     <Compile Include="System\Net\Windows\RequestContextBase.cs" />
     <Compile Include="System\Net\Windows\SyncRequestContext.cs" />
     <Compile Include="System\Net\Windows\ListenerAsyncResult.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
     <Compile Include="System\Net\Windows\HttpResponseStream.Windows.cs" />
@@ -134,204 +134,204 @@
     <Compile Include="System\Net\Windows\HttpRequestStream.Windows.cs" />
     <Compile Include="System\Net\Windows\WebSockets\WebSocketHttpListenerDuplexStream.cs" />
     <Compile Include="System\Net\Windows\WebSockets\WebSocketProtocolComponent.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
       <Link>Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.Structs.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.Structs.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.Structs.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketAbortHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketAbortHandle.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketAbortHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketBeginClientHandshake.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketBeginClientHandshake.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketBeginClientHandshake.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketBeginServerHandshake.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketBeginServerHandshake.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketBeginServerHandshake.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketCompleteAction.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketCompleteAction.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketCompleteAction.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketCreateClientHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketCreateClientHandle.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketCreateClientHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketCreateServerHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketCreateServerHandle.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketCreateServerHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketDeleteHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketDeleteHandle.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketDeleteHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketEndServerHandshake.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketEndServerHandshake.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketEndServerHandshake.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketGetAction.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketGetAction.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketGetAction.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketReceive.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketReceive.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketReceive.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WebSocket\Interop.WebSocketSend.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WebSocket\Interop.WebSocketSend.cs">
       <Link>Common\Interop\Windows\WebSocket\Interop.WebSocketSend.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\HttpApi\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\HttpApi\Interop.ErrorCodes.cs">
       <Link>Common\Interop\Windows\HttpApi\Interop.ErrorCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\HttpApi\Interop.HttpApi.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\HttpApi\Interop.HttpApi.cs">
       <Link>Common\Interop\Windows\HttpApi\Interop.HttpApi.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs">
       <Link>Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
       <Link>Common\Interop\Windows\mincore\Interop.CancelIoEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\mincore\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\mincore\Interop.LoadLibraryEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\mincore_obsolete\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\mincore_obsolete\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\mincore_obsolete\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
     <!-- Add NTAuthentication -->
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NTAuthentication.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SSPIHandleCache.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs">
       <Link>Common\System\Net\Security\SSPIHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.cs</Link>
     </Compile>
     <!-- Windows specific NTAuthentication -->
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.Windows.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\SspiCli\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
+++ b/src/libraries/System.Net.HttpListener/tests/System.Net.HttpListener.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="SimpleHttpTests.cs" />
     <Compile Include="WebSocketTests.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
@@ -63,226 +63,226 @@
     <Compile Include="System\Net\Mail\SmtpNegotiateAuthenticationModule.cs" />
     <Compile Include="System\Net\Mail\SmtpNtlmAuthenticationModule.cs" />
     <Compile Include="System\Net\DelegatedStream.cs" />
-    <Compile Include="$(CommonPath)\System\Net\TlsStream.cs">
+    <Compile Include="$(CommonPath)System\Net\TlsStream.cs">
       <Link>Common\System\Net\TlsStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailBnfHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailBnfHelper.cs">
       <Link>Common\System\Net\Mail\MailBnfHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DotAtomReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DotAtomReader.cs">
       <Link>Common\System\Net\Mail\DotAtomReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddressParser.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddressParser.cs">
       <Link>Common\System\Net\Mail\MailAddressParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedStringFormatReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedStringFormatReader.cs">
       <Link>Common\System\Net\Mail\QuotedStringFormatReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\WhitespaceReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\WhitespaceReader.cs">
       <Link>Common\System\Net\Mail\WhitespaceReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedPairReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedPairReader.cs">
       <Link>Common\System\Net\Mail\QuotedPairReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DomainLiteralReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DomainLiteralReader.cs">
       <Link>Common\System\Net\Mail\DomainLiteralReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NTAuthentication.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SSPIHandleCache.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs">
       <Link>Common\System\Net\Security\SSPIHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteNegoContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteNegoContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteNegoContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeNegoCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SecChannelBindings.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs">
       <Link>Common\System\Net\Security\Unix\SecChannelBindings.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.Windows.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\SspiCli\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
@@ -21,13 +21,13 @@
     <Compile Include="SmtpClientTest.cs" />
     <Compile Include="SmtpExceptionTest.cs" />
     <Compile Include="SmtpServer.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -138,226 +138,226 @@
       <Link>ProductionCode\BufferBuilder.cs</Link>
     </Compile>
 
-    <Compile Include="$(CommonPath)\System\Net\TlsStream.cs">
+    <Compile Include="$(CommonPath)System\Net\TlsStream.cs">
       <Link>Common\System\Net\TlsStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailBnfHelper.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailBnfHelper.cs">
       <Link>Common\System\Net\Mail\MailBnfHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DotAtomReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DotAtomReader.cs">
       <Link>Common\System\Net\Mail\DotAtomReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\MailAddressParser.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\MailAddressParser.cs">
       <Link>Common\System\Net\Mail\MailAddressParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedStringFormatReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedStringFormatReader.cs">
       <Link>Common\System\Net\Mail\QuotedStringFormatReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\WhitespaceReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\WhitespaceReader.cs">
       <Link>Common\System\Net\Mail\WhitespaceReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\QuotedPairReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\QuotedPairReader.cs">
       <Link>Common\System\Net\Mail\QuotedPairReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Mail\DomainLiteralReader.cs">
+    <Compile Include="$(CommonPath)System\Net\Mail\DomainLiteralReader.cs">
       <Link>Common\System\Net\Mail\DomainLiteralReader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NTAuthentication.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SSPIHandleCache.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs">
       <Link>Common\System\Net\Security\SSPIHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteNegoContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteNegoContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteNegoContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeNegoCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SecChannelBindings.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs">
       <Link>Common\System\Net\Security\Unix\SecChannelBindings.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Windows specific files -->
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NetEventSource.Security.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NetEventSource.Security.Windows.cs">
       <Link>Common\System\Net\Security\NetEventSource.Security.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\SspiCli\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -9,32 +9,32 @@
     <Compile Include="System\Net\IPHostEntry.cs" />
     <Compile Include="System\Net\NetEventSource.NameResolution.cs" />
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
     <!-- System.Net common -->
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolType.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolType.cs">
       <Link>Common\System\Net\Sockets\ProtocolType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketType.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs">
       <Link>Common\System\Net\Sockets\SocketType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPEndPointStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPEndPointStatics.cs">
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
   </ItemGroup>
@@ -42,96 +42,96 @@
     <Compile Include="System\Net\NameResolutionPal.Windows.cs" />
     <Compile Include="System\Net\NameResolutionPal.Win32.cs" />
     <!-- Debug only -->
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
     <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPAddressExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs">
       <Link>Common\System\Net\Internals\IPAddressExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Windows.cs">
       <Link>Common\System\Net\Internals\SocketExceptionFactory.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Windows</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\AddressInfoHints.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\AddressInfoHints.cs">
       <Link>Interop\Windows\WinSock\AddressInfoHints.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\hostent.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\hostent.cs">
       <Link>Interop\Windows\WinSock\hostent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.closesocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.closesocket.cs">
       <Link>Interop\Windows\WinSock\Interop.closesocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.gethostname.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.gethostname.cs">
       <Link>Interop\Windows\WinSock\Interop.gethostname.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetNameInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetNameInfoW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetNameInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAStartup.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAStartup.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAStartup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASocketW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASocketW.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASocketW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
       <Link>Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolFamily.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs">
       <Link>Common\System\Net\Sockets\ProtocolFamily.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\NameResolutionPal.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\Internals\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Unix</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs">
       <Link>Common\System\Net\Internals\SocketExceptionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Unix.cs">
       <Link>Common\System\Net\Internals\SocketExceptionFactory.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs">
+    <Compile Include="$(CommonPath)Interop\Interop.CheckedAccess.cs">
       <Link>Common\System\Net\Internals\Interop.CheckedAccess.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\CoreLib\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
@@ -140,19 +140,19 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs">
       <Link>Interop\Unix\System.Native\Interop.HostEntries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Socket.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Socket.cs">
       <Link>Interop\Unix\System.Native\Interop.Socket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
@@ -12,16 +12,16 @@
     <Compile Include="LoggingTest.cs" />
     <Compile Include="TestSettings.cs" />
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Sockets.cs">
       <Link>Common\System\Net\Configuration.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -19,28 +19,28 @@
     <Compile Include="Fakes\DebugThreadTracking.cs" />
     <Compile Include="Fakes\DnsFake.cs" />
     <Compile Include="Fakes\IPAddressFakeExtensions.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolType.cs" Condition="'$(OSGroup)' == 'Windows_NT'">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolType.cs" Condition="'$(OSGroup)' == 'Windows_NT'">
       <Link>Common\System\Net\Sockets\ProtocolType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketType.cs" Condition="'$(OSGroup)' == 'Windows_NT'">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs" Condition="'$(OSGroup)' == 'Windows_NT'">
       <Link>Common\System\Net\Sockets\SocketType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPEndPointStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPEndPointStatics.cs">
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
   </ItemGroup>
@@ -51,95 +51,95 @@
     <Compile Include="..\..\src\System\Net\NameResolutionPal.Win32.cs">
       <Link>ProductionCode\System\Net\NameResolutionPal.Win32.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs">
       <Link>System\Net\SocketProtocolSupportPal.Windows</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows</Link>
     </Compile>
     <!-- Debug only -->
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\AddressInfoHints.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\AddressInfoHints.cs">
       <Link>Interop\Windows\WinSock\AddressInfoHints.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\hostent.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\hostent.cs">
       <Link>Interop\Windows\WinSock\hostent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.closesocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.closesocket.cs">
       <Link>Interop\Windows\WinSock\Interop.closesocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.gethostname.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.gethostname.cs">
       <Link>Interop\Windows\WinSock\Interop.gethostname.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetNameInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetNameInfoW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetNameInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAStartup.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAStartup.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAStartup.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASocketW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASocketW.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASocketW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
       <Link>Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolFamily.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs">
       <Link>Common\System\Net\Sockets\ProtocolFamily.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Common\CoreLi\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\Internals\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs">
+    <Compile Include="$(CommonPath)Interop\Interop.CheckedAccess.cs">
       <Link>Common\System\Net\Internals\Interop.CheckedAccess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs">
       <Link>ProductionCode\Common\System\Net\Internals\SocketExceptionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.Unix.cs">
       <Link>ProductionCode\Common\System\Net\Internals\SocketExceptionFactory.Unix.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\NameResolutionPal.Unix.cs">
       <Link>ProductionCode\System\Net\NameResolutionPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs">
       <Link>System\Net\SocketProtocolSupportPal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\CoreLib\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
@@ -148,19 +148,19 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs">
       <Link>Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Socket.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Socket.cs">
       <Link>Interop\Unix\System.Native\Interop.Socket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
@@ -31,13 +31,13 @@
   </ItemGroup>
   <!-- Production Code under test-->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs">
       <Link>ProductionCode\Common\System\Net\Internals\SocketExceptionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -43,26 +43,26 @@
     <Compile Include="System\Net\NetworkInformation\UnicastIPAddressInformation.cs" />
     <Compile Include="System\Net\NetworkInformation\UnicastIPAddressInformationCollection.cs" />
     <Compile Include="System\Net\NetworkInformation\InternalIPAddressCollection.cs" />
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformation.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformation.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\NetworkInformationException.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\NetworkInformationException.cs">
       <Link>Common\System\Net\NetworkInformation\NetworkInformationException.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
       <Link>Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
       <Link>Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs</Link>
     </Compile>
     <Compile Include="System\Net\NetworkInformation\IPGlobalPropertiesPal.Windows.cs" />
@@ -89,63 +89,63 @@
     <Compile Include="System\Net\NetworkInformation\SystemUnicastIPAddressInformation.cs" />
     <Compile Include="System\Net\NetworkInformation\TeredoHelper.cs" />
     <!-- System.Net common -->
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\StartIPOptions.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\StartIPOptions.cs">
       <Link>Common\System\Net\NetworkInformation\StartIPOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Windows.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Windows.cs</Link>
     </Compile>
     <!-- Common -->
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
       <Link>Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.NetworkInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.NetworkInformation.cs">
       <Link>Interop\Windows\IpHlpApi\Interop.NetworkInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Interop\Windows\Kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WinsockBSD.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WinsockBSD.cs">
       <Link>Interop\Windows\WinSock\Interop.WinsockBSD.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAEventSelect.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAEventSelect.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAEventSelect.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAIoctl.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAIoctl.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAIoctl.cs</Link>
     </Compile>
   </ItemGroup>
@@ -164,22 +164,22 @@
     <Compile Include="System\Net\NetworkInformation\UnixNetworkInterface.cs" />
     <Compile Include="System\Net\NetworkInformation\UnixUnicastIPAddressInformation.cs" />
     <!-- Unix Common -->
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.EnumerateInterfaceAddresses.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.EnumerateInterfaceAddresses.cs">
       <Link>Interop\Unix\System.Native\Interop.EnumerateInterfaceAddresses.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs">
       <Link>System\Net\NetworkInformation\HostInformationPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetDomainName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetDomainName.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MapTcpState.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MapTcpState.cs">
       <Link>Interop\Unix\System.Native\Interop.MapTcpState.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -188,7 +188,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\RowConfigReader.cs">
+    <Compile Include="$(CommonPath)System\IO\RowConfigReader.cs">
       <Link>Common\System\IO\RowConfigReader.cs</Link>
     </Compile>
   </ItemGroup>
@@ -216,13 +216,13 @@
     <Compile Include="System\Net\NetworkInformation\StringParsingHelpers.Misc.cs" />
     <Compile Include="System\Net\NetworkInformation\StringParsingHelpers.Statistics.cs" />
     <!-- Linux Common -->
-    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+    <Compile Include="$(CommonPath)System\IO\StringParser.cs">
       <Link>Common\System\IO\StringParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Linux\Interop.LinuxNetDeviceFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\Interop.LinuxNetDeviceFlags.cs">
       <Link>Interop\Linux\Interop.LinuxNetDeviceFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Linux\System.Native\Interop.NetworkChange.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\System.Native\Interop.NetworkChange.cs">
       <Link>Interop\Linux\System.Native\Interop.NetworkChange.cs</Link>
     </Compile>
   </ItemGroup>
@@ -243,35 +243,35 @@
     <Compile Include="System\Net\NetworkInformation\BsdTcpStatistics.cs" />
     <Compile Include="System\Net\NetworkInformation\BsdUdpStatistics.cs" />
     <!-- BSD Common -->
-    <Compile Include="$(CommonPath)\Interop\BSD\System.Native\Interop.ProtocolStatistics.cs">
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.ProtocolStatistics.cs">
       <Link>Interop\BSD\System.Native\Interop.ProtocolStatistics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs">
       <Link>Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOsx)' == 'true'">
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.OSX.cs" />
     <!-- OSX Common -->
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.RunLoop.cs">
       <Link>Interop\OSX\Interop.RunLoop.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.SystemConfiguration.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.SystemConfiguration.cs">
       <Link>Interop\OSX\Interop.SystemConfiguration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true'">
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.UnknownUnix.cs" />
-    <Compile Include="$(CommonPath)\Interop\FreeBSD\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs">
       <Link>Interop\FreeBSD\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -47,22 +47,22 @@
     <Compile Include="ConnectionsParsingTests.cs" />
     <Compile Include="StatisticsParsingTests.cs" />
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Sockets.cs">
       <Link>Common\System\Net\Capability.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\StringParser.cs">
+    <Compile Include="$(CommonPath)System\IO\StringParser.cs">
       <Link>Common\System\IO\StringParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\RowConfigReader.cs">
+    <Compile Include="$(CommonPath)System\IO\RowConfigReader.cs">
       <Link>Common\System\IO\RowConfigReader.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
@@ -16,31 +16,31 @@
   </ItemGroup>
   <!-- System.Net Common -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Logging -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- System.Net.Internals -->
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPAddressExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs">
       <Link>Common\System\Net\Internals\IPAddressExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPEndPointExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs">
       <Link>Common\System\Net\Internals\IPEndPointExtensions.cs</Link>
     </Compile>
   </ItemGroup>
@@ -49,23 +49,23 @@
     <Compile Include="System\Net\NetworkInformation\IcmpV6MessageConstants.cs" />
     <Compile Include="System\Net\NetworkInformation\Ping.Unix.cs" />
     <!-- System.Net Common -->
-    <Compile Include="$(CommonPath)\System\Net\RawSocketPermissions.cs">
+    <Compile Include="$(CommonPath)System\Net\RawSocketPermissions.cs">
       <Link>Common\System\Net\RawSocketPermissions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\UnixCommandLinePing.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\UnixCommandLinePing.cs">
       <Link>Common\System\Net\NetworkInformation\UnixCommandLinePing.cs</Link>
     </Compile>
     <!-- Interop -->
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
@@ -74,10 +74,10 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.ReadLink.cs">
       <Link>Interop\Unix\System.Native\Interop.ReadLink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Socket.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Socket.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Socket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>
@@ -86,45 +86,45 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <!-- System.Net Common -->
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.ICMP.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.ICMP.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.ICMP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.closesocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.closesocket.cs">
       <Link>Common\Interop\Windows\WinSock\Interop.closesocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASocketW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASocketW.cs">
       <Link>Common\Interop\Windows\WinSock\Interop.WSASocketW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
       <Link>Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs</Link>
     </Compile>
     <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketType.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs">
       <Link>Common\System\Net\Sockets\SocketType.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
@@ -12,25 +12,25 @@
     <Compile Include="TestSettings.cs" />
     <Compile Include="UnixPingUtilityTests.cs" />
     <!-- System.Net Common -->
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>SocketCommon\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Ping.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Ping.cs">
       <Link>SocketCommon\Configuration.Ping.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\RawSocketPermissions.cs">
+    <Compile Include="$(CommonPath)System\Net\RawSocketPermissions.cs">
       <Link>Common\System\Net\RawSocketPermissions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.ReadLink.cs">
       <Link>Interop\Unix\System.Native\Interop.ReadLink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\UnixCommandLinePing.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\UnixCommandLinePing.cs">
       <Link>Common\System\Net\NetworkInformation\UnixCommandLinePing.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.RawSocketPermissions.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.RawSocketPermissions.cs">
       <Link>Common\System\Net\Capability.RawSocketPermissions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -28,10 +28,10 @@
     <Compile Include="System\Net\IPAddress.cs" />
     <Compile Include="System\Net\IPAddressParser.cs" />
     <Compile Include="System\Net\IPEndPoint.cs" />
-    <Compile Include="$(CommonPath)\System\Net\IPv4AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs">
       <Link>System\Net\IPv4AddressHelper.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPv6AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs">
       <Link>System\Net\IPv6AddressHelper.Common.cs</Link>
     </Compile>
     <Compile Include="System\Net\IWebProxy.cs" />
@@ -49,43 +49,43 @@
     <Compile Include="System\Net\Cache\RequestCachePolicy.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ChannelBinding.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ChannelBindingKind.cs" />
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieComparer.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieComparer.cs">
       <Link>ProductionCode\System\Net\CookieComparer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieFields.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieFields.cs">
       <Link>Common\System\Net\CookieFields.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieParser.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieParser.cs">
       <Link>Common\System\Net\CookieParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\TcpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs">
       <Link>Common\System\Net\TcpValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformation.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformation.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Marvin.cs">
+    <Compile Include="$(CommonPath)System\Marvin.cs">
       <Link>Common\System\Marvin.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
@@ -95,103 +95,103 @@
       <Link>Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs</Link>
     </Compile>
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.Alg.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.Alg.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.Alg.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SchProtocols.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SchProtocols.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SchProtocols.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.ErrorCodes.cs">
       <Link>Common\Interop\Windows\WinSock\Interop.ErrorCodes.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Net\SocketException.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Windows.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
       <Link>Common\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
     <Compile Include="System\Net\SocketException.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketErrorPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs">
       <Link>Common\System\Net\Sockets\SocketErrorPal.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetDomainName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetDomainName.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
       <Link>Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -21,7 +21,7 @@
     <Compile Include="LoggingTest.cs" />
     <Compile Include="RequestCachePolicyTest.cs" />
     <Compile Include="CookieContainerAddTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -26,22 +26,22 @@
     <Compile Include="..\..\src\System\Net\IPAddressParser.cs">
       <Link>ProductionCode\System\Net\IPAddressParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPv4AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs">
       <Link>ProductionCode\System\Net\IPv4AddressHelper.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPv6AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs">
       <Link>ProductionCode\System\Net\IPv6AddressHelper.Common.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\IPEndPoint.cs">
       <Link>ProductionCode\System\Net\IPEndPoint.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\EndPoint.cs">
       <Link>ProductionCode\System\Net\EndPoint.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Marvin.cs">
+    <Compile Include="$(CommonPath)System\Marvin.cs">
       <Link>ProductionCode\Common\System\Marvin.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
@@ -55,22 +55,22 @@
     <Compile Include="..\..\src\System\Net\SocketException.cs">
       <Link>ProductionCode\System\Net\SocketException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>ProductionCode\Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>ProductionCode\Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>ProductionCode\Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\TcpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs">
       <Link>ProductionCode\Common\System\Net\TcpValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>ProductionCode\Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.ErrorCodes.cs">
       <Link>ProductionCode\Common\Interop\Windows\WinSock\Interop.ErrorCodes.cs</Link>
     </Compile>
   </ItemGroup>
@@ -78,46 +78,46 @@
     <Compile Include="..\..\src\System\Net\SocketException.Windows.cs">
       <Link>ProductionCode\System\Net\SocketException.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Windows.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.ErrorCodes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.FIXED_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.GetNetworkParams.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs">
       <Link>Common\Interop\Windows\IpHlpApi\Interop.IP_ADDR_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtStatus.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtStatus.cs">
       <Link>ProductionCode\Common\Interop\Windows\NtDll\Interop.NtStatus.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
       <Link>ProductionCode\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
       <Link>ProductionCode\Common\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs</Link>
     </Compile>
   </ItemGroup>
@@ -125,46 +125,46 @@
     <Compile Include="..\..\src\System\Net\SocketException.Unix.cs">
       <Link>ProductionCode\System\Net\SocketException.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\HostInformationPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs">
       <Link>Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketErrorPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs">
       <Link>Common\System\Net\Sockets\SocketErrorPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.CheckedAccess.cs">
+    <Compile Include="$(CommonPath)Interop\Interop.CheckedAccess.cs">
       <Link>ProductionCode\Common\Interop\Interop.CheckedAccess.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>ProductionCode\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetDomainName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetDomainName.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetHostName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNameInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.HostEntry.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.HostEntry.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
       <Link>ProductionCode\Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -38,16 +38,16 @@
     <Compile Include="..\..\src\System\Net\Sockets\AddressFamily.cs">
       <Link>ProductionCode\System\Net\Sockets\AddressFamily.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieComparer.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieComparer.cs">
       <Link>ProductionCode\System\Net\CookieComparer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieFields.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieFields.cs">
       <Link>Common\System\Net\CookieFields.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CookieParser.cs">
+    <Compile Include="$(CommonPath)System\Net\CookieParser.cs">
       <Link>ProductionCode\System\Net\CookieParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>ProductionCode\System\Net\SocketAddress.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\IPEndPoint.cs">
@@ -69,41 +69,41 @@
     <Compile Include="Fakes\HostInformation.cs" />
     <Compile Include="Fakes\IPv4AddressHelper.cs" />
     <Compile Include="Fakes\IPv6AddressHelper.cs" />
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>ProductionCode\Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>ProductionCode\Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>ProductionCode\Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\TcpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs">
       <Link>ProductionCode\Common\System\Net\TcpValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>ProductionCode\Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Marvin.cs">
+    <Compile Include="$(CommonPath)System\Marvin.cs">
       <Link>Common\System\Marvin.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
       <Link>Common\System\Text\StringBuilderCache.cs</Link>
     </Compile>
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>ProductionCode\Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>ProductionCode\Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.ErrorCodes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.ErrorCodes.cs">
       <Link>ProductionCode\Common\Interop\Windows\WinSock\Interop.ErrorCodes.cs</Link>
     </Compile>
   </ItemGroup>
@@ -111,16 +111,16 @@
     <Compile Include="..\..\src\System\Net\SocketException.Windows.cs">
       <Link>ProductionCode\System\Net\SocketException.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs">
       <Link>ProductionCode\System\Net\NetworkInformation\InterfaceInfoPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs">
       <Link>ProductionCode\Common\Interop\Windows\IpHlpApi\Interop.if_nametoindex.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
@@ -128,25 +128,25 @@
     <Compile Include="..\..\src\System\Net\SocketException.Unix.cs">
       <Link>ProductionCode\System\Net\SocketException.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs">
       <Link>ProductionCode\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketErrorPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs">
       <Link>ProductionCode\Common\System\Net\Sockets\SocketErrorPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>ProductionCode\Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>ProductionCode\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs">
       <Link>ProductionCode\Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/libraries/System.Net.Requests/src/System.Net.Requests.csproj
@@ -45,43 +45,43 @@
     <Compile Include="System\Net\Cache\HttpRequestCacheLevel.cs" />
     <Compile Include="System\Net\Cache\HttpRequestCachePolicy.cs" />
     <Compile Include="System\Net\NetEventSource.Requests.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpDateParser.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpDateParser.cs">
       <Link>Common\System\Net\HttpDateParser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpValidationHelpers.cs">
       <Link>Common\System\Net\HttpValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\TlsStream.cs">
+    <Compile Include="$(CommonPath)System\Net\TlsStream.cs">
       <Link>Common\System\Net\TlsStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
@@ -89,16 +89,16 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\WinInet\Interop.wininet_errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinInet\Interop.wininet_errors.cs">
       <Link>Common\Interop\Windows\WinInet\Interop.wininet_errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
     <Compile Include="System\Net\WebExceptionPal.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
     <Compile Include="System\Net\WebExceptionPal.Unix.cs" />

--- a/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -10,25 +10,25 @@
     <Compile Include="HttpWebResponseTest.cs" />
     <Compile Include="RequestStreamTest.cs" />
     <Compile Include="WebRequestTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
       <Link>Common\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs">
       <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -46,58 +46,58 @@
     <Compile Include="System\Security\Authentication\ExtendedProtection\ProtectionScenario.cs" />
     <Compile Include="System\Security\Authentication\ExtendedProtection\ServiceNameCollection.cs" />
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
     <!-- Debug only -->
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandle.cs">
       <Link>Common\System\Net\DebugSafeHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
     <!-- System.Net common -->
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
     <!-- Common -->
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SSPIHandleCache.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs">
       <Link>Common\System\Net\Security\SSPIHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsPal.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)System\Net\NegotiationInfoClass.cs">
       <Link>Common\System\Net\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\NTAuthentication.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusPal.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
     </Compile>
   </ItemGroup>
@@ -148,164 +148,164 @@
     <Compile Include="System\Net\Security\SslStreamPal.Windows.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Windows.cs" />
     <Compile Include="System\Net\Security\StreamSizes.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBuffer.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBuffer.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBuffer.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityBufferType.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityBufferType.Windows.cs">
       <Link>Common\System\Net\Security\SecurityBufferType.Windows.cs</Link>
     </Compile>
     <!-- NegotiateStream -->
-    <Compile Include="$(CommonPath)\System\Net\SecurityStatusAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityStatusAdapterPal.Windows.cs">
       <Link>Common\System\Net\SecurityStatusAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Windows.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Windows.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\SecurityContextTokenHandle.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\SecurityContextTokenHandle.cs">
       <Link>Common\System\Net\Security\SecurityContextTokenHandle.cs</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.certificates_types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.certificates_types.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.certificates_types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.Alerts.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.Alerts.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.Alerts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SchProtocols.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SchProtocols.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SchProtocols.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_ConnectionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs">
       <Link>Common\Interop\Windows\SChannel\SecPkgContext_CipherInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.Sec_Application_Protocols.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.Sec_Application_Protocols.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.Sec_Application_Protocols.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\UnmanagedCertificateContext.cs">
       <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs">
       <Link>Common\Interop\Windows\SChannel\UnmanagedCertificateContext.IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Bindings.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Bindings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\GlobalSSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\GlobalSSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\GlobalSSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SSPI.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SSPI.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SSPI.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_NegotiationInfoW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\NegotiationInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\NegotiationInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\NegotiationInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_Sizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_Sizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\BidirectionalDictionary.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs">
       <Link>Common\System\Collections\Generic\BidirectionalDictionary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SafeDeleteContext.cs">
       <Link>Common\Interop\Windows\SspiCli\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecurityPackageInfoClass.cs">
       <Link>Common\Interop\Windows\SspiCli\SecurityPackageInfoClass.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecuritySafeHandles.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecuritySafeHandles.cs">
       <Link>Common\Interop\Windows\SspiCli\SecuritySafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIAuthType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIAuthType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIAuthType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\ISSPIInterface.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\ISSPIInterface.cs">
       <Link>Common\Interop\Windows\SspiCli\ISSPIInterface.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPISecureChannelType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPISecureChannelType.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPISecureChannelType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs">
       <Link>Common\Interop\Windows\SspiCli\SecPkgContext_StreamSizes.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ContextFlagsAdapterPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Http\TlsCertificateExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Http\TlsCertificateExtensions.cs">
       <Link>Common\System\Net\Http\TlsCertificateExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\NegotiateStreamPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\NegotiateStreamPal.Unix.cs">
       <Link>Common\System\Net\Security\NegotiateStreamPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteNegoContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteNegoContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteNegoContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeNegoCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeNegoCredentials.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SecChannelBindings.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs">
       <Link>Common\System\Net\Security\Unix\SecChannelBindings.cs</Link>
     </Compile>
     <Compile Include="System\Net\Security\NegotiateStreamPal.Unix.cs" />
@@ -320,117 +320,117 @@
     <Compile Include="System\Net\Security\SslStreamPal.Unix.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Linux.cs" />
     <Compile Include="System\Net\Security\StreamSizes.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\Security\CertificateValidation.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs">
       <Link>Common\System\Net\Security\CertificateValidation.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSsl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSsl.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeDeleteSslContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteSslContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeDeleteSslContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeCertContext.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeCertContext.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeCertContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Security\Unix\SafeFreeSslCredentials.cs">
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeFreeSslCredentials.cs">
       <Link>Common\System\Net\Security\Unix\SafeFreeSslCredentials.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFArray.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFData.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFDate.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFDate.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFDate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFError.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFString.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SslErr.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SslErr.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SslErr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ssl.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ssl.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ssl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
     <Compile Include="System\Net\CertificateValidationPal.OSX.cs" />

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -30,52 +30,52 @@
         <Compile Include="ServiceNameCollectionTest.cs" />
         <Compile Include="NegotiateStreamKerberosTest.cs" />
         <!-- Common test files -->
-        <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
+        <Compile Include="$(CommonTestPath)System\IO\DelegateStream.cs">
           <Link>Common\System\IO\DelegateStream.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs">
           <Link>Common\System\Net\Capability.Security.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\SslStreamCertificatePolicy.cs">
+        <Compile Include="$(CommonTestPath)System\Net\SslStreamCertificatePolicy.cs">
           <Link>Common\System\Net\SslStreamCertificatePolicy.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
           <Link>Common\System\Net\Configuration.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs">
           <Link>Common\System\Net\Configuration.Security.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs">
           <Link>Common\System\Net\Configuration.Certificates.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
           <Link>Common\System\Net\Configuration.Http.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\HttpsTestClient.cs">
+        <Compile Include="$(CommonTestPath)System\Net\HttpsTestClient.cs">
           <Link>Common\System\Net\HttpsTestClient.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\HttpsTestServer.cs">
+        <Compile Include="$(CommonTestPath)System\Net\HttpsTestServer.cs">
           <Link>Common\System\Net\HttpsTestServer.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\SslProtocolSupport.cs">
+        <Compile Include="$(CommonTestPath)System\Net\SslProtocolSupport.cs">
           <Link>Common\System\Net\SslProtocolSupport.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
+        <Compile Include="$(CommonTestPath)System\Net\TestLogging.cs">
           <Link>Common\System\Net\TestLogging.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+        <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs">
           <Link>Common\System\Net\VerboseTestLogging.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+        <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
           <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetwork.cs">
+        <Compile Include="$(CommonTestPath)System\Net\VirtualNetwork\VirtualNetwork.cs">
           <Link>Common\System\Net\VirtualNetwork\VirtualNetwork.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetworkStream.cs">
+        <Compile Include="$(CommonTestPath)System\Net\VirtualNetwork\VirtualNetworkStream.cs">
           <Link>Common\System\Net\VirtualNetwork\VirtualNetworkStream.cs</Link>
         </Compile>
-        <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+        <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
           <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
         </Compile>
         <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
@@ -102,25 +102,25 @@
       </ItemGroup>
       <ItemGroup>
         <Compile Include="LoggingTest.cs" />
-        <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+        <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
           <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
         </Compile>
       </ItemGroup>
       <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
         <Compile Include="IdentityValidator.Windows.cs" />
-        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Windows.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Windows.cs">
           <Link>Common\System\Net\Capability.Security.Windows.cs</Link>
         </Compile>
       </ItemGroup>
       <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
         <Compile Include="IdentityValidator.Unix.cs" />
-        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Unix.cs">
+        <Compile Include="$(CommonTestPath)System\Net\Capability.Security.Unix.cs">
           <Link>Common\System\Net\Capability.Security.Unix.cs</Link>
         </Compile>
-        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+        <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
           <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
         </Compile>
-        <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+        <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
           <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
         </Compile>
       </ItemGroup>
@@ -143,16 +143,16 @@
         <Compile Include="NegotiateStreamTest.Linux.cs" />
         <Compile Include="UnixGssFakeNegotiateStream.cs" />
         <Compile Include="UnixGssFakeStreamFramer.cs" />
-        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+        <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
           <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
         </Compile>
-        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+        <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
           <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
         </Compile>
-        <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+        <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
           <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
         </Compile>
-        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+        <Compile Include="$(CommonPath)Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
           <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
         </Compile>
       </ItemGroup>

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -25,7 +25,7 @@
     <Compile Include="Fakes\FakeAuthenticatedStream.cs" />
     <Compile Include="Fakes\FakeLazyAsyncResult.cs" />
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Net\SslProtocolSupport.cs">
+    <Compile Include="$(CommonTestPath)System\Net\SslProtocolSupport.cs">
       <Link>CommonTest\System\Net\SslProtocolSupport.cs</Link>
     </Compile>
   </ItemGroup>
@@ -55,7 +55,7 @@
     <Compile Include="..\..\src\System\Net\SslStreamContext.cs">
       <Link>ProductionCode\System\Net\SslStreamContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>ProductionCode\Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Security\TlsAlertType.cs">
@@ -64,17 +64,17 @@
     <Compile Include="..\..\src\System\Net\Security\TlsAlertMessage.cs">
       <Link>ProductionCode\Common\System\Net\TlsAlertMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.Alerts.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.Alerts.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.Alerts.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>ProductionCode\Common\System\Net\InternalException.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -51,64 +51,64 @@
       <Link>System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\DebugThreadTracking.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\DebugThreadTracking.cs">
       <Link>Common\System\Net\Logging\DebugThreadTracking.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+    <Compile Include="$(CommonPath)System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
     </Compile>
     <!-- Debug only -->
-    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandleMinusOneIsInvalid.cs">
+    <Compile Include="$(CommonPath)System\Net\DebugSafeHandleMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugSafeHandleMinusOneIsInvalid.cs</Link>
     </Compile>
     <!-- System.Net common -->
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
+    <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
+    <Compile Include="$(CommonPath)System\Net\ByteOrder.cs">
       <Link>Common\System\Net\ByteOrder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPEndPointStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPEndPointStatics.cs">
       <Link>Common\System\Net\IPEndPointStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\IPAddressParserStatics.cs">
+    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs">
       <Link>Common\System\Net\IPAddressParserStatics.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\ExceptionCheck.cs">
+    <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs">
       <Link>Common\System\Net\ExceptionCheck.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\RangeValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\RangeValidationHelpers.cs">
       <Link>Common\System\Net\RangeValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddress.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs">
       <Link>Common\System\Net\SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\TcpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs">
       <Link>Common\System\Net\TcpValidationHelpers.cs</Link>
     </Compile>
     <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPEndPointExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs">
       <Link>Common\System\Net\Internals\IPEndPointExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\IPAddressExtensions.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs">
       <Link>Common\System\Net\Internals\IPAddressExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Internals\SocketExceptionFactory.cs">
+    <Compile Include="$(CommonPath)System\Net\Internals\SocketExceptionFactory.cs">
       <Link>Common\System\Net\Internals\SocketExceptionFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolFamily.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs">
       <Link>Common\System\Net\Sockets\ProtocolFamily.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\ProtocolType.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolType.cs">
       <Link>Common\System\Net\Sockets\ProtocolType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketType.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs">
       <Link>Common\System\Net\Sockets\SocketType.cs</Link>
     </Compile>
   </ItemGroup>
@@ -127,116 +127,116 @@
     <Compile Include="System\Net\Sockets\SocketPal.Windows.cs" />
     <Compile Include="System\Net\Sockets\TransmitFileAsyncResult.Windows.cs" />
     <Compile Include="System\Net\Sockets\UnixDomainSocketEndPoint.Windows.cs" />
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Windows.cs">
       <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs">
       <Link>Common\System\Net\SocketAddressPal.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Windows.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Windows</Link>
     </Compile>
     <!-- Interop -->
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.accept.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.accept.cs">
       <Link>Interop\Windows\WinSock\Interop.accept.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.bind.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.bind.cs">
       <Link>Interop\Windows\WinSock\Interop.bind.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.closesocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.closesocket.cs">
       <Link>Interop\Windows\WinSock\Interop.closesocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.getpeername.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.getpeername.cs">
       <Link>Interop\Windows\WinSock\Interop.getpeername.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.getsockname.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.getsockname.cs">
       <Link>Interop\Windows\WinSock\Interop.getsockname.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.getsockopt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.getsockopt.cs">
       <Link>Interop\Windows\WinSock\Interop.getsockopt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.ioctlsocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.ioctlsocket.cs">
       <Link>Interop\Windows\WinSock\Interop.ioctlsocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.listen.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.listen.cs">
       <Link>Interop\Windows\WinSock\Interop.listen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.recv.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.recv.cs">
       <Link>Interop\Windows\WinSock\Interop.recv.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.recvfrom.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.recvfrom.cs">
       <Link>Interop\Windows\WinSock\Interop.recvfrom.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.select.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.select.cs">
       <Link>Interop\Windows\WinSock\Interop.select.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.send.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.send.cs">
       <Link>Interop\Windows\WinSock\Interop.send.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.sendto.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.sendto.cs">
       <Link>Interop\Windows\WinSock\Interop.sendto.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.setsockopt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.setsockopt.cs">
       <Link>Interop\Windows\WinSock\Interop.setsockopt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.shutdown.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.shutdown.cs">
       <Link>Interop\Windows\WinSock\Interop.shutdown.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.TransmitFile.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.TransmitFile.cs">
       <Link>Interop\Windows\WinSock\Interop.TransmitFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WinsockBSD.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WinsockBSD.cs">
       <Link>Interop\Windows\WinSock\Interop.WinsockBSD.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WinsockAsync.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WinsockAsync.cs">
       <Link>Interop\Windows\WinSock\Interop.WinsockAsync.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAConnect.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAConnect.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAConnect.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAGetOverlappedResult.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAGetOverlappedResult.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAGetOverlappedResult.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSAIoctl.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSAIoctl.cs">
       <Link>Interop\Windows\WinSock\Interop.WSAIoctl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSARecv.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSARecv.cs">
       <Link>Interop\Windows\WinSock\Interop.WSARecv.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSARecvFrom.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSARecvFrom.cs">
       <Link>Interop\Windows\WinSock\Interop.WSARecvFrom.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASend.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASend.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASend.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASendTo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASendTo.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASendTo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASocketW.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASocketW.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASocketW.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.WSASocketW.SafeCloseSocket.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WSASocketW.SafeCloseSocket.cs">
       <Link>Interop\Windows\WinSock\Interop.WSASocketW.SafeCloseSocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs">
       <Link>Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\SafeNativeOverlapped.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\SafeNativeOverlapped.cs">
       <Link>Interop\Windows\WinSock\SafeNativeOverlapped.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinSock\WSABuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\WSABuffer.cs">
       <Link>Interop\Windows\WinSock\WSABuffer.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
       <Link>Common\Interop\Windows\Interop.CancelIoEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs">
       <Link>Interop\Windows\Kernel32\Interop.SetFileCompletionNotificationModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\CompletionPortHelper.Windows.cs">
+    <Compile Include="$(CommonPath)System\Net\CompletionPortHelper.Windows.cs">
       <Link>Common\System\Net\CompletionPortHelper.Windows.cs</Link>
     </Compile>
   </ItemGroup>
@@ -254,19 +254,19 @@
     <Compile Include="System\Net\Sockets\SocketAsyncEventArgs.Unix.cs" />
     <Compile Include="System\Net\Sockets\SocketPal.Unix.cs" />
     <Compile Include="System\Net\Sockets\UnixDomainSocketEndPoint.Unix.cs" />
-    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketAddressPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs">
       <Link>Common\System\Net\SocketAddressPal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SocketProtocolSupportPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.Unix.cs">
       <Link>Common\System\Net\SocketProtocolSupportPal.Unix</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Sockets\SocketErrorPal.Unix.cs">
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs">
       <Link>Common\System\Net\Sockets\SocketErrorPal.Unix</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
@@ -275,103 +275,103 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
       <Link>Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Accept.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Accept.cs">
       <Link>Interop\Unix\System.Native\Interop.Accept.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Bind.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Bind.cs">
       <Link>Interop\Unix\System.Native\Interop.Bind.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Connect.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Connect.cs">
       <Link>Interop\Unix\System.Native\Interop.Connect.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs">
       <Link>Interop\Unix\System.Native\Interop.Fcntl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Disconnect.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Disconnect.cs">
       <Link>Common\Interop\Unix\Interop.Disconnect.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetBytesAvailable.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetBytesAvailable.cs">
       <Link>Interop\Unix\System.Native\Interop.GetBytesAvailable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetDomainSocketSizes.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainSocketSizes.cs">
       <Link>Common\Interop\Unix\Interop.GetDomainSocketSizes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPeerName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetPeerName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSocketErrorOption.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetSocketErrorOption.cs">
       <Link>Interop\Unix\System.Native\Interop.GetSocketErrorOption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSockName.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetSockName.cs">
       <Link>Interop\Unix\System.Native\Interop.GetSockName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetSockOpt.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetSockOpt.cs">
       <Link>Interop\Unix\System.Native\Interop.GetSockOpt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.IPAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IPPacketInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPPacketInformation.cs">
       <Link>Interop\Unix\System.Native\Interop.IPPacketInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.LingerOption.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.LingerOption.cs">
       <Link>Interop\Unix\System.Native\Interop.LingerOption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SendFile.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SendFile.cs">
       <Link>Interop\Unix\System.Native\Interop.SendFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSendTimeout.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetSendTimeout.cs">
       <Link>Interop\Unix\System.Native\Interop.SetSendTimeout.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetReceiveTimeout.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetReceiveTimeout.cs">
       <Link>Interop\Unix\System.Native\Interop.SetReceiveTimeout.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Listen.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Listen.cs">
       <Link>Interop\Unix\System.Native\Interop.Listen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MemSet.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MemSet.cs">
       <Link>Interop\Unix\System.Native\Interop.MemSet.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MessageHeader.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MessageHeader.cs">
       <Link>Interop\Unix\System.Native\Interop.MessageHeader.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MulticastOption.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MulticastOption.cs">
       <Link>Interop\Unix\System.Native\Interop.MulticastOption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Interop\Unix\System.Native\Interop.Poll.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PlatformSocketSupport.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.PlatformSocketSupport.cs">
       <Link>Interop\Unix\System.Native\Interop.PlatformSocketSupport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ReceiveMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ReceiveMessage.cs">
       <Link>Interop\Unix\System.Native\Interop.ReceiveMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SendMessage.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SendMessage.cs">
       <Link>Interop\Unix\System.Native\Interop.SendMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSockOpt.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetSockOpt.cs">
       <Link>Interop\Unix\System.Native\Interop.SetSockOpt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Shutdown.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Shutdown.cs">
       <Link>Interop\Unix\System.Native\Interop.Shutdown.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Socket.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Socket.cs">
       <Link>Interop\Unix\System.Native\Interop.Socket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketEvent.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketEvent.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketEvent.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs">
       <Link>Interop\Unix\System.Native\Interop.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Write.cs">

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -55,62 +55,62 @@
     <Compile Include="UdpClientTest.cs" />
     <Compile Include="UnixDomainSocketTest.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
     <!-- Common Sockets files -->
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>SocketCommon\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Sockets.cs">
       <Link>SocketCommon\Configuration.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\TestSettings.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\TestSettings.cs">
       <Link>SocketCommon\TestSettings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Fletcher32.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Fletcher32.cs">
       <Link>SocketCommon\Fletcher32.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestExtensions.cs">
       <Link>SocketCommon\SocketTestExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestServer.cs">
       <Link>SocketCommon\SocketTestServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestServerAsync.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestServerAsync.cs">
       <Link>SocketCommon\SocketTestServerAsync.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestServerAPM.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestServerAPM.cs">
       <Link>SocketCommon\SocketTestServerAPM.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketImplementationType.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketImplementationType.cs">
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Sockets.cs">
       <Link>Common\System\Net\Capability.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
+    <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Stress.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Stress.Tests.csproj
@@ -9,51 +9,51 @@
     <Compile Include="SocketTestClientAPMMock.cs" />
     <Compile Include="SocketTestServerAPMMock.cs" />
     <!-- Common Sockets files -->
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\TestSettings.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\TestSettings.cs">
       <Link>SocketCommon\TestSettings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestServer.cs">
       <Link>SocketCommon\SocketTestServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketTestServerAsync.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketTestServerAsync.cs">
       <Link>SocketCommon\SocketTestServerAsync.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketImplementationType.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\SocketImplementationType.cs">
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketPerformanceTests.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Performance\SocketPerformanceTests.cs">
       <Link>SocketCommon\SocketPerformanceFactories.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketTestClient.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Performance\SocketTestClient.cs">
       <Link>SocketCommon\SocketTestClient.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketTestClientAsync.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Performance\SocketTestClientAsync.cs">
       <Link>SocketCommon\SocketTestClientAsync.cs</Link>
     </Compile>
     <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs">
       <Link>Common\System\Net\VerboseTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Sockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Sockets.cs">
       <Link>Common\System\Net\Capability.Sockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketTestMemcmp.Windows.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Performance\SocketTestMemcmp.Windows.cs">
       <Link>SocketCommon\SocketTestMemcmp.Windows.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonTestPath)\System\Net\Sockets\Performance\SocketTestMemcmp.Unix.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Sockets\Performance\SocketTestMemcmp.Unix.cs">
       <Link>SocketCommon\SocketTestMemcmp.Unix.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -6,19 +6,19 @@
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>
     <Compile Include="System\Net\WebClient.cs" />
-    <Compile Include="$(CommonPath)\System\IO\DelegatingStream.cs">
+    <Compile Include="$(CommonPath)System\IO\DelegatingStream.cs">
       <Link>Common\System\IO\DelegatingStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\IO\ChunkedMemoryStream.cs">
+    <Compile Include="$(CommonPath)System\IO\ChunkedMemoryStream.cs">
       <Link>Common\System\IO\ChunkedMemoryStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\BeginEndAwaitableAdapter.cs">
+    <Compile Include="$(CommonPath)System\Threading\Tasks\BeginEndAwaitableAdapter.cs">
       <Link>Common\System\Threading\Tasks\BeginEndAwaitableAdapter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs">
+    <Compile Include="$(CommonPath)System\Threading\Tasks\RendezvousAwaitable.cs">
       <Link>Common\System\Threading\Tasks\RendezvousAwaitable.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/libraries/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -5,22 +5,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WebClientTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs">
       <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.csproj
+++ b/src/libraries/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.csproj
@@ -12,19 +12,19 @@
     <Compile Include="System\Net\HeaderInfo.cs" />
     <Compile Include="System\Net\HeaderInfoTable.cs" />
     <Compile Include="System\Net\NetEventSource.WebHeaderCollection.cs" />
-    <Compile Include="$(CommonPath)\System\Net\CaseInsensitiveAscii.cs">
+    <Compile Include="$(CommonPath)System\Net\CaseInsensitiveAscii.cs">
       <Link>Common\System\Net\CaseInsensitiveAscii.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\StringExtensions.cs">
+    <Compile Include="$(CommonPath)System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpValidationHelpers.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpValidationHelpers.cs">
       <Link>Common\System\Net\HttpValidationHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -9,20 +9,20 @@
     <Compile Include="System\Net\WebSockets\ClientWebSocketOptions.cs" />
     <Compile Include="System\Net\WebSockets\NetEventSource.WebSockets.cs" />
     <!-- Common -->
-    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs">
       <Link>Common\System\Net\Logging\NetEventSource.Common.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\UriScheme.cs">
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs">
       <Link>Common\System\Net\UriScheme.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
     <Compile Include="System\Net\WebSockets\WebSocketHandle.Managed.cs" />
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\SecurityProtocol.cs">
+    <Compile Include="$(CommonPath)System\Net\SecurityProtocol.cs">
       <Link>Common\System\Net\SecurityProtocol.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -9,37 +9,37 @@
     <DefaultReferenceExclusions Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs">
       <Link>Common\System\Net\Configuration.Certificates.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs">
       <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.WebSockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.WebSockets.cs">
       <Link>Common\System\Net\Configuration.WebSockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+    <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackProxyServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackProxyServer.cs">
       <Link>Common\System\Net\Http\LoopbackProxyServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs">
       <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
     <Compile Include="AbortTest.cs" />

--- a/src/libraries/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/libraries/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -6,10 +6,10 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netstandard2.0-Debug;netstandard2.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\ManagedWebSocket.cs">
       <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
     <Compile Include="System\Net\WebSockets\ManagedWebSocket.netstandard.cs" />

--- a/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/System.Net.WebSockets.WebSocketProtocol.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/System.Net.WebSockets.WebSocketProtocol.Tests.csproj
@@ -3,16 +3,16 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Net\WebSockets\WebSocketCreateTest.cs">
+    <Compile Include="$(CommonTestPath)System\Net\WebSockets\WebSocketCreateTest.cs">
       <Link>Common\System\Net\WebSockets\WebSocketCreateTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.WebSockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.WebSockets.cs">
       <Link>Common\System\Net\Configuration.WebSockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
     <Compile Include="WebSocketProtocolTests.cs" />

--- a/src/libraries/System.Net.WebSockets/src/System.Net.WebSockets.csproj
+++ b/src/libraries/System.Net.WebSockets/src/System.Net.WebSockets.csproj
@@ -16,10 +16,10 @@
     <Compile Include="System\Net\WebSockets\WebSocketMessageType.cs" />
     <Compile Include="System\Net\WebSockets\WebSocketReceiveResult.cs" />
     <Compile Include="System\Net\WebSockets\WebSocketState.cs" />
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\WebSocketValidate.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\WebSocketValidate.cs">
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
+    <Compile Include="$(CommonPath)System\Net\WebSockets\ManagedWebSocket.cs">
       <Link>Common\System\Net\WebSockets\ManagedWebSocket.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
@@ -7,16 +7,16 @@
     <Compile Include="WebSocketTests.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
     <Compile Include="WebSocketExceptionTests.cs" />
     <Compile Include="WebSocketReceiveResultTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\WebSockets\WebSocketCreateTest.cs">
+    <Compile Include="$(CommonTestPath)System\Net\WebSockets\WebSocketCreateTest.cs">
       <Link>Common\System\Net\WebSockets\WebSocketCreateTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.WebSockets.cs">
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.WebSockets.cs">
       <Link>Common\System\Net\Configuration.WebSockets.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
+    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -3,22 +3,22 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerableTest.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerableTest.cs">
       <Link>Common\System\CollectionsIEnumerableTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollectionTest.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollectionTest.cs">
       <Link>Common\System\CollectionsICollectionTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IListTest.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IListTest.cs">
       <Link>Common\System\CollectionsIListTest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\Utils.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\Utils.cs">
       <Link>Common\System\CollectionsUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionaryTest.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionaryTest.cs">
       <Link>Common\System\CollectionsIDictionaryTest.cs</Link>
     </Compile>
     <Compile Include="ObservableCollection\ObservableCollection_ConstructorAndPropertyTests.cs" />
@@ -38,7 +38,7 @@
     <Compile Include="ReadOnlyDictionary\ReadOnlyDictionaryTests.cs" />
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollection_EventsTests.cs" />
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollectionTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>
@@ -51,7 +51,7 @@
     <Compile Include="KeyedCollection\Serialization.cs" />
     <Compile Include="ReadOnlyDictionary\ReadOnlyDictionary_SerializationTests.cs" />
     <Compile Include="ReadOnlyObservableCollection\ReadOnlyObservableCollection_SerializationTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -19,7 +19,7 @@
     <TextSources>System\Text</TextSources>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="$(RuntimeSerializationSources)\Attributes.cs" />
@@ -130,9 +130,9 @@
     <Compile Include="$(JsonSources)\JsonEncodingStreamWrapper.cs" />
     <Compile Include="$(JsonSources)\JsonFormatGeneratorStatics.cs" />
     <Compile Include="System\Runtime\Serialization\AccessorBuilder.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReference.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeTypeReferenceCollection.cs" />
-    <Compile Include="$(CommonPath)\System\CodeDom\CodeObject.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeTypeReference.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeTypeReferenceCollection.cs" />
+    <Compile Include="$(CommonPath)System\CodeDom\CodeObject.cs" />
     <Compile Include="System\Runtime\Serialization\DataContractSet.cs" />
     <Compile Include="System\Runtime\Serialization\ExportOptions.cs" />
     <Compile Include="System\Runtime\Serialization\IExtensibleDataObject.cs" />

--- a/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
@@ -6,7 +6,7 @@
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
   </ItemGroup>
@@ -17,11 +17,11 @@
     <Compile Include="System\DomainNameHelper.cs" />
     <Compile Include="System\GenericUriParser.cs" />
     <Compile Include="System\IPv4AddressHelper.cs" />
-    <Compile Include="$(CommonPath)\System\Net\IPv4AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs">
       <Link>System\IPv4AddressHelper.Common.cs</Link>
     </Compile>
     <Compile Include="System\IPv6AddressHelper.cs" />
-    <Compile Include="$(CommonPath)\System\Net\IPv6AddressHelper.Common.cs">
+    <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs">
       <Link>System\IPv6AddressHelper.Common.cs</Link>
     </Compile>
     <Compile Include="System\IriHelper.cs" />

--- a/src/libraries/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
+++ b/src/libraries/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.Xml\src\System.Private.Xml.csproj" />
-    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\EnumerableHelpers.cs">
       <Link>System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">

--- a/src/libraries/System.Private.Xml.Linq/tests/Properties/System.Xml.Linq.Properties.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/Properties/System.Xml.Linq.Properties.Tests.csproj
@@ -13,9 +13,9 @@
     <Compile Include="XElement_Value.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/tests/Streaming/System.Xml.Linq.Streaming.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/Streaming/System.Xml.Linq.Streaming.Tests.csproj
@@ -7,9 +7,9 @@
     <Compile Include="StreamingOutput.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/System.Xml.Linq.TreeManipulation.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/TreeManipulation/System.Xml.Linq.TreeManipulation.Tests.csproj
@@ -3,10 +3,10 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="AddFirstAddFirstIntoDocument.cs" />
@@ -50,9 +50,9 @@
     <Compile Include="SaveWithFileName.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/tests/XDocument.Common/XDocument.Common.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/XDocument.Common/XDocument.Common.csproj
@@ -15,8 +15,8 @@
     <Compile Include="XLinqTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml.Linq/tests/XPath/XDocument/System.Xml.XPath.XDocument.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/XPath/XDocument/System.Xml.XPath.XDocument.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <RootNamespace>System.Xml.XPath.XDocument.Tests</RootNamespace>
-    <CommonPathXPath>$(CommonPath)\System\Xml\XPath</CommonPathXPath>
+    <CommonPathXPath>$(CommonPath)System\Xml\XPath</CommonPathXPath>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/System.Xml.Linq.Misc.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/System.Xml.Linq.Misc.Tests.csproj
@@ -14,9 +14,9 @@
     <Compile Include="LoadSaveAsyncTests.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs">
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="CommonTests.cs" />
@@ -19,9 +19,9 @@
     <Compile Include="XmlReaderDiff.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeReader/System.Xml.Linq.xNodeReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeReader/System.Xml.Linq.xNodeReader.Tests.csproj
@@ -24,9 +24,9 @@
     <Compile Include="XNodeReaderAPI.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="..\XDocument.Common\XDocument.Common.csproj" />
     <ProjectReference Include="..\XDocument.Test.ModuleCore\XDocument.Test.ModuleCore.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -11,7 +11,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Text\StringBuilderCache.cs">
       <Link>System\StringBuilderCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Marvin.cs">
+    <Compile Include="$(CommonPath)System\Marvin.cs">
       <Link>System\Marvin.cs</Link>
     </Compile>
     <Compile Include="System\Xml\BinaryXml\XmlBinaryReader.cs" />
@@ -800,7 +800,7 @@
       <Link>System\LocalAppContextSwitches.Common.cs</Link>
     </Compile>
     <Compile Include="System\Xml\Core\LocalAppContextSwitches.cs" />
-    <Compile Include="$(CommonPath)\System\CSharpHelpers.cs" />
+    <Compile Include="$(CommonPath)System\CSharpHelpers.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Windows.cs" />

--- a/src/libraries/System.Private.Xml/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
@@ -5,11 +5,11 @@
   <ItemGroup>
     <Compile Include="CharReaderTests.cs" />
     <Compile Include="InheritedCases.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
@@ -5,11 +5,11 @@
   <ItemGroup>
     <Compile Include="CReaderTestModule.cs" />
     <Compile Include="InheritedCases.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/FactoryReader/System.Xml.RW.FactoryReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/FactoryReader/System.Xml.RW.FactoryReader.Tests.csproj
@@ -7,11 +7,11 @@
     <Compile Include="InheritedCases.cs" />
     <Compile Include="Normalization.cs" />
     <Compile Include="TCNormalization.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
@@ -10,11 +10,11 @@
     <Compile Include="TCUserNameTable.cs" />
     <Compile Include="TestFiles.cs" />
     <Compile Include="XmlNameTable.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
@@ -21,12 +21,12 @@
     <Compile Include="TCOneByteStream.cs" />
     <Compile Include="TCReaderSettings.cs" />
     <Compile Include="TCRSGeneric.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\BaseLibManaged\BaseLibManaged.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\BaseLibManaged\BaseLibManaged.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/SubtreeReader/System.Xml.RW.SubtreeReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/SubtreeReader/System.Xml.RW.SubtreeReader.Tests.csproj
@@ -5,11 +5,11 @@
   <ItemGroup>
     <Compile Include="InheritedCases.cs" />
     <Compile Include="SubtreeReaderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Readers/WrappedReader/System.Xml.RW.WrappedReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/WrappedReader/System.Xml.RW.WrappedReader.Tests.csproj
@@ -5,11 +5,11 @@
   <ItemGroup>
     <Compile Include="InheritedCases.cs" />
     <Compile Include="WrappedReaderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="..\..\XmlReaderLib\System.Xml.RW.XmlReaderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Writers/RwFactory/System.Xml.RW.RwFactory.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Writers/RwFactory/System.Xml.RW.RwFactory.Tests.csproj
@@ -14,10 +14,10 @@
     <Compile Include="CXmlDriverVariation.cs" />
     <Compile Include="ReaderFactory.cs" />
     <Compile Include="WriterFactory.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -38,9 +38,9 @@
     <Compile Include="XmlWriterTestCaseBase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />

--- a/src/libraries/System.Private.Xml/tests/XPath/XPathDocument/System.Xml.XPath.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XPath/XPathDocument/System.Xml.XPath.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);FEATURE_XML_XPATH_ID</DefineConstants>
     <RootNamespace>System.Xml.XPath.Tests</RootNamespace>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
-    <CommonPathXPath>$(CommonPath)\System\Xml\XPath</CommonPathXPath>
+    <CommonPathXPath>$(CommonPath)System\Xml\XPath</CommonPathXPath>
   </PropertyGroup>
   <ItemGroup>
     <!-- XPath.XPathDocument navigator -->

--- a/src/libraries/System.Private.Xml/tests/XPath/XmlDocument/System.Xml.XPath.XmlDocument.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XPath/XmlDocument/System.Xml.XPath.XmlDocument.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);FEATURE_XML_XPATH_ID</DefineConstants>
     <RootNamespace>System.Xml.XPath.XmlDocument.Tests</RootNamespace>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
-    <CommonPathXPath>$(CommonPath)\System\Xml\XPath</CommonPathXPath>
+    <CommonPathXPath>$(CommonPath)System\Xml\XPath</CommonPathXPath>
   </PropertyGroup>
   <ItemGroup>
     <!-- XPath.XmlDocument navigator -->

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
@@ -37,10 +37,10 @@
     <Compile Include="XmlIdeographicCharConvertTests1.cs" />
     <Compile Include="XmlIdeographicCharConvertTests2.cs" />
     <Compile Include="XmlIdeographicCharConvertTests3.cs" />
-    <Compile Include="$(CommonTestPath)\System\Xml\DisableParallelization.cs" />
+    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/XmlDocument/System.Xml.XmlDocument.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlDocument/System.Xml.XmlDocument.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
     <Compile Include="XmlDocumentTests\LoadTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/System.Xml.XmlNodeReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/System.Xml.XmlNodeReader.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/System.Xml.RW.XmlReader.Tests.csproj
@@ -7,7 +7,7 @@
     <Compile Include="DisposeTests.cs" />
     <Compile Include="BaseUriTests.cs" />
     <Compile Include="ReaderEncodingTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\TrackingSynchronizationContext.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\TrackingSynchronizationContext.cs">
       <Link>Common\System\Threading\TrackingSynchronizationContext.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlReaderLib/System.Xml.RW.XmlReaderLib.csproj
@@ -73,7 +73,7 @@
     <Compile Include="XmlException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/XmlResolver/System.Xml.XmlResolver.Tests/System.Xml.XmlResolver.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlResolver/System.Xml.XmlResolver.Tests/System.Xml.XmlResolver.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/System.Xml.XmlSchemaSet.Tests.csproj
@@ -34,7 +34,7 @@
     <Compile Include="TC_SchemaSet_ValidationEventHandler.cs" />
     <Compile Include="TC_SchemaSet_XmlNameTable.cs" />
     <Compile Include="TC_SchemaSet_XmlResolver.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj
@@ -20,7 +20,7 @@
     <Compile Include="ValidatorModule.cs" />
     <Compile Include="XmlTestSettings.cs" />
     <Compile Include="CXmlTestResolver.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/ReflectionOnly/System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.RuntimeOnly.cs" />
     <Compile Include="$(TestSourceFolder)..\XmlSerializerTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/System.Xml.XmlSerializer.Tests.csproj
@@ -3,7 +3,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.RuntimeOnly.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)XmlSerializerTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -22,9 +22,9 @@
           Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
     <ProjectReference Include="..\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
@@ -24,8 +24,8 @@
           Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
@@ -19,8 +19,8 @@
           Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\ModuleCore\ModuleCore.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
-    <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlDiff\XmlDiff.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
+    <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -9,7 +9,7 @@
   <ItemGroup Condition="'$(TargetsNetStandard)' != 'true'">
     <Compile Include="System\Reflection\DispatchProxy.cs" />
     <Compile Include="System\Reflection\DispatchProxyGenerator.cs" />
-    <Compile Include="$(CommonPath)\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs">
+    <Compile Include="$(CommonPath)System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs">
       <Link>Common\System\Reflection\Emit\IgnoreAccessChecksToAttributeBuilder.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -8,7 +8,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard2.0-Debug;netstandard2.0-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -6,22 +6,22 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
       <Link>Common\Interop\Windows\Interop.GetModuleHandle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Interop.LoadLibraryEx.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
+    <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\tests\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="Metadata\BlobContentIdTests.cs" />

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -6,22 +6,22 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Interop.FreeLibrary.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
       <Link>Common\Interop\Windows\Interop.GetModuleHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
       <Link>Common\Interop\Windows\Interop.LoadLibraryEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="Metadata\BlobContentIdTests.cs" />

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/System.Reflection.MetadataLoadContext.Tests.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/System.Reflection.MetadataLoadContext.Tests.csproj
@@ -4,10 +4,10 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\TempDirectory.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs">
       <Link>Common\System\IO\TempDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="src\SampleMetadata\SampleMetadata.cs" />

--- a/src/libraries/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
+++ b/src/libraries/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
@@ -3,7 +3,7 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="$(CommonTestPath)\Data\TinyAssembly.dll">
+    <None Include="$(CommonTestPath)Data\TinyAssembly.dll">
       <Link>TinyAssembly.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/libraries/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
+++ b/src/libraries/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
@@ -3,7 +3,7 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\..\Common\tests\Data\TinyAssembly.dll">
+    <None Include="$(CommonTestPath)\Data\TinyAssembly.dll">
       <Link>TinyAssembly.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/libraries/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
@@ -7,7 +7,7 @@
     <Compile Include="AssemblyTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\..\..\Common\tests\Data\TinyAssembly.dll">
+    <EmbeddedResource Include="$(CommonTestPath)\Data\TinyAssembly.dll">
       <Link>Assembly\TinyAssembly.dll</Link>
       <LogicalName>TinyAssembly.dll</LogicalName>
     </EmbeddedResource>

--- a/src/libraries/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
@@ -7,7 +7,7 @@
     <Compile Include="AssemblyTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\TinyAssembly.dll">
+    <EmbeddedResource Include="$(CommonTestPath)Data\TinyAssembly.dll">
       <Link>Assembly\TinyAssembly.dll</Link>
       <LogicalName>TinyAssembly.dll</LogicalName>
     </EmbeddedResource>

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -6,11 +6,11 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Reflection\MockParameterInfo.cs">
+    <Compile Include="$(CommonTestPath)System\Reflection\MockParameterInfo.cs">
       <Link>Common\System\Reflection\MockParameterInfo.cs</Link>
     </Compile>    
-    <Compile Include="$(CommonTestPath)\System\MockType.cs" Link="Common\System\MockType.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\MockType.cs" Link="Common\System\MockType.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>    
     <Compile Include="AssemblyNameTests.cs" />

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="$(CommonTestPath)\System\Reflection\MockParameterInfo.cs">
       <Link>Common\System\Reflection\MockParameterInfo.cs</Link>
     </Compile>    
-    <Compile Include="..\..\Common\tests\System\MockType.cs" Link="Common\System\MockType.cs" />
+    <Compile Include="$(CommonTestPath)\System\MockType.cs" Link="Common\System\MockType.cs" />
     <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>    

--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Resources\ResourceWriter.cs" Link="System\Resources\Extensions\ResourceWriter.cs" />
+    <Compile Include="$(CommonPath)System\Resources\ResourceWriter.cs" Link="System\Resources\Extensions\ResourceWriter.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PinnedBufferMemoryStream.cs" Link="System\IO\PinnedBufferMemoryStream.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Resources\FastResourceComparer.cs" Link="System\Resources\FastResourceComparer.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Resources\ResourceReader.cs" Link="System\Resources\Extensions\ResourceReader.cs" />

--- a/src/libraries/System.Resources.Reader/tests/System.Resources.Reader.Tests.csproj
+++ b/src/libraries/System.Resources.Reader/tests/System.Resources.Reader.Tests.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
     <TestRuntime>true</TestRuntime>

--- a/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
@@ -18,7 +18,7 @@
     <Compile Include="SatelliteContractVersionAttributeTests.cs" />
     <Compile Include="MissingSatelliteAssemblyException.cs" />
     <Compile Include="ResourceSetTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">
+    <Compile Include="$(CommonTestPath)System\Drawing\Helpers.cs">
       <Link>Common\System\Drawing\Helpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Resources.Writer/src/System.Resources.Writer.csproj
+++ b/src/libraries/System.Resources.Writer/src/System.Resources.Writer.csproj
@@ -10,7 +10,7 @@
     <Compile Include="System\Resources\__FastResourceComparer.cs" />
     <Compile Include="System\Resources\IResourceWriter.cs" />
     <Compile Include="System\Resources\ResourceWriter.core.cs" />
-    <Compile Include="$(CommonPath)\System\Resources\ResourceWriter.cs" Link="System\Resources\ResourceWriter.cs" />
+    <Compile Include="$(CommonPath)System\Resources\ResourceWriter.cs" Link="System\Resources\ResourceWriter.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Resources\ResourceTypeCode.cs" Link="System\Resources\ResourceTypeCode.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -52,13 +52,13 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Runtime\Caching\MemoryMonitor.Windows.cs" />
     <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalMemoryStatusEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GlobalMemoryStatusEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GlobalMemoryStatusEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.MEMORY_BASIC_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -42,7 +42,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
       <Link>System\Threading\Tasks\TaskToApm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\HResults.cs">
+    <Compile Include="$(CommonPath)System\HResults.cs">
       <Link>Common\System\HResults.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">
@@ -58,16 +58,16 @@
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
       <Link>System\IO\Win32Marshal.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOLEAN.cs">
       <Link>Common\Interop\Windows\Interop.BOOLEAN.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
@@ -110,10 +110,10 @@
   <!-- UNIX -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Runtime\Versioning\VersioningHelper.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -122,7 +122,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
       <Link>Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetPid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPid.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetPid.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.ChDir.cs">

--- a/src/libraries/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/libraries/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -73,19 +73,19 @@
     <Compile Include="System\Runtime\ProfileOptimization.cs" />
     <Compile Include="System\Runtime\CompilerServices\SwitchExpressionExceptionTests.cs" />
 
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNodeName.cs" Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNodeName.cs" Condition="'$(TargetsUnix)' == 'true'">
       <Link>Common\Interop\Unix\System.Native\Interop.GetNodeName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\PathFeatures.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PathFeatures.cs">
       <Link>Common\System\IO\PathFeatures.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\ShouldNotBeInvokedException.cs">
+    <Compile Include="$(CommonTestPath)System\ShouldNotBeInvokedException.cs">
       <Link>Common\System\ShouldNotBeInvokedException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>Common\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -15,36 +15,36 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetUnixName.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetUnixName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetUnixVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetUnixVersion.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetUnixVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetOSArchitecture.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetOSArchitecture.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetOSArchitecture.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetProcessArchitecture.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetProcessArchitecture.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetProcessArchitecture.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.ProcessorArchitecture.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ProcessorArchitecture.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.ProcessorArchitecture.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RtlGetVersion.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RtlGetVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs">
       <Link>Common\Interop\Windows\NtDll\Interop.RTL_OSVERSIONINFOEX.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Runtime\InteropServices\RuntimeInformation\RuntimeInformation.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetNativeSystemInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNativeSystemInfo.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetNativeSystemInfo.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SYSTEM_INFO.cs">

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -7,7 +7,7 @@
     <Compile Include="CheckPlatformTests.cs" />
     <Compile Include="CheckPlatformTests.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
     <Compile Include="DescriptionNameTests.cs" />
-    <Compile Include="$(CommonPath)\Interop\Linux\cgroups\Interop.cgroups.cs">
+    <Compile Include="$(CommonPath)Interop\Linux\cgroups\Interop.cgroups.cs">
       <Link>Common\Interop\Linux\Interop.cgroups.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -11,10 +11,10 @@
     <Compile Include="$(CoreLibSharedDir)System\HResults.cs">
       <Link>System\HResults.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoGetStandardMarshal.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Ole32\Interop.CoGetStandardMarshal.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CoGetStandardMarshal.cs</Link>
     </Compile>
     <Compile Include="System\Runtime\CompilerServices\IDispatchConstantAttribute.cs" />

--- a/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
+++ b/src/libraries/System.Runtime.Numerics/src/System.Runtime.Numerics.csproj
@@ -20,7 +20,7 @@
     <Compile Include="System\Numerics\Complex.cs" />
     <Compile Include="System\Globalization\FormatProvider.BigInteger.cs" />
     <Compile Include="System\Globalization\FormatProvider.NumberBuffer.cs" />
-    <Compile Include="$(CommonPath)\System\Globalization\FormatProvider.Number.cs">
+    <Compile Include="$(CommonPath)System\Globalization\FormatProvider.Number.cs">
       <Link>System\Globalization\FormatProvider.Number.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -22,10 +22,10 @@
     <Compile Include="SurrogateSelectorTests.cs" />
     <Compile Include="TargetFrameworkMoniker.cs" />
     <Compile Include="TypeSerializableValue.cs" />
-    <Compile Include="$(CommonTestPath)\System\NonRuntimeType.cs">
+    <Compile Include="$(CommonTestPath)System\NonRuntimeType.cs">
       <Link>Common\System\NonRuntimeType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/ReflectionOnly/System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.RuntimeOnly.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractJsonSerializer.cs" />

--- a/src/libraries/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -6,6 +6,6 @@
     <Compile Include="$(TestSourceFolder)DataContractJsonSerializer.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.RuntimeOnly.cs" />
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/Canonicalization/System.Runtime.Serialization.Xml.Canonicalization.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/Canonicalization/System.Runtime.Serialization.Xml.Canonicalization.csproj
@@ -7,7 +7,7 @@
     <Compile Include="$(TestSourceFolder)CanonicalizationTestHelper.cs" />
     <Compile Include="$(TestSourceFolder)TestConfigHelper.cs" />
     <Compile Include="$(TestSourceFolder)XmlCanonicalizationTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
     <Compile Include="CryptoCanonicalization\AncestralNamespaceContextProviderProxy.cs" />

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/ReflectionOnly/System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\DataContractSerializerStressTests.cs" />
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\SerializationTypes.RuntimeOnly.cs" />
@@ -12,10 +12,10 @@
     <Compile Include="$(TestSourceFolder)..\MyResolver.cs" />
     <Compile Include="$(TestSourceFolder)..\XmlDictionaryReaderTests.cs" />
     <Compile Include="$(TestSourceFolder)..\XmlDictionaryWriterTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\DataContractSerializerHelper.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\DataContractSerializerHelper.cs">
       <Link>Common\System\Runtime\Serialization\DataContractSerializerHelper.cs</Link>
     </Compile>
     <Compile Include="$(TestSourceFolder)..\SerializationTestTypes\ObjRefSample.cs">

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -15,13 +15,13 @@
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRSampleType.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\DCRTypeLibrary.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\Primitives.cs" />
-    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+    <Compile Include="$(CommonTestPath)System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\DataContractSerializerHelper.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\DataContractSerializerHelper.cs">
       <Link>Common\System\Runtime\Serialization\DataContractSerializerHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Utils.cs" />
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTestTypes\ObjRefSample.cs" />
     <Compile Include="SerializationTestTypes\Collections.cs" />
     <Compile Include="SerializationTestTypes\DataContract.cs" />

--- a/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
+++ b/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
@@ -23,7 +23,7 @@
     <Compile Include="System\Windows\Media\Animation\KeyTime.cs" />
     <Compile Include="System\Windows\Media\Animation\RepeatBehavior.cs" />
     <Compile Include="System\Windows\Media\Media3D\Matrix3D.cs" />
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
       <Link>Common\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/libraries/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -83,10 +83,10 @@
     <Compile Include="System\VoidTypeParameter.cs" />
     <Compile Include="System\Windows\TokenizerHelper.cs" />
     <Compile Include="System\Windows\UI\Color.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.RoGetActivationFactory.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Mincore\Interop.RoGetActivationFactory.cs">
       <Link>Common\Interop\Windows\Mincore\Interop.RoGetActivationFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
       <Link>Common\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\WinRTFolderPaths.cs">
@@ -98,13 +98,13 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.RoGetBufferMarshaler.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Mincore\Interop.RoGetBufferMarshaler.cs">
       <Link>Common\Interop\Windows\Mincore\Interop.RoGetBufferMarshaler.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -7,43 +7,43 @@
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
+    <Compile Include="$(CommonTestPath)System\EnumTypes.cs">
       <Link>Common\System\EnumTypes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\MockType.cs">
+    <Compile Include="$(CommonTestPath)System\MockType.cs">
       <Link>Common\System\MockType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.Generic.Tests.cs">
       <Link>Common\System\Collections\ICollection.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.Generic.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.Generic.Tests.cs">
       <Link>Common\System\Collections\IList.Generic.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.Generic.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.Generic.cs">
       <Link>Common\System\Collections\TestBase.Generic.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\TestBase.NonGeneric.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\TestBase.NonGeneric.cs">
       <Link>Common\System\Collections\TestBase.NonGeneric.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\Tests\System\StringTests.cs">
+    <Compile Include="$(CommonTestPath)Tests\System\StringTests.cs">
       <Link>System\StringTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IDictionary.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IDictionary.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IDictionary.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IList.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IList.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IList.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\ICollection.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\ICollection.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\ICollection.NonGeneric.Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
     <Compile Include="Helpers.cs" />
@@ -234,7 +234,7 @@
     <Compile Include="System\Type\TypePropertyTests.cs" />
     <Compile Include="System\Type\TypeTests.cs" />
     <Compile Include="System\Type\TypeTests.Get.cs" />
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+    <Compile Include="$(CommonTestPath)System\RandomDataGenerator.cs">
       <Link>Common\System\RandomDataGenerator.cs</Link>
     </Compile>
   </ItemGroup>
@@ -256,16 +256,16 @@
     <Compile Include="System\Text\Unicode\Utf8Tests.cs" />
     <Compile Include="System\Text\Unicode\Utf8UtilityTests.ValidateBytes.cs" />
     <Compile Include="System\ArgIteratorTests.cs" />
-    <Compile Include="$(CommonPath)\..\tests\System\RealFormatterTestsBase.netcoreapp.cs" Link="System\RealFormatterTestsBase.netcoreapp.cs" />
+    <Compile Include="$(CommonPath)..\tests\System\RealFormatterTestsBase.netcoreapp.cs" Link="System\RealFormatterTestsBase.netcoreapp.cs" />
     <Compile Include="System\RealFormatterTests.cs" />
-    <Compile Include="$(CommonPath)\..\tests\System\RealParserTestsBase.netcoreapp.cs" Link="System\RealParserTestsBase.netcoreapp.cs" />
+    <Compile Include="$(CommonPath)..\tests\System\RealParserTestsBase.netcoreapp.cs" Link="System\RealParserTestsBase.netcoreapp.cs" />
     <Compile Include="System\RealParserTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' != 'true'">
     <Compile Include="System\StringSplitExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
     <EmbeddedResource Include="System\Reflection\EmbeddedImage.png">
@@ -274,20 +274,20 @@
     <EmbeddedResource Include="System\Reflection\EmbeddedTextFile.txt">
       <LogicalName>System.Reflection.Tests.EmbeddedTextFile.txt</LogicalName>
     </EmbeddedResource>
-    <Compile Include="$(CommonTestPath)\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs">
       <Link>Common\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.11.0.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\UnicodeData.11.0.txt">
       <Link>System\Text\Unicode\UnicodeData.11.0.txt</Link>
       <LogicalName>UnicodeData.11.0.txt</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\CaseFolding-12.1.0.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\CaseFolding-12.1.0.txt">
       <Link>System\Text\Unicode\CaseFolding-12.1.0.txt</Link>
       <LogicalName>CaseFolding-12.1.0.txt</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\PropList-12.1.0.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\PropList-12.1.0.txt">
       <Link>System\Text\Unicode\PropList-12.1.0.txt</Link>
       <LogicalName>PropList-12.1.0.txt</LogicalName>
     </EmbeddedResource>

--- a/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -23,85 +23,85 @@
     <Compile Include="System\Security\AccessControl\Win32.cs" />
     <Compile Include="System\Security\Principal\Win32.cs" />
     <!-- PInvoke sources -->
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeTokenHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeTokenHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LUID.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LUID.cs">
       <Link>Common\Interop\Interop.LUID.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LUID_AND_ATTRIBUTES.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LUID_AND_ATTRIBUTES.cs">
       <Link>Common\Interop\Interop.LUID_AND_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.TOKEN_PRIVILEGE.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.TOKEN_PRIVILEGE.cs">
       <Link>Common\Interop\Interop.TOKEN_PRIVILEGE.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SecurityImpersonationLevel.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SecurityImpersonationLevel.cs">
       <Link>Common\Interop\Interop.SecurityImpersonationLevel.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ProcessOptions.cs">
       <Link>Common\Interop\Interop.ProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LookupPrivilegeValue.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LookupPrivilegeValue.cs">
       <Link>Common\Interop\Interop.LookupPrivilegeValue.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
       <Link>Common\Interop\Interop.RevertToSelf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ConvertSdToStringSd.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ConvertSdToStringSd.cs">
       <Link>Common\Interop\Interop.ConvertSdToStringSd.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ConvertStringSdToSd.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ConvertStringSdToSd.cs">
       <Link>Common\Interop\Interop.ConvertStringSdToSd.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetSecurityInfoByHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetSecurityInfoByHandle.cs">
       <Link>Common\Interop\Interop.GetSecurityInfoByHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SetSecurityInfoByHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SetSecurityInfoByHandle.cs">
       <Link>Common\Interop\Interop.SetSecurityInfoByHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetSecurityInfoByName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetSecurityInfoByName.cs">
       <Link>Common\Interop\Interop.GetSecurityInfoByName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SetSecurityInfoByName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SetSecurityInfoByName.cs">
       <Link>Common\Interop\Interop.SetSecurityInfoByName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetSecurityDescriptorLength.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetSecurityDescriptorLength.cs">
       <Link>Common\Interop\Interop.GetSecurityDescriptorLength.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Common\Interop\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenThreadToken_SafeTokenHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenThreadToken_SafeTokenHandle.cs">
       <Link>Common\Interop\Interop.OpenThreadToken_SafeTokenHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenProcessToken_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenProcessToken_IntPtr.cs">
       <Link>Common\Interop\Interop.OpenProcessToken_IntPtrs.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Interop.GetCurrentProcess_IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SetThreadToken.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SetThreadToken.cs">
       <Link>Common\Interop\Interop.SetThreadToken.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentThread.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentThread.cs">
       <Link>Common\Interop\Interop.GetCurrentThread.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.AdjustTokenPrivileges.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.AdjustTokenPrivileges.cs">
       <Link>Common\Interop\Interop.AdjustTokenPrivileges.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.DuplicateTokenEx_SafeTokenHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DuplicateTokenEx_SafeTokenHandle.cs">
       <Link>Common\Interop\Interop.DuplicateTokenEx_SafeTokenHandle.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -5,8 +5,8 @@
     <NoWarn>CS1573;CS3016;CA5350;CA5351;CA5379;CA5384;CA5385;$(NoWarn)</NoWarn>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets"/>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets"/>
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
     <Compile Include="Internal\Cryptography\AesImplementation.cs" />
     <Compile Include="Internal\Cryptography\DesImplementation.cs" />
@@ -84,191 +84,191 @@
     <Compile Include="System\Security\Cryptography\SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\TripleDES.cs" />
     <Compile Include="System\Security\Cryptography\XmlKeyHelper.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\HashProvider.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\HashProvider.cs">
       <Link>Internal\Cryptography\HashProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs">
       <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSAKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSAKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\DSAKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\EccKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\EccKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\EccKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyBlobHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyBlobHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeyBlobHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\KeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeySizeHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeySizeHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Oids.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs">
       <Link>Common\System\Security\Cryptography\Oids.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\PasswordBasedEncryption.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PasswordBasedEncryption.cs">
       <Link>Common\System\Security\Cryptography\PasswordBasedEncryption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Pkcs12Kdf.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs">
       <Link>Common\System\Security\Cryptography\Pkcs12Kdf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSAKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\RSAKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RsaPaddingProcessor.cs">
       <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\CurveAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\CurveAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\CurveAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\CurveAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\CurveAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\CurveAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\CurveAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DssParms.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DssParms.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DssParms.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DssParms.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DssParms.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DssParms.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DssParms.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECDomainParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\ECDomainParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECPrivateKey.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\ECPrivateKey.xml">
       <Link>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\FieldID.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\FieldID.xml">
       <Link>Common\System\Security\Cryptography\Asn1\FieldID.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\FieldID.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\FieldID.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\FieldID.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\FieldID.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SpecifiedECDomain.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</DependentUpon>
     </Compile>
@@ -295,16 +295,16 @@
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Windows.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.Windows.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Windows.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipherBCrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\AesBCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\AesBCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\AesBCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Cng.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Cng.cs">
       <Link>Common\Interop\Windows\BCrypt\Cng.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs">
@@ -313,264 +313,264 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\BCrypt\Interop.NTSTATUS.cs">
       <Link>Interop\Windows\BCrypt\Interop.NTSTATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.Blobs.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.Blobs.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.Blobs.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptHashData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHashData.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptHashData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptBuffer.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
       <Link>Internal\Windows\BCrypt\BCryptAlgorithmCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\DESBCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\DESBCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\DESBCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\RC2BCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\RC2BCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\RC2BCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
       <Link>Common\Interop\Windows\BCrypt\TripleDesBCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.HashIdAlg.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.HashIdAlg.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.HashIdAlg.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.ErrorCode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.ErrorCode.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.ErrorCode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.EncryptDecrypt.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.Keys.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Keys.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.Keys.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.Properties.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Properties.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.ErrorCode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.SignVerify.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.SignVerify.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\CngCommon.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.Hash.cs">
       <Link>Internal\Cryptography\CngCommon.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\CngCommon.SignVerify.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.SignVerify.cs">
       <Link>Internal\Cryptography\CngCommon.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\HashProviderCng.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\HashProviderCng.cs">
       <Link>Internal\Cryptography\HashProviderCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\ErrorCodeHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\ErrorCodeHelper.cs">
       <Link>Internal\Cryptography\Windows\ErrorCodeHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Internal\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CngPkcs8.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CngPkcs8.cs">
       <Link>Common\System\Security\Cryptography\CngPkcs8.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.cs">
       <Link>Common\System\Security\Cryptography\DSACng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\DSACng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\DSACng.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECCng.HashAlgorithm.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECCng.HashAlgorithm.cs">
       <Link>Common\System\Security\Cryptography\ECCng.HashAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanCng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanCng.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.HashData.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.HashData.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.HashData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.cs">
       <Link>Common\System\Security\Cryptography\RSACng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.EncryptDecrypt.cs">
       <Link>Common\System\Security\Cryptography\RSACng.EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\RSACng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' and '$(TargetsOSX)' != 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.RAND.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSAOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\DSAOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECDsaOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECOpenSsl.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECOpenSsl.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECOpenSsl.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\RSAOpenSsl.cs</Link>
     </Compile>
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
@@ -584,88 +584,88 @@
     <Compile Include="System\Security\Cryptography\ECDiffieHellman.Create.OpenSsl.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFArray.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFData.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFError.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFString.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Digest.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Hmac.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyAgree.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyAgree.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyAgree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSASecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSASecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\DSASecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\EccSecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\EccSecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\EccSecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanSecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanSecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanSecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaSecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaSecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\ECDsaSecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSASecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSASecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\RSASecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\SecKeyPair.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\SecKeyPair.cs">
       <Link>Common\System\Security\Cryptography\SecKeyPair.cs</Link>
     </Compile>
     <Compile Include="Internal\Cryptography\AesImplementation.OSX.cs" />
@@ -678,28 +678,28 @@
     <Compile Include="System\Security\Cryptography\ECDiffieHellman.Create.SecurityTransforms.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanDerivation.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanDerivation.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanDerivation.cs</Link>
     </Compile>
     <Compile Include="System\Security\Cryptography\AesCcm.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -3,94 +3,94 @@
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+    <Compile Include="$(CommonTestPath)System\RandomDataGenerator.cs">
       <Link>CommonTest\System\RandomDataGenerator.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
     </Compile>
     <Compile Include="AesProvider.cs" />
@@ -127,7 +127,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="DefaultECDsaProvider.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
@@ -135,43 +135,43 @@
     <Compile Include="DefaultECDiffieHellmanProvider.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs</Link>
     </Compile>
     <Compile Include="AesManagedTests.cs" />
@@ -202,67 +202,67 @@
     <Compile Include="Sha384ManagedTests.cs" />
     <Compile Include="Sha512ManagedTests.cs" />
     <Compile Include="SignatureDescriptionTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
     <Compile Include="AesAEADTests.cs" />

--- a/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -11,8 +11,8 @@
     <GeneratePlatformNotSupportedAssemblyMessage>SR.PlatformNotSupported_CryptographyCng</GeneratePlatformNotSupportedAssemblyMessage>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.3.0.0</AssemblyVersion>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetsWindows)' == 'true'" />
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetsWindows)' == 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetsWindows)' == 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetsWindows)' == 'true'" />
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="System\Security\Cryptography\AesCng.cs" />
     <Compile Include="System\Security\Cryptography\CngAlgorithm.cs" />
@@ -67,312 +67,312 @@
     <Compile Include="Internal\Cryptography\ProviderPropertyName.cs" />
     <Compile Include="Internal\Cryptography\SymmetricImportExportExtensions.cs" />
     <Compile Include="Internal\Cryptography\CngSymmetricAlgorithmCore.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\AesBCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\AesBCryptModes.cs">
       <Link>Interop\Windows\BCrypt\AesBCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Cng.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Cng.cs">
       <Link>Interop\Windows\BCrypt\Cng.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\BCrypt\Interop.NTSTATUS.cs">
       <Link>Interop\Windows\BCrypt\Interop.NTSTATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs">
       <Link>Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.Blobs.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.Blobs.cs">
       <Link>Interop\Windows\BCrypt\Interop.Blobs.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs">
       <Link>Interop\Windows\BCrypt\Interop.CreateCryptographicException.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptHashData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHashData.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptHashData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
       <Link>Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\BCryptAlgorithmCache.cs">
       <Link>Internal\Windows\BCrypt\BCryptAlgorithmCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptChainingModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptChainingModes.cs">
       <Link>Internal\Windows\BCrypt\Interop.BCryptChainingModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptKeyDataBlob.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptKeyDataBlob.cs">
       <Link>Internal\Windows\BCrypt\Interop.BCryptKeyDataBlob.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\TripleDesBCryptModes.cs">
       <Link>Interop\Windows\BCrypt\TripleDesBCryptModes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Internal\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.HashIdAlg.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.HashIdAlg.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.HashIdAlg.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs">
       <Link>Internal\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.EncryptDecrypt.cs">
       <Link>Internal\Windows\NCrypt\Interop.EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.ErrorCode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.ErrorCode.cs">
       <Link>Internal\Windows\NCrypt\Interop.ErrorCode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.Keys.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Keys.cs">
       <Link>Internal\Windows\NCrypt\Interop.Keys.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptAlgorithms.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptAlgorithms.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptAlgorithms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptFreeObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptCipherKeyBlob.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptCipherKeyBlob.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptCipherKeyBlob.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptPropertyNames.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptPropertyNames.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptPropertyNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptOpenStorageProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptBuffer.cs">
       <Link>Internal\Windows\NCrypt\Interop.NCryptBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.Properties.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Properties.cs">
       <Link>Internal\Windows\NCrypt\Interop.Properties.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.SignVerify.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.SignVerify.cs">
       <Link>Internal\Windows\NCrypt\Interop.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.UiPolicy.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.UiPolicy.cs">
       <Link>Internal\Windows\NCrypt\Interop.UiPolicy.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Internal\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptHashHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeUnicodeStringHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\ErrorCodeHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\ErrorCodeHelper.cs">
       <Link>Internal\Cryptography\Windows\ErrorCodeHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\CngCommon.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.Hash.cs">
       <Link>Internal\Cryptography\CngCommon.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\CngCommon.SignVerify.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\CngCommon.SignVerify.cs">
       <Link>Internal\Cryptography\CngCommon.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\HashProvider.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\HashProvider.cs">
       <Link>Internal\Cryptography\HashProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\HashProviderCng.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\HashProviderCng.cs">
       <Link>Internal\Cryptography\HashProviderCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherBCrypt.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipherBCrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs">
       <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CngPkcs8.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CngPkcs8.cs">
       <Link>Common\System\Security\Cryptography\CngPkcs8.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.cs">
       <Link>Common\System\Security\Cryptography\DSACng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\DSACng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSACng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\DSACng.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanCng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanCng.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECCng.HashAlgorithm.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECCng.HashAlgorithm.cs">
       <Link>Common\System\Security\Cryptography\ECCng.HashAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.HashData.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.HashData.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.HashData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaCng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaCng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\ECDsaCng.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\KeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeySizeHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeySizeHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Oids.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs">
       <Link>Common\System\Security\Cryptography\Oids.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\PasswordBasedEncryption.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PasswordBasedEncryption.cs">
       <Link>Common\System\Security\Cryptography\PasswordBasedEncryption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Pkcs12Kdf.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs">
       <Link>Common\System\Security\Cryptography\Pkcs12Kdf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.cs">
       <Link>Common\System\Security\Cryptography\RSACng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.EncryptDecrypt.cs">
       <Link>Common\System\Security\Cryptography\RSACng.EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\RSACng.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSACng.SignVerify.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.SignVerify.cs">
       <Link>Common\System\Security\Cryptography\RSACng.SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RsaPaddingProcessor.cs">
       <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</DependentUpon>
     </Compile>

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -15,79 +15,79 @@
     <Compile Include="TestData.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.Data.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.Data.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCornerTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesCornerTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\DecryptorReusability.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\DecryptorReusability.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesFactory.cs</Link>
     </Compile>
     <Compile Include="AesProvider.cs" />
     <Compile Include="TripleDESCngProvider.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs</Link>
     </Compile>
     <Compile Include="ECDsaCngProvider.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs</Link>
     </Compile>
     <Compile Include="RSACngProvider.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
   </ItemGroup>
@@ -99,107 +99,107 @@
     <Compile Include="ECDHCngPkcs8Tests.cs" />
     <Compile Include="ECDsaCngPkcs8Tests.cs" />
     <Compile Include="RSACngPkcs8Tests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
     <Compile Condition="'$(TargetsWindows)' == 'true'" Include="AesCngTests.cs" />
     <Compile Condition="'$(TargetsWindows)' == 'true'" Include="TripleDESCngTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesContractTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesModeTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesModeTests.cs</Link>
     </Compile>
-    <Compile Condition="'$(TargetsWindows)' == 'true'" Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
+    <Compile Condition="'$(TargetsWindows)' == 'true'" Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
     </Compile>
-    <Compile Condition="'$(TargetsWindows)' == 'true'" Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
+    <Compile Condition="'$(TargetsWindows)' == 'true'" Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesCipherTests.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesCipherTests.cs</Link>
     </Compile>
     <Compile Include="ECDiffieHellmanCngTests.cs" />
     <Compile Include="ECDiffieHellmanCngProvider.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -23,10 +23,10 @@
     <Compile Include="System\Security\Cryptography\SHA512CryptoServiceProvider.cs" />
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.cs" />
     <Compile Include="Internal\Cryptography\Helpers.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeySizeHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeySizeHelpers.cs</Link>
     </Compile>
   </ItemGroup>
@@ -39,7 +39,7 @@
     <Compile Include="System\Security\Cryptography\RC2CryptoServiceProvider.Unix.cs" />
     <Compile Include="System\Security\Cryptography\RSACryptoServiceProvider.Unix.cs" />
     <Compile Include="Internal\Cryptography\Unix\HashAlgorithmNames.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs</Link>
     </Compile>
   </ItemGroup>
@@ -55,97 +55,97 @@
     <Compile Include="System\Security\Cryptography\CapiHelper.SymmetricKey.cs" />
     <Compile Include="System\Security\Cryptography\Utils.cs" />
     <Compile Include="Internal\Cryptography\BasicSymmetricCipherCsp.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs">
       <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs">
       <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs">
       <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptCreateHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptCreateHash.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptCreateHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDecrypt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDecrypt.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDeriveKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDeriveKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDeriveKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptEncrypt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptEncrypt.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptEncrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptExportKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptExportKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptExportKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGenKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGenKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGenKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetDefaultProvider.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetDefaultProvider.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetDefaultProvider.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetHashParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetHashParam.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetHashParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetKeyParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetKeyParam.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetKeyParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetUserKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetUserKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetUserKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptHashData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptHashData.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptHashData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptImportKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptImportKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptImportKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptSetKeyParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptSetKeyParam.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptSetKeyParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptSignHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptSignHash.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptSignHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeHashHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeHashHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeHashHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeKeyHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeKeyHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeKeyHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeProvHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeProvHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeProvHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -10,31 +10,31 @@
     <Compile Include="RSACryptoServiceProviderProvider.cs" />
     <Compile Include="RSACryptoServiceProviderTests.cs" />
     <Compile Include="ShimHelpers.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\CryptoUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\CryptoUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
   </ItemGroup>
@@ -51,67 +51,67 @@
     <Compile Include="RNGCryptoServiceProviderTests.cs" />
     <Compile Include="SHAxCryptoServiceProviderTests.cs" />
     <Compile Include="TripleDESCryptoServiceProviderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Tests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -4,8 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" Condition=" '$(TargetsOSX)' == 'true' " />
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(TargetsOSX)' == 'true' " />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition=" '$(TargetsOSX)' == 'true' " />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(TargetsOSX)' == 'true' " />
   <ItemGroup>
     <Compile Include="Internal\Cryptography\AsnFormatter.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.cs" />
@@ -17,10 +17,10 @@
     <Compile Include="System\Security\Cryptography\OidCollection.cs" />
     <Compile Include="System\Security\Cryptography\OidEnumerator.cs" />
     <Compile Include="System\Security\Cryptography\OidGroup.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
   </ItemGroup>
@@ -31,28 +31,28 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\BCrypt\Interop.NTSTATUS.cs">
       <Link>Interop\Windows\BCrypt\Interop.NTSTATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Cng.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Cng.cs">
       <Link>Common\Interop\Windows\BCrypt\Cng.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptFormatObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptFormatObject.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptFormatObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Internal\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
@@ -60,69 +60,69 @@
     <Compile Include="Internal\Cryptography\AsnFormatter.Unix.cs" />
     <Compile Include="Internal\Cryptography\OidLookup.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslAsnFormatter.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.LookupFriendlyNameByOid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.LookupFriendlyNameByOid.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.LookupFriendlyNameByOid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</DependentUpon>
     </Compile>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -3,9 +3,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
     <Compile Include="Asn1\Reader\Asn1ReaderTests.cs" />
@@ -53,10 +53,10 @@
     <Compile Include="Base64TransformsTests.cs" />
     <Compile Include="Oid.cs" />
     <Compile Include="OidCollectionTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -10,130 +10,130 @@
          without a RID so that it applies in desktop packages.config projects as well -->
     <PackageTargetRuntime />
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(TargetsUnix)' == 'true' " />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(TargetsUnix)' == 'true' " />
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Security\Cryptography\DSAOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\ECDsaOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Dsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcDsa.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EcKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Dsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Dsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Dsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Ecdh.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.EcKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Rsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.Rsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeDsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEcKeyHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPkeyCtxHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpPKeyHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSAOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\DSAOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanDerivation.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanDerivation.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanDerivation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSsl.Derive.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs">
       <Link>Common\System\Security\Cryptography\ECDiffieHellmanOpenSslPublicKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECDsaOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\ECOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECOpenSsl.ImportExport.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECOpenSsl.ImportExport.cs">
       <Link>Common\System\Security\Cryptography\ECOpenSsl.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyBlobHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyBlobHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeyBlobHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAOpenSsl.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSAOpenSsl.cs">
       <Link>Common\System\Security\Cryptography\RSAOpenSsl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RsaPaddingProcessor.cs">
       <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -6,82 +6,82 @@
   <ItemGroup>
     <Compile Include="EcDsaOpenSslTests.cs" />
     <Compile Include="RSAOpenSslProvider.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hmac.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Tls.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.NistValidation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
     <Compile Include="EcDiffieHellmanOpenSslProvider.cs" />
@@ -90,66 +90,66 @@
     <Compile Include="RsaOpenSslTests.cs" />
     <Compile Include="DsaOpenSslProvider.cs" />
     <Compile Include="DsaOpenSslTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AsymmetricSignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyGeneration.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignVerify.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSATestData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSASignatureFormatter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAXml.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\ECKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDhKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTests.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.netcoreapp.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs</Link>
     </Compile>
     <Compile Include="SafeEvpPKeyHandleTests.cs" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -9,8 +9,8 @@
     <Nullable>annotations</Nullable>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netcoreapp3.0-Windows_NT-Debug;netcoreapp3.0-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Release;netstandard2.0-Windows_NT-Debug;netstandard2.0-Windows_NT-Release;netstandard2.1-Debug;netstandard2.1-Release;netstandard2.1-Windows_NT-Debug;netstandard2.1-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
   <!-- Don't delete these clauses even if they look useless. They tell the VS IDE that "Windows_Debug", etc., are
        valid configuration for this project and stop it from trying to "fix up" the .sln file -->
   <!-- API types (platform independent) -->
@@ -54,23 +54,23 @@
     <Compile Include="Internal\Cryptography\PkcsHelpers.cs" />
     <Compile Include="Internal\Cryptography\PkcsPal.cs" />
     <Compile Include="Internal\Cryptography\RecipientInfoPal.cs" />
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Internal types (platform: AnyOS) -->
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml</DependentUpon>
     </Compile>
@@ -155,226 +155,226 @@
   </ItemGroup>
   <!-- Interop types (platform: Windows) -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsPartialFacadeAssembly)' != 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDestroyHash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptDestroyKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptGetProvParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.CryptReleaseContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeHashHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeHashHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeHashHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeKeyHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeKeyHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeKeyHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\SafeProvHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\SafeProvHandle.cs">
       <Link>Common\Interop\Windows\Advapi32\SafeProvHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CERT_CONTEXT.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CERT_CONTEXT.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CERT_CONTEXT.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CERT_ID.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CERT_ID.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CERT_ID.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CERT_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CERT_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CERT_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CERT_ISSUER_SERIAL_NUMBER.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CERT_ISSUER_SERIAL_NUMBER.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CERT_ISSUER_SERIAL_NUMBER.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CERT_PUBLIC_KEY_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CERT_PUBLIC_KEY_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CERT_PUBLIC_KEY_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertContextPropId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertContextPropId.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertContextPropId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertCreateCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertCreateCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertCreateCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertGetCertificateContextProperty.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertGetCertificateContextProperty.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertGetCertificateContextProperty.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertGetPublicKeyLength.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertGetPublicKeyLength.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertGetPublicKeyLength.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertIdChoice.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertIdChoice.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertIdChoice.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertNameStrTypeAndFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertNameStrTypeAndFlags.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertNameStrTypeAndFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertNameToStr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertNameToStr.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertNameToStr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_CMS_RECIPIENT_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_CMS_RECIPIENT_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_CMS_RECIPIENT_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_CTRL_DECRYPT_PARA.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_CTRL_DECRYPT_PARA.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_CTRL_DECRYPT_PARA.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_CTRL_KEY_AGREE_DECRYPT_PARA.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_CTRL_KEY_AGREE_DECRYPT_PARA.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_CTRL_KEY_AGREE_DECRYPT_PARA.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_ENVELOPED_ENCODE_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_ENVELOPED_ENCODE_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_ENVELOPED_ENCODE_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_KEY_AGREE_RECIPIENT_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_KEY_TRANS_RECIPIENT_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_RC2_AUX_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_RC2_AUX_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_RC2_AUX_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCODE_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCODE_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCODE_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMSG_RECIPIENT_ENCRYPTED_KEY_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMsgCmsRecipientChoice.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMsgCmsRecipientChoice.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMsgCmsRecipientChoice.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CMsgKeyAgreeOriginatorChoice.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CMsgKeyAgreeOriginatorChoice.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CMsgKeyAgreeOriginatorChoice.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CmsKeyAgreeKeyChoice.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CmsKeyAgreeKeyChoice.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CmsKeyAgreeKeyChoice.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_ALGORITHM_IDENTIFIER.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_ALGORITHM_IDENTIFIER.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_ALGORITHM_IDENTIFIER.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE_TYPE_VALUE.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE_TYPE_VALUE.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTE_TYPE_VALUE.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTES.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTES.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_BIT_BLOB.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_BIT_BLOB.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_BIT_BLOB.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_KEY_PROV_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_KEY_PROV_INFO.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_KEY_PROV_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CRYPT_RC2_CBC_PARAMETERS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CRYPT_RC2_CBC_PARAMETERS.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CRYPT_RC2_CBC_PARAMETERS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKey.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKeyFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKeyFlags.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptAcquireCertificatePrivateKeyFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptDecodeObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptDecodeObject.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptDecodeObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptDecodeObjectStructType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptDecodeObjectStructType.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptDecodeObjectStructType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptEncodeDecodeWrappers.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptEncodeDecodeWrappers.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptEncodeDecodeWrappers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptEncodeObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptEncodeObject.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptEncodeObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptKeySpec.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptKeySpec.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptKeySpec.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgControl.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgControl.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgControl.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgGetParam.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgGetParam.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgGetParam.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgOpenToDecode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgOpenToDecode.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgOpenToDecode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgOpenToEncode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgOpenToEncode.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgOpenToEncode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgParamType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgParamType.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgParamType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgType.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgUpdate.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgUpdate.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgUpdate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptRc2Version.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptRc2Version.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptRc2Version.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptReleaseContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptReleaseContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptReleaseContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.ErrorCode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.ErrorCode.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.ErrorCode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.MsgControlType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.MsgControlType.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.MsgControlType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.MsgEncodingType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.MsgEncodingType.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.MsgEncodingType.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Heap.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Heap.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.Heap.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.ErrorCode.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.ErrorCode.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.ErrorCode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.Properties.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Properties.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.Properties.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs">
       <Link>Common\Interop\Windows\NCrypt\Interop.NCryptFreeObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- Common types (platform: Windows) -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsPartialFacadeAssembly)' != 'true'">
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Common\Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
   </ItemGroup>
@@ -415,147 +415,147 @@
     <Reference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Oids.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs">
       <Link>Common\System\Security\Cryptography\Oids.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PssParamsAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PssParamsAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\OaepParamsAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\OaepParamsAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\OaepParamsAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\OaepParamsAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\OaepParamsAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\OaepParamsAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\OaepParamsAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</DependentUpon>
     </Compile>
@@ -653,59 +653,59 @@
     <Compile Include="System\Security\Cryptography\Pkcs\SignerInfoEnumerator.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' or '$(TargetFramework)' == 'netstandard2.1'">
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\KeyFormatHelper.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DigestInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DigestInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\MacData.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\PasswordBasedEncryption.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PasswordBasedEncryption.cs">
       <Link>Common\System\Security\Cryptography\PasswordBasedEncryption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Pkcs12Kdf.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs">
       <Link>Common\System\Security\Cryptography\Pkcs12Kdf.cs</Link>
     </Compile>
     <AsnXml Include="System\Security\Cryptography\Pkcs\Asn1\SecretBagAsn.xml" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/System.Security.Cryptography.Pkcs.Tests.csproj
@@ -4,7 +4,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
     <Compile Include="Certificates.cs" />

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
@@ -24,19 +24,19 @@
     <Compile Include="System\Security\Cryptography\PbeEncryptionAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\PbeParameters.cs" />
     <Compile Include="System\Security\Cryptography\SymmetricAlgorithm.cs" />
-    <Compile Include="$(CommonPath)\System\Threading\Tasks\ForceAsyncAwaiter.cs">
+    <Compile Include="$(CommonPath)System\Threading\Tasks\ForceAsyncAwaiter.cs">
       <Link>Common\System\Threading\Tasks\ForceAsyncAwaiter.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeySizeHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeySizeHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Oids.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs">
       <Link>Common\System\Security\Cryptography\Oids.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/System.Security.Cryptography.Primitives.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(CommonTestPath)\Tests.props" />
+  <Import Project="$(CommonTestPath)Tests.props" />
   <PropertyGroup>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\PositionValueStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs">
       <Link>CommonTest\System\IO\PositionValueStream.cs</Link>
     </Compile>
     <Compile Include="AsymmetricAlgorithm\Trivial.cs" />

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -10,28 +10,28 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true' and ('$(TargetsNetStandard)' != 'true' or '$(TargetsWindows)' == 'true')">
     <Compile Include="System\Security\Cryptography\DataProtectionScope.cs" />
     <Compile Include="System\Security\Cryptography\ProtectedData.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptProtectData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptProtectData.cs">
       <Link>Interop\Windows\Crypt32\Interop.CryptProtectData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptUnprotectData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptUnprotectData.cs">
       <Link>Interop\Windows\Crypt32\Interop.CryptUnprotectData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptProtectDataFlags.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptProtectDataFlags.cs">
       <Link>Interop\Windows\Crypt32\Interop.CryptProtectDataFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.DATA_BLOB.cs">
       <Link>Interop\Windows\Crypt32\Interop.DATA_BLOB.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Internal\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProtectedDataTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -6,108 +6,108 @@
     <NoWarn>$(NoWarn);CS3016;CA5379;CA5384;CA5385</NoWarn>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" />
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
     <Compile Include="Internal\Cryptography\ICertificatePal.cs" />
     <Compile Include="Internal\Cryptography\ICertificatePalCore.cs" />
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Oids.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs">
       <Link>Common\System\Security\Cryptography\Oids.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyBlobHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyBlobHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeyBlobHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeySizeHelpers.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs">
       <Link>Common\System\Security\Cryptography\KeySizeHelpers.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\AttributeAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EdiPartyNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\GeneralNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\OtherNameAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PssParamsAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PssParamsAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PssParamsAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SubjectPublicKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
     <Compile Include="Internal\Cryptography\CertificateExtensionsCommon.cs" />
@@ -246,52 +246,52 @@
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.GetCertContentType.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.PublicKey.cs" />
     <Compile Include="Internal\Cryptography\Pal.Windows\X509Pal.X500DistinguishedName.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertCloseStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertNameToStr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertNameToStr.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertNameToStr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptMsgClose.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptMsgClose.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CryptFormatObject.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptFormatObject.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptFormatObject.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.FindOidInfo.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.FindOidInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Internal\Cryptography\Windows\CryptoThrowHelper.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\Windows\CryptoThrowHelper.cs">
       <Link>Common\Internal\Cryptography\Windows\CryptoThrowHelper.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Internal\Windows\kernel32\Interop.FormatMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptDestroyKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyKey.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.BCryptDestroyKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptExportKey.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptExportKey.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.BCryptExportKey.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.BCryptGetProperty.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\BCrypt\Interop.Blobs.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.Blobs.cs">
       <Link>Common\Interop\Windows\BCrypt\Interop.Blobs.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\BCrypt\Interop.NTSTATUS.cs">
       <Link>Interop\Windows\BCrypt\Interop.NTSTATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBCryptKeyHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptKeyHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBCryptKeyHandle.cs</Link>
     </Compile>
   </ItemGroup>
@@ -304,13 +304,13 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointNameAsn.xml.cs">
       <DependentUpon>System\Security\Cryptography\X509Certificates\Asn1\DistributionPointNameAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\KeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\PasswordBasedEncryption.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PasswordBasedEncryption.cs">
       <Link>Common\System\Security\Cryptography\PasswordBasedEncryption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Pkcs12Kdf.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs">
       <Link>Common\System\Security\Cryptography\Pkcs12Kdf.cs</Link>
     </Compile>
     <Compile Include="System\Security\Cryptography\X509Certificates\Asn1\ReasonFlagsAsn.cs" />
@@ -334,7 +334,7 @@
     <Compile Include="Internal\Cryptography\Pal.Unix\StorePal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Pal.cs" />
     <Compile Include="Internal\Cryptography\Pal.Unix\X509Persistence.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -343,61 +343,61 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Permissions.cs">
       <Link>Interop\Unix\System.Native\Interop.Permissions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Encode.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Encode.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Encode.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs12.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs12.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs12.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs7.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs7.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs7.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Rsa.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FChMod.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.FChMod.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.FChMod.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs">
@@ -409,40 +409,40 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Interop\Unix\System.Native\Interop.Stat.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.PooledCrypto.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.PooledCrypto.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.PooledCrypto.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs12Handle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeRsaHandle.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Collections\Generic\ReferenceEqualityComparer.cs">
+    <Compile Include="$(CommonPath)System\Collections\Generic\ReferenceEqualityComparer.cs">
       <Link>Common\System\Collections\Generic\ReferenceEqualityComparer.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\IO\PersistedFiles.Unix.cs">
@@ -453,161 +453,161 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' and '$(IsPartialFacadeAssembly)' != 'true'">
-    <Compile Include="$(CommonPath)\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs">
       <Link>Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Hash.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFArray.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFData.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFDate.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFDate.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFDate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFError.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFString.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Ecc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.Export.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Trust.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Trust.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Trust.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Chain.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Store.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Store.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509Store.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSAKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSAKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\DSAKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\DSASecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\DSASecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\DSASecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\EccKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\EccKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\EccKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\EccSecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\EccSecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\EccSecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\ECDsaSecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\ECDsaSecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\ECDsaSecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\KeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\KeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\PasswordBasedEncryption.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PasswordBasedEncryption.cs">
       <Link>Common\System\Security\Cryptography\PasswordBasedEncryption.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Pkcs12Kdf.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Pkcs12Kdf.cs">
       <Link>Common\System\Security\Cryptography\Pkcs12Kdf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSAKeyFormatHelper.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSAKeyFormatHelper.cs">
       <Link>Common\System\Security\Cryptography\RSAKeyFormatHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RsaPaddingProcessor.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RsaPaddingProcessor.cs">
       <Link>Common\System\Security\Cryptography\RsaPaddingProcessor.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\RSASecurityTransforms.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\RSASecurityTransforms.cs">
       <Link>Common\System\Security\Cryptography\RSASecurityTransforms.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\SecKeyPair.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\SecKeyPair.cs">
       <Link>Common\System\Security\Cryptography\SecKeyPair.cs</Link>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\CurveAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\CurveAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\CurveAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\CurveAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\CurveAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\CurveAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\CurveAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DssParms.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DssParms.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DssParms.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DssParms.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DssParms.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DssParms.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DssParms.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECDomainParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\ECDomainParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\ECDomainParameters.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECPrivateKey.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\ECPrivateKey.xml">
       <Link>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\ECPrivateKey.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\FieldID.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\FieldID.xml">
       <Link>Common\System\Security\Cryptography\Asn1\FieldID.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\FieldID.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\FieldID.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\FieldID.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\FieldID.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\RSAPrivateKeyAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\RSAPublicKeyAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\SpecifiedECDomain.xml">
       <Link>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\SpecifiedECDomain.xml</DependentUpon>
     </Compile>
@@ -626,116 +626,116 @@
     <Compile Include="Internal\Cryptography\Pal.OSX\X509Pal.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DigestInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\DigestInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\DigestInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\CertBagAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\MacData.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\MacData.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\PfxAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs12\SafeBagAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\ContentInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedContentInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Pkcs7\EncryptedDataAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</DependentUpon>
     </Compile>
-    <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</Link>
     </AsnXml>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs">
       <Link>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\Rc2CbcParameters.xml</DependentUpon>
     </Compile>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -6,12 +6,12 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
-    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+    <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs">
       <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
     <Compile Include="Cert.cs" />
@@ -40,7 +40,7 @@
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />
     <Compile Include="X509StoreTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
     <Compile Include="ImportTests.cs" />
@@ -65,7 +65,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' and '$(TargetsOSX)' != 'true' ">
     <Compile Include="X509FilesystemTests.Unix.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
@@ -77,7 +77,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetPwUid.cs">
       <Link>Common\Interop\Unix\Interop.GetPwUid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FChMod.cs">
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.FChMod.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.FChMod.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Permissions.cs">
@@ -96,40 +96,40 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
     <Compile Include="X509StoreMutableTests.OSX.cs" />
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFArray.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFArray.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFArray.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFData.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFData.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFError.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFError.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.CFString.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.CoreFoundation.CFString.cs">
       <Link>Common\Interop\OSX\Interop.CoreFoundation.CFString.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs">
       <Link>Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/libraries/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -18,168 +18,168 @@
     <Compile Include="System\Security\Principal\Win32.cs" />
     <Compile Include="System\Security\Principal\WindowsIdentity.cs" />
     <Compile Include="System\Security\Principal\WindowsPrincipal.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.UNICODE_STRING.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.UNICODE_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.OBJECT_ATTRIBUTES.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.OBJECT_ATTRIBUTES.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.TOKENS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.TOKENS.cs">
       <Link>Common\Interop\Interop.TOKENS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Interop.WinError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.Winnt.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.Winnt.cs">
       <Link>Common\Interop\Interop.Winnt.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\NtDll\Interop.NtStatus.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\NtDll\Interop.NtStatus.cs">
       <Link>Common\Interop\Interop.NtStatus.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LSAStructs.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LSAStructs.cs">
       <Link>Common\Interop\Interop.LSAStructs.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SECURITY_LOGON_SESSION_DATA.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SECURITY_LOGON_SESSION_DATA.cs">
       <Link>Common\Interop\Interop.SECURITY_LOGON_SESSION_DATA.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Interop.GetCurrentProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentThread.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCurrentThread.cs">
       <Link>Common\Interop\Interop.GetCurrentThread.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ClaimSecurityAttributes.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ClaimSecurityAttributes.cs">
       <Link>Common\Interop\Interop.ClaimSecurityAttributes.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenProcessToken_SafeAccessTokenHandle.cs">
       <Link>Common\Interop\Interop.OpenProcessToken.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetTokenInformation.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetTokenInformation.cs">
       <Link>Common\Interop\Interop.GetTokenInformation.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.DuplicateTokenEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DuplicateTokenEx.cs">
       <Link>Common\Interop\Interop.DuplicateTokenEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DuplicateHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle.cs">
       <Link>Common\Interop\Interop.DuplicateHandle.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Common\Interop\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaGetLogonSessionData.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaGetLogonSessionData.cs">
       <Link>Common\Interop\Interop.LsaGetLogonSessionData.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaFreeReturnBuffer.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaFreeReturnBuffer.cs">
       <Link>Common\Interop\Interop.LsaFreeReturnBuffer.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaLookupNames2.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaLookupNames2.cs">
       <Link>Common\Interop\Interop.LsaLookupNames2.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaLookupSids.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaLookupSids.cs">
       <Link>Common\Interop\Interop.LsaLookupSids.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaClose.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaClose.cs">
       <Link>Common\Interop\Interop.LsaClose.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaFreeMemory.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaFreeMemory.cs">
       <Link>Common\Interop\Interop.LsaFreeMemory.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaOpenPolicy.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaOpenPolicy.cs">
       <Link>Common\Interop\Interop.LsaOpenPolicy.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ConvertStringSidToSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ConvertStringSidToSid.cs">
       <Link>Common\Interop\Interop.ConvertStringSidToSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CreateWellKnownSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CreateWellKnownSid.cs">
       <Link>Common\Interop\Interop.CreateWellKnownSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetWindowsAccountDomainSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetWindowsAccountDomainSid.cs">
       <Link>Common\Interop\Interop.GetWindowsAccountDomainSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.IsWellKnownSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.IsWellKnownSid.cs">
       <Link>Common\Interop\Interop.IsWellKnownSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.IsEqualDomainSid.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.IsEqualDomainSid.cs">
       <Link>Common\Interop\Interop.IsEqualDomainSid.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenThreadToken.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenThreadToken.cs">
       <Link>Common\Interop\Interop.OpenThreadToken.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
       <Link>Common\Interop\Interop.RevertToSelf.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ImpersonateLoggedOnUser.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ImpersonateLoggedOnUser.cs">
       <Link>Common\Interop\Interop.ImpersonateLoggedOnUser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LsaNtStatusToWinError.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LsaNtStatusToWinError.cs">
       <Link>Common\Interop\Interop.LsaNtStatusToWinError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.LSA_STRING.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.LSA_STRING.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.LSA_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalFree.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalFree.cs">
       <Link>Common\Interop\Interop.LocalFree.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Interop.LocalAlloc.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.AuthenticationPackageNames.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.AuthenticationPackageNames.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.AuthenticationPackageNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.KerbLogonSubmitType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.KerbLogonSubmitType.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.KerbLogonSubmitType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.KerbS4uLogin.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.KerbS4uLogin.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.KerbS4uLogin.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaConnectUntrusted.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaConnectUntrusted.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.LsaConnectUntrusted.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaDeregisterLogonProcess.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaDeregisterLogonProcess.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.LsaDeregisterLogonProcess.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaLogonUser.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaLogonUser.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.LsaLogonUser.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.LsaLookupAuthenticationPackage.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.LsaLookupAuthenticationPackage.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.LsaLookupAuthenticationPackage.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.QuotaLimits.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.QuotaLimits.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.QuotaLimits.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.SecurityLogonType.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.SecurityLogonType.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.SecurityLogonType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\Interop.TokenSource.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\SspiCli\Interop.TokenSource.cs">
       <Link>Common\Interop\Windows\SspiCli\Interop.TokenSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.AllocateLocallyUniqueId.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.AllocateLocallyUniqueId.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.AllocateLocallyUniqueId.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLsaHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLsaHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaMemoryHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLsaMemoryHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLsaMemoryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaPolicyHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLsaPolicyHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLsaPolicyHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLsaReturnBufferHandle.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLsaReturnBufferHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLsaReturnBufferHandle.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CheckTokenMembership.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CheckTokenMembership.cs">
       <Link>Common\Interop\Interop.CheckTokenMembership.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
+++ b/src/libraries/System.Security.Principal.Windows/tests/System.Security.Principal.Windows.Tests.csproj
@@ -11,7 +11,7 @@
     <Compile Include="WellKnownSidTypeTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>Common\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -10,73 +10,73 @@
     <Compile Include="$(CoreLibSharedDir)System\Text\ValueStringBuilder.cs">
       <Link>System\Text\ValueStringBuilder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs">
       <Link>Common\Interop\Windows\Interop.ServiceProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs">
       <Link>Common\Interop\Windows\Interop.CloseServiceHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ControlService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ControlService.cs">
       <Link>Common\Interop\Windows\Interop.ControlService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EnumDependentServices.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.EnumDependentServices.cs">
       <Link>Common\Interop\Windows\Interop.EnumDependentServices.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EnumServicesStatusEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.EnumServicesStatusEx.cs">
       <Link>Common\Interop\Windows\Interop.EnumServicesStatusEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetServiceDisplayName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetServiceDisplayName.cs">
       <Link>Common\Interop\Windows\Interop.GetServiceDisplayName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.GetServiceKeyName.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.GetServiceKeyName.cs">
       <Link>Common\Interop\Windows\Interop.GetServiceKeyName.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenSCManager.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenSCManager.cs">
       <Link>Common\Interop\Windows\Interop.OpenSCManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenService.cs">
       <Link>Common\Interop\Windows\Interop.OpenService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.QueryServiceConfig.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceConfig.cs">
       <Link>Common\Interop\Windows\Interop.QueryServiceConfig.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.QueryServiceStatus.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceStatus.cs">
       <Link>Common\Interop\Windows\Interop.QueryServiceStatus.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.StartService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.StartService.cs">
       <Link>Common\Interop\Windows\Interop.StartService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ENUM_SERVICE_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ENUM_SERVICE_STATUS.cs">
       <Link>Common\Interop\Windows\Interop.ENUM_SERVICE_STATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ENUM_SERVICE_STATUS_PROCESS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ENUM_SERVICE_STATUS_PROCESS.cs">
       <Link>Common\Interop\Windows\Interop.ENUM_SERVICE_STATUS_PROCESS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.QUERY_SERVICE_CONFIG.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QUERY_SERVICE_CONFIG.cs">
       <Link>Common\Interop\Windows\Interop.QUERY_SERVICE_CONFIG.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SERVICE_STATUS.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_STATUS.cs">
       <Link>Common\Interop\Windows\Interop.SERVICE_STATUS.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SERVICE_TABLE_ENTRY.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_TABLE_ENTRY.cs">
       <Link>Common\Interop\Windows\Interop.SERVICE_TABLE_ENTRY.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SetServiceStatus.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SetServiceStatus.cs">
       <Link>Common\Interop\Windows\Interop.SetServiceStatus.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.WTSSESSION_NOTIFICATION.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.WTSSESSION_NOTIFICATION.cs">
       <Link>Common\Interop\Windows\Interop.WTSSESSION_NOTIFICATION.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.RegisterServiceCtrlHandlerEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RegisterServiceCtrlHandlerEx.cs">
       <Link>Common\Interop\Windows\Interop.RegisterServiceCtrlHandlerEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.StartServiceCtrlDispatcher.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.StartServiceCtrlDispatcher.cs">
       <Link>Common\Interop\Windows\Interop.StartServiceCtrlDispatcher.cs</Link>
     </Compile>
     <Compile Include="Microsoft\Win32\SafeHandles\SafeServiceHandle.cs" />

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/System.ServiceProcess.ServiceController.TestService.csproj
@@ -14,37 +14,37 @@
     <Compile Include="..\..\src\Microsoft\Win32\SafeHandles\SafeServiceHandle.cs">
       <Link>Microsoft\Win32\SafeHandles\SafeServiceHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs">
       <Link>Common\Interop\Windows\Interop.ServiceProcessOptions.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs">
       <Link>Common\Interop\Windows\Interop.CloseServiceHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenSCManager.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenSCManager.cs">
       <Link>Common\Interop\Windows\Interop.OpenSCManager.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.OpenService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenService.cs">
       <Link>Common\Interop\Windows\Interop.OpenService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.CreateService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CreateService.cs">
       <Link>Common\Interop\Windows\Interop.CreateService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SERVICE_DESCRIPTION.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_DESCRIPTION.cs">
       <Link>Common\Interop\Windows\Interop.SERVICE_DESCRIPTION.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ChangeServiceConfig2.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ChangeServiceConfig2.cs">
       <Link>Common\Interop\Windows\Interop.ChangeServiceConfig2.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.SERVICE_DELAYED_AUTOSTART_INFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_DELAYED_AUTOSTART_INFO.cs">
       <Link>Common\Interop\Windows\Interop.SERVICE_DELAYED_AUTOSTART_INFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.DeleteService.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DeleteService.cs">
       <Link>Common\Interop\Windows\Interop.DeleteService.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -30,13 +30,13 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\Text\CodePagesEncodingProvider.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
       <Link>Interop\Windows\Interop.BOOL.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetCPInfoEx.cs">
       <Link>Common\Interop\Windows\Interop.GetCPInfoEx.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs">

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -70,7 +70,7 @@
     <Compile Include="UTF8Encoding\UTF8EncodingGetMaxByteCount.cs" />
     <Compile Include="UTF8Encoding\UTF8EncodingGetMaxCharCount.cs" />
     <Compile Include="UTF8Encoding\UTF8EncodingTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs" />
+    <Compile Include="$(CommonTestPath)System\RandomDataGenerator.cs" />
     <Compile Include="Encoding\Encoding.cs" />
     <Compile Include="UnicodeEncoding\UnicodeEncoding.cs" />
     <Compile Include="Decoder\Decoder.cs" />

--- a/src/libraries/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
+++ b/src/libraries/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
@@ -51,7 +51,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Text\UnicodeUtility.cs">
       <Link>System\Text\UnicodeUtility.cs</Link>
     </Compile>
-    <EmbeddedResource Include="$(CommonTestPath)\Data\UnicodeData.12.1.txt">
+    <EmbeddedResource Include="$(CommonTestPath)Data\UnicodeData.12.1.txt">
       <LogicalName>UnicodeData.12.1.txt</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -172,7 +172,7 @@
   <ItemGroup Condition="'$(TargetsNetStandard)' == 'true' or '$(TargetsNetFx)' == 'true'">
     <Compile Include="System\Collections\Generic\StackExtensions.netstandard.cs" />
     <!-- Common or Common-branched source files -->
-    <Compile Include="$(CommonPath)\System\Buffers\ArrayBufferWriter.cs">
+    <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs">
       <Link>Common\System\Buffers\ArrayBufferWriter.cs</Link>
     </Compile>
     <Reference Include="mscorlib" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\IO\WrappedMemoryStream.cs">
+    <Compile Include="$(CommonTestPath)System\IO\WrappedMemoryStream.cs">
       <Link>CommonTest\System\IO\WrappedMemoryStream.cs</Link>
     </Compile>
     <Compile Include="BitStackTests.cs" />
@@ -115,7 +115,7 @@
     <Compile Include="..\src\System\Text\Json\BitStack.cs" Link="BitStack.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
-    <Compile Include="$(CommonPath)\System\Buffers\ArrayBufferWriter.cs">
+    <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs">
       <Link>CommonTest\System\Buffers\ArrayBufferWriter.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -43,7 +43,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexTree.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexWriter.cs" />
     <!-- Common or Common-branched source files -->
-    <Compile Include="$(CommonPath)\System\NotImplemented.cs">
+    <Compile Include="$(CommonPath)System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.cs">

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -36,7 +36,7 @@
     <Compile Include="PrecompiledRegexScenarioTest.cs" />
     <Compile Include="RegexCompilationInfoTests.cs" />
     <Compile Include="RegexGroupNameTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
+++ b/src/libraries/System.Threading.AccessControl/src/System.Threading.AccessControl.csproj
@@ -10,7 +10,7 @@
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs" Link="Interop\Windows\Kernel32\Interop.MAX_PATH.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetStandard)' == 'true' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs" Link="Interop\Windows\Interop.BOOL.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.Libraries.cs" Link="Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.EventWaitHandle.cs" Link="Interop\Windows\Kernel32\Interop.EventWaitHandle.cs" />

--- a/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -24,8 +24,8 @@
     <Compile Include="System\Threading\Channels\IDebugEnumerator.cs" />
     <Compile Include="System\Threading\Channels\SingleConsumerUnboundedChannel.cs" />
     <Compile Include="System\Threading\Channels\UnboundedChannel.cs" />
-    <Compile Include="$(CommonPath)\Internal\Padding.cs" Link="Common\Internal\Padding.cs" />
-    <Compile Include="$(CommonPath)\System\Collections\Concurrent\SingleProducerConsumerQueue.cs" Link="Common\System\Collections\Concurrent\SingleProducerConsumerQueue.cs" />
+    <Compile Include="$(CommonPath)Internal\Padding.cs" Link="Common\Internal\Padding.cs" />
+    <Compile Include="$(CommonPath)System\Collections\Concurrent\SingleProducerConsumerQueue.cs" Link="Common\System\Collections\Concurrent\SingleProducerConsumerQueue.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
+++ b/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
@@ -13,7 +13,7 @@
     <Compile Include="UnboundedChannelTests.cs" />
     <Compile Include="Stress.cs" />
     <Compile Include="DebugAttributeTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/libraries/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="OverlappedTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -40,7 +40,7 @@
     <Compile Include="Internal\SpscTargetCore.cs" />
     <Compile Include="Internal\TargetCore.cs" />
     <Compile Include="Internal\TargetRegistry.cs" />
-    <Compile Include="$(CommonPath)\Internal\Padding.cs">
+    <Compile Include="$(CommonPath)Internal\Padding.cs">
       <Link>Common\Internal\Padding.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -21,10 +21,10 @@
     <Compile Include="Dataflow\TransformBlockTests.cs" />
     <Compile Include="Dataflow\TransformManyBlockTests.cs" />
     <Compile Include="Dataflow\WriteOnceBlockTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\DebuggerAttributes.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs">
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
@@ -8,10 +8,10 @@
     <Compile Include="AsyncValueTaskMethodBuilderTests.cs" />
     <Compile Include="ManualResetValueTaskSourceTests.cs" />
     <Compile Include="ValueTaskTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs">
       <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs">
       <Link>Common\System\Threading\Tasks\Sources\ManualResetValueTaskSourceFactory.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -7,7 +7,7 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
     <Compile Include="BreakTests.cs" />
@@ -25,7 +25,7 @@
     <Compile Include="RangePartitionerThreadSafetyTests.cs" />
     <Compile Include="RespectParentCancellationTest.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadPoolHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -45,10 +45,10 @@
     <Compile Include="System.Runtime.CompilerServices\TaskAwaiterTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\YieldAwaitableTests.cs" />
     <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadPoolHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
     <Compile Include="Task\TaskDisposeTests.cs" />
@@ -60,7 +60,7 @@
     <Compile Include="System.Runtime.CompilerServices\AsyncTaskMethodBuilderTests.netcoreapp.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredAsyncDisposable.netcoreapp.cs" />
     <Compile Include="System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.netcoreapp.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
+++ b/src/libraries/System.Threading.Thread/tests/System.Threading.Thread.Tests.csproj
@@ -13,7 +13,7 @@
     <Compile Include="ThreadTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
     <ProjectReference Include="STAMain\STAMain.csproj" />

--- a/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
+++ b/src/libraries/System.Threading.ThreadPool/tests/System.Threading.ThreadPool.Tests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="ThreadPoolTests.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
+++ b/src/libraries/System.Threading.Timer/tests/System.Threading.Timer.Tests.csproj
@@ -10,7 +10,7 @@
     <Compile Include="TimerFiringTests.cs" />
     <Compile Include="TimerDisposeTests.cs" />
     <Compile Include="TimerMetricsTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading/src/System.Threading.csproj
+++ b/src/libraries/System.Threading/src/System.Threading.csproj
@@ -14,7 +14,7 @@
     <Compile Include="System\Threading\HostExecutionContextManager.cs" />
     <Compile Include="System\Threading\LockCookie.cs" />
     <Compile Include="System\Threading\ReaderWriterLock.cs" />
-    <Compile Include="$(CommonPath)\System\HResults.cs">
+    <Compile Include="$(CommonPath)System\HResults.cs">
       <Link>Common\System\HResults.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/libraries/System.Threading/tests/System.Threading.Tests.csproj
@@ -35,10 +35,10 @@
     <Compile Include="XunitAssemblyAttributes.cs" />
     <Compile Include="ExecutionContextTests.cs" />
     <Compile Include="SynchronizationContextTests.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+    <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs">
       <Link>CommonTest\System\Diagnostics\Tracing\TestEventListener.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\ThreadTestHelpers.cs">
+    <Compile Include="$(CommonTestPath)System\Threading\ThreadTestHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadTestHelpers.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -5,55 +5,55 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netcoreapp3.0-Windows_NT-Debug;netcoreapp3.0-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertAddCertificateLinkToStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertAddCertificateLinkToStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertAddCertificateLinkToStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertCloseStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertCloseStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertDuplicateCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertDuplicateCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertDuplicateCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore_IntPtr.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore_IntPtr.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertEnumCertificatesInStore_IntPtr.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertFreeCertificateContext.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Crypt32\Interop.CertOpenStore.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CertOpenStore.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CertOpenStore.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\CryptUI\Interop.CryptUIDlgCertificate.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\CryptUI\Interop.CryptUIDlgCertificate.cs">
       <Link>Common\Interop\Windows\Crypt32\Interop.CryptUIDlgCertificate.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.MessageBeep.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\User32\Interop.MessageBeep.cs">
       <Link>Common\Interop\Windows\User32\Interop.MessageBeep.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.MMCKINFO.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.MMCKINFO.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.MMCKINFO.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.mmioAscend.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.mmioAscend.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.mmioAscend.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.mmioClose.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.mmioClose.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.mmioClose.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.mmioDescend.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.mmioDescend.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.mmioDescend.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.mmioRead.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.mmioRead.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.mmioRead.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.mmioOpen.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.mmioOpen.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.mmioOpen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\WinMm\Interop.PlaySound.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\WinMm\Interop.PlaySound.cs">
       <Link>Common\Interop\Windows\WinMm\Interop.PlaySound.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs</Link>
     </Compile>
     <Compile Include="System\Security\Cryptography\X509Certificates\X509Certificate2UI.cs" />

--- a/src/libraries/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/libraries/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -8,7 +8,7 @@
     <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">
+    <Compile Include="$(CommonTestPath)System\Drawing\Helpers.cs">
       <Link>Common\System\Drawing\Helpers.cs</Link>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
It is easier to review per commit. 

1st commit fixes test build.
2nd commit updates `CommonPath` and `CommonTestPath` properties to use `NormalizeDirectory`.
3rd commit reacts to usage of `NormalizeDirectory` as it contains a trailing `\` (this to be consistent with all our path properties).