### PR TITLE
Fix system IO ports native dependency for package testing

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -24,9 +24,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>8743c312a9d1ce4035140046d44bb959c44f194f</Sha>
     </Dependency>
-    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19563.6">
+    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19563.3">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
+      <Sha>cf64918877d98577363bb40d5eafac52beb80a79</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19563.3">
       <Uri>https://github.com/dotnet/coreclr</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,7 @@
     <MicrosoftNETCoreTargetsVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreTargetsVersion>
     <SystemTextJsonVersion>5.0.0-alpha.1.19563.6</SystemTextJsonVersion>
     <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19563.6</SystemTextEncodingsWebVersion>
-    <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19563.6</runtimenativeSystemIOPortsVersion>
+    <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19563.3</runtimenativeSystemIOPortsVersion>
     <!-- Standard dependencies -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19563.1</NETStandardLibraryVersion>
     <!-- dotnet-optimization dependencies -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/63

We can't update this version until we produce a new package from the runtime repository. 

For package testing we depend on a static version of runtime.native.System.IO.Ports package which is gotten through the version in Versions.props updated by BAR. The problem is that we're depending on a version which contains the freebsd RID in it's dependencies since that was the last BAR update we got from corefx and we're no longer updating that version. So I downgraded it and it is fixed.