### PR TITLE
Allow passing down an upper case subset category

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -18,6 +18,7 @@ Param(
 function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -subset                 Build a subset, print availabe subsets with -subset help"
+  Write-Host "  -subsetCategory         Build a subsetCategory, print availabe subsetCategories with -subset help"
   Write-Host "  -os                     Build operating system: Windows_NT or Unix"
   Write-Host "  -arch                   Build platform: x86, x64, arm or arm64"
   Write-Host "  -configuration <value>  Build configuration: Debug or Release (short: -c)"
@@ -54,6 +55,8 @@ function Get-Help() {
 if ($MyInvocation.InvocationName -eq ".") {
   exit 0
 }
+
+$subsetCategory = $subsetCategory.ToLowerInvariant()
 
 # VS Test Explorer support for libraries
 if ($vs -and $subsetCategory -eq "libraries") {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -16,6 +16,7 @@ usage()
 {
   echo "Common settings:"
   echo "  --subset                   Build a subset, print availabe subsets with -subset help"
+  echo "  --subsetCategory         Build a subsetCategory, print availabe subsetCategories with -subset help"
   echo "  --os                       Build operating system: Windows_NT or Unix"
   echo "  --arch                     Build platform: x86, x64, arm or arm64"
   echo "  --configuration <value>    Build configuration: Debug or Release (short: -c)"
@@ -64,8 +65,8 @@ while [[ $# > 0 ]]; do
       exit 0
       ;;
      -subsetcategory)
-      subsetCategory=$2
-      arguments="$arguments /p:SubsetCategory=$2"
+      subsetCategory="$(echo "$2" | awk '{print tolower($0)}')"
+      arguments="$arguments /p:SubsetCategory=$subsetCategory"
       shift 2
       ;;
      -subset)


### PR DESCRIPTION
Without this when passing down the `Libraries` subset category on upper case it won't work as expected as we would append the actions twice if their passed in:

```
PS E:\repos\runtime> .\build.cmd -subsetCategory Libraries -build -restore -buildtests
E:\repos\runtime\eng\common\build.ps1 : Cannot bind parameter because parameter 'build' is specified more than once. To provide multiple values to parameters that can accept multiple values, use the array syntax. For example, "-parameter value1,value2,value3".
At line:1 char:79
+ ... /common/build.ps1" -restore -build /p:subsetCategory=Libraries -build /p:Buil ...
+ ~~~~~~
+ CategoryInfo : InvalidArgument: (:) [build.ps1], ParameterBindingException
+ FullyQualifiedErrorId : ParameterAlreadyBound,build.ps1
```