### PR TITLE
WIP: Run tests sequentially by default

### DIFF
--- a/src/coreclr/tests/src/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/src/helixpublishwitharcade.proj
@@ -182,9 +182,7 @@
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-    <_XUnitParallelMode>collections</_XUnitParallelMode>
-    <_XUnitParallelMode Condition=" '$(LongRunningGCTests)' == 'true' ">none</_XUnitParallelMode>
-    <_XUnitParallelMode Condition=" '$(GcSimulatorTests)' == 'true' ">none</_XUnitParallelMode>
+    <_XUnitParallelMode>none</_XUnitParallelMode>
     <XUnitRunnerArgs>-parallel $(_XUnitParallelMode) -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
   </PropertyGroup>
 

--- a/src/coreclr/tests/tests.targets
+++ b/src/coreclr/tests/tests.targets
@@ -43,7 +43,8 @@
     <PropertyGroup>
       <XunitConsoleRunner>$(CORE_ROOT)\xunit.console.dll</XunitConsoleRunner>
 
-      <XunitArgs>-parallel $(ParallelRun)</XunitArgs>
+      <!-- Xunit has a concurrency bug manifesting as COR_E_INVALIDOPERATION on random Xunit wrapper assemblies -->
+      <XunitArgs>-parallel none</XunitArgs>
       <XunitArgs>$(XunitArgs) -html $(__TestRunHtmlLog)</XunitArgs>
       <XunitArgs>$(XunitArgs) -xml $(__TestRunXmlLog)</XunitArgs>
       <XunitArgs>$(XunitArgs) @(IncludeTraitsItems->'-trait %(Identity)', ' ')</XunitArgs>


### PR DESCRIPTION
It turns out that the stock Xunit runner has a parallelism bug
we were previously working around by using a custom version with
Egor's fix. After we migrated CoreCLR to the combined
dotnet/runtime repo and switched over to a common Xunit runner,
this popped up as non-deterministic failures in Linux runs.
Based on Stephen Toub's suggestion I'm proposing to switch
the runner over to run tests sequentially by default - the
perf penalty should be low and in fact this might even make some
of the tests more stable.

Thanks

Tomas