### PR TITLE
Improve Regex performance (in particular RegexOptions.Compiled)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
@@ -6,32 +6,21 @@ namespace System.Text.RegularExpressions
 {
     internal sealed class CompiledRegexRunner : RegexRunner
     {
-        private Action<RegexRunner>? _goMethod;
-        private Func<RegexRunner, bool>? _findFirstCharMethod;
-        private Action<RegexRunner>? _initTrackCountMethod;
+        private readonly Action<RegexRunner> _goMethod;
+        private readonly Func<RegexRunner, bool> _findFirstCharMethod;
+        private readonly Action<RegexRunner> _initTrackCountMethod;
 
-        public CompiledRegexRunner() { }
-
-        public void SetDelegates(Action<RegexRunner> go, Func<RegexRunner, bool> firstChar, Action<RegexRunner> trackCount)
+        public CompiledRegexRunner(Action<RegexRunner> go, Func<RegexRunner, bool> firstChar, Action<RegexRunner> trackCount)
         {
             _goMethod = go;
             _findFirstCharMethod = firstChar;
             _initTrackCountMethod = trackCount;
         }
 
-        protected override void Go()
-        {
-            _goMethod!(this);
-        }
+        protected override void Go() => _goMethod(this);
 
-        protected override bool FindFirstChar()
-        {
-            return _findFirstCharMethod!(this);
-        }
+        protected override bool FindFirstChar() => _findFirstCharMethod(this);
 
-        protected override void InitTrackCount()
-        {
-            _initTrackCountMethod!(this);
-        }
+        protected override void InitTrackCount() => _initTrackCountMethod(this);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
@@ -5,27 +5,21 @@
 // This is the only concrete implementation of RegexRunnerFactory,
 // but we cannot combine them due to RegexRunnerFactory having shipped public.
 
-using System.Reflection.Emit;
-
 namespace System.Text.RegularExpressions
 {
     internal sealed class CompiledRegexRunnerFactory : RegexRunnerFactory
     {
-        private readonly DynamicMethod _goMethod;
-        private readonly DynamicMethod _findFirstCharMethod;
-        private readonly DynamicMethod _initTrackCountMethod;
+        private readonly Action<RegexRunner> _go;
+        private readonly Func<RegexRunner, bool> _findFirstChar;
+        private readonly Action<RegexRunner> _initTrackCount;
 
-        public CompiledRegexRunnerFactory(DynamicMethod go, DynamicMethod findFirstChar, DynamicMethod initTrackCount)
+        public CompiledRegexRunnerFactory(Action<RegexRunner> go, Func<RegexRunner, bool> findFirstChar, Action<RegexRunner> initTrackCount)
         {
-            _goMethod = go;
-            _findFirstCharMethod = findFirstChar;
-            _initTrackCountMethod = initTrackCount;
+            _go = go;
+            _findFirstChar = findFirstChar;
+            _initTrackCount = initTrackCount;
         }
 
-        protected internal override RegexRunner CreateInstance() =>
-            new CompiledRegexRunner(
-                (Action<RegexRunner>)_goMethod.CreateDelegate(typeof(Action<RegexRunner>)),
-                (Func<RegexRunner, bool>)_findFirstCharMethod.CreateDelegate(typeof(Func<RegexRunner, bool>)),
-                (Action<RegexRunner>)_initTrackCountMethod.CreateDelegate(typeof(Action<RegexRunner>)));
+        protected internal override RegexRunner CreateInstance() => new CompiledRegexRunner(_go, _findFirstChar, _initTrackCount);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
@@ -15,21 +15,17 @@ namespace System.Text.RegularExpressions
         private readonly DynamicMethod _findFirstCharMethod;
         private readonly DynamicMethod _initTrackCountMethod;
 
-        public CompiledRegexRunnerFactory(DynamicMethod go, DynamicMethod firstChar, DynamicMethod trackCount)
+        public CompiledRegexRunnerFactory(DynamicMethod go, DynamicMethod findFirstChar, DynamicMethod initTrackCount)
         {
             _goMethod = go;
-            _findFirstCharMethod = firstChar;
-            _initTrackCountMethod = trackCount;
+            _findFirstCharMethod = findFirstChar;
+            _initTrackCountMethod = initTrackCount;
         }
 
-        protected internal override RegexRunner CreateInstance()
-        {
-            CompiledRegexRunner runner = new CompiledRegexRunner();
-            runner.SetDelegates((Action<RegexRunner>)_goMethod.CreateDelegate(typeof(Action<RegexRunner>)),
-                                (Func<RegexRunner, bool>)_findFirstCharMethod.CreateDelegate(typeof(Func<RegexRunner, bool>)),
-                                (Action<RegexRunner>)_initTrackCountMethod.CreateDelegate(typeof(Action<RegexRunner>)));
-
-            return runner;
-        }
+        protected internal override RegexRunner CreateInstance() =>
+            new CompiledRegexRunner(
+                (Action<RegexRunner>)_goMethod.CreateDelegate(typeof(Action<RegexRunner>)),
+                (Func<RegexRunner, bool>)_findFirstCharMethod.CreateDelegate(typeof(Func<RegexRunner, bool>)),
+                (Action<RegexRunner>)_initTrackCountMethod.CreateDelegate(typeof(Action<RegexRunner>)));
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -129,8 +129,7 @@ namespace System.Text.RegularExpressions
             // Gets the weakly cached replacement helper or creates one if there isn't one already.
             RegexReplacement repl = RegexReplacement.GetOrCreate(_regex._replref!, replacement, _regex.caps!, _regex.capsize,
                 _regex.capnames!, _regex.roptions);
-            Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
-            var vsb = new ValueStringBuilder(charInitSpan);
+            var vsb = new ValueStringBuilder(stackalloc char[ReplaceBufferSize]);
 
             repl.ReplacementImpl(ref vsb, this);
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -73,7 +73,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static Match Empty { get; } = new Match(null, 1, string.Empty, 0, 0, 0);
 
-        internal virtual void Reset(Regex regex, string text, int textbeg, int textend, int textstart)
+        internal void Reset(Regex regex, string text, int textbeg, int textend, int textstart)
         {
             _regex = regex;
             Text = text;
@@ -137,7 +137,7 @@ namespace System.Text.RegularExpressions
             return vsb.ToString();
         }
 
-        internal virtual ReadOnlySpan<char> GroupToStringImpl(int groupnum)
+        internal ReadOnlySpan<char> GroupToStringImpl(int groupnum)
         {
             int c = _matchcount[groupnum];
             if (c == 0)
@@ -180,7 +180,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Adds a capture to the group specified by "cap"
         /// </summary>
-        internal virtual void AddMatch(int cap, int start, int len)
+        internal void AddMatch(int cap, int start, int len)
         {
             int capcount;
 
@@ -210,7 +210,7 @@ namespace System.Text.RegularExpressions
            If there were no such thing as backtracking, this would be as simple as calling RemoveMatch(cap).
            However, since we have backtracking, we need to keep track of everything.
          */
-        internal virtual void BalanceMatch(int cap)
+        internal void BalanceMatch(int cap)
         {
             _balancing = true;
 
@@ -236,7 +236,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Removes a group match by capnum
         /// </summary>
-        internal virtual void RemoveMatch(int cap)
+        internal void RemoveMatch(int cap)
         {
             _matchcount[cap]--;
         }
@@ -244,7 +244,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Tells if a group was matched by capnum
         /// </summary>
-        internal virtual bool IsMatched(int cap)
+        internal bool IsMatched(int cap)
         {
             return cap < _matchcount.Length && _matchcount[cap] > 0 && _matches[cap][_matchcount[cap] * 2 - 1] != (-3 + 1);
         }
@@ -252,7 +252,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns the index of the last specified matched group by capnum
         /// </summary>
-        internal virtual int MatchIndex(int cap)
+        internal int MatchIndex(int cap)
         {
             int i = _matches[cap][_matchcount[cap] * 2 - 2];
             if (i >= 0)
@@ -264,7 +264,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Returns the length of the last specified matched group by capnum
         /// </summary>
-        internal virtual int MatchLength(int cap)
+        internal int MatchLength(int cap)
         {
             int i = _matches[cap][_matchcount[cap] * 2 - 1];
             if (i >= 0)
@@ -276,7 +276,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Tidy the match so that it can be used as an immutable result
         /// </summary>
-        internal virtual void Tidy(int textpos)
+        internal void Tidy(int textpos)
         {
             int[] interval = _matches[0];
             Index = interval[0];

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace System.Text.RegularExpressions
 {
@@ -218,13 +219,15 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Used as a key for CacheCodeEntry
         /// </summary>
+        [StructLayout(LayoutKind.Auto)]
         internal readonly struct CachedCodeEntryKey : IEquatable<CachedCodeEntryKey>
         {
             private readonly RegexOptions _options;
             private readonly string _cultureKey;
             private readonly string _pattern;
+            private readonly bool _hasTimeout;
 
-            public CachedCodeEntryKey(RegexOptions options, string cultureKey, string pattern)
+            public CachedCodeEntryKey(RegexOptions options, string cultureKey, string pattern, bool hasTimeout)
             {
                 SysDebug.Assert(cultureKey != null, "Culture must be provided");
                 SysDebug.Assert(pattern != null, "Pattern must be provided");
@@ -232,32 +235,29 @@ namespace System.Text.RegularExpressions
                 _options = options;
                 _cultureKey = cultureKey;
                 _pattern = pattern;
+                _hasTimeout = hasTimeout;
             }
 
-            public override bool Equals(object? obj)
-            {
-                return obj is CachedCodeEntryKey && Equals((CachedCodeEntryKey)obj);
-            }
+            public override bool Equals(object? obj) =>
+                obj is CachedCodeEntryKey other && Equals(other);
 
-            public bool Equals(CachedCodeEntryKey other)
-            {
-                return _pattern.Equals(other._pattern) && _options == other._options && _cultureKey.Equals(other._cultureKey);
-            }
+            public bool Equals(CachedCodeEntryKey other) =>
+                _pattern.Equals(other._pattern) &&
+                _options == other._options &&
+                _cultureKey.Equals(other._cultureKey) &&
+                _hasTimeout == other._hasTimeout;
 
-            public static bool operator ==(CachedCodeEntryKey left, CachedCodeEntryKey right)
-            {
-                return left.Equals(right);
-            }
+            public static bool operator ==(CachedCodeEntryKey left, CachedCodeEntryKey right) =>
+                left.Equals(right);
 
-            public static bool operator !=(CachedCodeEntryKey left, CachedCodeEntryKey right)
-            {
-                return !left.Equals(right);
-            }
+            public static bool operator !=(CachedCodeEntryKey left, CachedCodeEntryKey right) =>
+                !left.Equals(right);
 
-            public override int GetHashCode()
-            {
-                return ((int)_options) ^ _cultureKey.GetHashCode() ^ _pattern.GetHashCode();
-            }
+            public override int GetHashCode() =>
+                ((int)_options) ^
+                _cultureKey.GetHashCode() ^
+                _pattern.GetHashCode() ^
+                Convert.ToInt32(_hasTimeout);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -161,8 +161,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                Span<char> charInitSpan = stackalloc char[ReplaceBufferSize];
-                var vsb = new ValueStringBuilder(charInitSpan);
+                var vsb = new ValueStringBuilder(stackalloc char[ReplaceBufferSize]);
 
                 if (!regex.RightToLeft)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -18,11 +18,10 @@ namespace System.Text.RegularExpressions
         // InfiniteMatchTimeout specifies that match timeout is switched OFF. It allows for faster code paths
         // compared to simply having a very large timeout.
         // We do not want to ask users to use System.Threading.Timeout.InfiniteTimeSpan as a parameter because:
-        //   (1) We do not want to imply any relation between having using a RegEx timeout and using multi-threading.
+        //   (1) We do not want to imply any relation between using a Regx timeout and using multi-threading.
         //   (2) We do not want to require users to take ref to a contract assembly for threading just to use RegEx.
-        //       There may in theory be a SKU that has RegEx, but no multithreading.
-        // We create a public Regex.InfiniteMatchTimeout constant, which for consistency uses the save underlying
-        // value as Timeout.InfiniteTimeSpan creating an implementation detail dependency only.
+        // We create a public Regex.InfiniteMatchTimeout constant, which for consistency uses the same underlying
+        // value as Timeout.InfiniteTimeSpan, creating an implementation detail dependency only.
         public static readonly TimeSpan InfiniteMatchTimeout = Timeout.InfiniteTimeSpan;
 
         // DefaultMatchTimeout specifies the match timeout to use if no other timeout was specified

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -305,18 +305,15 @@ namespace System.Text.RegularExpressions
 
             if (capslist == null)
             {
-                int max = capsize;
-                result = new string[max];
-
-                for (int i = 0; i < max; i++)
+                result = new string[capsize];
+                for (int i = 0; i < result.Length; i++)
                 {
-                    result[i] = Convert.ToString(i, CultureInfo.InvariantCulture);
+                    result[i] = i.ToString();
                 }
             }
             else
             {
-                result = new string[capslist.Length];
-                Array.Copy(capslist, result, capslist.Length);
+                result = capslist.AsSpan().ToArray();
             }
 
             return result;
@@ -375,7 +372,7 @@ namespace System.Text.RegularExpressions
             if (capslist == null)
             {
                 if (i >= 0 && i < capsize)
-                    return i.ToString(CultureInfo.InvariantCulture);
+                    return i.ToString();
 
                 return string.Empty;
             }
@@ -469,10 +466,9 @@ namespace System.Text.RegularExpressions
             if (runner == null)
             {
                 // Use the compiled RegexRunner factory if the code was compiled to MSIL
-                if (factory != null)
-                    runner = factory.CreateInstance();
-                else
-                    runner = new RegexInterpreter(_code!, UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
+                runner = factory != null ?
+                    factory.CreateInstance() :
+                    new RegexInterpreter(_code!, UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
             }
 
             Match? match;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -14,6 +14,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 #endif
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace System.Text.RegularExpressions
 {
@@ -115,8 +116,8 @@ namespace System.Text.RegularExpressions
             CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ?
                 CultureInfo.InvariantCulture :
                 CultureInfo.CurrentCulture;
-            var key = new CachedCodeEntryKey(options, culture.ToString(), pattern);
-            CachedCodeEntry? cached = GetCachedCode(key, false);
+            var key = new CachedCodeEntryKey(options, culture.ToString(), pattern, matchTimeout != InfiniteMatchTimeout);
+            CachedCodeEntry? cached = GetCachedCode(key, isToAdd: false);
 
             if (cached == null)
             {
@@ -165,7 +166,7 @@ namespace System.Text.RegularExpressions
             // if the compile option is set, then compile the code if it's not already
             if (UseOptionC() && factory == null)
             {
-                factory = Compile(_code!, roptions);
+                factory = Compile(_code!, roptions, matchTimeout != InfiniteMatchTimeout);
 
                 if (addToCache && cached != null)
                 {
@@ -222,9 +223,9 @@ namespace System.Text.RegularExpressions
         /// instantiating a non-compiled regex.
         /// </summary>
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        private RegexRunnerFactory Compile(RegexCode code, RegexOptions roptions)
+        private RegexRunnerFactory Compile(RegexCode code, RegexOptions roptions, bool hasTimeout)
         {
-            return RegexCompiler.Compile(code!, roptions);
+            return RegexCompiler.Compile(code!, roptions, hasTimeout);
         }
 #endif
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -29,10 +29,10 @@ namespace System.Text.RegularExpressions
     internal sealed class RegexCharClass
     {
         // Constants
-        private const int FLAGS = 0;
-        private const int SETLENGTH = 1;
-        private const int CATEGORYLENGTH = 2;
-        private const int SETSTART = 3;
+        internal const int FLAGS = 0;
+        internal const int SETLENGTH = 1;
+        internal const int CATEGORYLENGTH = 2;
+        internal const int SETSTART = 3;
 
         private const string NullCharString = "\0";
         private const char NullChar = '\0';
@@ -72,7 +72,6 @@ namespace System.Text.RegularExpressions
         internal const string NotECMADigitClass = "\x01\x02\x00" + ECMADigitSet;
 
         internal const string AnyClass = "\x00\x01\x00\x00";
-        internal const string EmptyClass = "\x00\x00\x00";
 
         // UnicodeCategory is zero based, so we add one to each value and subtract it off later
         private const int DefinedCategoriesCapacity = 38;
@@ -756,12 +755,12 @@ namespace System.Text.RegularExpressions
                 return false;
         }
 
-        private static bool IsSubtraction(string charClass)
+        internal static bool IsSubtraction(string charClass)
         {
             return (charClass.Length > SETSTART + charClass[SETLENGTH] + charClass[CATEGORYLENGTH]);
         }
 
-        private static bool IsNegated(string set)
+        internal static bool IsNegated(string set)
         {
             return (set != null && set[FLAGS] == 1);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -889,7 +889,7 @@ namespace System.Text.RegularExpressions
 
         private static bool CharInCategory(char ch, string set, int start, int mySetLength, int myCategoryLength)
         {
-            UnicodeCategory chcategory = CharUnicodeInfo.GetUnicodeCategory(ch);
+            UnicodeCategory chcategory = char.GetUnicodeCategory(ch);
 
             int i = start + SETSTART + mySetLength;
             int end = i + myCategoryLength;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1070,9 +1070,8 @@ namespace System.Text.RegularExpressions
             int rangeLen = _rangelist.Count * 2;
             int strGuessCount = rangeLen + categoriesLength + 3;
 
-            Span<char> buffer = strGuessCount <= 256 ? stackalloc char[256] : null;
-            ValueStringBuilder vsb = buffer != null ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder vsb = strGuessCount <= 256 ?
+                new ValueStringBuilder(stackalloc char[256]) :
                 new ValueStringBuilder(strGuessCount);
 
             int flags = _negate ? 1 : 0;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// The RegexCompiler class is internal to the Regex package.
-// It translates a block of RegexCode to MSIL, and creates a
-// subclass of the RegexRunner type.
-
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -14,19 +10,12 @@ using System.Runtime.InteropServices;
 
 namespace System.Text.RegularExpressions
 {
-    /*
-     * RegexDynamicModule
-     *
-     * Because dynamic modules are expensive and not thread-safe, we create
-     * one dynamic module per-thread, and cache as much information about it
-     * as we can.
-     *
-     * While we're at it, we just create one RegexCompiler per thread
-     * as well, and have RegexCompiler inherit from RegexDynamicModule.
-     */
+    /// <summary>
+    /// RegexCompiler translates a block of RegexCode to MSIL, and creates a
+    /// subclass of the RegexRunner type.
+    /// </summary>
     internal abstract class RegexCompiler
     {
-        // fields that never change
         private static readonly FieldInfo s_textbegF = RegexRunnerField("runtextbeg");
         private static readonly FieldInfo s_textendF = RegexRunnerField("runtextend");
         private static readonly FieldInfo s_textstartF = RegexRunnerField("runtextstart");
@@ -78,68 +67,59 @@ namespace System.Text.RegularExpressions
         private LocalBuilder? _cultureV;      // current culture is cached in local variable to prevent many thread local storage accesses for CultureInfo.CurrentCulture
         private LocalBuilder? _loopV;         // counter for setrep and setloop
 
-        protected RegexCode? _code;              // the RegexCode object (used for debugging only)
-        protected int[]? _codes;             // the RegexCodes being translated
-        protected string[]? _strings;           // the stringtable associated with the RegexCodes
-        protected RegexPrefix? _fcPrefix;          // the possible first chars computed by RegexFCD
-        protected RegexBoyerMoore? _bmPrefix;          // a prefix as a boyer-moore machine
-        protected int _anchors;           // the set of anchors
-        protected bool _hasTimeout; // whether the regex has a non-infinite timeout
+        protected RegexCode? _code;           // the RegexCode object (used for debugging only)
+        protected int[]? _codes;              // the RegexCodes being translated
+        protected string[]? _strings;         // the stringtable associated with the RegexCodes
+        protected RegexPrefix? _fcPrefix;     // the possible first chars computed by RegexFCD
+        protected RegexBoyerMoore? _bmPrefix; // a prefix as a boyer-moore machine
+        protected int _anchors;               // the set of anchors
+        protected bool _hasTimeout;           // whether the regex has a non-infinite timeout
 
-        private Label[]? _labels;            // a label for every operation in _codes
-        private BacktrackNote[]? _notes;             // a list of the backtracking states to be generated
-        private int _notecount;         // true count of _notes (allocation grows exponentially)
-        protected int _trackcount;        // count of backtracking states (used to reduce allocations)
+        private Label[]? _labels;             // a label for every operation in _codes
+        private BacktrackNote[]? _notes;      // a list of the backtracking states to be generated
+        private int _notecount;               // true count of _notes (allocation grows exponentially)
+        protected int _trackcount;            // count of backtracking states (used to reduce allocations)
 
-        private Label _backtrack;         // label for backtracking
+        private Label _backtrack;             // label for backtracking
 
 
-        private int _regexopcode;       // the current opcode being processed
-        private int _codepos;           // the current code being translated
-        private int _backpos;           // the current backtrack-note being translated
+        private int _regexopcode;             // the current opcode being processed
+        private int _codepos;                 // the current code being translated
+        private int _backpos;                 // the current backtrack-note being translated
 
-        protected RegexOptions _options;           // options
+        protected RegexOptions _options;      // options
 
         // special code fragments
-        private int[]? _uniquenote;        // _notes indices for code that should be emitted <= once
-        private int[]? _goto;              // indices for forward-jumps-through-switch (for allocations)
+        private int[]? _uniquenote;           // _notes indices for code that should be emitted <= once
+        private int[]? _goto;                 // indices for forward-jumps-through-switch (for allocations)
 
         // indices for unique code fragments
-        private const int Stackpop = 0;    // pop one
-        private const int Stackpop2 = 1;    // pop two
-        private const int Capback = 3;    // uncapture
-        private const int Capback2 = 4;    // uncapture 2
-        private const int Branchmarkback2 = 5;    // back2 part of branchmark
-        private const int Lazybranchmarkback2 = 6;    // back2 part of lazybranchmark
-        private const int Branchcountback2 = 7;    // back2 part of branchcount
-        private const int Lazybranchcountback2 = 8;    // back2 part of lazybranchcount
-        private const int Forejumpback = 9;    // back part of forejump
+        private const int Stackpop = 0;       // pop one
+        private const int Stackpop2 = 1;      // pop two
+        private const int Capback = 3;        // uncapture
+        private const int Capback2 = 4;       // uncapture 2
+        private const int Branchmarkback2 = 5;      // back2 part of branchmark
+        private const int Lazybranchmarkback2 = 6;  // back2 part of lazybranchmark
+        private const int Branchcountback2 = 7;     // back2 part of branchcount
+        private const int Lazybranchcountback2 = 8; // back2 part of lazybranchcount
+        private const int Forejumpback = 9;         // back part of forejump
         private const int Uniquecount = 10;
         private const int LoopTimeoutCheckCount = 2048; // A conservative value to guarantee the correct timeout handling.
 
-        private static FieldInfo RegexRunnerField(string fieldname)
-        {
-            return typeof(RegexRunner).GetField(fieldname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
-        }
+        private static FieldInfo RegexRunnerField(string fieldname) => typeof(RegexRunner).GetField(fieldname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
 
-        private static MethodInfo RegexRunnerMethod(string methname)
-        {
-            return typeof(RegexRunner).GetMethod(methname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
-        }
+        private static MethodInfo RegexRunnerMethod(string methname) => typeof(RegexRunner).GetMethod(methname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
 
-        /*
-         * Entry point to dynamically compile a regular expression.  The expression is compiled to
-         * an in-memory assembly.
-         */
-        internal static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout)
-        {
-            return new RegexLWCGCompiler().FactoryInstanceFromCode(code, options, hasTimeout);
-        }
+        /// <summary>
+        /// Entry point to dynamically compile a regular expression.  The expression is compiled to
+        /// an in-memory assembly.
+        /// </summary>
+        internal static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout) => new RegexLWCGCompiler().FactoryInstanceFromCode(code, options, hasTimeout);
 
-        /*
-         * Keeps track of an operation that needs to be referenced in the backtrack-jump
-         * switch table, and that needs backtracking code to be emitted (if flags != 0)
-         */
+        /// <summary>
+        /// Keeps track of an operation that needs to be referenced in the backtrack-jump
+        /// switch table, and that needs backtracking code to be emitted (if flags != 0)
+        /// </summary>
         private sealed class BacktrackNote
         {
             internal int _codepos;
@@ -154,17 +134,19 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Adds a backtrack note to the list of them, and returns the index of the new
-         * note (which is also the index for the jump used by the switch table)
-         */
+        /// <summary>
+        /// Adds a backtrack note to the list of them, and returns the index of the new
+        /// note (which is also the index for the jump used by the switch table)
+        /// </summary>
         private int AddBacktrackNote(int flags, Label l, int codepos)
         {
             if (_notes == null || _notecount >= _notes.Length)
             {
-                BacktrackNote[] newnotes = new BacktrackNote[_notes == null ? 16 : _notes.Length * 2];
+                var newnotes = new BacktrackNote[_notes == null ? 16 : _notes.Length * 2];
                 if (_notes != null)
-                    System.Array.Copy(_notes, newnotes, _notecount);
+                {
+                    Array.Copy(_notes, newnotes, _notecount);
+                }
                 _notes = newnotes;
             }
 
@@ -173,133 +155,84 @@ namespace System.Text.RegularExpressions
             return _notecount++;
         }
 
-        /*
-         * Adds a backtrack note for the current operation; creates a new label for
-         * where the code will be, and returns the switch index.
-         */
-        private int AddTrack()
-        {
-            return AddTrack(RegexCode.Back);
-        }
+        /// <summary>
+        /// Adds a backtrack note for the current operation; creates a new label for
+        /// where the code will be, and returns the switch index.
+        /// </summary>
+        private int AddTrack() => AddTrack(RegexCode.Back);
 
-        /*
-         * Adds a backtrack note for the current operation; creates a new label for
-         * where the code will be, and returns the switch index.
-         */
-        private int AddTrack(int flags)
-        {
-            return AddBacktrackNote(flags, DefineLabel(), _codepos);
-        }
+        /// <summary>
+        /// Adds a backtrack note for the current operation; creates a new label for
+        /// where the code will be, and returns the switch index.
+        /// </summary>
+        private int AddTrack(int flags) => AddBacktrackNote(flags, DefineLabel(), _codepos);
 
-        /*
-         * Adds a switchtable entry for the specified position (for the forward
-         * logic; does not cause backtracking logic to be generated)
-         */
+        /// <summary>
+        /// Adds a switchtable entry for the specified position (for the forward
+        /// logic; does not cause backtracking logic to be generated)
+        /// </summary>
         private int AddGoto(int destpos)
         {
             if (_goto![destpos] == -1)
+            {
                 _goto[destpos] = AddBacktrackNote(0, _labels![destpos], destpos);
+            }
 
             return _goto[destpos];
         }
 
-        /*
-         * Adds a note for backtracking code that only needs to be generated once;
-         * if it's already marked to be generated, returns the switch index
-         * for the unique piece of code.
-         */
-        private int AddUniqueTrack(int i)
-        {
-            return AddUniqueTrack(i, RegexCode.Back);
-        }
+        /// <summary>
+        /// Adds a note for backtracking code that only needs to be generated once;
+        /// if it's already marked to be generated, returns the switch index
+        /// for the unique piece of code.
+        /// </summary>
+        private int AddUniqueTrack(int i) => AddUniqueTrack(i, RegexCode.Back);
 
-        /*
-         * Adds a note for backtracking code that only needs to be generated once;
-         * if it's already marked to be generated, returns the switch index
-         * for the unique piece of code.
-         */
+        /// <summary>
+        /// Adds a note for backtracking code that only needs to be generated once;
+        /// if it's already marked to be generated, returns the switch index
+        /// for the unique piece of code.
+        /// </summary>
         private int AddUniqueTrack(int i, int flags)
         {
             if (_uniquenote![i] == -1)
+            {
                 _uniquenote[i] = AddTrack(flags);
+            }
 
             return _uniquenote[i];
         }
 
-        /*
-         * A macro for _ilg.DefineLabel
-         */
-        private Label DefineLabel()
-        {
-            return _ilg!.DefineLabel();
-        }
+        /// <summary>A macro for _ilg.DefineLabel</summary>
+        private Label DefineLabel() => _ilg!.DefineLabel();
 
-        /*
-         * A macro for _ilg.MarkLabel
-         */
-        private void MarkLabel(Label l)
-        {
-            _ilg!.MarkLabel(l);
-        }
+        /// <summary>A macro for _ilg.MarkLabel</summary>
+        private void MarkLabel(Label l) => _ilg!.MarkLabel(l);
 
-        /*
-         * Returns the ith operand of the current operation
-         */
-        private int Operand(int i)
-        {
-            return _codes![_codepos + i + 1];
-        }
+        /// <summary>Returns the ith operand of the current operation.</summary>
+        private int Operand(int i) => _codes![_codepos + i + 1];
 
-        /*
-         * True if the current operation is marked for the leftward direction
-         */
-        private bool IsRtl()
-        {
-            return (_regexopcode & RegexCode.Rtl) != 0;
-        }
+        /// <summary>True if the current operation is marked for the leftward direction.</summary>
+        private bool IsRtl() => (_regexopcode & RegexCode.Rtl) != 0;
 
-        /*
-         * True if the current operation is marked for case insensitive operation
-         */
-        private bool IsCi()
-        {
-            return (_regexopcode & RegexCode.Ci) != 0;
-        }
+        /// <summary>True if the current operation is marked for case insensitive operation.</summary>
+        private bool IsCi() => (_regexopcode & RegexCode.Ci) != 0;
 
 #if DEBUG
-        /*
-         * True if we need to do the backtrack logic for the current operation
-         */
-        private bool IsBack()
-        {
-            return (_regexopcode & RegexCode.Back) != 0;
-        }
+        /// <summary>True if we need to do the backtrack logic for the current operation.</summary>
+        private bool IsBack() => (_regexopcode & RegexCode.Back) != 0;
 
-        /*
-         * True if we need to do the second-backtrack logic for the current operation
-         */
-        private bool IsBack2()
-        {
-            return (_regexopcode & RegexCode.Back2) != 0;
-        }
+        /// <summary>True if we need to do the second-backtrack logic for the current operation.</summary>
+        private bool IsBack2() => (_regexopcode & RegexCode.Back2) != 0;
 #endif
 
-        /*
-         * Returns the raw regex opcode (masking out Back and Rtl)
-         */
-        private int Code()
-        {
-            return _regexopcode & RegexCode.Mask;
-        }
+        /// <summary>Returns the raw regex opcode (masking out Back and Rtl).</summary>
+        private int Code() => _regexopcode & RegexCode.Mask;
 
-        private void Ldstr(string str)
-        {
-            _ilg!.Emit(OpCodes.Ldstr, str);
-        }
+        /// <summary>A macro for _ilg.Emit(Opcodes.Ldstr, str)</summary>
+        private void Ldstr(string str) => _ilg!.Emit(OpCodes.Ldstr, str);
 
-        /*
-         * A macro for the various forms of Ldc
-         */
+        /// <summary>A macro for the various forms of Ldc.</summary>
         private void Ldc(int i)
         {
             Debug.Assert(_ilg != null);
@@ -328,6 +261,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>A macro for the various forms of LdcI8.</summary>
         private void LdcI8(long i)
         {
             if (i <= int.MaxValue && i >= int.MinValue)
@@ -341,123 +275,47 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Dup)
-         */
-        private void Dup()
-        {
-            _ilg!.Emit(OpCodes.Dup);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Dup).</summary>
+        private void Dup() => _ilg!.Emit(OpCodes.Dup);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Ret)
-         */
-        private void Ret()
-        {
-            _ilg!.Emit(OpCodes.Ret);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Ret).</summary>
+        private void Ret() => _ilg!.Emit(OpCodes.Ret);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Rem)
-         */
-        private void Rem()
-        {
-            _ilg!.Emit(OpCodes.Rem);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Rem).</summary>
+        private void Rem() => _ilg!.Emit(OpCodes.Rem);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Ceq)
-         */
-        private void Ceq()
-        {
-            _ilg!.Emit(OpCodes.Ceq);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Ceq).</summary>
+        private void Ceq() => _ilg!.Emit(OpCodes.Ceq);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Clt_Un)
-         */
-        private void CgtUn()
-        {
-            _ilg!.Emit(OpCodes.Cgt_Un);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Cgt_Un).</summary>
+        private void CgtUn() => _ilg!.Emit(OpCodes.Cgt_Un);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Clt_Un)
-         */
-        private void CltUn()
-        {
-            _ilg!.Emit(OpCodes.Clt_Un);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Clt_Un).</summary>
+        private void CltUn() => _ilg!.Emit(OpCodes.Clt_Un);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Pop)
-         */
-        private void Pop()
-        {
-            _ilg!.Emit(OpCodes.Pop);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Pop).</summary>
+        private void Pop() => _ilg!.Emit(OpCodes.Pop);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Add)
-         */
-        private void Add()
-        {
-            _ilg!.Emit(OpCodes.Add);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Add).</summary>
+        private void Add() => _ilg!.Emit(OpCodes.Add);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Add); a true flag can turn it into a Sub
-         */
-        private void Add(bool negate)
-        {
-            if (negate)
-                _ilg!.Emit(OpCodes.Sub);
-            else
-                _ilg!.Emit(OpCodes.Add);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Add); a true flag can turn it into a Sub.</summary>
+        private void Add(bool negate) => _ilg!.Emit(negate ? OpCodes.Sub : OpCodes.Add);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Sub)
-         */
-        private void Sub()
-        {
-            _ilg!.Emit(OpCodes.Sub);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Sub).</summary>
+        private void Sub() => _ilg!.Emit(OpCodes.Sub);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Sub); a true flag can turn it into a Add
-         */
-        private void Sub(bool negate)
-        {
-            if (negate)
-                _ilg!.Emit(OpCodes.Add);
-            else
-                _ilg!.Emit(OpCodes.Sub);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Sub) or _ilg.Emit(OpCodes.Add).</summary>
+        private void Sub(bool negate) => _ilg!.Emit(negate ? OpCodes.Add : OpCodes.Sub);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Div)
-         */
-        private void Div()
-        {
-            _ilg!.Emit(OpCodes.Div);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Div).</summary>
+        private void Div() => _ilg!.Emit(OpCodes.Div);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.And)
-         */
-        private void And()
-        {
-            _ilg!.Emit(OpCodes.And);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.And).</summary>
+        private void And() => _ilg!.Emit(OpCodes.And);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Shl)
-         */
-        private void Shl()
-        {
-            _ilg!.Emit(OpCodes.Shl);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Shl).</summary>
+        private void Shl() => _ilg!.Emit(OpCodes.Shl);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Shr).</summary>
         private void Shr() => _ilg!.Emit(OpCodes.Shr);
@@ -465,43 +323,27 @@ namespace System.Text.RegularExpressions
         /// <summary>A macro for _ilg.Emit(OpCodes.Ldloc_S).</summary>
         private void Ldloc(LocalBuilder lt) => _ilg!.Emit(OpCodes.Ldloc_S, lt);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Stloc);
-         */
-        private void Stloc(LocalBuilder lt)
-        {
-            _ilg!.Emit(OpCodes.Stloc_S, lt);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Stloc).</summary>
+        private void Stloc(LocalBuilder lt) => _ilg!.Emit(OpCodes.Stloc_S, lt);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Ldarg_0);
-         */
-        private void Ldthis()
-        {
-            _ilg!.Emit(OpCodes.Ldarg_0);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Ldarg_0).</summary>
+        private void Ldthis() => _ilg!.Emit(OpCodes.Ldarg_0);
 
-        /*
-         * A macro for Ldthis(); Ldfld();
-         */
+        /// <summary>A macro for Ldthis(); Ldfld();</summary>
         private void Ldthisfld(FieldInfo ft)
         {
             Ldthis();
             _ilg!.Emit(OpCodes.Ldfld, ft);
         }
 
-        /*
-         * A macro for Ldthis(); Ldfld(); Stloc();
-         */
+        /// <summary>A macro for Ldthis(); Ldfld(); Stloc();</summary>
         private void Mvfldloc(FieldInfo ft, LocalBuilder lt)
         {
             Ldthisfld(ft);
             Stloc(lt);
         }
 
-        /*
-         * A macro for Ldthis(); Ldthisfld(); Stloc();
-         */
+        /// <summary>A macro for Ldthis(); Ldloc(); Stfld();</summary>
         private void Mvlocfld(LocalBuilder lt, FieldInfo ft)
         {
             Ldthis();
@@ -509,193 +351,76 @@ namespace System.Text.RegularExpressions
             Stfld(ft);
         }
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Stfld);
-         */
-        private void Stfld(FieldInfo ft)
-        {
-            _ilg!.Emit(OpCodes.Stfld, ft);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Stfld).</summary>
+        private void Stfld(FieldInfo ft) => _ilg!.Emit(OpCodes.Stfld, ft);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Callvirt);
-         */
-        private void Callvirt(MethodInfo mt)
-        {
-            _ilg!.Emit(OpCodes.Callvirt, mt);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Callvirt, mt).</summary>
+        private void Callvirt(MethodInfo mt) => _ilg!.Emit(OpCodes.Callvirt, mt);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Call);
-         */
-        private void Call(MethodInfo mt)
-        {
-            _ilg!.Emit(OpCodes.Call, mt);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Call, mt).</summary>
+        private void Call(MethodInfo mt) => _ilg!.Emit(OpCodes.Call, mt);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Newobj);
-         */
-        private void Newobj(ConstructorInfo ct)
-        {
-            _ilg!.Emit(OpCodes.Newobj, ct);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Newobj, ct).</summary>
+        private void Newobj(ConstructorInfo ct) => _ilg!.Emit(OpCodes.Newobj, ct);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Brfalse) (long form)
-         */
-        private void BrfalseFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Brfalse, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Brfalse) (long form).</summary>
+        private void BrfalseFar(Label l) => _ilg!.Emit(OpCodes.Brfalse, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Brtrue) (long form)
-         */
-        private void BrtrueFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Brtrue, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Brtrue) (long form).</summary>
+        private void BrtrueFar(Label l) => _ilg!.Emit(OpCodes.Brtrue, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Br) (long form)
-         */
-        private void BrFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Br, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Br) (long form).</summary>
+        private void BrFar(Label l) => _ilg!.Emit(OpCodes.Br, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Ble) (long form)
-         */
-        private void BleFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Ble, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Ble) (long form).</summary>
+        private void BleFar(Label l) => _ilg!.Emit(OpCodes.Ble, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Blt) (long form)
-         */
-        private void BltFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Blt, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Blt) (long form).</summary>
+        private void BltFar(Label l) => _ilg!.Emit(OpCodes.Blt, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bge) (long form)
-         */
-        private void BgeFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bge, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bge) (long form).</summary>
+        private void BgeFar(Label l) => _ilg!.Emit(OpCodes.Bge, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bgt) (long form)
-         */
-        private void BgtFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bgt, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bgt) (long form).</summary>
+        private void BgtFar(Label l) => _ilg!.Emit(OpCodes.Bgt, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bne) (long form)
-         */
-        private void BneFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bne_Un, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bne) (long form).</summary>
+        private void BneFar(Label l) => _ilg!.Emit(OpCodes.Bne_Un, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Beq) (long form)
-         */
-        private void BeqFar(Label l)
-        {
-            _ilg!.Emit(OpCodes.Beq, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Beq) (long form).</summary>
+        private void BeqFar(Label l) => _ilg!.Emit(OpCodes.Beq, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Brfalse_S) (short jump)
-         */
-        private void Brfalse(Label l)
-        {
-            _ilg!.Emit(OpCodes.Brfalse_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Brfalse_S) (short jump).</summary>
+        private void Brfalse(Label l) => _ilg!.Emit(OpCodes.Brfalse_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Br_S) (short jump)
-         */
-        private void Br(Label l)
-        {
-            _ilg!.Emit(OpCodes.Br_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Br_S) (short jump).</summary>
+        private void Br(Label l) => _ilg!.Emit(OpCodes.Br_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Ble_S) (short jump)
-         */
-        private void Ble(Label l)
-        {
-            _ilg!.Emit(OpCodes.Ble_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Ble_S) (short jump).</summary>
+        private void Ble(Label l) => _ilg!.Emit(OpCodes.Ble_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Blt_S) (short jump)
-         */
-        private void Blt(Label l)
-        {
-            _ilg!.Emit(OpCodes.Blt_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Blt_S) (short jump).</summary>
+        private void Blt(Label l) => _ilg!.Emit(OpCodes.Blt_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bge_S) (short jump)
-         */
-        private void Bge(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bge_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bge_S) (short jump).</summary>
+        private void Bge(Label l) => _ilg!.Emit(OpCodes.Bge_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bgt_S) (short jump)
-         */
-        private void Bgt(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bgt_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bgt_S) (short jump).</summary>
+        private void Bgt(Label l) => _ilg!.Emit(OpCodes.Bgt_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bleun_S) (short jump)
-         */
-        private void Bgtun(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bgt_Un_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bleun_S) (short jump).</summary>
+        private void Bgtun(Label l) => _ilg!.Emit(OpCodes.Bgt_Un_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Bne_S) (short jump)
-         */
-        private void Bne(Label l)
-        {
-            _ilg!.Emit(OpCodes.Bne_Un_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Bne_S) (short jump).</summary>
+        private void Bne(Label l) => _ilg!.Emit(OpCodes.Bne_Un_S, l);
 
-        /*
-         * A macro for _ilg.Emit(OpCodes.Beq_S) (short jump)
-         */
-        private void Beq(Label l)
-        {
-            _ilg!.Emit(OpCodes.Beq_S, l);
-        }
+        /// <summary>A macro for _ilg.Emit(OpCodes.Beq_S) (short jump).</summary>
+        private void Beq(Label l) => _ilg!.Emit(OpCodes.Beq_S, l);
 
-        /*
-         * A macro for the Ldlen instruction
-         */
-        private void Ldlen()
-        {
-            _ilg!.Emit(OpCodes.Ldlen);
-        }
+        /// <summary>A macro for the Ldlen instruction).</summary>
+        private void Ldlen() => _ilg!.Emit(OpCodes.Ldlen);
 
-        /*
-         * Loads the char to the right of the current position
-         */
+        /// <summary>Loads the char to the right of the current position.</summary>
         private void Rightchar()
         {
             Ldloc(_textV!);
@@ -703,9 +428,7 @@ namespace System.Text.RegularExpressions
             Callvirt(s_getcharM);
         }
 
-        /*
-         * Loads the char to the right of the current position and advances the current position
-         */
+        /// <summary>Loads the char to the right of the current position and advances the current position.</summary>
         private void Rightcharnext()
         {
             Ldloc(_textV!);
@@ -717,9 +440,7 @@ namespace System.Text.RegularExpressions
             Callvirt(s_getcharM);
         }
 
-        /*
-         * Loads the char to the left of the current position
-         */
+        /// <summary>Loads the char to the left of the current position.</summary>
         private void Leftchar()
         {
             Ldloc(_textV!);
@@ -729,9 +450,7 @@ namespace System.Text.RegularExpressions
             Callvirt(s_getcharM);
         }
 
-        /*
-         * Loads the char to the left of the current position and advances (leftward)
-         */
+        /// <summary>Loads the char to the left of the current position and advances (leftward).</summary>
         private void Leftcharnext()
         {
             Ldloc(_textV!);
@@ -743,9 +462,7 @@ namespace System.Text.RegularExpressions
             Callvirt(s_getcharM);
         }
 
-        /*
-         * Creates a backtrack note and pushes the switch index it on the tracking stack
-         */
+        /// <summary>Creates a backtrack note and pushes the switch index it on the tracking stack.</summary>
         private void Track()
         {
             ReadyPushTrack();
@@ -753,12 +470,10 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Pushes the current switch index on the tracking stack so the backtracking
-         * logic will be repeated again next time we backtrack here.
-         *
-         * <
-         */
+        /// <summary>
+        /// Pushes the current switch index on the tracking stack so the backtracking
+        /// logic will be repeated again next time we backtrack here.
+        /// </summary>
         private void Trackagain()
         {
             ReadyPushTrack();
@@ -766,9 +481,7 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Saves the value of a local variable on the tracking stack
-         */
+        /// <summary>Saves the value of a local variable on the tracking stack.</summary>
         private void PushTrack(LocalBuilder lt)
         {
             ReadyPushTrack();
@@ -776,10 +489,10 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Creates a backtrack note for a piece of code that should only be generated once,
-         * and emits code that pushes the switch index on the backtracking stack.
-         */
+        /// <summary>
+        /// Creates a backtrack note for a piece of code that should only be generated once,
+        /// and emits code that pushes the switch index on the backtracking stack.
+        /// </summary>
         private void TrackUnique(int i)
         {
             ReadyPushTrack();
@@ -787,11 +500,11 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Creates a second-backtrack note for a piece of code that should only be
-         * generated once, and emits code that pushes the switch index on the
-         * backtracking stack.
-         */
+        /// <summary>
+        /// Creates a second-backtrack note for a piece of code that should only be
+        /// generated once, and emits code that pushes the switch index on the
+        /// backtracking stack.
+        /// </summary>
         private void TrackUnique2(int i)
         {
             ReadyPushTrack();
@@ -799,9 +512,7 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Prologue to code that will push an element on the tracking stack
-         */
+        /// <summary>Prologue to code that will push an element on the tracking stack.</summary>
         private void ReadyPushTrack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _trackV!);
@@ -812,9 +523,7 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Stloc_S, _trackposV!);
         }
 
-        /*
-         * Pops an element off the tracking stack (leave it on the operand stack)
-         */
+        /// <summary>Pops an element off the tracking stack (leave it on the operand stack).</summary>
         private void PopTrack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _trackV!);
@@ -826,9 +535,7 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Ldelem_I4);
         }
 
-        /*
-         * Retrieves the top entry on the tracking stack without popping
-         */
+        /// <summary>Retrieves the top entry on the tracking stack without popping.</summary>
         private void TopTrack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _trackV!);
@@ -836,9 +543,7 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Ldelem_I4);
         }
 
-        /*
-         * Saves the value of a local variable on the grouping stack
-         */
+        /// <summary>Saves the value of a local variable on the grouping stack.</summary>
         private void PushStack(LocalBuilder lt)
         {
             ReadyPushStack();
@@ -846,9 +551,7 @@ namespace System.Text.RegularExpressions
             DoPush();
         }
 
-        /*
-         * Prologue to code that will replace the ith element on the grouping stack
-         */
+        /// <summary>Prologue to code that will replace the ith element on the grouping stack.</summary>
         internal void ReadyReplaceStack(int i)
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _stackV!);
@@ -860,9 +563,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Prologue to code that will push an element on the grouping stack
-         */
+        /// <summary>Prologue to code that will push an element on the grouping stack.</summary>
         private void ReadyPushStack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _stackV!);
@@ -873,9 +574,7 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Stloc_S, _stackposV!);
         }
 
-        /*
-         * Retrieves the top entry on the stack without popping
-         */
+        /// <summary>Retrieves the top entry on the stack without popping.</summary>
         private void TopStack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _stackV!);
@@ -883,9 +582,7 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Ldelem_I4);
         }
 
-        /*
-         * Pops an element off the grouping stack (leave it on the operand stack)
-         */
+        /// <summary>Pops an element off the grouping stack (leave it on the operand stack).</summary>
         private void PopStack()
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _stackV!);
@@ -897,17 +594,10 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Ldelem_I4);
         }
 
-        /*
-         * Pops 1 element off the grouping stack and discards it
-         */
-        private void PopDiscardStack()
-        {
-            PopDiscardStack(1);
-        }
+        /// <summary>Pops 1 element off the grouping stack and discards it.</summary>
+        private void PopDiscardStack() => PopDiscardStack(1);
 
-        /*
-         * Pops i elements off the grouping stack and discards them
-         */
+        /// <summary>Pops i elements off the grouping stack and discards them.</summary>
         private void PopDiscardStack(int i)
         {
             _ilg!.Emit(OpCodes.Ldloc_S, _stackposV!);
@@ -916,45 +606,31 @@ namespace System.Text.RegularExpressions
             _ilg.Emit(OpCodes.Stloc_S, _stackposV!);
         }
 
-        /*
-         * Epilogue to code that will replace an element on a stack (use Ld* in between)
-         */
-        private void DoReplace()
-        {
-            _ilg!.Emit(OpCodes.Stelem_I4);
-        }
+        /// <summary>Epilogue to code that will replace an element on a stack (use Ld* in between).</summary>
+        private void DoReplace() => _ilg!.Emit(OpCodes.Stelem_I4);
 
-        /*
-         * Epilogue to code that will push an element on a stack (use Ld* in between)
-         */
-        private void DoPush()
-        {
-            _ilg!.Emit(OpCodes.Stelem_I4);
-        }
+        /// <summary>Epilogue to code that will push an element on a stack (use Ld* in between).</summary>
+        private void DoPush() => _ilg!.Emit(OpCodes.Stelem_I4);
 
-        /*
-         * Jump to the backtracking switch
-         */
-        private void Back()
-        {
-            _ilg!.Emit(OpCodes.Br, _backtrack);
-        }
+        /// <summary>Jump to the backtracking switch.</summary>
+        private void Back() => _ilg!.Emit(OpCodes.Br, _backtrack);
 
-        /*
-         * Branch to the MSIL corresponding to the regex code at i
-         *
-         * A trick: since track and stack space is gobbled up unboundedly
-         * only as a result of branching backwards, this is where we check
-         * for sufficient space and trigger reallocations.
-         *
-         * If the "goto" is backwards, we generate code that checks
-         * available space against the amount of space that would be needed
-         * in the worst case by code that will only go forward; if there's
-         * not enough, we push the destination on the tracking stack, then
-         * we jump to the place where we invoke the allocator.
-         *
-         * Since forward gotos pose no threat, they just turn into a Br.
-         */
+        /// <summary>
+        /// Branch to the MSIL corresponding to the regex code at i
+        /// </summary>
+        /// <remarks>
+        /// A trick: since track and stack space is gobbled up unboundedly
+        /// only as a result of branching backwards, this is where we check
+        /// for sufficient space and trigger reallocations.
+        ///
+        /// If the "goto" is backwards, we generate code that checks
+        /// available space against the amount of space that would be needed
+        /// in the worst case by code that will only go forward; if there's
+        /// not enough, we push the destination on the tracking stack, then
+        /// we jump to the place where we invoke the allocator.
+        ///
+        /// Since forward gotos pose no threat, they just turn into a Br.
+        /// </remarks>
         private void Goto(int i)
         {
             if (i < _codepos)
@@ -980,31 +656,19 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Returns the position of the next operation in the regex code, taking
-         * into account the different numbers of arguments taken by operations
-         */
-        private int NextCodepos()
-        {
-            return _codepos + RegexCode.OpcodeSize(_codes![_codepos]);
-        }
+        /// <summary>
+        /// Returns the position of the next operation in the regex code, taking
+        /// into account the different numbers of arguments taken by operations
+        /// </summary>
+        private int NextCodepos() => _codepos + RegexCode.OpcodeSize(_codes![_codepos]);
 
-        /*
-         * The label for the next (forward) operation
-         */
-        private Label AdvanceLabel()
-        {
-            return _labels![NextCodepos()];
-        }
+        /// <summary>The label for the next (forward) operation.</summary>
+        private Label AdvanceLabel() => _labels![NextCodepos()];
 
-        /*
-         * Goto the next (forward) operation
-         */
-        private void Advance()
-        {
-            _ilg!.Emit(OpCodes.Br, AdvanceLabel());
-        }
+        /// <summary>Goto the next (forward) operation.</summary>
+        private void Advance() => _ilg!.Emit(OpCodes.Br, AdvanceLabel());
 
+        /// <summary>Sets the culture local to CultureInfo.CurrentCulture.</summary>
         private void InitLocalCultureInfo()
         {
             Debug.Assert(_cultureV != null);
@@ -1012,6 +676,7 @@ namespace System.Text.RegularExpressions
             Stloc(_cultureV);
         }
 
+        /// <summary>Invokes either char.ToLower(..., _culture) or char.ToLowerInvariant(...).</summary>
         private void CallToLower()
         {
             if (_cultureV == null || _options.HasFlag(RegexOptions.CultureInvariant))
@@ -1025,21 +690,19 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Generates the first section of the MSIL. This section contains all
-         * the forward logic, and corresponds directly to the regex codes.
-         *
-         * In the absence of backtracking, this is all we would need.
-         */
+        /// <summary>
+        /// Generates the first section of the MSIL. This section contains all
+        /// the forward logic, and corresponds directly to the regex codes.
+        /// In the absence of backtracking, this is all we would need.
+        /// </summary>
         private void GenerateForwardSection()
         {
-            int codepos;
-
             _labels = new Label[_codes!.Length];
             _goto = new int[_codes.Length];
 
             // initialize
 
+            int codepos;
             for (codepos = 0; codepos < _codes.Length; codepos += RegexCode.OpcodeSize(_codes[codepos]))
             {
                 _goto[codepos] = -1;
@@ -1047,8 +710,7 @@ namespace System.Text.RegularExpressions
             }
 
             _uniquenote = new int[Uniquecount];
-            for (int i = 0; i < Uniquecount; i++)
-                _uniquenote[i] = -1;
+            Array.Fill(_uniquenote, -1);
 
             // emit variable initializers
 
@@ -1073,17 +735,14 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Generates the middle section of the MSIL. This section contains the
-         * big switch jump that allows us to simulate a stack of addresses,
-         * and it also contains the calls that expand the tracking and the
-         * grouping stack when they get too full.
-         */
+        /// <summary>
+        /// Generates the middle section of the MSIL. This section contains the
+        /// big switch jump that allows us to simulate a stack of addresses,
+        /// and it also contains the calls that expand the tracking and the
+        /// grouping stack when they get too full.
+        /// </summary>
         private void GenerateMiddleSection()
         {
-            Label[] table;
-            int i;
-
             // Backtrack switch
             MarkLabel(_backtrack);
 
@@ -1097,25 +756,24 @@ namespace System.Text.RegularExpressions
             Mvfldloc(s_trackF, _trackV!);
             Mvfldloc(s_stackF, _stackV!);
 
-
             PopTrack();
 
-            table = new Label[_notecount];
-            for (i = 0; i < _notecount; i++)
+            var table = new Label[_notecount];
+            for (int i = 0; i < _notecount; i++)
+            {
                 table[i] = _notes![i]._label;
+            }
 
             _ilg!.Emit(OpCodes.Switch, table);
         }
 
-        /*
-         * Generates the last section of the MSIL. This section contains all of
-         * the backtracking logic.
-         */
+        /// <summary>
+        /// Generates the last section of the MSIL. This section contains all of
+        /// the backtracking logic.
+        /// </summary>
         private void GenerateBacktrackSection()
         {
-            int i;
-
-            for (i = 0; i < _notecount; i++)
+            for (int i = 0; i < _notecount; i++)
             {
                 BacktrackNote n = _notes![i];
                 if (n._flags != 0)
@@ -1129,13 +787,13 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Generates FindFirstChar
-         */
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // !!!! This function must be kept synchronized with FindFirstChar in      !!!!
         // !!!! RegexInterpreter.cs                                                !!!!
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        /// <summary>
+        /// Generates FindFirstChar.
+        /// </summary>
         protected void GenerateFindFirstChar()
         {
             _textposV = DeclareInt();
@@ -1154,11 +812,11 @@ namespace System.Text.RegularExpressions
                 }
             }
 
-            if (0 != (_anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)))
+            if ((_anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)) != 0)
             {
                 if (!_code!.RightToLeft)
                 {
-                    if (0 != (_anchors & RegexFCD.Beginning))
+                    if ((_anchors & RegexFCD.Beginning) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1172,7 +830,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l1);
                     }
 
-                    if (0 != (_anchors & RegexFCD.Start))
+                    if ((_anchors & RegexFCD.Start) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1186,7 +844,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l1);
                     }
 
-                    if (0 != (_anchors & RegexFCD.EndZ))
+                    if ((_anchors & RegexFCD.EndZ) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1202,7 +860,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l1);
                     }
 
-                    if (0 != (_anchors & RegexFCD.End))
+                    if ((_anchors & RegexFCD.End) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1216,7 +874,7 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    if (0 != (_anchors & RegexFCD.End))
+                    if ((_anchors & RegexFCD.End) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1230,7 +888,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l1);
                     }
 
-                    if (0 != (_anchors & RegexFCD.EndZ))
+                    if ((_anchors & RegexFCD.EndZ) != 0)
                     {
                         Label l1 = DefineLabel();
                         Label l2 = DefineLabel();
@@ -1245,7 +903,7 @@ namespace System.Text.RegularExpressions
                         Ldthisfld(s_textF);
                         Ldthisfld(s_textposF);
                         Callvirt(s_getcharM);
-                        Ldc((int)'\n');
+                        Ldc('\n');
                         Beq(l2);
                         MarkLabel(l1);
                         Ldthis();
@@ -1256,7 +914,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l2);
                     }
 
-                    if (0 != (_anchors & RegexFCD.Start))
+                    if ((_anchors & RegexFCD.Start) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1270,7 +928,7 @@ namespace System.Text.RegularExpressions
                         MarkLabel(l1);
                     }
 
-                    if (0 != (_anchors & RegexFCD.Beginning))
+                    if ((_anchors & RegexFCD.Beginning) != 0)
                     {
                         Label l1 = DefineLabel();
                         Ldthisfld(s_textposF);
@@ -1283,17 +941,12 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                // <
-
-
                 Ldc(1);
                 Ret();
             }
             else if (_bmPrefix != null && _bmPrefix.NegativeUnicode == null)
             {
                 // Compiled Boyer-Moore string matching
-                // <
-
 
                 LocalBuilder chV = _tempV;
                 LocalBuilder testV = _tempV;
@@ -1304,13 +957,8 @@ namespace System.Text.RegularExpressions
                 Label lStart = DefineLabel();
                 Label lPartialMatch = DefineLabel();
 
-
-                int chLast;
-                int i;
                 int beforefirst;
                 int last;
-                Label[] table;
-
                 if (!_code!.RightToLeft)
                 {
                     beforefirst = -1;
@@ -1322,13 +970,10 @@ namespace System.Text.RegularExpressions
                     last = 0;
                 }
 
-                chLast = _bmPrefix.Pattern[last];
+                int chLast = _bmPrefix.Pattern[last];
 
                 Mvfldloc(s_textF, _textV);
-                if (!_code.RightToLeft)
-                    Ldthisfld(s_textendF);
-                else
-                    Ldthisfld(s_textbegF);
+                Ldthisfld(_code.RightToLeft ? s_textbegF : s_textendF);
                 Stloc(limitV);
 
                 Ldthisfld(s_textposF);
@@ -1347,10 +992,7 @@ namespace System.Text.RegularExpressions
 
                 MarkLabel(lDefaultAdvance);
 
-                if (!_code.RightToLeft)
-                    Ldc(_bmPrefix.Pattern.Length);
-                else
-                    Ldc(-_bmPrefix.Pattern.Length);
+                Ldc(_code.RightToLeft ? -_bmPrefix.Pattern.Length : _bmPrefix.Pattern.Length);
 
                 MarkLabel(lAdvance);
 
@@ -1363,13 +1005,19 @@ namespace System.Text.RegularExpressions
                 Ldloc(_textposV);
                 Ldloc(limitV);
                 if (!_code.RightToLeft)
+                {
                     BgeFar(lFail);
+                }
                 else
+                {
                     BltFar(lFail);
+                }
 
                 Rightchar();
                 if (_bmPrefix.CaseInsensitive)
+                {
                     CallToLower();
+                }
 
                 Dup();
                 Stloc(chV);
@@ -1384,23 +1032,24 @@ namespace System.Text.RegularExpressions
                 Ldc(_bmPrefix.HighASCII - _bmPrefix.LowASCII);
                 Bgtun(lDefaultAdvance);
 
-                table = new Label[_bmPrefix.HighASCII - _bmPrefix.LowASCII + 1];
+                var table = new Label[_bmPrefix.HighASCII - _bmPrefix.LowASCII + 1];
 
-                for (i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
+                for (int i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
                 {
-                    if (_bmPrefix.NegativeASCII[i] == beforefirst)
-                        table[i - _bmPrefix.LowASCII] = lDefaultAdvance;
-                    else
-                        table[i - _bmPrefix.LowASCII] = DefineLabel();
+                    table[i - _bmPrefix.LowASCII] = (_bmPrefix.NegativeASCII[i] == beforefirst) ?
+                        lDefaultAdvance :
+                        DefineLabel();
                 }
 
                 Ldloc(chV);
                 _ilg!.Emit(OpCodes.Switch, table);
 
-                for (i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
+                for (int i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
                 {
                     if (_bmPrefix.NegativeASCII[i] == beforefirst)
+                    {
                         continue;
+                    }
 
                     MarkLabel(table[i - _bmPrefix.LowASCII]);
 
@@ -1413,15 +1062,12 @@ namespace System.Text.RegularExpressions
                 Ldloc(_textposV);
                 Stloc(testV);
 
-                for (i = _bmPrefix.Pattern.Length - 2; i >= 0; i--)
+                for (int i = _bmPrefix.Pattern.Length - 2; i >= 0; i--)
                 {
                     Label lNext = DefineLabel();
-                    int charindex;
-
-                    if (!_code.RightToLeft)
-                        charindex = i;
-                    else
-                        charindex = _bmPrefix.Pattern.Length - 1 - i;
+                    int charindex = _code.RightToLeft ?
+                        _bmPrefix.Pattern.Length - 1 - i :
+                        i;
 
                     Ldloc(_textV);
                     Ldloc(testV);
@@ -1431,7 +1077,9 @@ namespace System.Text.RegularExpressions
                     Stloc(testV);
                     Callvirt(s_getcharM);
                     if (_bmPrefix.CaseInsensitive)
+                    {
                         CallToLower();
+                    }
 
                     Ldc(_bmPrefix.Pattern[charindex]);
                     Beq(lNext);
@@ -1439,7 +1087,6 @@ namespace System.Text.RegularExpressions
                     BrFar(lAdvance);
 
                     MarkLabel(lNext);
-
                 }
 
                 Ldthis();
@@ -1456,10 +1103,7 @@ namespace System.Text.RegularExpressions
                 MarkLabel(lFail);
 
                 Ldthis();
-                if (!_code.RightToLeft)
-                    Ldthisfld(s_textendF);
-                else
-                    Ldthisfld(s_textbegF);
+                Ldthisfld(_code.RightToLeft ? s_textbegF : s_textendF);
                 Stfld(s_textposF);
                 Ldc(0);
                 Ret();
@@ -1507,17 +1151,22 @@ namespace System.Text.RegularExpressions
                 Stloc(cV);
 
                 if (_code.RightToLeft)
+                {
                     Leftcharnext();
+                }
                 else
+                {
                     Rightcharnext();
+                }
 
                 if (_fcPrefix.GetValueOrDefault().CaseInsensitive)
+                {
                     CallToLower();
+                }
 
                 if (!RegexCharClass.IsSingleton(_fcPrefix.GetValueOrDefault().Prefix))
                 {
                     EmitCallCharInClass(_fcPrefix.GetValueOrDefault().Prefix, charInClassV);
-
                     BrtrueFar(l2);
                 }
                 else
@@ -1531,51 +1180,18 @@ namespace System.Text.RegularExpressions
                 Ldloc(cV);
                 Ldc(0);
                 if (!RegexCharClass.IsSingleton(_fcPrefix.GetValueOrDefault().Prefix))
+                {
                     BgtFar(l1);
+                }
                 else
+                {
                     Bgt(l1);
+                }
 
                 Ldc(0);
                 BrFar(l3);
 
                 MarkLabel(l2);
-
-                /*          // CURRENTLY DISABLED
-                            // If for some reason we have a prefix we didn't use, use it now.
-
-                            if (_bmPrefix != null) {
-                                if (!_code._rightToLeft) {
-                                    Ldthisfld(_textendF);
-                                    Ldloc(_textposV);
-                                }
-                                else {
-                                    Ldloc(_textposV);
-                                    Ldthisfld(_textbegF);
-                                }
-                                Sub();
-                                Ldc(_bmPrefix._pattern.Length - 1);
-                                BltFar(l5);
-
-                                for (int i = 1; i < _bmPrefix._pattern.Length; i++) {
-                                    Ldloc(_textV);
-                                    Ldloc(_textposV);
-                                    if (!_code._rightToLeft) {
-                                        Ldc(i - 1);
-                                        Add();
-                                    }
-                                    else {
-                                        Ldc(i);
-                                        Sub();
-                                    }
-                                    Callvirt(_getcharM);
-                                    if (!_code._rightToLeft)
-                                        Ldc(_bmPrefix._pattern[i]);
-                                    else
-                                        Ldc(_bmPrefix._pattern[_bmPrefix._pattern.Length - 1 - i]);
-                                    BneFar(l5);
-                                }
-                            }
-                */
 
                 Ldloc(_textposV);
                 Ldc(1);
@@ -1595,9 +1211,7 @@ namespace System.Text.RegularExpressions
 
         }
 
-        /*
-         * Generates a very simple method that sets the _trackcount field.
-         */
+        /// <summary>Generates a very simple method that sets the _trackcount field.</summary>
         protected void GenerateInitTrackCount()
         {
             Ldthis();
@@ -1606,41 +1220,19 @@ namespace System.Text.RegularExpressions
             Ret();
         }
 
-        /*
-         * Declares a local int
-         */
-        private LocalBuilder DeclareInt()
-        {
-            return _ilg!.DeclareLocal(typeof(int));
-        }
+        /// <summary>Declares a local int.</summary>
+        private LocalBuilder DeclareInt() => _ilg!.DeclareLocal(typeof(int));
 
-        /*
-         * Declares a local CultureInfo
-         */
-        private LocalBuilder? DeclareCultureInfo()
-        {
-            return _ilg!.DeclareLocal(typeof(CultureInfo)); // cache local variable to avoid unnecessary TLS
-        }
+        /// <summary>Declares a local CultureInfo.</summary>
+        private LocalBuilder? DeclareCultureInfo() => _ilg!.DeclareLocal(typeof(CultureInfo)); // cache local variable to avoid unnecessary TLS
 
-        /*
-         * Declares a local int array
-         */
-        private LocalBuilder DeclareIntArray()
-        {
-            return _ilg!.DeclareLocal(typeof(int[]));
-        }
+        /// <summary>Declares a local int[].</summary>
+        private LocalBuilder DeclareIntArray() => _ilg!.DeclareLocal(typeof(int[]));
 
-        /*
-         * Declares a local string
-         */
-        private LocalBuilder DeclareString()
-        {
-            return _ilg!.DeclareLocal(typeof(string));
-        }
+        /// <summary>Declares a local string.</summary>
+        private LocalBuilder DeclareString() => _ilg!.DeclareLocal(typeof(string));
 
-        /*
-         * Generates the code for "RegexRunner.Go"
-         */
+        /// <summary>Generates the code for "RegexRunner.Go".</summary>
         protected void GenerateGo()
         {
             // declare some locals
@@ -1708,14 +1300,10 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        /*
-         * Some simple debugging stuff
-         */
+        /// <summary>Debug.WriteLine</summary>
         private static readonly MethodInfo? s_debugWriteLine = typeof(Debug).GetMethod("WriteLine", new Type[] { typeof(string) });
 
-        /*
-         * Debug only: emit code to print out a message
-         */
+        /// <summary>Debug only: emit code to print out a message.</summary>
         private void Message(string str)
         {
             Ldstr(str);
@@ -1724,18 +1312,19 @@ namespace System.Text.RegularExpressions
 
 #endif
 
-        /*
-         * The main translation function. It translates the logic for a single opcode at
-         * the current position. The structure of this function exactly mirrors
-         * the structure of the inner loop of RegexInterpreter.Go().
-         *
-         * The C# code from RegexInterpreter.Go() that corresponds to each case is
-         * included as a comment.
-         *
-         * Note that since we're generating code, we can collapse many cases that are
-         * dealt with one-at-a-time in RegexIntepreter. We can also unroll loops that
-         * iterate over constant strings or sets.
-         */
+        /// <summary>
+        /// The main translation function. It translates the logic for a single opcode at
+        /// the current position. The structure of this function exactly mirrors
+        /// the structure of the inner loop of RegexInterpreter.Go().
+        /// </summary>
+        /// <remarks>
+        /// The C# code from RegexInterpreter.Go() that corresponds to each case is
+        /// included as a comment.
+        ///
+        /// Note that since we're generating code, we can collapse many cases that are
+        /// dealt with one-at-a-time in RegexIntepreter. We can also unroll loops that
+        /// iterate over constant strings or sets.
+        /// </remarks>
         private void GenerateOneCode()
         {
 #if DEBUG
@@ -1746,16 +1335,28 @@ namespace System.Text.RegularExpressions
                 Mvlocfld(_stackposV!, s_stackposF);
                 Ldthis();
                 Callvirt(s_dumpstateM);
-                StringBuilder sb = new StringBuilder();
+
+                var sb = new StringBuilder();
                 if (_backpos > 0)
+                {
                     sb.AppendFormat("{0:D6} ", _backpos);
+                }
                 else
+                {
                     sb.Append("       ");
+                }
                 sb.Append(_code!.OpcodeDescription(_codepos));
+
                 if (IsBack())
+                {
                     sb.Append(" Back");
+                }
+
                 if (IsBack2())
+                {
                     sb.Append(" Back2");
+                }
+
                 Message(sb.ToString());
             }
 #endif
@@ -1908,11 +1509,7 @@ namespace System.Text.RegularExpressions
 
                     PushTrack(_tempV!);
 
-                    if (Operand(0) != -1 && Operand(1) != -1)
-                        TrackUnique(Capback2);
-                    else
-                        TrackUnique(Capback);
-
+                    TrackUnique(Operand(0) != -1 && Operand(1) != -1 ? Capback2 : Capback);
                     break;
 
 
@@ -2000,7 +1597,6 @@ namespace System.Text.RegularExpressions
                     DoPush();
                     Back();
                     break;
-
 
                 case RegexCode.Lazybranchmark:
                     //: StackPop();
@@ -2105,7 +1701,6 @@ namespace System.Text.RegularExpressions
                     TrackUnique(Stackpop2);
                     break;
 
-
                 case RegexCode.Nullcount | RegexCode.Back:
                 case RegexCode.Setcount | RegexCode.Back:
                     //: Stackframe(2);
@@ -2113,7 +1708,6 @@ namespace System.Text.RegularExpressions
                     PopDiscardStack(2);
                     Back();
                     break;
-
 
                 case RegexCode.Branchcount:
                     //: Stackframe(2);
@@ -2329,11 +1923,6 @@ namespace System.Text.RegularExpressions
 
                 case RegexCode.Lazybranchcount | RegexCode.Back2:
                     // <
-
-
-
-
-
                     ReadyReplaceStack(1);
                     PopTrack();
                     DoReplace();
@@ -2367,7 +1956,6 @@ namespace System.Text.RegularExpressions
                     PopDiscardStack(2);
                     Back();
                     break;
-
 
                 case RegexCode.Backjump:
                     //: Stackframe(2);
@@ -2458,7 +2046,7 @@ namespace System.Text.RegularExpressions
                         Ldloc(_textbegV!);
                         Ble(l1);
                         Leftchar();
-                        Ldc((int)'\n');
+                        Ldc('\n');
                         BneFar(_backtrack);
                         break;
                     }
@@ -2472,7 +2060,7 @@ namespace System.Text.RegularExpressions
                         Ldloc(_textendV!);
                         Bge(l1);
                         Rightchar();
-                        Ldc((int)'\n');
+                        Ldc('\n');
                         BneFar(_backtrack);
                         break;
                     }
@@ -2487,9 +2075,13 @@ namespace System.Text.RegularExpressions
                     Ldloc(_textendV!);
                     Callvirt(s_isboundaryM);
                     if (Code() == RegexCode.Boundary)
+                    {
                         BrfalseFar(_backtrack);
+                    }
                     else
+                    {
                         BrtrueFar(_backtrack);
+                    }
                     break;
 
                 case RegexCode.ECMABoundary:
@@ -2502,9 +2094,13 @@ namespace System.Text.RegularExpressions
                     Ldloc(_textendV!);
                     Callvirt(s_isECMABoundaryM);
                     if (Code() == RegexCode.ECMABoundary)
+                    {
                         BrfalseFar(_backtrack);
+                    }
                     else
+                    {
                         BrtrueFar(_backtrack);
+                    }
                     break;
 
                 case RegexCode.Beginning:
@@ -2535,7 +2131,7 @@ namespace System.Text.RegularExpressions
                     Ldloc(_textendV!);
                     Bge(_labels![NextCodepos()]);
                     Rightchar();
-                    Ldc((int)'\n');
+                    Ldc('\n');
                     BneFar(_backtrack);
                     break;
 
@@ -2581,28 +2177,31 @@ namespace System.Text.RegularExpressions
                     }
 
                     if (IsCi())
+                    {
                         CallToLower();
+                    }
 
                     if (Code() == RegexCode.Set)
                     {
                         EmitCallCharInClass(_strings![Operand(0)], charInClassV);
-
                         BrfalseFar(_backtrack);
                     }
                     else
                     {
                         Ldc(Operand(0));
                         if (Code() == RegexCode.One)
+                        {
                             BneFar(_backtrack);
+                        }
                         else
+                        {
                             BeqFar(_backtrack);
+                        }
                     }
                     break;
 
                 case RegexCode.Multi:
                 case RegexCode.Multi | RegexCode.Ci:
-                    //
-                    // <
                     //: String Str = _strings[Operand(0)];
                     //: int i, c;
                     //: if (Rightchars() < (c = Str.Length))
@@ -2634,9 +2233,11 @@ namespace System.Text.RegularExpressions
                             }
                             Callvirt(s_getcharM);
                             if (IsCi())
+                            {
                                 CallToLower();
+                            }
 
-                            Ldc((int)str[i]);
+                            Ldc(str[i]);
                             BneFar(_backtrack);
                         }
 
@@ -2682,7 +2283,7 @@ namespace System.Text.RegularExpressions
                             {
                                 CallToLower();
                             }
-                            Ldc((int)str[i]);
+                            Ldc(str[i]);
                             BneFar(_backtrack);
                         }
 
@@ -2719,9 +2320,13 @@ namespace System.Text.RegularExpressions
                         Ldc(Operand(0));
                         Callvirt(s_ismatchedM);
                         if ((_options & RegexOptions.ECMAScript) != 0)
+                        {
                             Brfalse(AdvanceLabel());
+                        }
                         else
+                        {
                             BrfalseFar(_backtrack); // !IsMatched() -> back
+                        }
 
                         Ldthis();
                         Ldc(Operand(0));
@@ -2773,7 +2378,9 @@ namespace System.Text.RegularExpressions
                         Sub(IsRtl());
                         Callvirt(s_getcharM);
                         if (IsCi())
+                        {
                             CallToLower();
+                        }
 
                         Ldloc(_textV!);
                         Ldloc(_textposV!);
@@ -2788,13 +2395,14 @@ namespace System.Text.RegularExpressions
                         Sub(IsRtl());
                         Callvirt(s_getcharM);
                         if (IsCi())
+                        {
                             CallToLower();
+                        }
 
                         Beq(l1);
                         Back();
                         break;
                     }
-
 
                 case RegexCode.Onerep:
                 case RegexCode.Notonerep:
@@ -2869,7 +2477,9 @@ namespace System.Text.RegularExpressions
                         }
                         Callvirt(s_getcharM);
                         if (IsCi())
+                        {
                             CallToLower();
+                        }
 
                         if (Code() == RegexCode.Setrep)
                         {
@@ -2878,26 +2488,32 @@ namespace System.Text.RegularExpressions
                                 EmitTimeoutCheck();
                             }
                             EmitCallCharInClass(_strings![Operand(0)], charInClassV);
-
                             BrfalseFar(_backtrack);
                         }
                         else
                         {
                             Ldc(Operand(0));
                             if (Code() == RegexCode.Onerep)
+                            {
                                 BneFar(_backtrack);
+                            }
                             else
+                            {
                                 BeqFar(_backtrack);
+                            }
                         }
                         Ldloc(lenV);
                         Ldc(0);
                         if (Code() == RegexCode.Setrep)
+                        {
                             BgtFar(l1);
+                        }
                         else
+                        {
                             Bgt(l1);
+                        }
                         break;
                     }
-
 
                 case RegexCode.Oneloop:
                 case RegexCode.Notoneloop:
@@ -2926,7 +2542,6 @@ namespace System.Text.RegularExpressions
                     //: }
                     //: if (c > i)
                     //:     Track(c - i - 1, Textpos() - 1);
-
                     {
                         LocalBuilder cV = _tempV!;
                         LocalBuilder lenV = _temp2V!;
@@ -2935,9 +2550,11 @@ namespace System.Text.RegularExpressions
                         Label l2 = DefineLabel();
 
                         int c = Operand(1);
-
                         if (c == 0)
+                        {
                             break;
+                        }
+
                         if (!IsRtl())
                         {
                             Ldloc(_textendV!);
@@ -2973,16 +2590,26 @@ namespace System.Text.RegularExpressions
                         Stloc(cV);
                         Ldc(0);
                         if (Code() == RegexCode.Setloop)
+                        {
                             BleFar(l2);
+                        }
                         else
+                        {
                             Ble(l2);
+                        }
 
                         if (IsRtl())
+                        {
                             Leftcharnext();
+                        }
                         else
+                        {
                             Rightcharnext();
+                        }
                         if (IsCi())
+                        {
                             CallToLower();
+                        }
 
                         if (Code() == RegexCode.Setloop)
                         {
@@ -2991,16 +2618,19 @@ namespace System.Text.RegularExpressions
                                 EmitTimeoutCheck();
                             }
                             EmitCallCharInClass(_strings![Operand(0)], charInClassV);
-
                             BrtrueFar(l1);
                         }
                         else
                         {
                             Ldc(Operand(0));
                             if (Code() == RegexCode.Oneloop)
+                            {
                                 Beq(l1);
+                            }
                             else
+                            {
                                 Bne(l1);
+                            }
                         }
 
                         Ldloc(_textposV!);
@@ -3092,9 +2722,10 @@ namespace System.Text.RegularExpressions
                         LocalBuilder cV = _tempV!;
 
                         int c = Operand(1);
-
                         if (c == 0)
+                        {
                             break;
+                        }
 
                         if (!IsRtl())
                         {
@@ -3160,26 +2791,35 @@ namespace System.Text.RegularExpressions
                     Stloc(_temp2V!);
 
                     if (!IsRtl())
+                    {
                         Rightcharnext();
+                    }
                     else
+                    {
                         Leftcharnext();
+                    }
 
                     if (IsCi())
+                    {
                         CallToLower();
+                    }
 
                     if (Code() == RegexCode.Setlazy)
                     {
                         EmitCallCharInClass(_strings![Operand(0)], charInClassV);
-
                         BrfalseFar(_backtrack);
                     }
                     else
                     {
                         Ldc(Operand(0));
                         if (Code() == RegexCode.Onelazy)
+                        {
                             BneFar(_backtrack);
+                        }
                         else
+                        {
                             BeqFar(_backtrack);
+                        }
                     }
 
                     Ldloc(_temp2V!);
@@ -3200,6 +2840,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Emits a call to RegexRunner.CharInClass or a functional equivalent.</summary>
         private void EmitCallCharInClass(string charClass, LocalBuilder tempLocal)
         {
             // We need to perform the equivalent of calling RegexRunner.CharInClass(ch, charClass),
@@ -3363,11 +3004,10 @@ namespace System.Text.RegularExpressions
             MarkLabel(doneLabel);
         }
 
+        /// <summary>Emits a timeout check.</summary>
         private void EmitTimeoutCheck()
         {
             Debug.Assert(_hasTimeout && _loopV != null);
-
-            Label label = DefineLabel();
 
             // Increment counter for each loop iteration.
             Ldloc(_loopV);
@@ -3376,6 +3016,7 @@ namespace System.Text.RegularExpressions
             Stloc(_loopV);
 
             // Emit code to check the timeout every 2000th-iteration.
+            Label label = DefineLabel();
             Ldloc(_loopV);
             Ldc(LoopTimeoutCheckCount);
             Rem();
@@ -3384,7 +3025,6 @@ namespace System.Text.RegularExpressions
             Brfalse(label);
             Ldthis();
             Callvirt(s_checkTimeoutM);
-
             MarkLabel(label);
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1934,7 +1934,6 @@ namespace System.Text.RegularExpressions
                     Back();
                     break;
 
-
                 case RegexCode.Setjump:
                     //: Stack(Trackpos(), Crawlpos());
                     //: Track();
@@ -2247,7 +2246,6 @@ namespace System.Text.RegularExpressions
                         Stloc(_textposV!);
                         break;
                     }
-
 
                 case RegexCode.Multi | RegexCode.Rtl:
                 case RegexCode.Multi | RegexCode.Ci | RegexCode.Rtl:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -299,10 +299,30 @@ namespace System.Text.RegularExpressions
          */
         private void Ldc(int i)
         {
-            if (i <= 127 && i >= -128)
-                _ilg!.Emit(OpCodes.Ldc_I4_S, (byte)i);
+            Debug.Assert(_ilg != null);
+
+            if ((uint)i < 8)
+            {
+                _ilg.Emit(i switch
+                {
+                    0 => OpCodes.Ldc_I4_0,
+                    1 => OpCodes.Ldc_I4_1,
+                    2 => OpCodes.Ldc_I4_2,
+                    3 => OpCodes.Ldc_I4_3,
+                    4 => OpCodes.Ldc_I4_4,
+                    5 => OpCodes.Ldc_I4_5,
+                    6 => OpCodes.Ldc_I4_6,
+                    _ => OpCodes.Ldc_I4_7,
+                });
+            }
+            else if (i <= 127 && i >= -128)
+            {
+                _ilg.Emit(OpCodes.Ldc_I4_S, (byte)i);
+            }
             else
-                _ilg!.Emit(OpCodes.Ldc_I4, i);
+            {
+                _ilg.Emit(OpCodes.Ldc_I4, i);
+            }
         }
 
         private void LdcI8(long i)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -108,11 +108,11 @@ namespace System.Text.RegularExpressions
 
                         if (curNode.M > 0 && curNode.M < Cutoff)
                         {
-                            string pref = string.Empty.PadRight(curNode.M, curNode.Ch);
+                            string pref = new string(curNode.Ch, curNode.M);
                             return new RegexPrefix(pref, 0 != (curNode.Options & RegexOptions.IgnoreCase));
                         }
-                        else
-                            return RegexPrefix.Empty;
+
+                        return RegexPrefix.Empty;
 
                     case RegexNode.One:
                         return new RegexPrefix(curNode.Ch.ToString(), 0 != (curNode.Options & RegexOptions.IgnoreCase));

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -54,10 +54,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static RegexPrefix? FirstChars(RegexTree t)
         {
-            // Create/rent buffers
-            Span<int> intSpan = stackalloc int[StackBufferSize];
-
-            RegexFCD s = new RegexFCD(intSpan);
+            RegexFCD s = new RegexFCD(stackalloc int[StackBufferSize]);
             RegexFC? fc = s.RegexFCFromRegexTree(t);
             s.Dispose();
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -17,7 +17,7 @@ namespace System.Text.RegularExpressions
         /*
          * The top-level driver. Initializes everything then calls the Generate* methods.
          */
-        public RegexRunnerFactory FactoryInstanceFromCode(RegexCode code, RegexOptions options)
+        public RegexRunnerFactory FactoryInstanceFromCode(RegexCode code, RegexOptions options, bool hasTimeout)
         {
             _code = code;
             _codes = code.Codes;
@@ -27,6 +27,7 @@ namespace System.Text.RegularExpressions
             _anchors = code.Anchors;
             _trackcount = code.TrackCount;
             _options = options;
+            _hasTimeout = hasTimeout;
 
             // pick a unique number for the methods we generate
             int regexnum = Interlocked.Increment(ref s_regexCount);
@@ -53,10 +54,10 @@ namespace System.Text.RegularExpressions
             // By giving them a parameter which represents "this", we're tricking them into
             // being instance methods.
 
-            MethodAttributes attribs = MethodAttributes.Public | MethodAttributes.Static;
-            CallingConventions conventions = CallingConventions.Standard;
+            const MethodAttributes Attribs = MethodAttributes.Public | MethodAttributes.Static;
+            const CallingConventions Conventions = CallingConventions.Standard;
 
-            DynamicMethod dm = new DynamicMethod(methname, attribs, conventions, returntype, s_paramTypes, hostType, false /*skipVisibility*/);
+            DynamicMethod dm = new DynamicMethod(methname, Attribs, Conventions, returntype, s_paramTypes, hostType, false /*skipVisibility*/);
             _ilg = dm.GetILGenerator();
             return dm;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -38,7 +38,10 @@ namespace System.Text.RegularExpressions
             DynamicMethod trackCountMethod = DefineDynamicMethod("InitTrackCount" + regexnumString, null, typeof(CompiledRegexRunner));
             GenerateInitTrackCount();
 
-            return new CompiledRegexRunnerFactory(goMethod, firstCharMethod, trackCountMethod);
+            return new CompiledRegexRunnerFactory(
+                (Action<RegexRunner>)goMethod.CreateDelegate(typeof(Action<RegexRunner>)),
+                (Func<RegexRunner, bool>)firstCharMethod.CreateDelegate(typeof(Func<RegexRunner, bool>)),
+                (Action<RegexRunner>)trackCountMethod.CreateDelegate(typeof(Action<RegexRunner>)));
         }
 
         /// <summary>Begins the definition of a new method (no args) with a specified return value.</summary>
@@ -51,7 +54,7 @@ namespace System.Text.RegularExpressions
             const MethodAttributes Attribs = MethodAttributes.Public | MethodAttributes.Static;
             const CallingConventions Conventions = CallingConventions.Standard;
 
-            DynamicMethod dm = new DynamicMethod(methname, Attribs, Conventions, returntype, s_paramTypes, hostType, false /*skipVisibility*/);
+            var dm = new DynamicMethod(methname, Attribs, Conventions, returntype, s_paramTypes, hostType, skipVisibility: false);
             _ilg = dm.GetILGenerator();
             return dm;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -5,7 +5,6 @@
 using System.Threading;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
@@ -30,8 +29,7 @@ namespace System.Text.RegularExpressions
             _hasTimeout = hasTimeout;
 
             // pick a unique number for the methods we generate
-            int regexnum = Interlocked.Increment(ref s_regexCount);
-            string regexnumString = regexnum.ToString(CultureInfo.InvariantCulture);
+            string regexnumString = ((uint)Interlocked.Increment(ref s_regexCount)).ToString();
 
             DynamicMethod goMethod = DefineDynamicMethod("Go" + regexnumString, null, typeof(CompiledRegexRunner));
             GenerateGo();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -13,9 +13,7 @@ namespace System.Text.RegularExpressions
         private static int s_regexCount = 0;
         private static readonly Type[] s_paramTypes = new Type[] { typeof(RegexRunner) };
 
-        /*
-         * The top-level driver. Initializes everything then calls the Generate* methods.
-         */
+        /// <summary>The top-level driver. Initializes everything then calls the Generate* methods.</summary>
         public RegexRunnerFactory FactoryInstanceFromCode(RegexCode code, RegexOptions options, bool hasTimeout)
         {
             _code = code;
@@ -43,9 +41,7 @@ namespace System.Text.RegularExpressions
             return new CompiledRegexRunnerFactory(goMethod, firstCharMethod, trackCountMethod);
         }
 
-        /*
-         * Begins the definition of a new method (no args) with a specified return value
-         */
+        /// <summary>Begins the definition of a new method (no args) with a specified return value.</summary>
         public DynamicMethod DefineDynamicMethod(string methname, Type? returntype, Type hostType)
         {
             // We're claiming that these are static methods, but really they are instance methods.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -476,7 +476,7 @@ namespace System.Text.RegularExpressions
                     if (prev.NType == One)
                     {
                         prev.NType = Multi;
-                        prev.Str = Convert.ToString(prev.Ch, CultureInfo.InvariantCulture);
+                        prev.Str = prev.Ch.ToString();
                     }
 
                     if ((optionsAt & RegexOptions.RightToLeft) == 0)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1746,11 +1746,12 @@ namespace System.Text.RegularExpressions
          */
         private void NoteCaptureSlot(int i, int pos)
         {
-            if (!_caps.ContainsKey(i))
+            object boxedI = i; // workaround to remove a boxed int when adding to the hashtable
+            if (!_caps.ContainsKey(boxedI))
             {
                 // the rhs of the hashtable isn't used in the parser
 
-                _caps.Add(i, pos);
+                _caps.Add(boxedI, pos);
                 _capcount++;
 
                 if (_captop <= i)
@@ -1812,7 +1813,7 @@ namespace System.Text.RegularExpressions
                     _capnumlist[i++] = (int)de.Key;
                 }
 
-                Array.Sort(_capnumlist, Comparer<int>.Default);
+                Array.Sort(_capnumlist);
             }
 
             // merge capsnumlist into capnamelist

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1948,7 +1948,7 @@ namespace System.Text.RegularExpressions
         /*
          * For categorizing ASCII characters.
         */
-        private static readonly byte[] s_category = new byte[] {
+        private static ReadOnlySpan<byte> Category => new byte[] {
             // 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
                0, 0, 0, 0, 0, 0, 0, 0, 0, X, X, 0, X, X, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             //    !  "  #  $  %  &  '  (  )  *  +  ,  -  .  /  0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ?
@@ -1963,7 +1963,7 @@ namespace System.Text.RegularExpressions
          */
         private static bool IsSpecial(char ch)
         {
-            return (ch <= '|' && s_category[ch] >= S);
+            return (ch <= '|' && Category[ch] >= S);
         }
 
         /*
@@ -1971,7 +1971,7 @@ namespace System.Text.RegularExpressions
          */
         private static bool IsStopperX(char ch)
         {
-            return (ch <= '|' && s_category[ch] >= X);
+            return (ch <= '|' && Category[ch] >= X);
         }
 
         /*
@@ -1979,7 +1979,7 @@ namespace System.Text.RegularExpressions
          */
         private static bool IsQuantifier(char ch)
         {
-            return (ch <= '{' && s_category[ch] >= Q);
+            return (ch <= '{' && Category[ch] >= Q);
         }
 
         private bool IsTrueQuantifier()
@@ -1989,7 +1989,7 @@ namespace System.Text.RegularExpressions
             int startpos = Textpos();
             char ch = CharAt(startpos);
             if (ch != '{')
-                return ch <= '{' && s_category[ch] >= Q;
+                return ch <= '{' && Category[ch] >= Q;
 
             int pos = startpos;
             int nChars = CharsRight();
@@ -2014,7 +2014,7 @@ namespace System.Text.RegularExpressions
          */
         private static bool IsSpace(char ch)
         {
-            return (ch <= ' ' && s_category[ch] == X);
+            return (ch <= ' ' && Category[ch] == X);
         }
 
         /*
@@ -2022,7 +2022,7 @@ namespace System.Text.RegularExpressions
          */
         private static bool IsMetachar(char ch)
         {
-            return (ch <= '|' && s_category[ch] >= E);
+            return (ch <= '|' && Category[ch] >= E);
         }
 
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -84,8 +84,7 @@ namespace System.Text.RegularExpressions
 
         public static RegexTree Parse(string pattern, RegexOptions options, CultureInfo culture)
         {
-            Span<RegexOptions> optionSpan = stackalloc RegexOptions[OptionStackDefaultSize];
-            var parser = new RegexParser(pattern, options, culture, optionSpan);
+            var parser = new RegexParser(pattern, options, culture, stackalloc RegexOptions[OptionStackDefaultSize]);
 
             parser.CountCaptures();
             parser.Reset(options);
@@ -103,8 +102,7 @@ namespace System.Text.RegularExpressions
         public static RegexReplacement ParseReplacement(string pattern, RegexOptions options, Hashtable caps, int capsize, Hashtable capnames)
         {
             CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
-            Span<RegexOptions> optionSpan = stackalloc RegexOptions[OptionStackDefaultSize];
-            var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, optionSpan);
+            var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, stackalloc RegexOptions[OptionStackDefaultSize]);
 
             RegexNode root = parser.ScanReplacement();
             var regexReplacement = new RegexReplacement(pattern, root, caps);
@@ -136,9 +134,8 @@ namespace System.Text.RegularExpressions
             // characters need to be encoded.
             // For larger string we rent the input string's length plus a fixed
             // conservative amount of chars from the ArrayPool.
-            Span<char> buffer = input.Length <= (EscapeMaxBufferSize / 3) ? stackalloc char[EscapeMaxBufferSize] : default;
-            ValueStringBuilder vsb = !buffer.IsEmpty ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder vsb = input.Length <= (EscapeMaxBufferSize / 3) ?
+                new ValueStringBuilder(stackalloc char[EscapeMaxBufferSize]) :
                 new ValueStringBuilder(input.Length + 200);
 
             char ch = input[i];
@@ -199,14 +196,12 @@ namespace System.Text.RegularExpressions
 
         private static string UnescapeImpl(string input, int i)
         {
-            Span<RegexOptions> optionSpan = stackalloc RegexOptions[OptionStackDefaultSize];
-            var parser = new RegexParser(input, RegexOptions.None, CultureInfo.InvariantCulture, optionSpan);
+            var parser = new RegexParser(input, RegexOptions.None, CultureInfo.InvariantCulture, stackalloc RegexOptions[OptionStackDefaultSize]);
 
             // In the worst case the escaped string has the same length.
             // For small inputs we use stack allocation.
-            Span<char> buffer = input.Length <= EscapeMaxBufferSize ? stackalloc char[EscapeMaxBufferSize] : default;
-            ValueStringBuilder vsb = !buffer.IsEmpty ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder vsb = input.Length <= EscapeMaxBufferSize ?
+                new ValueStringBuilder(stackalloc char[EscapeMaxBufferSize]) :
                 new ValueStringBuilder(input.Length);
 
             vsb.Append(input.AsSpan(0, i));

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1849,7 +1849,7 @@ namespace System.Text.RegularExpressions
                     }
                     else
                     {
-                        string str = Convert.ToString(j, _culture);
+                        string str = j.ToString(_culture);
                         _capnamelist.Add(str);
                         _capnames[str] = j;
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -33,8 +33,7 @@ namespace System.Text.RegularExpressions
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            Span<char> buffer = stackalloc char[256];
-            ValueStringBuilder vsb = new ValueStringBuilder(buffer);
+            ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[256]);
             List<string> strings = new List<string>();
             List<int> rules = new List<int>();
 
@@ -203,8 +202,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                Span<char> charInitSpan = stackalloc char[256];
-                var vsb = new ValueStringBuilder(charInitSpan);
+                var vsb = new ValueStringBuilder(stackalloc char[256]);
 
                 if (!regex.RightToLeft)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -33,9 +33,10 @@ namespace System.Text.RegularExpressions
             if (concat.Type() != RegexNode.Concatenate)
                 throw new ArgumentException(SR.ReplacementError);
 
-            ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[256]);
-            List<string> strings = new List<string>();
-            List<int> rules = new List<int>();
+            Span<char> vsbStack = stackalloc char[256];
+            var vsb = new ValueStringBuilder(vsbStack);
+            var strings = new List<string>();
+            var rules = new List<int>();
 
             for (int i = 0; i < concat.ChildCount(); i++)
             {
@@ -56,7 +57,7 @@ namespace System.Text.RegularExpressions
                         {
                             rules.Add(strings.Count);
                             strings.Add(vsb.ToString());
-                            vsb.Length = 0;
+                            vsb = new ValueStringBuilder(vsbStack);
                         }
                         int slot = child.M;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -49,10 +49,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static RegexCode Write(RegexTree tree)
         {
-            Span<int> emittedSpan = stackalloc int[EmittedSize];
-            Span<int> intStackSpan = stackalloc int[IntStackSize];
-
-            var writer = new RegexWriter(emittedSpan, intStackSpan);
+            var writer = new RegexWriter(stackalloc int[EmittedSize], stackalloc int[IntStackSize]);
             RegexCode code = writer.RegexCodeFromRegexTree(tree);
             writer.Dispose();
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -15,11 +15,11 @@ namespace System.Text.RegularExpressions.Tests
     {
         public static IEnumerable<object[]> Ctor_TestData()
         {
-            yield return new object[] { "foo", RegexOptions.None, Timeout.InfiniteTimeSpan };
-            yield return new object[] { "foo", RegexOptions.RightToLeft, Timeout.InfiniteTimeSpan };
-            yield return new object[] { "foo", RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
-            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan };
-            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
+            yield return new object[] { "foo", RegexOptions.None, Regex.InfiniteMatchTimeout };
+            yield return new object[] { "foo", RegexOptions.RightToLeft, Regex.InfiniteMatchTimeout };
+            yield return new object[] { "foo", RegexOptions.Compiled, Regex.InfiniteMatchTimeout };
+            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant, Regex.InfiniteMatchTimeout };
+            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled, Regex.InfiniteMatchTimeout };
             yield return new object[] { "foo", RegexOptions.None, new TimeSpan(1) };
             yield return new object[] { "foo", RegexOptions.None, TimeSpan.FromMilliseconds(int.MaxValue - 1) };
         }
@@ -28,7 +28,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Ctor_TestData))]
         public static void Ctor(string pattern, RegexOptions options, TimeSpan matchTimeout)
         {
-            if (matchTimeout == Timeout.InfiniteTimeSpan)
+            if (matchTimeout == Regex.InfiniteMatchTimeout)
             {
                 if (options == RegexOptions.None)
                 {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -672,6 +672,7 @@ namespace System.Text.RegularExpressions.Tests
         private void GroupsTest(object[] testCase)
         {
             Groups((string)testCase[0], (string)testCase[1], (RegexOptions)testCase[2], (string[])testCase[3]);
+            Groups((string)testCase[0], (string)testCase[1], RegexOptions.Compiled | (RegexOptions)testCase[2], (string[])testCase[3]);
         }
 
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -14,124 +14,117 @@ namespace System.Text.RegularExpressions.Tests
 {
     public class RegexGroupTests
     {
-        private static readonly CultureInfo s_enUSCulture = new CultureInfo("en-US");
-        private static readonly CultureInfo s_invariantCulture = new CultureInfo("");
-        private static readonly CultureInfo s_czechCulture = new CultureInfo("cs-CZ");
-        private static readonly CultureInfo s_danishCulture = new CultureInfo("da-DK");
-        private static readonly CultureInfo s_turkishCulture = new CultureInfo("tr-TR");
-        private static readonly CultureInfo s_azeriLatinCulture = new CultureInfo("az-Latn-AZ");
-
         public static IEnumerable<object[]> Groups_Basic_TestData()
         {
             // (A - B) B is a subset of A(ie B only contains chars that are in A)
-            yield return new object[] { "[abcd-[d]]+", "dddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
+            yield return new object[] { null, "[abcd-[d]]+", "dddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
 
-            yield return new object[] { @"[\d-[357]]+", "33312468955", RegexOptions.None, new string[] { "124689" } };
-            yield return new object[] { @"[\d-[357]]+", "51246897", RegexOptions.None, new string[] { "124689" } };
-            yield return new object[] { @"[\d-[357]]+", "3312468977", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[357]]+", "33312468955", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[357]]+", "51246897", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[357]]+", "3312468977", RegexOptions.None, new string[] { "124689" } };
 
-            yield return new object[] { @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\w-[\d]]+", "0AZaz9", RegexOptions.None, new string[] { "AZaz" } };
-            yield return new object[] { @"[\w-[\p{Ll}]]+", "a09AZz", RegexOptions.None, new string[] { "09AZ" } };
+            yield return new object[] { null, @"[\w-[\d]]+", "0AZaz9", RegexOptions.None, new string[] { "AZaz" } };
+            yield return new object[] { null, @"[\w-[\p{Ll}]]+", "a09AZz", RegexOptions.None, new string[] { "09AZ" } };
 
-            yield return new object[] { @"[\d-[13579]]+", "1024689", RegexOptions.ECMAScript, new string[] { "02468" } };
-            yield return new object[] { @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
-            yield return new object[] { @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
+            yield return new object[] { null, @"[\d-[13579]]+", "1024689", RegexOptions.ECMAScript, new string[] { "02468" } };
+            yield return new object[] { null, @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
+            yield return new object[] { null, @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
 
-            yield return new object[] { @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
-            yield return new object[] { @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\p{Ll}-[ae-z]]+", "aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
-            yield return new object[] { @"[\p{Nd}-[2468]]+", "20135798", RegexOptions.None, new string[] { "013579" } };
+            yield return new object[] { null, @"[\p{Ll}-[ae-z]]+", "aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
+            yield return new object[] { null, @"[\p{Nd}-[2468]]+", "20135798", RegexOptions.None, new string[] { "013579" } };
 
-            yield return new object[] { @"[\P{Lu}-[ae-z]]+", "aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
-            yield return new object[] { @"[\P{Nd}-[\p{Ll}]]+", "az09AZ'[]", RegexOptions.None, new string[] { "AZ'[]" } };
+            yield return new object[] { null, @"[\P{Lu}-[ae-z]]+", "aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
+            yield return new object[] { null, @"[\P{Nd}-[\p{Ll}]]+", "az09AZ'[]", RegexOptions.None, new string[] { "AZ'[]" } };
 
             // (A - B) B is a superset of A (ie B contains chars that are in A plus other chars that are not in A)
-            yield return new object[] { "[abcd-[def]]+", "fedddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
+            yield return new object[] { null, "[abcd-[def]]+", "fedddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
 
-            yield return new object[] { @"[\d-[357a-z]]+", "az33312468955", RegexOptions.None, new string[] { "124689" } };
-            yield return new object[] { @"[\d-[de357fgA-Z]]+", "AZ51246897", RegexOptions.None, new string[] { "124689" } };
-            yield return new object[] { @"[\d-[357\p{Ll}]]+", "az3312468977", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[357a-z]]+", "az33312468955", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[de357fgA-Z]]+", "AZ51246897", RegexOptions.None, new string[] { "124689" } };
+            yield return new object[] { null, @"[\d-[357\p{Ll}]]+", "az3312468977", RegexOptions.None, new string[] { "124689" } };
 
-            yield return new object[] { @"[\w-[b-y\s]]+", " \tbbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y\s]]+", " \tbbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\w-[\d\p{Po}]]+", "!#0AZaz9", RegexOptions.None, new string[] { "AZaz" } };
-            yield return new object[] { @"[\w-[\p{Ll}\s]]+", "a09AZz", RegexOptions.None, new string[] { "09AZ" } };
+            yield return new object[] { null, @"[\w-[\d\p{Po}]]+", "!#0AZaz9", RegexOptions.None, new string[] { "AZaz" } };
+            yield return new object[] { null, @"[\w-[\p{Ll}\s]]+", "a09AZz", RegexOptions.None, new string[] { "09AZ" } };
 
-            yield return new object[] { @"[\d-[13579a-zA-Z]]+", "AZ1024689", RegexOptions.ECMAScript, new string[] { "02468" } };
-            yield return new object[] { @"[\d-[13579abcd]]+", "abcd\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
-            yield return new object[] { @"[\d-[13579\s]]+", " \t\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
+            yield return new object[] { null, @"[\d-[13579a-zA-Z]]+", "AZ1024689", RegexOptions.ECMAScript, new string[] { "02468" } };
+            yield return new object[] { null, @"[\d-[13579abcd]]+", "abcd\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
+            yield return new object[] { null, @"[\d-[13579\s]]+", " \t\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
 
-            yield return new object[] { @"[\w-[b-y\p{Po}]]+", "!#bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y\p{Po}]]+", "!#bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\w-[b-y!.,]]+", "!.,bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
-            yield return new object[] { "[\\w-[b-y\x00-\x0F]]+", "\0bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, @"[\w-[b-y!.,]]+", "!.,bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
+            yield return new object[] { null, "[\\w-[b-y\x00-\x0F]]+", "\0bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
 
-            yield return new object[] { @"[\p{Ll}-[ae-z0-9]]+", "09aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
-            yield return new object[] { @"[\p{Nd}-[2468az]]+", "az20135798", RegexOptions.None, new string[] { "013579" } };
+            yield return new object[] { null, @"[\p{Ll}-[ae-z0-9]]+", "09aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
+            yield return new object[] { null, @"[\p{Nd}-[2468az]]+", "az20135798", RegexOptions.None, new string[] { "013579" } };
 
-            yield return new object[] { @"[\P{Lu}-[ae-zA-Z]]+", "AZaaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
-            yield return new object[] { @"[\P{Nd}-[\p{Ll}0123456789]]+", "09az09AZ'[]", RegexOptions.None, new string[] { "AZ'[]" } };
+            yield return new object[] { null, @"[\P{Lu}-[ae-zA-Z]]+", "AZaaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
+            yield return new object[] { null, @"[\P{Nd}-[\p{Ll}0123456789]]+", "09az09AZ'[]", RegexOptions.None, new string[] { "AZ'[]" } };
 
             // (A - B) B only contains chars that are not in A
-            yield return new object[] { "[abc-[defg]]+", "dddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
+            yield return new object[] { null, "[abc-[defg]]+", "dddaabbccddd", RegexOptions.None, new string[] { "aabbcc" } };
 
-            yield return new object[] { @"[\d-[abc]]+", "abc09abc", RegexOptions.None, new string[] { "09" } };
-            yield return new object[] { @"[\d-[a-zA-Z]]+", "az09AZ", RegexOptions.None, new string[] { "09" } };
-            yield return new object[] { @"[\d-[\p{Ll}]]+", "az09az", RegexOptions.None, new string[] { "09" } };
+            yield return new object[] { null, @"[\d-[abc]]+", "abc09abc", RegexOptions.None, new string[] { "09" } };
+            yield return new object[] { null, @"[\d-[a-zA-Z]]+", "az09AZ", RegexOptions.None, new string[] { "09" } };
+            yield return new object[] { null, @"[\d-[\p{Ll}]]+", "az09az", RegexOptions.None, new string[] { "09" } };
 
-            yield return new object[] { @"[\w-[\x00-\x0F]]+", "bbbaaaABYZ09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABYZ09zzzyyy" } };
+            yield return new object[] { null, @"[\w-[\x00-\x0F]]+", "bbbaaaABYZ09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABYZ09zzzyyy" } };
 
-            yield return new object[] { @"[\w-[\s]]+", "0AZaz9", RegexOptions.None, new string[] { "0AZaz9" } };
-            yield return new object[] { @"[\w-[\W]]+", "0AZaz9", RegexOptions.None, new string[] { "0AZaz9" } };
-            yield return new object[] { @"[\w-[\p{Po}]]+", "#a09AZz!", RegexOptions.None, new string[] { "a09AZz" } };
+            yield return new object[] { null, @"[\w-[\s]]+", "0AZaz9", RegexOptions.None, new string[] { "0AZaz9" } };
+            yield return new object[] { null, @"[\w-[\W]]+", "0AZaz9", RegexOptions.None, new string[] { "0AZaz9" } };
+            yield return new object[] { null, @"[\w-[\p{Po}]]+", "#a09AZz!", RegexOptions.None, new string[] { "a09AZz" } };
 
-            yield return new object[] { @"[\d-[\D]]+", "azAZ1024689", RegexOptions.ECMAScript, new string[] { "1024689" } };
-            yield return new object[] { @"[\d-[a-zA-Z]]+", "azAZ\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
-            yield return new object[] { @"[\d-[\p{Ll}]]+", "\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
+            yield return new object[] { null, @"[\d-[\D]]+", "azAZ1024689", RegexOptions.ECMAScript, new string[] { "1024689" } };
+            yield return new object[] { null, @"[\d-[a-zA-Z]]+", "azAZ\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
+            yield return new object[] { null, @"[\d-[\p{Ll}]]+", "\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
 
-            yield return new object[] { @"[a-zA-Z0-9-[\s]]+", " \tazAZ09", RegexOptions.None, new string[] { "azAZ09" } };
+            yield return new object[] { null, @"[a-zA-Z0-9-[\s]]+", " \tazAZ09", RegexOptions.None, new string[] { "azAZ09" } };
 
-            yield return new object[] { @"[a-zA-Z0-9-[\W]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABCD09zzzyyy" } };
-            yield return new object[] { @"[a-zA-Z0-9-[^a-zA-Z0-9]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABCD09zzzyyy" } };
+            yield return new object[] { null, @"[a-zA-Z0-9-[\W]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABCD09zzzyyy" } };
+            yield return new object[] { null, @"[a-zA-Z0-9-[^a-zA-Z0-9]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "bbbaaaABCD09zzzyyy" } };
 
-            yield return new object[] { @"[\p{Ll}-[A-Z]]+", "AZaz09", RegexOptions.None, new string[] { "az" } };
-            yield return new object[] { @"[\p{Nd}-[a-z]]+", "az09", RegexOptions.None, new string[] { "09" } };
+            yield return new object[] { null, @"[\p{Ll}-[A-Z]]+", "AZaz09", RegexOptions.None, new string[] { "az" } };
+            yield return new object[] { null, @"[\p{Nd}-[a-z]]+", "az09", RegexOptions.None, new string[] { "09" } };
 
-            yield return new object[] { @"[\P{Lu}-[\p{Lu}]]+", "AZazAZ", RegexOptions.None, new string[] { "az" } };
-            yield return new object[] { @"[\P{Lu}-[A-Z]]+", "AZazAZ", RegexOptions.None, new string[] { "az" } };
-            yield return new object[] { @"[\P{Nd}-[\p{Nd}]]+", "azAZ09", RegexOptions.None, new string[] { "azAZ" } };
-            yield return new object[] { @"[\P{Nd}-[2-8]]+", "1234567890azAZ1234567890", RegexOptions.None, new string[] { "azAZ" } };
+            yield return new object[] { null, @"[\P{Lu}-[\p{Lu}]]+", "AZazAZ", RegexOptions.None, new string[] { "az" } };
+            yield return new object[] { null, @"[\P{Lu}-[A-Z]]+", "AZazAZ", RegexOptions.None, new string[] { "az" } };
+            yield return new object[] { null, @"[\P{Nd}-[\p{Nd}]]+", "azAZ09", RegexOptions.None, new string[] { "azAZ" } };
+            yield return new object[] { null, @"[\P{Nd}-[2-8]]+", "1234567890azAZ1234567890", RegexOptions.None, new string[] { "azAZ" } };
 
             // Alternating construct
-            yield return new object[] { @"([ ]|[\w-[0-9]])+", "09az AZ90", RegexOptions.None, new string[] { "az AZ", "Z" } };
-            yield return new object[] { @"([0-9-[02468]]|[0-9-[13579]])+", "az1234567890za", RegexOptions.None, new string[] { "1234567890", "0" } };
-            yield return new object[] { @"([^0-9-[a-zAE-Z]]|[\w-[a-zAF-Z]])+", "azBCDE1234567890BCDEFza", RegexOptions.None, new string[] { "BCDE1234567890BCDE", "E" } };
-            yield return new object[] { @"([\p{Ll}-[aeiou]]|[^\w-[\s]])+", "aeiobcdxyz!@#aeio", RegexOptions.None, new string[] { "bcdxyz!@#", "#" } };
+            yield return new object[] { null, @"([ ]|[\w-[0-9]])+", "09az AZ90", RegexOptions.None, new string[] { "az AZ", "Z" } };
+            yield return new object[] { null, @"([0-9-[02468]]|[0-9-[13579]])+", "az1234567890za", RegexOptions.None, new string[] { "1234567890", "0" } };
+            yield return new object[] { null, @"([^0-9-[a-zAE-Z]]|[\w-[a-zAF-Z]])+", "azBCDE1234567890BCDEFza", RegexOptions.None, new string[] { "BCDE1234567890BCDE", "E" } };
+            yield return new object[] { null, @"([\p{Ll}-[aeiou]]|[^\w-[\s]])+", "aeiobcdxyz!@#aeio", RegexOptions.None, new string[] { "bcdxyz!@#", "#" } };
 
             // Multiple character classes using character class subtraction
-            yield return new object[] { @"98[\d-[9]][\d-[8]][\d-[0]]", "98911 98881 98870 98871", RegexOptions.None, new string[] { "98871" } };
-            yield return new object[] { @"m[\w-[^aeiou]][\w-[^aeiou]]t", "mbbt mect meet", RegexOptions.None, new string[] { "meet" } };
+            yield return new object[] { null, @"98[\d-[9]][\d-[8]][\d-[0]]", "98911 98881 98870 98871", RegexOptions.None, new string[] { "98871" } };
+            yield return new object[] { null, @"m[\w-[^aeiou]][\w-[^aeiou]]t", "mbbt mect meet", RegexOptions.None, new string[] { "meet" } };
 
             // Negation with character class subtraction
-            yield return new object[] { "[abcdef-[^bce]]+", "adfbcefda", RegexOptions.None, new string[] { "bce" } };
-            yield return new object[] { "[^cde-[ag]]+", "agbfxyzga", RegexOptions.None, new string[] { "bfxyz" } };
+            yield return new object[] { null, "[abcdef-[^bce]]+", "adfbcefda", RegexOptions.None, new string[] { "bce" } };
+            yield return new object[] { null, "[^cde-[ag]]+", "agbfxyzga", RegexOptions.None, new string[] { "bfxyz" } };
 
             // Misc The idea here is come up with real world examples of char class subtraction. Things that
             // would be difficult to define without it
-            yield return new object[] { @"[\p{L}-[^\p{Lu}]]+", "09',.abcxyzABCXYZ", RegexOptions.None, new string[] { "ABCXYZ" } };
+            yield return new object[] { null, @"[\p{L}-[^\p{Lu}]]+", "09',.abcxyzABCXYZ", RegexOptions.None, new string[] { "ABCXYZ" } };
 
-            yield return new object[] { @"[\p{IsGreek}-[\P{Lu}]]+", "\u0390\u03FE\u0386\u0388\u03EC\u03EE\u0400", RegexOptions.None, new string[] { "\u03FE\u0386\u0388\u03EC\u03EE" } };
-            yield return new object[] { @"[\p{IsBasicLatin}-[G-L]]+", "GAFMZL", RegexOptions.None, new string[] { "AFMZ" } };
+            yield return new object[] { null, @"[\p{IsGreek}-[\P{Lu}]]+", "\u0390\u03FE\u0386\u0388\u03EC\u03EE\u0400", RegexOptions.None, new string[] { "\u03FE\u0386\u0388\u03EC\u03EE" } };
+            yield return new object[] { null, @"[\p{IsBasicLatin}-[G-L]]+", "GAFMZL", RegexOptions.None, new string[] { "AFMZ" } };
 
-            yield return new object[] { "[a-zA-Z-[aeiouAEIOU]]+", "aeiouAEIOUbcdfghjklmnpqrstvwxyz", RegexOptions.None, new string[] { "bcdfghjklmnpqrstvwxyz" } };
+            yield return new object[] { null, "[a-zA-Z-[aeiouAEIOU]]+", "aeiouAEIOUbcdfghjklmnpqrstvwxyz", RegexOptions.None, new string[] { "bcdfghjklmnpqrstvwxyz" } };
 
             // The following is an overly complex way of matching an ip address using char class subtraction
-            yield return new object[] { @"^
+            yield return new object[] { null, @"^
             (?<octet>^
                 (
                     (
@@ -164,324 +157,324 @@ namespace System.Text.RegularExpressions.Tests
             , "255", RegexOptions.IgnorePatternWhitespace, new string[] { "255", "255", "2", "5", "5", "", "255", "2", "5" } };
 
             // Character Class Substraction
-            yield return new object[] { @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
-            yield return new object[] { @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
-            yield return new object[] { @"[^a-f-[\x00-\x60\u007B-\uFFFF]]+", "aaafffgggzzz{{{", RegexOptions.None, new string[] { "gggzzz" } };
-            yield return new object[] { @"[\[\]a-f-[[]]+", "gggaaafff]]][[[", RegexOptions.None, new string[] { "aaafff]]]" } };
-            yield return new object[] { @"[\[\]a-f-[]]]+", "gggaaafff[[[]]]", RegexOptions.None, new string[] { "aaafff[[[" } };
+            yield return new object[] { null, @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
+            yield return new object[] { null, @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
+            yield return new object[] { null, @"[^a-f-[\x00-\x60\u007B-\uFFFF]]+", "aaafffgggzzz{{{", RegexOptions.None, new string[] { "gggzzz" } };
+            yield return new object[] { null, @"[\[\]a-f-[[]]+", "gggaaafff]]][[[", RegexOptions.None, new string[] { "aaafff]]]" } };
+            yield return new object[] { null, @"[\[\]a-f-[]]]+", "gggaaafff[[[]]]", RegexOptions.None, new string[] { "aaafff[[[" } };
 
-            yield return new object[] { @"[ab\-\[cd-[-[]]]]", "a]]", RegexOptions.None, new string[] { "a]]" } };
-            yield return new object[] { @"[ab\-\[cd-[-[]]]]", "b]]", RegexOptions.None, new string[] { "b]]" } };
-            yield return new object[] { @"[ab\-\[cd-[-[]]]]", "c]]", RegexOptions.None, new string[] { "c]]" } };
-            yield return new object[] { @"[ab\-\[cd-[-[]]]]", "d]]", RegexOptions.None, new string[] { "d]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[-[]]]]", "a]]", RegexOptions.None, new string[] { "a]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[-[]]]]", "b]]", RegexOptions.None, new string[] { "b]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[-[]]]]", "c]]", RegexOptions.None, new string[] { "c]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[-[]]]]", "d]]", RegexOptions.None, new string[] { "d]]" } };
 
-            yield return new object[] { @"[ab\-\[cd-[[]]]]", "a]]", RegexOptions.None, new string[] { "a]]" } };
-            yield return new object[] { @"[ab\-\[cd-[[]]]]", "b]]", RegexOptions.None, new string[] { "b]]" } };
-            yield return new object[] { @"[ab\-\[cd-[[]]]]", "c]]", RegexOptions.None, new string[] { "c]]" } };
-            yield return new object[] { @"[ab\-\[cd-[[]]]]", "d]]", RegexOptions.None, new string[] { "d]]" } };
-            yield return new object[] { @"[ab\-\[cd-[[]]]]", "-]]", RegexOptions.None, new string[] { "-]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[[]]]]", "a]]", RegexOptions.None, new string[] { "a]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[[]]]]", "b]]", RegexOptions.None, new string[] { "b]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[[]]]]", "c]]", RegexOptions.None, new string[] { "c]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[[]]]]", "d]]", RegexOptions.None, new string[] { "d]]" } };
+            yield return new object[] { null, @"[ab\-\[cd-[[]]]]", "-]]", RegexOptions.None, new string[] { "-]]" } };
 
-            yield return new object[] { @"[a-[c-e]]+", "bbbaaaccc", RegexOptions.None, new string[] { "aaa" } };
-            yield return new object[] { @"[a-[c-e]]+", "```aaaccc", RegexOptions.None, new string[] { "aaa" } };
+            yield return new object[] { null, @"[a-[c-e]]+", "bbbaaaccc", RegexOptions.None, new string[] { "aaa" } };
+            yield return new object[] { null, @"[a-[c-e]]+", "```aaaccc", RegexOptions.None, new string[] { "aaa" } };
 
-            yield return new object[] { @"[a-d\--[bc]]+", "cccaaa--dddbbb", RegexOptions.None, new string[] { "aaa--ddd" } };
+            yield return new object[] { null, @"[a-d\--[bc]]+", "cccaaa--dddbbb", RegexOptions.None, new string[] { "aaa--ddd" } };
 
             // Not Character class substraction
-            yield return new object[] { @"[\0- [bc]+", "!!!\0\0\t\t  [[[[bbbcccaaa", RegexOptions.None, new string[] { "\0\0\t\t  [[[[bbbccc" } };
-            yield return new object[] { "[[abcd]-[bc]]+", "a-b]", RegexOptions.None, new string[] { "a-b]" } };
-            yield return new object[] { "[-[e-g]+", "ddd[[[---eeefffggghhh", RegexOptions.None, new string[] { "[[[---eeefffggg" } };
-            yield return new object[] { "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
-            yield return new object[] { "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
-            yield return new object[] { "[a-e - m-p]+", "---a b c d e m n o p---", RegexOptions.None, new string[] { "a b c d e m n o p" } };
-            yield return new object[] { "[^-[bc]]", "b] c] -] aaaddd]", RegexOptions.None, new string[] { "d]" } };
-            yield return new object[] { "[^-[bc]]", "b] c] -] aaa]ddd]", RegexOptions.None, new string[] { "a]" } };
+            yield return new object[] { null, @"[\0- [bc]+", "!!!\0\0\t\t  [[[[bbbcccaaa", RegexOptions.None, new string[] { "\0\0\t\t  [[[[bbbccc" } };
+            yield return new object[] { null, "[[abcd]-[bc]]+", "a-b]", RegexOptions.None, new string[] { "a-b]" } };
+            yield return new object[] { null, "[-[e-g]+", "ddd[[[---eeefffggghhh", RegexOptions.None, new string[] { "[[[---eeefffggg" } };
+            yield return new object[] { null, "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
+            yield return new object[] { null, "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
+            yield return new object[] { null, "[a-e - m-p]+", "---a b c d e m n o p---", RegexOptions.None, new string[] { "a b c d e m n o p" } };
+            yield return new object[] { null, "[^-[bc]]", "b] c] -] aaaddd]", RegexOptions.None, new string[] { "d]" } };
+            yield return new object[] { null, "[^-[bc]]", "b] c] -] aaa]ddd]", RegexOptions.None, new string[] { "a]" } };
 
             // Make sure we correctly handle \-
-            yield return new object[] { @"[a\-[bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
-            yield return new object[] { @"[a\-[\-\-bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
-            yield return new object[] { @"[a\-\[\-\[\-bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
-            yield return new object[] { @"[abc\--[b]]+", "[[[```bbbaaa---cccddd", RegexOptions.None, new string[] { "aaa---ccc" } };
-            yield return new object[] { @"[abc\-z-[b]]+", "```aaaccc---zzzbbb", RegexOptions.None, new string[] { "aaaccc---zzz" } };
-            yield return new object[] { @"[a-d\-[b]+", "```aaabbbcccddd----[[[[]]]", RegexOptions.None, new string[] { "aaabbbcccddd----[[[[" } };
-            yield return new object[] { @"[abcd\-d\-[bc]+", "bbbaaa---[[[dddccc", RegexOptions.None, new string[] { "bbbaaa---[[[dddccc" } };
+            yield return new object[] { null, @"[a\-[bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
+            yield return new object[] { null, @"[a\-[\-\-bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
+            yield return new object[] { null, @"[a\-\[\-\[\-bc]+", "```bbbaaa---[[[cccddd", RegexOptions.None, new string[] { "bbbaaa---[[[ccc" } };
+            yield return new object[] { null, @"[abc\--[b]]+", "[[[```bbbaaa---cccddd", RegexOptions.None, new string[] { "aaa---ccc" } };
+            yield return new object[] { null, @"[abc\-z-[b]]+", "```aaaccc---zzzbbb", RegexOptions.None, new string[] { "aaaccc---zzz" } };
+            yield return new object[] { null, @"[a-d\-[b]+", "```aaabbbcccddd----[[[[]]]", RegexOptions.None, new string[] { "aaabbbcccddd----[[[[" } };
+            yield return new object[] { null, @"[abcd\-d\-[bc]+", "bbbaaa---[[[dddccc", RegexOptions.None, new string[] { "bbbaaa---[[[dddccc" } };
 
             // Everything works correctly with option RegexOptions.IgnorePatternWhitespace
-            yield return new object[] { "[a - c - [ b ] ]+", "dddaaa   ccc [[[[ bbb ]]]", RegexOptions.IgnorePatternWhitespace, new string[] { " ]]]" } };
-            yield return new object[] { "[a - c - [ b ] +", "dddaaa   ccc [[[[ bbb ]]]", RegexOptions.IgnorePatternWhitespace, new string[] { "aaa   ccc [[[[ bbb " } };
+            yield return new object[] { null, "[a - c - [ b ] ]+", "dddaaa   ccc [[[[ bbb ]]]", RegexOptions.IgnorePatternWhitespace, new string[] { " ]]]" } };
+            yield return new object[] { null, "[a - c - [ b ] +", "dddaaa   ccc [[[[ bbb ]]]", RegexOptions.IgnorePatternWhitespace, new string[] { "aaa   ccc [[[[ bbb " } };
 
             // Unicode Char Classes
-            yield return new object[] { @"(\p{Lu}\w*)\s(\p{Lu}\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
-            yield return new object[] { @"(\p{Lu}\p{Ll}*)\s(\p{Lu}\p{Ll}*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
-            yield return new object[] { @"(\P{Ll}\p{Ll}*)\s(\P{Ll}\p{Ll}*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
-            yield return new object[] { @"(\P{Lu}+\p{Lu})\s(\P{Lu}+\p{Lu})", "hellO worlD", RegexOptions.None, new string[] { "hellO worlD", "hellO", "worlD" } };
-            yield return new object[] { @"(\p{Lt}\w*)\s(\p{Lt}*\w*)", "\u01C5ello \u01C5orld", RegexOptions.None, new string[] { "\u01C5ello \u01C5orld", "\u01C5ello", "\u01C5orld" } };
-            yield return new object[] { @"(\P{Lt}\w*)\s(\P{Lt}*\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"(\p{Lu}\w*)\s(\p{Lu}\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"(\p{Lu}\p{Ll}*)\s(\p{Lu}\p{Ll}*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"(\P{Ll}\p{Ll}*)\s(\P{Ll}\p{Ll}*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"(\P{Lu}+\p{Lu})\s(\P{Lu}+\p{Lu})", "hellO worlD", RegexOptions.None, new string[] { "hellO worlD", "hellO", "worlD" } };
+            yield return new object[] { null, @"(\p{Lt}\w*)\s(\p{Lt}*\w*)", "\u01C5ello \u01C5orld", RegexOptions.None, new string[] { "\u01C5ello \u01C5orld", "\u01C5ello", "\u01C5orld" } };
+            yield return new object[] { null, @"(\P{Lt}\w*)\s(\P{Lt}*\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
 
             // Character ranges IgnoreCase
-            yield return new object[] { @"[@-D]+", "eE?@ABCDabcdeE", RegexOptions.IgnoreCase, new string[] { "@ABCDabcd" } };
-            yield return new object[] { @"[>-D]+", "eE=>?@ABCDabcdeE", RegexOptions.IgnoreCase, new string[] { ">?@ABCDabcd" } };
-            yield return new object[] { @"[\u0554-\u0557]+", "\u0583\u0553\u0554\u0555\u0556\u0584\u0585\u0586\u0557\u0558", RegexOptions.IgnoreCase, new string[] { "\u0554\u0555\u0556\u0584\u0585\u0586\u0557" } };
-            yield return new object[] { @"[X-\]]+", "wWXYZxyz[\\]^", RegexOptions.IgnoreCase, new string[] { "XYZxyz[\\]" } };
-            yield return new object[] { @"[X-\u0533]+", "\u0551\u0554\u0560AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563\u0564", RegexOptions.IgnoreCase, new string[] { "AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563" } };
-            yield return new object[] { @"[X-a]+", "wWAXYZaxyz", RegexOptions.IgnoreCase, new string[] { "AXYZaxyz" } };
-            yield return new object[] { @"[X-c]+", "wWABCXYZabcxyz", RegexOptions.IgnoreCase, new string[] { "ABCXYZabcxyz" } };
-            yield return new object[] { @"[X-\u00C0]+", "\u00C1\u00E1\u00C0\u00E0wWABCXYZabcxyz", RegexOptions.IgnoreCase, new string[] { "\u00C0\u00E0wWABCXYZabcxyz" } };
-            yield return new object[] { @"[\u0100\u0102\u0104]+", "\u00FF \u0100\u0102\u0104\u0101\u0103\u0105\u0106", RegexOptions.IgnoreCase, new string[] { "\u0100\u0102\u0104\u0101\u0103\u0105" } };
-            yield return new object[] { @"[B-D\u0130]+", "aAeE\u0129\u0131\u0068 BCDbcD\u0130\u0069\u0070", RegexOptions.IgnoreCase, new string[] { "BCDbcD\u0130\u0069" } };
-            yield return new object[] { @"[\u013B\u013D\u013F]+", "\u013A\u013B\u013D\u013F\u013C\u013E\u0140\u0141", RegexOptions.IgnoreCase, new string[] { "\u013B\u013D\u013F\u013C\u013E\u0140" } };
+            yield return new object[] { null, @"[@-D]+", "eE?@ABCDabcdeE", RegexOptions.IgnoreCase, new string[] { "@ABCDabcd" } };
+            yield return new object[] { null, @"[>-D]+", "eE=>?@ABCDabcdeE", RegexOptions.IgnoreCase, new string[] { ">?@ABCDabcd" } };
+            yield return new object[] { null, @"[\u0554-\u0557]+", "\u0583\u0553\u0554\u0555\u0556\u0584\u0585\u0586\u0557\u0558", RegexOptions.IgnoreCase, new string[] { "\u0554\u0555\u0556\u0584\u0585\u0586\u0557" } };
+            yield return new object[] { null, @"[X-\]]+", "wWXYZxyz[\\]^", RegexOptions.IgnoreCase, new string[] { "XYZxyz[\\]" } };
+            yield return new object[] { null, @"[X-\u0533]+", "\u0551\u0554\u0560AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563\u0564", RegexOptions.IgnoreCase, new string[] { "AXYZaxyz\u0531\u0532\u0533\u0561\u0562\u0563" } };
+            yield return new object[] { null, @"[X-a]+", "wWAXYZaxyz", RegexOptions.IgnoreCase, new string[] { "AXYZaxyz" } };
+            yield return new object[] { null, @"[X-c]+", "wWABCXYZabcxyz", RegexOptions.IgnoreCase, new string[] { "ABCXYZabcxyz" } };
+            yield return new object[] { null, @"[X-\u00C0]+", "\u00C1\u00E1\u00C0\u00E0wWABCXYZabcxyz", RegexOptions.IgnoreCase, new string[] { "\u00C0\u00E0wWABCXYZabcxyz" } };
+            yield return new object[] { null, @"[\u0100\u0102\u0104]+", "\u00FF \u0100\u0102\u0104\u0101\u0103\u0105\u0106", RegexOptions.IgnoreCase, new string[] { "\u0100\u0102\u0104\u0101\u0103\u0105" } };
+            yield return new object[] { null, @"[B-D\u0130]+", "aAeE\u0129\u0131\u0068 BCDbcD\u0130\u0069\u0070", RegexOptions.IgnoreCase, new string[] { "BCDbcD\u0130\u0069" } };
+            yield return new object[] { null, @"[\u013B\u013D\u013F]+", "\u013A\u013B\u013D\u013F\u013C\u013E\u0140\u0141", RegexOptions.IgnoreCase, new string[] { "\u013B\u013D\u013F\u013C\u013E\u0140" } };
 
             // Escape Chars
-            yield return new object[] { "(Cat)\r(Dog)", "Cat\rDog", RegexOptions.None, new string[] { "Cat\rDog", "Cat", "Dog" } };
-            yield return new object[] { "(Cat)\t(Dog)", "Cat\tDog", RegexOptions.None, new string[] { "Cat\tDog", "Cat", "Dog" } };
-            yield return new object[] { "(Cat)\f(Dog)", "Cat\fDog", RegexOptions.None, new string[] { "Cat\fDog", "Cat", "Dog" } };
+            yield return new object[] { null, "(Cat)\r(Dog)", "Cat\rDog", RegexOptions.None, new string[] { "Cat\rDog", "Cat", "Dog" } };
+            yield return new object[] { null, "(Cat)\t(Dog)", "Cat\tDog", RegexOptions.None, new string[] { "Cat\tDog", "Cat", "Dog" } };
+            yield return new object[] { null, "(Cat)\f(Dog)", "Cat\fDog", RegexOptions.None, new string[] { "Cat\fDog", "Cat", "Dog" } };
 
             // Miscellaneous { witout matching }
-            yield return new object[] { @"{5", "hello {5 world", RegexOptions.None, new string[] { "{5" } };
-            yield return new object[] { @"{5,", "hello {5, world", RegexOptions.None, new string[] { "{5," } };
-            yield return new object[] { @"{5,6", "hello {5,6 world", RegexOptions.None, new string[] { "{5,6" } };
+            yield return new object[] { null, @"{5", "hello {5 world", RegexOptions.None, new string[] { "{5" } };
+            yield return new object[] { null, @"{5,", "hello {5, world", RegexOptions.None, new string[] { "{5," } };
+            yield return new object[] { null, @"{5,6", "hello {5,6 world", RegexOptions.None, new string[] { "{5,6" } };
 
             // Miscellaneous inline options
-            yield return new object[] { @"(?n:(?<cat>cat)(\s+)(?<dog>dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog", "cat", "dog" } };
-            yield return new object[] { @"(?n:(cat)(\s+)(dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog" } };
-            yield return new object[] { @"(?n:(cat)(?<SpaceChars>\s+)(dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog", "   " } };
-            yield return new object[] { @"(?x:
+            yield return new object[] { null, @"(?n:(?<cat>cat)(\s+)(?<dog>dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(?n:(cat)(\s+)(dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog" } };
+            yield return new object[] { null, @"(?n:(cat)(?<SpaceChars>\s+)(dog))", "cat   dog", RegexOptions.None, new string[] { "cat   dog", "   " } };
+            yield return new object[] { null, @"(?x:
                             (?<cat>cat) # Cat statement
                             (\s+) # Whitespace chars
                             (?<dog>dog # Dog statement
                             ))", "cat   dog", RegexOptions.None, new string[] { "cat   dog", "   ", "cat", "dog" } };
-            yield return new object[] { @"(?+i:cat)", "CAT", RegexOptions.None, new string[] { "CAT" } };
+            yield return new object[] { null, @"(?+i:cat)", "CAT", RegexOptions.None, new string[] { "CAT" } };
 
             // \d, \D, \s, \S, \w, \W, \P, \p inside character range
-            yield return new object[] { @"cat([\d]*)dog", "hello123cat230927dog1412d", RegexOptions.None, new string[] { "cat230927dog", "230927" } };
-            yield return new object[] { @"([\D]*)dog", "65498catdog58719", RegexOptions.None, new string[] { "catdog", "cat" } };
-            yield return new object[] { @"cat([\s]*)dog", "wiocat   dog3270", RegexOptions.None, new string[] { "cat   dog", "   " } };
-            yield return new object[] { @"cat([\S]*)", "sfdcatdog    3270", RegexOptions.None, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"cat([\w]*)", "sfdcatdog    3270", RegexOptions.None, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"cat([\W]*)dog", "wiocat   dog3270", RegexOptions.None, new string[] { "cat   dog", "   " } };
-            yield return new object[] { @"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
-            yield return new object[] { @"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"cat([\d]*)dog", "hello123cat230927dog1412d", RegexOptions.None, new string[] { "cat230927dog", "230927" } };
+            yield return new object[] { null, @"([\D]*)dog", "65498catdog58719", RegexOptions.None, new string[] { "catdog", "cat" } };
+            yield return new object[] { null, @"cat([\s]*)dog", "wiocat   dog3270", RegexOptions.None, new string[] { "cat   dog", "   " } };
+            yield return new object[] { null, @"cat([\S]*)", "sfdcatdog    3270", RegexOptions.None, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"cat([\w]*)", "sfdcatdog    3270", RegexOptions.None, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"cat([\W]*)dog", "wiocat   dog3270", RegexOptions.None, new string[] { "cat   dog", "   " } };
+            yield return new object[] { null, @"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", "Hello World", RegexOptions.None, new string[] { "Hello World", "Hello", "World" } };
 
             // \x, \u, \a, \b, \e, \f, \n, \r, \t, \v, \c, inside character range
-            yield return new object[] { @"(cat)([\x41]*)(dog)", "catAAAdog", RegexOptions.None, new string[] { "catAAAdog", "cat", "AAA", "dog" } };
-            yield return new object[] { @"(cat)([\u0041]*)(dog)", "catAAAdog", RegexOptions.None, new string[] { "catAAAdog", "cat", "AAA", "dog" } };
-            yield return new object[] { @"(cat)([\a]*)(dog)", "cat\a\a\adog", RegexOptions.None, new string[] { "cat\a\a\adog", "cat", "\a\a\a", "dog" } };
-            yield return new object[] { @"(cat)([\b]*)(dog)", "cat\b\b\bdog", RegexOptions.None, new string[] { "cat\b\b\bdog", "cat", "\b\b\b", "dog" } };
-            yield return new object[] { @"(cat)([\e]*)(dog)", "cat\u001B\u001B\u001Bdog", RegexOptions.None, new string[] { "cat\u001B\u001B\u001Bdog", "cat", "\u001B\u001B\u001B", "dog" } };
-            yield return new object[] { @"(cat)([\f]*)(dog)", "cat\f\f\fdog", RegexOptions.None, new string[] { "cat\f\f\fdog", "cat", "\f\f\f", "dog" } };
-            yield return new object[] { @"(cat)([\r]*)(dog)", "cat\r\r\rdog", RegexOptions.None, new string[] { "cat\r\r\rdog", "cat", "\r\r\r", "dog" } };
-            yield return new object[] { @"(cat)([\v]*)(dog)", "cat\v\v\vdog", RegexOptions.None, new string[] { "cat\v\v\vdog", "cat", "\v\v\v", "dog" } };
+            yield return new object[] { null, @"(cat)([\x41]*)(dog)", "catAAAdog", RegexOptions.None, new string[] { "catAAAdog", "cat", "AAA", "dog" } };
+            yield return new object[] { null, @"(cat)([\u0041]*)(dog)", "catAAAdog", RegexOptions.None, new string[] { "catAAAdog", "cat", "AAA", "dog" } };
+            yield return new object[] { null, @"(cat)([\a]*)(dog)", "cat\a\a\adog", RegexOptions.None, new string[] { "cat\a\a\adog", "cat", "\a\a\a", "dog" } };
+            yield return new object[] { null, @"(cat)([\b]*)(dog)", "cat\b\b\bdog", RegexOptions.None, new string[] { "cat\b\b\bdog", "cat", "\b\b\b", "dog" } };
+            yield return new object[] { null, @"(cat)([\e]*)(dog)", "cat\u001B\u001B\u001Bdog", RegexOptions.None, new string[] { "cat\u001B\u001B\u001Bdog", "cat", "\u001B\u001B\u001B", "dog" } };
+            yield return new object[] { null, @"(cat)([\f]*)(dog)", "cat\f\f\fdog", RegexOptions.None, new string[] { "cat\f\f\fdog", "cat", "\f\f\f", "dog" } };
+            yield return new object[] { null, @"(cat)([\r]*)(dog)", "cat\r\r\rdog", RegexOptions.None, new string[] { "cat\r\r\rdog", "cat", "\r\r\r", "dog" } };
+            yield return new object[] { null, @"(cat)([\v]*)(dog)", "cat\v\v\vdog", RegexOptions.None, new string[] { "cat\v\v\vdog", "cat", "\v\v\v", "dog" } };
 
             // \d, \D, \s, \S, \w, \W, \P, \p inside character range ([0-5]) with ECMA Option
-            yield return new object[] { @"cat([\d]*)dog", "hello123cat230927dog1412d", RegexOptions.ECMAScript, new string[] { "cat230927dog", "230927" } };
-            yield return new object[] { @"([\D]*)dog", "65498catdog58719", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
-            yield return new object[] { @"cat([\s]*)dog", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "   " } };
-            yield return new object[] { @"cat([\S]*)", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"cat([\w]*)", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"cat([\W]*)dog", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "   " } };
-            yield return new object[] { @"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "Hello", "World" } };
-            yield return new object[] { @"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"cat([\d]*)dog", "hello123cat230927dog1412d", RegexOptions.ECMAScript, new string[] { "cat230927dog", "230927" } };
+            yield return new object[] { null, @"([\D]*)dog", "65498catdog58719", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
+            yield return new object[] { null, @"cat([\s]*)dog", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "   " } };
+            yield return new object[] { null, @"cat([\S]*)", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"cat([\w]*)", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"cat([\W]*)dog", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "   " } };
+            yield return new object[] { null, @"([\p{Lu}]\w*)\s([\p{Lu}]\w*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "Hello", "World" } };
+            yield return new object[] { null, @"([\P{Ll}][\p{Ll}]*)\s([\P{Ll}][\p{Ll}]*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "Hello", "World" } };
 
             // \d, \D, \s, \S, \w, \W, \P, \p outside character range ([0-5]) with ECMA Option
-            yield return new object[] { @"(cat)\d*dog", "hello123cat230927dog1412d", RegexOptions.ECMAScript, new string[] { "cat230927dog", "cat" } };
-            yield return new object[] { @"\D*(dog)", "65498catdog58719", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"(cat)\s*(dog)", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\S*", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
-            yield return new object[] { @"(cat)\w*", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
-            yield return new object[] { @"(cat)\W*(dog)", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "cat", "dog" } };
-            yield return new object[] { @"\p{Lu}(\w*)\s\p{Lu}(\w*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "ello", "orld" } };
-            yield return new object[] { @"\P{Ll}\p{Ll}*\s\P{Ll}\p{Ll}*", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World" } };
+            yield return new object[] { null, @"(cat)\d*dog", "hello123cat230927dog1412d", RegexOptions.ECMAScript, new string[] { "cat230927dog", "cat" } };
+            yield return new object[] { null, @"\D*(dog)", "65498catdog58719", RegexOptions.ECMAScript, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"(cat)\s*(dog)", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\S*", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
+            yield return new object[] { null, @"(cat)\w*", "sfdcatdog    3270", RegexOptions.ECMAScript, new string[] { "catdog", "cat" } };
+            yield return new object[] { null, @"(cat)\W*(dog)", "wiocat   dog3270", RegexOptions.ECMAScript, new string[] { "cat   dog", "cat", "dog" } };
+            yield return new object[] { null, @"\p{Lu}(\w*)\s\p{Lu}(\w*)", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World", "ello", "orld" } };
+            yield return new object[] { null, @"\P{Ll}\p{Ll}*\s\P{Ll}\p{Ll}*", "Hello World", RegexOptions.ECMAScript, new string[] { "Hello World" } };
 
             // Use < in a group
-            yield return new object[] { @"cat(?<dog121>dog)", "catcatdogdogcat", RegexOptions.None, new string[] { "catdog", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s*(?<cat>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
-            yield return new object[] { @"(?<1>cat)\s*(?<1>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
-            yield return new object[] { @"(?<2048>cat)\s*(?<2048>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\w+(?<dog-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
-            yield return new object[] { @"(?<cat>cat)\w+(?<-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "" } };
-            yield return new object[] { @"(?<cat>cat)\w+(?<cat-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "_Hello_World_" } };
-            yield return new object[] { @"(?<1>cat)\w+(?<dog-1>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
-            yield return new object[] { @"(?<cat>cat)\w+(?<2-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
-            yield return new object[] { @"(?<1>cat)\w+(?<2-1>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
+            yield return new object[] { null, @"cat(?<dog121>dog)", "catcatdogdogcat", RegexOptions.None, new string[] { "catdog", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s*(?<cat>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
+            yield return new object[] { null, @"(?<1>cat)\s*(?<1>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
+            yield return new object[] { null, @"(?<2048>cat)\s*(?<2048>dog)", "catcat    dogdogcat", RegexOptions.None, new string[] { "cat    dog", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\w+(?<dog-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
+            yield return new object[] { null, @"(?<cat>cat)\w+(?<-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "" } };
+            yield return new object[] { null, @"(?<cat>cat)\w+(?<cat-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "_Hello_World_" } };
+            yield return new object[] { null, @"(?<1>cat)\w+(?<dog-1>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
+            yield return new object[] { null, @"(?<cat>cat)\w+(?<2-cat>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
+            yield return new object[] { null, @"(?<1>cat)\w+(?<2-1>dog)", "cat_Hello_World_dog", RegexOptions.None, new string[] { "cat_Hello_World_dog", "", "_Hello_World_" } };
 
             // Quantifiers
-            yield return new object[] { @"(?<cat>cat){", "STARTcat{", RegexOptions.None, new string[] { "cat{", "cat" } };
-            yield return new object[] { @"(?<cat>cat){fdsa", "STARTcat{fdsa", RegexOptions.None, new string[] { "cat{fdsa", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1", "STARTcat{1", RegexOptions.None, new string[] { "cat{1", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1END", "STARTcat{1END", RegexOptions.None, new string[] { "cat{1END", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1,", "STARTcat{1,", RegexOptions.None, new string[] { "cat{1,", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1,END", "STARTcat{1,END", RegexOptions.None, new string[] { "cat{1,END", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1,2", "STARTcat{1,2", RegexOptions.None, new string[] { "cat{1,2", "cat" } };
-            yield return new object[] { @"(?<cat>cat){1,2END", "STARTcat{1,2END", RegexOptions.None, new string[] { "cat{1,2END", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){", "STARTcat{", RegexOptions.None, new string[] { "cat{", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){fdsa", "STARTcat{fdsa", RegexOptions.None, new string[] { "cat{fdsa", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1", "STARTcat{1", RegexOptions.None, new string[] { "cat{1", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1END", "STARTcat{1END", RegexOptions.None, new string[] { "cat{1END", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1,", "STARTcat{1,", RegexOptions.None, new string[] { "cat{1,", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1,END", "STARTcat{1,END", RegexOptions.None, new string[] { "cat{1,END", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1,2", "STARTcat{1,2", RegexOptions.None, new string[] { "cat{1,2", "cat" } };
+            yield return new object[] { null, @"(?<cat>cat){1,2END", "STARTcat{1,2END", RegexOptions.None, new string[] { "cat{1,2END", "cat" } };
 
             // Use IgnorePatternWhitespace
-            yield return new object[] { @"(cat) #cat
+            yield return new object[] { null, @"(cat) #cat
                             \s+ #followed by 1 or more whitespace
                             (dog)  #followed by dog
                             ", "cat    dog", RegexOptions.IgnorePatternWhitespace, new string[] { "cat    dog", "cat", "dog" } };
-            yield return new object[] { @"(cat) #cat
+            yield return new object[] { null, @"(cat) #cat
                             \s+ #followed by 1 or more whitespace
                             (dog)  #followed by dog", "cat    dog", RegexOptions.IgnorePatternWhitespace, new string[] { "cat    dog", "cat", "dog" } };
-            yield return new object[] { @"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace) (dog)  (?#followed by dog)", "cat    dog", RegexOptions.IgnorePatternWhitespace, new string[] { "cat    dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat) (?#cat)    \s+ (?#followed by 1 or more whitespace) (dog)  (?#followed by dog)", "cat    dog", RegexOptions.IgnorePatternWhitespace, new string[] { "cat    dog", "cat", "dog" } };
 
             // Back Reference
-            yield return new object[] { @"(?<cat>cat)(?<dog>dog)\k<cat>", "asdfcatdogcatdog", RegexOptions.None, new string[] { "catdogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k'cat'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\'cat'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)(?<dog>dog)\k<cat>", "asdfcatdogcatdog", RegexOptions.None, new string[] { "catdogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\k<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\k'cat'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\<cat>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\'cat'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
 
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k<1>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k'1'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\<1>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\'1'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\1", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\1", "asdfcat   dogcat   dog", RegexOptions.ECMAScript, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\k<1>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\k'1'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\<1>", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\'1'", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\1", "asdfcat   dogcat   dog", RegexOptions.None, new string[] { "cat   dogcat", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\1", "asdfcat   dogcat   dog", RegexOptions.ECMAScript, new string[] { "cat   dogcat", "cat", "dog" } };
 
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\k<dog>", "asdfcat   dogdog   dog", RegexOptions.None, new string[] { "cat   dogdog", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\2", "asdfcat   dogdog   dog", RegexOptions.None, new string[] { "cat   dogdog", "cat", "dog" } };
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\2", "asdfcat   dogdog   dog", RegexOptions.ECMAScript, new string[] { "cat   dogdog", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\k<dog>", "asdfcat   dogdog   dog", RegexOptions.None, new string[] { "cat   dogdog", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\2", "asdfcat   dogdog   dog", RegexOptions.None, new string[] { "cat   dogdog", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\2", "asdfcat   dogdog   dog", RegexOptions.ECMAScript, new string[] { "cat   dogdog", "cat", "dog" } };
 
             // Octal
-            yield return new object[] { @"(cat)(\077)", "hellocat?dogworld", RegexOptions.None, new string[] { "cat?", "cat", "?" } };
-            yield return new object[] { @"(cat)(\77)", "hellocat?dogworld", RegexOptions.None, new string[] { "cat?", "cat", "?" } };
-            yield return new object[] { @"(cat)(\176)", "hellocat~dogworld", RegexOptions.None, new string[] { "cat~", "cat", "~" } };
-            yield return new object[] { @"(cat)(\400)", "hellocat\0dogworld", RegexOptions.None, new string[] { "cat\0", "cat", "\0" } };
-            yield return new object[] { @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
-            yield return new object[] { @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
-            yield return new object[] { @"(cat)(\477)", "hellocat\u003Fdogworld", RegexOptions.None, new string[] { "cat\u003F", "cat", "\u003F" } };
-            yield return new object[] { @"(cat)(\777)", "hellocat\u00FFdogworld", RegexOptions.None, new string[] { "cat\u00FF", "cat", "\u00FF" } };
-            yield return new object[] { @"(cat)(\7770)", "hellocat\u00FF0dogworld", RegexOptions.None, new string[] { "cat\u00FF0", "cat", "\u00FF0" } };
+            yield return new object[] { null, @"(cat)(\077)", "hellocat?dogworld", RegexOptions.None, new string[] { "cat?", "cat", "?" } };
+            yield return new object[] { null, @"(cat)(\77)", "hellocat?dogworld", RegexOptions.None, new string[] { "cat?", "cat", "?" } };
+            yield return new object[] { null, @"(cat)(\176)", "hellocat~dogworld", RegexOptions.None, new string[] { "cat~", "cat", "~" } };
+            yield return new object[] { null, @"(cat)(\400)", "hellocat\0dogworld", RegexOptions.None, new string[] { "cat\0", "cat", "\0" } };
+            yield return new object[] { null, @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
+            yield return new object[] { null, @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
+            yield return new object[] { null, @"(cat)(\477)", "hellocat\u003Fdogworld", RegexOptions.None, new string[] { "cat\u003F", "cat", "\u003F" } };
+            yield return new object[] { null, @"(cat)(\777)", "hellocat\u00FFdogworld", RegexOptions.None, new string[] { "cat\u00FF", "cat", "\u00FF" } };
+            yield return new object[] { null, @"(cat)(\7770)", "hellocat\u00FF0dogworld", RegexOptions.None, new string[] { "cat\u00FF0", "cat", "\u00FF0" } };
 
-            yield return new object[] { @"(cat)(\077)", "hellocat?dogworld", RegexOptions.ECMAScript, new string[] { "cat?", "cat", "?" } };
-            yield return new object[] { @"(cat)(\77)", "hellocat?dogworld", RegexOptions.ECMAScript, new string[] { "cat?", "cat", "?" } };
-            yield return new object[] { @"(cat)(\7)", "hellocat\adogworld", RegexOptions.ECMAScript, new string[] { "cat\a", "cat", "\a" } };
-            yield return new object[] { @"(cat)(\40)", "hellocat dogworld", RegexOptions.ECMAScript, new string[] { "cat ", "cat", " " } };
-            yield return new object[] { @"(cat)(\040)", "hellocat dogworld", RegexOptions.ECMAScript, new string[] { "cat ", "cat", " " } };
-            yield return new object[] { @"(cat)(\176)", "hellocatcat76dogworld", RegexOptions.ECMAScript, new string[] { "catcat76", "cat", "cat76" } };
-            yield return new object[] { @"(cat)(\377)", "hellocat\u00FFdogworld", RegexOptions.ECMAScript, new string[] { "cat\u00FF", "cat", "\u00FF" } };
-            yield return new object[] { @"(cat)(\400)", "hellocat 0Fdogworld", RegexOptions.ECMAScript, new string[] { "cat 0", "cat", " 0" } };
+            yield return new object[] { null, @"(cat)(\077)", "hellocat?dogworld", RegexOptions.ECMAScript, new string[] { "cat?", "cat", "?" } };
+            yield return new object[] { null, @"(cat)(\77)", "hellocat?dogworld", RegexOptions.ECMAScript, new string[] { "cat?", "cat", "?" } };
+            yield return new object[] { null, @"(cat)(\7)", "hellocat\adogworld", RegexOptions.ECMAScript, new string[] { "cat\a", "cat", "\a" } };
+            yield return new object[] { null, @"(cat)(\40)", "hellocat dogworld", RegexOptions.ECMAScript, new string[] { "cat ", "cat", " " } };
+            yield return new object[] { null, @"(cat)(\040)", "hellocat dogworld", RegexOptions.ECMAScript, new string[] { "cat ", "cat", " " } };
+            yield return new object[] { null, @"(cat)(\176)", "hellocatcat76dogworld", RegexOptions.ECMAScript, new string[] { "catcat76", "cat", "cat76" } };
+            yield return new object[] { null, @"(cat)(\377)", "hellocat\u00FFdogworld", RegexOptions.ECMAScript, new string[] { "cat\u00FF", "cat", "\u00FF" } };
+            yield return new object[] { null, @"(cat)(\400)", "hellocat 0Fdogworld", RegexOptions.ECMAScript, new string[] { "cat 0", "cat", " 0" } };
 
             // Decimal
-            yield return new object[] { @"(cat)\s+(?<2147483646>dog)", "asdlkcat  dogiwod", RegexOptions.None, new string[] { "cat  dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(?<2147483647>dog)", "asdlkcat  dogiwod", RegexOptions.None, new string[] { "cat  dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(?<2147483646>dog)", "asdlkcat  dogiwod", RegexOptions.None, new string[] { "cat  dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(?<2147483647>dog)", "asdlkcat  dogiwod", RegexOptions.None, new string[] { "cat  dog", "cat", "dog" } };
 
             // Hex
-            yield return new object[] { @"(cat)(\x2a*)(dog)", "asdlkcat***dogiwod", RegexOptions.None, new string[] { "cat***dog", "cat", "***", "dog" } };
-            yield return new object[] { @"(cat)(\x2b*)(dog)", "asdlkcat+++dogiwod", RegexOptions.None, new string[] { "cat+++dog", "cat", "+++", "dog" } };
-            yield return new object[] { @"(cat)(\x2c*)(dog)", "asdlkcat,,,dogiwod", RegexOptions.None, new string[] { "cat,,,dog", "cat", ",,,", "dog" } };
-            yield return new object[] { @"(cat)(\x2d*)(dog)", "asdlkcat---dogiwod", RegexOptions.None, new string[] { "cat---dog", "cat", "---", "dog" } };
-            yield return new object[] { @"(cat)(\x2e*)(dog)", "asdlkcat...dogiwod", RegexOptions.None, new string[] { "cat...dog", "cat", "...", "dog" } };
-            yield return new object[] { @"(cat)(\x2f*)(dog)", "asdlkcat///dogiwod", RegexOptions.None, new string[] { "cat///dog", "cat", "///", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2a*)(dog)", "asdlkcat***dogiwod", RegexOptions.None, new string[] { "cat***dog", "cat", "***", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2b*)(dog)", "asdlkcat+++dogiwod", RegexOptions.None, new string[] { "cat+++dog", "cat", "+++", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2c*)(dog)", "asdlkcat,,,dogiwod", RegexOptions.None, new string[] { "cat,,,dog", "cat", ",,,", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2d*)(dog)", "asdlkcat---dogiwod", RegexOptions.None, new string[] { "cat---dog", "cat", "---", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2e*)(dog)", "asdlkcat...dogiwod", RegexOptions.None, new string[] { "cat...dog", "cat", "...", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2f*)(dog)", "asdlkcat///dogiwod", RegexOptions.None, new string[] { "cat///dog", "cat", "///", "dog" } };
 
-            yield return new object[] { @"(cat)(\x2A*)(dog)", "asdlkcat***dogiwod", RegexOptions.None, new string[] { "cat***dog", "cat", "***", "dog" } };
-            yield return new object[] { @"(cat)(\x2B*)(dog)", "asdlkcat+++dogiwod", RegexOptions.None, new string[] { "cat+++dog", "cat", "+++", "dog" } };
-            yield return new object[] { @"(cat)(\x2C*)(dog)", "asdlkcat,,,dogiwod", RegexOptions.None, new string[] { "cat,,,dog", "cat", ",,,", "dog" } };
-            yield return new object[] { @"(cat)(\x2D*)(dog)", "asdlkcat---dogiwod", RegexOptions.None, new string[] { "cat---dog", "cat", "---", "dog" } };
-            yield return new object[] { @"(cat)(\x2E*)(dog)", "asdlkcat...dogiwod", RegexOptions.None, new string[] { "cat...dog", "cat", "...", "dog" } };
-            yield return new object[] { @"(cat)(\x2F*)(dog)", "asdlkcat///dogiwod", RegexOptions.None, new string[] { "cat///dog", "cat", "///", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2A*)(dog)", "asdlkcat***dogiwod", RegexOptions.None, new string[] { "cat***dog", "cat", "***", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2B*)(dog)", "asdlkcat+++dogiwod", RegexOptions.None, new string[] { "cat+++dog", "cat", "+++", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2C*)(dog)", "asdlkcat,,,dogiwod", RegexOptions.None, new string[] { "cat,,,dog", "cat", ",,,", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2D*)(dog)", "asdlkcat---dogiwod", RegexOptions.None, new string[] { "cat---dog", "cat", "---", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2E*)(dog)", "asdlkcat...dogiwod", RegexOptions.None, new string[] { "cat...dog", "cat", "...", "dog" } };
+            yield return new object[] { null, @"(cat)(\x2F*)(dog)", "asdlkcat///dogiwod", RegexOptions.None, new string[] { "cat///dog", "cat", "///", "dog" } };
 
             // ScanControl
-            yield return new object[] { @"(cat)(\c@*)(dog)", "asdlkcat\0\0dogiwod", RegexOptions.None, new string[] { "cat\0\0dog", "cat", "\0\0", "dog" } };
-            yield return new object[] { @"(cat)(\cA*)(dog)", "asdlkcat\u0001dogiwod", RegexOptions.None, new string[] { "cat\u0001dog", "cat", "\u0001", "dog" } };
-            yield return new object[] { @"(cat)(\ca*)(dog)", "asdlkcat\u0001dogiwod", RegexOptions.None, new string[] { "cat\u0001dog", "cat", "\u0001", "dog" } };
+            yield return new object[] { null, @"(cat)(\c@*)(dog)", "asdlkcat\0\0dogiwod", RegexOptions.None, new string[] { "cat\0\0dog", "cat", "\0\0", "dog" } };
+            yield return new object[] { null, @"(cat)(\cA*)(dog)", "asdlkcat\u0001dogiwod", RegexOptions.None, new string[] { "cat\u0001dog", "cat", "\u0001", "dog" } };
+            yield return new object[] { null, @"(cat)(\ca*)(dog)", "asdlkcat\u0001dogiwod", RegexOptions.None, new string[] { "cat\u0001dog", "cat", "\u0001", "dog" } };
 
-            yield return new object[] { @"(cat)(\cC*)(dog)", "asdlkcat\u0003dogiwod", RegexOptions.None, new string[] { "cat\u0003dog", "cat", "\u0003", "dog" } };
-            yield return new object[] { @"(cat)(\cc*)(dog)", "asdlkcat\u0003dogiwod", RegexOptions.None, new string[] { "cat\u0003dog", "cat", "\u0003", "dog" } };
+            yield return new object[] { null, @"(cat)(\cC*)(dog)", "asdlkcat\u0003dogiwod", RegexOptions.None, new string[] { "cat\u0003dog", "cat", "\u0003", "dog" } };
+            yield return new object[] { null, @"(cat)(\cc*)(dog)", "asdlkcat\u0003dogiwod", RegexOptions.None, new string[] { "cat\u0003dog", "cat", "\u0003", "dog" } };
 
-            yield return new object[] { @"(cat)(\cD*)(dog)", "asdlkcat\u0004dogiwod", RegexOptions.None, new string[] { "cat\u0004dog", "cat", "\u0004", "dog" } };
-            yield return new object[] { @"(cat)(\cd*)(dog)", "asdlkcat\u0004dogiwod", RegexOptions.None, new string[] { "cat\u0004dog", "cat", "\u0004", "dog" } };
+            yield return new object[] { null, @"(cat)(\cD*)(dog)", "asdlkcat\u0004dogiwod", RegexOptions.None, new string[] { "cat\u0004dog", "cat", "\u0004", "dog" } };
+            yield return new object[] { null, @"(cat)(\cd*)(dog)", "asdlkcat\u0004dogiwod", RegexOptions.None, new string[] { "cat\u0004dog", "cat", "\u0004", "dog" } };
 
-            yield return new object[] { @"(cat)(\cX*)(dog)", "asdlkcat\u0018dogiwod", RegexOptions.None, new string[] { "cat\u0018dog", "cat", "\u0018", "dog" } };
-            yield return new object[] { @"(cat)(\cx*)(dog)", "asdlkcat\u0018dogiwod", RegexOptions.None, new string[] { "cat\u0018dog", "cat", "\u0018", "dog" } };
+            yield return new object[] { null, @"(cat)(\cX*)(dog)", "asdlkcat\u0018dogiwod", RegexOptions.None, new string[] { "cat\u0018dog", "cat", "\u0018", "dog" } };
+            yield return new object[] { null, @"(cat)(\cx*)(dog)", "asdlkcat\u0018dogiwod", RegexOptions.None, new string[] { "cat\u0018dog", "cat", "\u0018", "dog" } };
 
-            yield return new object[] { @"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
-            yield return new object[] { @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
+            yield return new object[] { null, @"(cat)(\cZ*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
+            yield return new object[] { null, @"(cat)(\cz*)(dog)", "asdlkcat\u001adogiwod", RegexOptions.None, new string[] { "cat\u001adog", "cat", "\u001a", "dog" } };
 
-            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
-            yield return new object[] { @"(cat)(\c[*)(dog)", "asdlkcat\u001Bdogiwod", RegexOptions.None, new string[] { "cat\u001Bdog", "cat", "\u001B", "dog" } };
+            yield return new object[] { null, @"(cat)(\c[*)(dog)", "asdlkcat\u001bdogiwod", RegexOptions.None, new string[] { "cat\u001bdog", "cat", "\u001b", "dog" } };
+            yield return new object[] { null, @"(cat)(\c[*)(dog)", "asdlkcat\u001Bdogiwod", RegexOptions.None, new string[] { "cat\u001Bdog", "cat", "\u001B", "dog" } };
 
             // Atomic Zero-Width Assertions \A \Z \z \G \b \B
             //\A
-            yield return new object[] { @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"\A(cat)\s+(dog)", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
 
             //\Z
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\Z", "cat   \n\n\n   dog\n", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
 
             //\z
-            yield return new object[] { @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
-            yield return new object[] { @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.None, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.Multiline, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
+            yield return new object[] { null, @"(cat)\s+(dog)\z", "cat   \n\n\n   dog", RegexOptions.ECMAScript, new string[] { "cat   \n\n\n   dog", "cat", "dog" } };
 
             //\b
-            yield return new object[] { @"\b@cat", "123START123@catEND", RegexOptions.None, new string[] { "@cat" } };
-            yield return new object[] { @"\b\<cat", "123START123<catEND", RegexOptions.None, new string[] { "<cat" } };
-            yield return new object[] { @"\b,cat", "satwe,,,START,catEND", RegexOptions.None, new string[] { ",cat" } };
-            yield return new object[] { @"\b\[cat", "`12START123[catEND", RegexOptions.None, new string[] { "[cat" } };
+            yield return new object[] { null, @"\b@cat", "123START123@catEND", RegexOptions.None, new string[] { "@cat" } };
+            yield return new object[] { null, @"\b\<cat", "123START123<catEND", RegexOptions.None, new string[] { "<cat" } };
+            yield return new object[] { null, @"\b,cat", "satwe,,,START,catEND", RegexOptions.None, new string[] { ",cat" } };
+            yield return new object[] { null, @"\b\[cat", "`12START123[catEND", RegexOptions.None, new string[] { "[cat" } };
 
             //\B
-            yield return new object[] { @"\B@cat", "123START123;@catEND", RegexOptions.None, new string[] { "@cat" } };
-            yield return new object[] { @"\B\<cat", "123START123'<catEND", RegexOptions.None, new string[] { "<cat" } };
-            yield return new object[] { @"\B,cat", "satwe,,,START',catEND", RegexOptions.None, new string[] { ",cat" } };
-            yield return new object[] { @"\B\[cat", "`12START123'[catEND", RegexOptions.None, new string[] { "[cat" } };
+            yield return new object[] { null, @"\B@cat", "123START123;@catEND", RegexOptions.None, new string[] { "@cat" } };
+            yield return new object[] { null, @"\B\<cat", "123START123'<catEND", RegexOptions.None, new string[] { "<cat" } };
+            yield return new object[] { null, @"\B,cat", "satwe,,,START',catEND", RegexOptions.None, new string[] { ",cat" } };
+            yield return new object[] { null, @"\B\[cat", "`12START123'[catEND", RegexOptions.None, new string[] { "[cat" } };
 
             // \w matching \p{Lm} (Letter, Modifier)
-            yield return new object[] { @"(\w+)\s+(\w+)", "cat\u02b0 dog\u02b1", RegexOptions.None, new string[] { "cat\u02b0 dog\u02b1", "cat\u02b0", "dog\u02b1" } };
-            yield return new object[] { @"(cat\w+)\s+(dog\w+)", "STARTcat\u30FC dog\u3005END", RegexOptions.None, new string[] { "cat\u30FC dog\u3005END", "cat\u30FC", "dog\u3005END" } };
-            yield return new object[] { @"(cat\w+)\s+(dog\w+)", "STARTcat\uff9e dog\uff9fEND", RegexOptions.None, new string[] { "cat\uff9e dog\uff9fEND", "cat\uff9e", "dog\uff9fEND" } };
+            yield return new object[] { null, @"(\w+)\s+(\w+)", "cat\u02b0 dog\u02b1", RegexOptions.None, new string[] { "cat\u02b0 dog\u02b1", "cat\u02b0", "dog\u02b1" } };
+            yield return new object[] { null, @"(cat\w+)\s+(dog\w+)", "STARTcat\u30FC dog\u3005END", RegexOptions.None, new string[] { "cat\u30FC dog\u3005END", "cat\u30FC", "dog\u3005END" } };
+            yield return new object[] { null, @"(cat\w+)\s+(dog\w+)", "STARTcat\uff9e dog\uff9fEND", RegexOptions.None, new string[] { "cat\uff9e dog\uff9fEND", "cat\uff9e", "dog\uff9fEND" } };
 
             // Positive and negative character classes [a-c]|[^b-c]
-            yield return new object[] { @"[^a]|d", "d", RegexOptions.None, new string[] { "d" } };
-            yield return new object[] { @"([^a]|[d])*", "Hello Worlddf", RegexOptions.None, new string[] { "Hello Worlddf", "f" } };
-            yield return new object[] { @"([^{}]|\n)+", "{{{{Hello\n World \n}END", RegexOptions.None, new string[] { "Hello\n World \n", "\n" } };
-            yield return new object[] { @"([a-d]|[^abcd])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
-            yield return new object[] { @"([^a]|[a])*", "once upon a time", RegexOptions.None, new string[] { "once upon a time", "e" } };
-            yield return new object[] { @"([a-d]|[^abcd]|[x-z]|^wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
-            yield return new object[] { @"([a-d]|[e-i]|[^e]|wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
+            yield return new object[] { null, @"[^a]|d", "d", RegexOptions.None, new string[] { "d" } };
+            yield return new object[] { null, @"([^a]|[d])*", "Hello Worlddf", RegexOptions.None, new string[] { "Hello Worlddf", "f" } };
+            yield return new object[] { null, @"([^{}]|\n)+", "{{{{Hello\n World \n}END", RegexOptions.None, new string[] { "Hello\n World \n", "\n" } };
+            yield return new object[] { null, @"([a-d]|[^abcd])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
+            yield return new object[] { null, @"([^a]|[a])*", "once upon a time", RegexOptions.None, new string[] { "once upon a time", "e" } };
+            yield return new object[] { null, @"([a-d]|[^abcd]|[x-z]|^wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
+            yield return new object[] { null, @"([a-d]|[e-i]|[^e]|wxyz])+", "\tonce\n upon\0 a- ()*&^%#time?", RegexOptions.None, new string[] { "\tonce\n upon\0 a- ()*&^%#time?", "?" } };
 
             // Canonical and noncanonical char class, where one group is in it's
             // simplest form [a-e] and another is more complex.
-            yield return new object[] { @"^(([^b]+ )|(.* ))$", "aaa ", RegexOptions.None, new string[] { "aaa ", "aaa ", "aaa ", "" } };
-            yield return new object[] { @"^(([^b]+ )|(.*))$", "aaa", RegexOptions.None, new string[] { "aaa", "aaa", "", "aaa" } };
-            yield return new object[] { @"^(([^b]+ )|(.* ))$", "bbb ", RegexOptions.None, new string[] { "bbb ", "bbb ", "", "bbb " } };
-            yield return new object[] { @"^(([^b]+ )|(.*))$", "bbb", RegexOptions.None, new string[] { "bbb", "bbb", "", "bbb" } };
-            yield return new object[] { @"^((a*)|(.*))$", "aaa", RegexOptions.None, new string[] { "aaa", "aaa", "aaa", "" } };
-            yield return new object[] { @"^((a*)|(.*))$", "aaabbb", RegexOptions.None, new string[] { "aaabbb", "aaabbb", "", "aaabbb" } };
+            yield return new object[] { null, @"^(([^b]+ )|(.* ))$", "aaa ", RegexOptions.None, new string[] { "aaa ", "aaa ", "aaa ", "" } };
+            yield return new object[] { null, @"^(([^b]+ )|(.*))$", "aaa", RegexOptions.None, new string[] { "aaa", "aaa", "", "aaa" } };
+            yield return new object[] { null, @"^(([^b]+ )|(.* ))$", "bbb ", RegexOptions.None, new string[] { "bbb ", "bbb ", "", "bbb " } };
+            yield return new object[] { null, @"^(([^b]+ )|(.*))$", "bbb", RegexOptions.None, new string[] { "bbb", "bbb", "", "bbb" } };
+            yield return new object[] { null, @"^((a*)|(.*))$", "aaa", RegexOptions.None, new string[] { "aaa", "aaa", "aaa", "" } };
+            yield return new object[] { null, @"^((a*)|(.*))$", "aaabbb", RegexOptions.None, new string[] { "aaabbb", "aaabbb", "", "aaabbb" } };
 
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))*", "{hello 1234567890 world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))+", "{hello 1234567890 world}", RegexOptions.None, new string[] { "hello", "o", "", "o", "" } };
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))*", "{HELLO 1234567890 world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))+", "{HELLO 1234567890 world}", RegexOptions.None, new string[] { "HELLO", "O", "", "", "O" } };
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))*", "{1234567890 hello  world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
-            yield return new object[] { @"(([0-9])|([a-z])|([A-Z]))+", "{1234567890 hello world}", RegexOptions.None, new string[] { "1234567890", "0", "0", "", "" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))*", "{hello 1234567890 world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))+", "{hello 1234567890 world}", RegexOptions.None, new string[] { "hello", "o", "", "o", "" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))*", "{HELLO 1234567890 world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))+", "{HELLO 1234567890 world}", RegexOptions.None, new string[] { "HELLO", "O", "", "", "O" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))*", "{1234567890 hello  world}", RegexOptions.None, new string[] { "", "", "", "", "" } };
+            yield return new object[] { null, @"(([0-9])|([a-z])|([A-Z]))+", "{1234567890 hello world}", RegexOptions.None, new string[] { "1234567890", "0", "0", "", "" } };
 
-            yield return new object[] { @"^(([a-d]*)|([a-z]*))$", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccdddeeefff", "aaabbbcccdddeeefff", "", "aaabbbcccdddeeefff" } };
-            yield return new object[] { @"^(([d-f]*)|([c-e]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "", "dddeeeccceee" } };
-            yield return new object[] { @"^(([c-e]*)|([d-f]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
+            yield return new object[] { null, @"^(([a-d]*)|([a-z]*))$", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccdddeeefff", "aaabbbcccdddeeefff", "", "aaabbbcccdddeeefff" } };
+            yield return new object[] { null, @"^(([d-f]*)|([c-e]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "", "dddeeeccceee" } };
+            yield return new object[] { null, @"^(([c-e]*)|([d-f]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
-            yield return new object[] { @"(([a-d]*)|([a-z]*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
-            yield return new object[] { @"(([d-f]*)|([c-e]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
-            yield return new object[] { @"(([c-e]*)|([d-f]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
+            yield return new object[] { null, @"(([a-d]*)|([a-z]*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
+            yield return new object[] { null, @"(([d-f]*)|([c-e]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
+            yield return new object[] { null, @"(([c-e]*)|([d-f]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
-            yield return new object[] { @"(([a-d]*)|(.*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
-            yield return new object[] { @"(([d-f]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
-            yield return new object[] { @"(([c-e]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
+            yield return new object[] { null, @"(([a-d]*)|(.*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
+            yield return new object[] { null, @"(([d-f]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
+            yield return new object[] { null, @"(([c-e]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
             // \p{Pi} (Punctuation Initial quote) \p{Pf} (Punctuation Final quote)
-            yield return new object[] { @"\p{Pi}(\w*)\p{Pf}", "\u00ABCat\u00BB   \u00BBDog\u00AB'", RegexOptions.None, new string[] { "\u00ABCat\u00BB", "Cat" } };
-            yield return new object[] { @"\p{Pi}(\w*)\p{Pf}", "\u2018Cat\u2019   \u2019Dog\u2018'", RegexOptions.None, new string[] { "\u2018Cat\u2019", "Cat" } };
+            yield return new object[] { null, @"\p{Pi}(\w*)\p{Pf}", "\u00ABCat\u00BB   \u00BBDog\u00AB'", RegexOptions.None, new string[] { "\u00ABCat\u00BB", "Cat" } };
+            yield return new object[] { null, @"\p{Pi}(\w*)\p{Pf}", "\u2018Cat\u2019   \u2019Dog\u2018'", RegexOptions.None, new string[] { "\u2018Cat\u2019", "Cat" } };
 
             // ECMAScript
-            yield return new object[] { @"(?<cat>cat)\s+(?<dog>dog)\s+\123\s+\234", "asdfcat   dog     cat23    dog34eia", RegexOptions.ECMAScript, new string[] { "cat   dog     cat23    dog34", "cat", "dog" } };
+            yield return new object[] { null, @"(?<cat>cat)\s+(?<dog>dog)\s+\123\s+\234", "asdfcat   dog     cat23    dog34eia", RegexOptions.ECMAScript, new string[] { "cat   dog     cat23    dog34", "cat", "dog" } };
 
             // Balanced Matching
-            yield return new object[] { @"<div>
+            yield return new object[] { null, @"<div>
             (?>
                 <div>(?<DEPTH>) |
                 </div> (?<-DEPTH>) |
@@ -490,31 +483,31 @@ namespace System.Text.RegularExpressions.Tests
             (?(DEPTH)(?!))
             </div>", "<div>this is some <div>red</div> text</div></div></div>", RegexOptions.IgnorePatternWhitespace, new string[] { "<div>this is some <div>red</div> text</div>", "" } };
 
-            yield return new object[] { @"(
+            yield return new object[] { null, @"(
             ((?'open'<+)[^<>]*)+
             ((?'close-open'>+)[^<>]*)+
             )+", "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", RegexOptions.IgnorePatternWhitespace, new string[] { "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", "<02deep_03<03deep_03>>>", "<03deep_03", ">>>", "<", "03deep_03" } };
 
-            yield return new object[] { @"(
+            yield return new object[] { null, @"(
             (?<start><)?
             [^<>]?
             (?<end-start>>)?
             )*", "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", RegexOptions.IgnorePatternWhitespace, new string[] { "<01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>>", "", "", "01deep_01<02deep_01<03deep_01>><02deep_02><02deep_03<03deep_03>>" } };
 
-            yield return new object[] { @"(
+            yield return new object[] { null, @"(
             (?<start><[^/<>]*>)?
             [^<>]?
             (?<end-start></[^/<>]*>)?
             )*", "<b><a>Cat</a></b>", RegexOptions.IgnorePatternWhitespace, new string[] { "<b><a>Cat</a></b>", "", "", "<a>Cat</a>" } };
 
-            yield return new object[] { @"(
+            yield return new object[] { null, @"(
             (?<start><(?<TagName>[^/<>]*)>)?
             [^<>]?
             (?<end-start></\k<TagName>>)?
             )*", "<b>cat</b><a>dog</a>", RegexOptions.IgnorePatternWhitespace, new string[] { "<b>cat</b><a>dog</a>", "", "", "a", "dog" } };
 
             // Balanced Matching With Backtracking
-            yield return new object[] { @"(
+            yield return new object[] { null, @"(
             (?<start><[^/<>]*>)?
             .?
             (?<end-start></[^/<>]*>)?
@@ -522,228 +515,158 @@ namespace System.Text.RegularExpressions.Tests
             (?(start)(?!)) ", "<b><a>Cat</a></b><<<<c>>>><<d><e<f>><g><<<>>>>", RegexOptions.IgnorePatternWhitespace, new string[] { "<b><a>Cat</a></b><<<<c>>>><<d><e<f>><g><<<>>>>", "", "", "<a>Cat" } };
 
             // Character Classes and Lazy quantifier
-            yield return new object[] { @"([0-9]+?)([\w]+?)", "55488aheiaheiad", RegexOptions.ECMAScript, new string[] { "55", "5", "5" } };
-            yield return new object[] { @"([0-9]+?)([a-z]+?)", "55488aheiaheiad", RegexOptions.ECMAScript, new string[] { "55488a", "55488", "a" } };
+            yield return new object[] { null, @"([0-9]+?)([\w]+?)", "55488aheiaheiad", RegexOptions.ECMAScript, new string[] { "55", "5", "5" } };
+            yield return new object[] { null, @"([0-9]+?)([a-z]+?)", "55488aheiaheiad", RegexOptions.ECMAScript, new string[] { "55488a", "55488", "a" } };
 
             // Miscellaneous/Regression scenarios
-            yield return new object[] { @"(?<openingtag>1)(?<content>.*?)(?=2)", "1" + Environment.NewLine + "<Projecaa DefaultTargets=\"x\"/>" + Environment.NewLine + "2", RegexOptions.Singleline | RegexOptions.ExplicitCapture,
+            yield return new object[] { null, @"(?<openingtag>1)(?<content>.*?)(?=2)", "1" + Environment.NewLine + "<Projecaa DefaultTargets=\"x\"/>" + Environment.NewLine + "2", RegexOptions.Singleline | RegexOptions.ExplicitCapture,
             new string[] { "1" + Environment.NewLine + "<Projecaa DefaultTargets=\"x\"/>" + Environment.NewLine, "1", Environment.NewLine + "<Projecaa DefaultTargets=\"x\"/>"+ Environment.NewLine } };
 
-            yield return new object[] { @"\G<%#(?<code>.*?)?%>", @"<%# DataBinder.Eval(this, ""MyNumber"") %>", RegexOptions.Singleline, new string[] { @"<%# DataBinder.Eval(this, ""MyNumber"") %>", @" DataBinder.Eval(this, ""MyNumber"") " } };
+            yield return new object[] { null, @"\G<%#(?<code>.*?)?%>", @"<%# DataBinder.Eval(this, ""MyNumber"") %>", RegexOptions.Singleline, new string[] { @"<%# DataBinder.Eval(this, ""MyNumber"") %>", @" DataBinder.Eval(this, ""MyNumber"") " } };
 
             // Nested Quantifiers
-            yield return new object[] { @"^[abcd]{0,0x10}*$", "a{0,0x10}}}", RegexOptions.None, new string[] { "a{0,0x10}}}" } };
+            yield return new object[] { null, @"^[abcd]{0,0x10}*$", "a{0,0x10}}}", RegexOptions.None, new string[] { "a{0,0x10}}}" } };
 
             // Lazy operator Backtracking
-            yield return new object[] { @"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/", "http://www.msn.com/", RegexOptions.IgnoreCase, new string[] { "http://www.msn.com/", "com", string.Empty } };
-            yield return new object[] { @"http://([a-zA-Z0-9\-]*\.?)*?/", @"http://www.google.com/", RegexOptions.IgnoreCase, new string[] { "http://www.google.com/", "com" } };
+            yield return new object[] { null, @"http://([a-zA-z0-9\-]*\.?)*?(:[0-9]*)??/", "http://www.msn.com/", RegexOptions.IgnoreCase, new string[] { "http://www.msn.com/", "com", string.Empty } };
+            yield return new object[] { null, @"http://([a-zA-Z0-9\-]*\.?)*?/", @"http://www.google.com/", RegexOptions.IgnoreCase, new string[] { "http://www.google.com/", "com" } };
 
-            yield return new object[] { @"([a-z]*?)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "c", string.Empty, "c" } };
-            yield return new object[] { @"^([a-z]*?)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
+            yield return new object[] { null, @"([a-z]*?)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "c", string.Empty, "c" } };
+            yield return new object[] { null, @"^([a-z]*?)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
 
             // Backtracking
-            yield return new object[] { @"([a-z]*)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
-            yield return new object[] { @"^([a-z]*)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
+            yield return new object[] { null, @"([a-z]*)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
+            yield return new object[] { null, @"^([a-z]*)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
 
             // Quantifiers
-            yield return new object[] { @"(cat){", "cat{", RegexOptions.None, new string[] { "cat{", "cat" } };
-            yield return new object[] { @"(cat){}", "cat{}", RegexOptions.None, new string[] { "cat{}", "cat" } };
-            yield return new object[] { @"(cat){,", "cat{,", RegexOptions.None, new string[] { "cat{,", "cat" } };
-            yield return new object[] { @"(cat){,}", "cat{,}", RegexOptions.None, new string[] { "cat{,}", "cat" } };
-            yield return new object[] { @"(cat){cat}", "cat{cat}", RegexOptions.None, new string[] { "cat{cat}", "cat" } };
-            yield return new object[] { @"(cat){cat,5}", "cat{cat,5}", RegexOptions.None, new string[] { "cat{cat,5}", "cat" } };
-            yield return new object[] { @"(cat){5,dog}", "cat{5,dog}", RegexOptions.None, new string[] { "cat{5,dog}", "cat" } };
-            yield return new object[] { @"(cat){cat,dog}", "cat{cat,dog}", RegexOptions.None, new string[] { "cat{cat,dog}", "cat" } };
-            yield return new object[] { @"(cat){,}?", "cat{,}?", RegexOptions.None, new string[] { "cat{,}", "cat" } };
-            yield return new object[] { @"(cat){cat}?", "cat{cat}?", RegexOptions.None, new string[] { "cat{cat}", "cat" } };
-            yield return new object[] { @"(cat){cat,5}?", "cat{cat,5}?", RegexOptions.None, new string[] { "cat{cat,5}", "cat" } };
-            yield return new object[] { @"(cat){5,dog}?", "cat{5,dog}?", RegexOptions.None, new string[] { "cat{5,dog}", "cat" } };
-            yield return new object[] { @"(cat){cat,dog}?", "cat{cat,dog}?", RegexOptions.None, new string[] { "cat{cat,dog}", "cat" } };
+            yield return new object[] { null, @"(cat){", "cat{", RegexOptions.None, new string[] { "cat{", "cat" } };
+            yield return new object[] { null, @"(cat){}", "cat{}", RegexOptions.None, new string[] { "cat{}", "cat" } };
+            yield return new object[] { null, @"(cat){,", "cat{,", RegexOptions.None, new string[] { "cat{,", "cat" } };
+            yield return new object[] { null, @"(cat){,}", "cat{,}", RegexOptions.None, new string[] { "cat{,}", "cat" } };
+            yield return new object[] { null, @"(cat){cat}", "cat{cat}", RegexOptions.None, new string[] { "cat{cat}", "cat" } };
+            yield return new object[] { null, @"(cat){cat,5}", "cat{cat,5}", RegexOptions.None, new string[] { "cat{cat,5}", "cat" } };
+            yield return new object[] { null, @"(cat){5,dog}", "cat{5,dog}", RegexOptions.None, new string[] { "cat{5,dog}", "cat" } };
+            yield return new object[] { null, @"(cat){cat,dog}", "cat{cat,dog}", RegexOptions.None, new string[] { "cat{cat,dog}", "cat" } };
+            yield return new object[] { null, @"(cat){,}?", "cat{,}?", RegexOptions.None, new string[] { "cat{,}", "cat" } };
+            yield return new object[] { null, @"(cat){cat}?", "cat{cat}?", RegexOptions.None, new string[] { "cat{cat}", "cat" } };
+            yield return new object[] { null, @"(cat){cat,5}?", "cat{cat,5}?", RegexOptions.None, new string[] { "cat{cat,5}", "cat" } };
+            yield return new object[] { null, @"(cat){5,dog}?", "cat{5,dog}?", RegexOptions.None, new string[] { "cat{5,dog}", "cat" } };
+            yield return new object[] { null, @"(cat){cat,dog}?", "cat{cat,dog}?", RegexOptions.None, new string[] { "cat{cat,dog}", "cat" } };
 
             // Grouping Constructs Invalid Regular Expressions
-            yield return new object[] { @"()", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
-            yield return new object[] { @"(?<cat>)", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
-            yield return new object[] { @"(?'cat')", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
-            yield return new object[] { @"(?:)", "cat", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { @"(?imn)", "cat", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { @"(?imn)cat", "(?imn)cat", RegexOptions.None, new string[] { "cat" } };
-            yield return new object[] { @"(?=)", "cat", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { @"(?<=)", "cat", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { @"(?>)", "cat", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"()", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
+            yield return new object[] { null, @"(?<cat>)", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
+            yield return new object[] { null, @"(?'cat')", "cat", RegexOptions.None, new string[] { string.Empty, string.Empty } };
+            yield return new object[] { null, @"(?:)", "cat", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(?imn)", "cat", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(?imn)cat", "(?imn)cat", RegexOptions.None, new string[] { "cat" } };
+            yield return new object[] { null, @"(?=)", "cat", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(?<=)", "cat", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(?>)", "cat", RegexOptions.None, new string[] { string.Empty } };
 
             // Alternation construct Invalid Regular Expressions
-            yield return new object[] { @"(?()|)", "(?()|)", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?()|)", "(?()|)", RegexOptions.None, new string[] { "" } };
 
-            yield return new object[] { @"(?(cat)|)", "cat", RegexOptions.None, new string[] { "" } };
-            yield return new object[] { @"(?(cat)|)", "dog", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)|)", "cat", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)|)", "dog", RegexOptions.None, new string[] { "" } };
 
-            yield return new object[] { @"(?(cat)catdog|)", "catdog", RegexOptions.None, new string[] { "catdog" } };
-            yield return new object[] { @"(?(cat)catdog|)", "dog", RegexOptions.None, new string[] { "" } };
-            yield return new object[] { @"(?(cat)dog|)", "dog", RegexOptions.None, new string[] { "" } };
-            yield return new object[] { @"(?(cat)dog|)", "cat", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)catdog|)", "catdog", RegexOptions.None, new string[] { "catdog" } };
+            yield return new object[] { null, @"(?(cat)catdog|)", "dog", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)dog|)", "dog", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)dog|)", "cat", RegexOptions.None, new string[] { "" } };
 
-            yield return new object[] { @"(?(cat)|catdog)", "cat", RegexOptions.None, new string[] { "" } };
-            yield return new object[] { @"(?(cat)|catdog)", "catdog", RegexOptions.None, new string[] { "" } };
-            yield return new object[] { @"(?(cat)|dog)", "dog", RegexOptions.None, new string[] { "dog" } };
+            yield return new object[] { null, @"(?(cat)|catdog)", "cat", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)|catdog)", "catdog", RegexOptions.None, new string[] { "" } };
+            yield return new object[] { null, @"(?(cat)|dog)", "dog", RegexOptions.None, new string[] { "dog" } };
 
             // Invalid unicode
-            yield return new object[] { "([\u0000-\uFFFF-[azAZ09]]|[\u0000-\uFFFF-[^azAZ09]])+", "azAZBCDE1234567890BCDEFAZza", RegexOptions.None, new string[] { "azAZBCDE1234567890BCDEFAZza", "a" } };
-            yield return new object[] { "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]+", "abcxyzABCXYZ123890", RegexOptions.None, new string[] { "bcxyzABCXYZ123890" } };
-            yield return new object[] { "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]]+", "bcxyzABCXYZ123890a", RegexOptions.None, new string[] { "a" } };
-            yield return new object[] { "[\u0000-\uFFFF-[\\p{P}\\p{S}\\p{C}]]+", "!@`';.,$+<>=\x0001\x001FazAZ09", RegexOptions.None, new string[] { "azAZ09" } };
+            yield return new object[] { null, "([\u0000-\uFFFF-[azAZ09]]|[\u0000-\uFFFF-[^azAZ09]])+", "azAZBCDE1234567890BCDEFAZza", RegexOptions.None, new string[] { "azAZBCDE1234567890BCDEFAZza", "a" } };
+            yield return new object[] { null, "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]+", "abcxyzABCXYZ123890", RegexOptions.None, new string[] { "bcxyzABCXYZ123890" } };
+            yield return new object[] { null, "[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[\u0000-\uFFFF-[a]]]]]]]+", "bcxyzABCXYZ123890a", RegexOptions.None, new string[] { "a" } };
+            yield return new object[] { null, "[\u0000-\uFFFF-[\\p{P}\\p{S}\\p{C}]]+", "!@`';.,$+<>=\x0001\x001FazAZ09", RegexOptions.None, new string[] { "azAZ09" } };
 
-            yield return new object[] { @"[\uFFFD-\uFFFF]+", "\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFD\uFFFE\uFFFF" } };
-            yield return new object[] { @"[\uFFFC-\uFFFE]+", "\uFFFB\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFC\uFFFD\uFFFE" } };
+            yield return new object[] { null, @"[\uFFFD-\uFFFF]+", "\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFD\uFFFE\uFFFF" } };
+            yield return new object[] { null, @"[\uFFFC-\uFFFE]+", "\uFFFB\uFFFC\uFFFD\uFFFE\uFFFF", RegexOptions.IgnoreCase, new string[] { "\uFFFC\uFFFD\uFFFE" } };
 
             // Empty Match
-            yield return new object[] { @"([a*]*)+?$", "ab", RegexOptions.None, new string[] { "", "" } };
-            yield return new object[] { @"(a*)+?$", "b", RegexOptions.None, new string[] { "", "" } };
+            yield return new object[] { null, @"([a*]*)+?$", "ab", RegexOptions.None, new string[] { "", "" } };
+            yield return new object[] { null, @"(a*)+?$", "b", RegexOptions.None, new string[] { "", "" } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_enUS()
         {
-            yield return new object[] { "CH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
-            yield return new object[] { "cH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
-            yield return new object[] { "AA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
-            yield return new object[] { "aA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
-            yield return new object[] { "\u0130", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
-            yield return new object[] { "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
+            yield return new object[] { "en-US", "CH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
+            yield return new object[] { "en-US", "cH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
+            yield return new object[] { "en-US", "AA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
+            yield return new object[] { "en-US", "aA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
+            yield return new object[] { "en-US", "\u0130", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
+            yield return new object[] { "en-US", "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_Czech()
         {
-            yield return new object[] { "CH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
-            yield return new object[] { "cH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
+            yield return new object[] { "cs-CZ", "CH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
+            yield return new object[] { "cs-CZ", "cH", "Ch", RegexOptions.IgnoreCase, new string[] { "Ch" } };
         }
 
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_Danish()
         {
-            yield return new object[] { "AA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
-            yield return new object[] { "aA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
+            yield return new object[] { "da-DK", "AA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
+            yield return new object[] { "da-DK", "aA", "Aa", RegexOptions.IgnoreCase, new string[] { "Aa" } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_Turkish()
         {
-            yield return new object[] { "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
-            yield return new object[] { "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
+            yield return new object[] { "tr-TR", "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
+            yield return new object[] { "tr-TR", "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_AzeriLatin()
         {
-            yield return new object[] { "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
-            yield return new object[] { "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
+            yield return new object[] { "az-Latn-AZ", "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
+            yield return new object[] { "az-Latn-AZ", "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
         }
 
-        private static CultureInfo GetDefaultCultureForTests()
+        [Theory]
+        [MemberData(nameof(Groups_Basic_TestData))]
+        [MemberData(nameof(Groups_CustomCulture_TestData_enUS))]
+        [MemberData(nameof(Groups_CustomCulture_TestData_Czech))]
+        [MemberData(nameof(Groups_CustomCulture_TestData_Danish))]
+        [MemberData(nameof(Groups_CustomCulture_TestData_Turkish))]
+        [MemberData(nameof(Groups_CustomCulture_TestData_AzeriLatin))]
+        public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups)
         {
-            CultureInfo defaultCulture = CultureInfo.CurrentCulture;
-
-            // In invariant culture, the unicode char matches differ from expected values provided.
-            if (defaultCulture.Equals(CultureInfo.InvariantCulture))
+            if (cultureName is null)
             {
-                defaultCulture = new CultureInfo("en-US");
+                CultureInfo culture = CultureInfo.CurrentCulture;
+                cultureName = culture.Equals(CultureInfo.InvariantCulture) ? "en-US" : culture.Name;
             }
 
-            return defaultCulture;
-        }
-
-        private static void Groups(string pattern, string input, RegexOptions options, string[] expectedGroups)
-        {
-            Regex regex = new Regex(pattern, options);
-            Match match = regex.Match(input);
-            Assert.True(match.Success, $"match.Success. pattern=/{pattern}/  input=[[[{input}]]]  culture={CultureInfo.CurrentCulture.Name}");
-
-            Assert.Equal(expectedGroups.Length, match.Groups.Count);
-            Assert.True(expectedGroups[0] == match.Value, string.Format("Culture used: {0}", CultureInfo.CurrentCulture));
-
-            int[] groupNumbers = regex.GetGroupNumbers();
-            string[] groupNames = regex.GetGroupNames();
-            for (int i = 0; i < expectedGroups.Length; i++)
+            using (new ThreadCultureChange(cultureName))
             {
-                Assert.Equal(expectedGroups[i], match.Groups[groupNumbers[i]].Value);
-                Assert.Equal(match.Groups[groupNumbers[i]], match.Groups[groupNames[i]]);
-
-                Assert.Equal(groupNumbers[i], regex.GroupNumberFromName(groupNames[i]));
-                Assert.Equal(groupNames[i], regex.GroupNameFromNumber(groupNumbers[i]));
+                Groups(pattern, input, options, expectedGroups);
+                Groups(pattern, input, RegexOptions.Compiled | options, expectedGroups);
             }
-        }
 
-        private void GroupsTest(object[] testCase)
-        {
-            Groups((string)testCase[0], (string)testCase[1], (RegexOptions)testCase[2], (string[])testCase[3]);
-            Groups((string)testCase[0], (string)testCase[1], RegexOptions.Compiled | (RegexOptions)testCase[2], (string[])testCase[3]);
-        }
-
-
-        [Fact]
-        public void GroupsEnUS()
-        {
-            using (new ThreadCultureChange(s_enUSCulture))
+            static void Groups(string pattern, string input, RegexOptions options, string[] expectedGroups)
             {
-                foreach (object[] testCase in Groups_CustomCulture_TestData_enUS())
+                Regex regex = new Regex(pattern, options);
+                Match match = regex.Match(input);
+                Assert.True(match.Success);
+
+                Assert.Equal(expectedGroups.Length, match.Groups.Count);
+                Assert.Equal(expectedGroups[0], match.Value);
+
+                int[] groupNumbers = regex.GetGroupNumbers();
+                string[] groupNames = regex.GetGroupNames();
+                for (int i = 0; i < expectedGroups.Length; i++)
                 {
-                    GroupsTest(testCase);
-                }
-            }
-        }
+                    Assert.Equal(expectedGroups[i], match.Groups[groupNumbers[i]].Value);
+                    Assert.Equal(match.Groups[groupNumbers[i]], match.Groups[groupNames[i]]);
 
-        [Fact]
-        public void GroupsCzech()
-        {
-            using (new ThreadCultureChange(s_czechCulture))
-            {
-                foreach (object[] testCase in Groups_CustomCulture_TestData_Czech())
-                {
-                    GroupsTest(testCase);
-                }
-            }
-        }
-
-        [Fact]
-        public void GroupsDanish()
-        {
-            using (new ThreadCultureChange(s_danishCulture))
-            {
-                foreach (object[] testCase in Groups_CustomCulture_TestData_Danish())
-                {
-                    GroupsTest(testCase);
-                }
-            }
-        }
-
-        [Fact]
-        public void GroupsTurkish()
-        {
-            using (new ThreadCultureChange(s_turkishCulture))
-            {
-                foreach (object[] testCase in Groups_CustomCulture_TestData_Turkish())
-                {
-                    GroupsTest(testCase);
-                }
-            }
-        }
-
-        [Fact]
-        public void GroupsAzeriLatin()
-        {
-            using (new ThreadCultureChange(s_azeriLatinCulture))
-            {
-                foreach (object[] testCase in Groups_CustomCulture_TestData_AzeriLatin())
-                {
-                    GroupsTest(testCase);
-                }
-            }
-        }
-
-        [Fact]
-        public void GroupsBasic()
-        {
-            using (new ThreadCultureChange(GetDefaultCultureForTests()))
-            {
-                foreach (object[] testCase in Groups_Basic_TestData())
-                {
-                    GroupsTest(testCase);
+                    Assert.Equal(groupNumbers[i], regex.GroupNumberFromName(groupNames[i]));
+                    Assert.Equal(groupNames[i], regex.GroupNameFromNumber(groupNumbers[i]));
                 }
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -684,6 +684,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [MemberData(nameof(Match_Advanced_TestData))]
+        [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Match_Advanced_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
         public void Match(string pattern, string input, RegexOptions options, int beginning, int length, CaptureData[] expected)
         {
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, beginning);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -144,6 +144,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [MemberData(nameof(Matches_TestData))]
+        [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Matches_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
         public void Matches(string pattern, string input, RegexOptions options, CaptureData[] expected)
         {
             if (options == RegexOptions.None)


### PR DESCRIPTION
(This builds on some experimentation that both @davidwrighton and @eerhardt had done.)

A few key changes for RegexOptions.Compiled:
- Avoid spitting out timeouts unless a timeout was actually set (the default timeout is infinite).
- Avoid calling CharInClass if the character class has a known better alternative, e.g. \d can use char.IsDigit instead.
- Avoid calling CharInClass if the character class contains a single range, e.g. [A-Z], where we can instead just emit a basic range check.
- Avoid calling CharInClass for ASCII inputs, instead using a 16-byte lookup table.  If the character class contains Unicode characters, then non-ASCII inputs fall back to still calling CharInClass.
- Avoid accessing CultureInfo.CurrentCulture unless we know we're going to need the result for ToLower calls, and we prefer to use ToLowerInvariant instead of using ToLower with CultureInfo.InvariantCulture.
- Generate more specific Ldc instructions when applicable (this is just about smaller IL).

A few general changes:
- Open-code IsWordChar and IsECMAWordChar.  We can write much more efficient implementations than using CharInClass.
- Make some internal virtual methods non-virtual, as nothing overrides them.
- Avoid some unnecessary allocations when character classes don't include categories.
- General clean-up to make working in the code easier.

A few benchmarks...

Running the RegexReduce benchmark from the dotnet/performance repo:

|         Method |        Toolchain |  options |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD |      Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |----------------- |--------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-----------:|------:|------:|----------:|
| RegexReduxMini | \new\corerun.exe | Compiled | 166.6 ms |  6.42 ms |  7.13 ms | 165.6 ms | 150.3 ms | 180.8 ms |  0.72 |    0.04 | 12000.0000 |     - |     - |  129.8 MB |
| RegexReduxMini | \old\corerun.exe | Compiled | 230.3 ms |  9.23 ms | 10.63 ms | 233.0 ms | 205.9 ms | 245.6 ms |  1.00 |    0.00 | 12000.0000 |     - |     - | 129.81 MB |

And running a few other random regexes:

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private static readonly Regex s_email = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", RegexOptions.Compiled);
    private static Regex s_date = new Regex(@"\b(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{2,4})\b", RegexOptions.Compiled);

    [Benchmark] public void Email() => s_email.IsMatch("yay.performance@dot.net");
    [Benchmark] public void Date() => s_date.IsMatch("Today is 11/18/2019");
}
```

| Method |        Toolchain |      Mean |    Error |   StdDev | Ratio |
|------- |----------------- |----------:|---------:|---------:|------:|
|  Email | \new\corerun.exe | 185.30 ns | 1.259 ns | 1.116 ns |  0.43 |
|  Email | \old\corerun.exe | 431.24 ns | 2.151 ns | 1.907 ns |  1.00 |
|        |                  |           |          |          |       |
|   Date | \new\corerun.exe |  97.41 ns | 3.024 ns | 3.105 ns |  0.37 |
|   Date | \old\corerun.exe | 262.80 ns | 3.529 ns | 2.947 ns |  1.00 |

cc: @danmosemsft, @adamsitnik, @ViktorHofer 