### PR TITLE
Add AnonymousPipeServerStream method that takes an ACL

### DIFF
--- a/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.sln
+++ b/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27213.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29411.138
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Pipes.AccessControl.Tests", "tests\System.IO.Pipes.AccessControl.Tests.csproj", "{A0356E61-19E1-4722-A53D-5D2616E16312}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
@@ -66,4 +66,9 @@ namespace System.IO.Pipes
         public void SetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
         public void SetAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
     }
+
+    public static class AnonymousPipeServerStreamAcl
+    {
+        public static System.IO.Pipes.AnonymousPipeServerStream Create(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize, System.IO.Pipes.PipeSecurity pipeSecurity) { throw null; }
+    }
 }

--- a/src/libraries/System.IO.Pipes.AccessControl/tests/AnonymousPipeTests/AnonymousPipeServerStreamAclTests.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/tests/AnonymousPipeTests/AnonymousPipeServerStreamAclTests.cs
@@ -1,0 +1,148 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public class AnonymousPipeServerStreamAclTests : PipeServerStreamAclTestBase
+    {
+        private const PipeDirection DefaultPipeDirection = PipeDirection.In;
+        private const HandleInheritability DefaultInheritability = HandleInheritability.None;
+        private const int DefaultBufferSize = 1;
+
+        [Fact]
+        public void Create_NullSecurity()
+        {
+            CreateAndVerifyAnonymousPipe(expectedSecurity: null).Dispose();
+        }
+
+        [Fact]
+        public void Create_NotSupportedPipeDirection()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                CreateAndVerifyAnonymousPipe(GetBasicPipeSecurity(), PipeDirection.InOut).Dispose();
+            });
+        }
+
+        [Theory]
+        [InlineData((PipeDirection)(int.MinValue))]
+        [InlineData((PipeDirection)0)]
+        [InlineData((PipeDirection)4)]
+        [InlineData((PipeDirection)(int.MaxValue))]
+        public void Create_InvalidPipeDirection(PipeDirection direction)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                CreateAndVerifyAnonymousPipe(GetBasicPipeSecurity(), direction).Dispose();
+            });
+        }
+
+        [Theory]
+        [InlineData((HandleInheritability)(int.MinValue))]
+        [InlineData((HandleInheritability)(-1))]
+        [InlineData((HandleInheritability)2)]
+        [InlineData((HandleInheritability)(int.MaxValue))]
+        public void Create_InvalidInheritability(HandleInheritability inheritability)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                CreateAndVerifyAnonymousPipe(GetBasicPipeSecurity(), inheritability: inheritability).Dispose();
+            });
+        }
+
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        public void Create_InvalidBufferSize(int bufferSize)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                CreateAndVerifyAnonymousPipe(GetBasicPipeSecurity(), bufferSize: bufferSize).Dispose();
+            });
+        }
+
+        public static IEnumerable<object[]> Create_ValidParameters_MemberData() =>
+            from direction in new[] { PipeDirection.In, PipeDirection.Out }
+            from inheritability in Enum.GetValues(typeof(HandleInheritability)).Cast<HandleInheritability>()
+            from bufferSize in new[] { 0, 1 }
+            select new object[] { direction, inheritability, bufferSize };
+
+        [Theory]
+        [MemberData(nameof(Create_ValidParameters_MemberData))]
+        public void Create_ValidParameters(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
+        {
+            CreateAndVerifyAnonymousPipe(GetBasicPipeSecurity(), direction, inheritability, bufferSize).Dispose();
+        }
+
+        public static IEnumerable<object[]> Create_CombineRightsAndAccessControl_MemberData() =>
+            from rights in Enum.GetValues(typeof(PipeAccessRights)).Cast<PipeAccessRights>()
+            from accessControl in new[] { AccessControlType.Allow, AccessControlType.Deny }
+            select new object[] { rights, accessControl };
+
+        // These tests match NetFX behavior
+        [Theory]
+        [MemberData(nameof(Create_CombineRightsAndAccessControl_MemberData))]
+        public void Create_CombineRightsAndAccessControl(PipeAccessRights rights, AccessControlType accessControl)
+        {
+            // These are the two cases that create a valid pipe when using Allow
+            if ((rights == PipeAccessRights.FullControl || rights == PipeAccessRights.ReadWrite) &&
+                accessControl == AccessControlType.Allow)
+            {
+                VerifyValidSecurity(rights, accessControl);
+            }
+            // When creating the PipeAccessRule for the PipeSecurity, the PipeAccessRule constructor calls AccessMaskFromRights, which explicilty removes the Synchronize bit from rights when AccessControlType is Deny
+            // and rights is not FullControl, so using Synchronize with Deny is not allowed
+            else  if (rights == PipeAccessRights.Synchronize && accessControl == AccessControlType.Deny)
+            {
+                Assert.Throws<ArgumentException>("accessMask", () =>
+                {
+                    PipeSecurity security = GetPipeSecurity(WellKnownSidType.BuiltinUsersSid, PipeAccessRights.Synchronize, AccessControlType.Deny);
+                });
+            }
+            // Any other case is not authorized
+            else
+            {
+                PipeSecurity security = GetPipeSecurity(WellKnownSidType.BuiltinUsersSid, rights, accessControl);
+                Assert.Throws<UnauthorizedAccessException>(() =>
+                {
+                    AnonymousPipeServerStreamAcl.Create(DefaultPipeDirection, DefaultInheritability, DefaultBufferSize, security).Dispose();
+                });
+            }
+        }
+
+        [Theory]
+        [InlineData(PipeAccessRights.ReadWrite | PipeAccessRights.Synchronize, AccessControlType.Allow)]
+        public void Create_ValidBitwiseRightsSecurity(PipeAccessRights rights, AccessControlType accessControl)
+        {
+            VerifyValidSecurity(rights, accessControl);
+        }
+
+        private void VerifyValidSecurity(PipeAccessRights rights, AccessControlType accessControl)
+        {
+            PipeSecurity security = GetPipeSecurity(WellKnownSidType.BuiltinUsersSid, rights, accessControl);
+            CreateAndVerifyAnonymousPipe(security).Dispose();
+        }
+
+        private AnonymousPipeServerStream CreateAndVerifyAnonymousPipe(
+            PipeSecurity expectedSecurity,
+            PipeDirection direction = DefaultPipeDirection,
+            HandleInheritability inheritability = DefaultInheritability,
+            int bufferSize = DefaultBufferSize)
+        {
+            AnonymousPipeServerStream pipe = AnonymousPipeServerStreamAcl.Create(direction, inheritability, bufferSize, expectedSecurity);
+            Assert.NotNull(pipe);
+
+            if (expectedSecurity != null)
+            {
+                PipeSecurity actualSecurity = pipe.GetAccessControl();
+                VerifyPipeSecurity(expectedSecurity, actualSecurity);
+            }
+
+            return pipe;
+        }
+
+    }
+}

--- a/src/libraries/System.IO.Pipes.AccessControl/tests/PipeServerStreamAclTestBase.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/tests/PipeServerStreamAclTestBase.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public class PipeServerStreamAclTestBase
+    {
+        protected PipeSecurity GetBasicPipeSecurity()
+        {
+            return GetPipeSecurity(
+                WellKnownSidType.BuiltinUsersSid,
+                PipeAccessRights.FullControl,
+                AccessControlType.Allow);
+        }
+
+        protected PipeSecurity GetPipeSecurity(WellKnownSidType sid, PipeAccessRights rights, AccessControlType accessControl)
+        {
+            var security = new PipeSecurity();
+            SecurityIdentifier identity = new SecurityIdentifier(sid, null);
+            var accessRule = new PipeAccessRule(identity, rights, accessControl);
+            security.AddAccessRule(accessRule);
+            return security;
+        }
+
+        protected void VerifyPipeSecurity(PipeSecurity expectedSecurity, PipeSecurity actualSecurity)
+        {
+            Assert.Equal(typeof(PipeAccessRights), expectedSecurity.AccessRightType);
+            Assert.Equal(typeof(PipeAccessRights), actualSecurity.AccessRightType);
+
+            List<PipeAccessRule> expectedAccessRules = expectedSecurity.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+                .Cast<PipeAccessRule>().ToList();
+
+            List<PipeAccessRule> actualAccessRules = actualSecurity.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+                .Cast<PipeAccessRule>().ToList();
+
+            Assert.Equal(expectedAccessRules.Count, actualAccessRules.Count);
+            if (expectedAccessRules.Count > 0)
+            {
+                Assert.All(expectedAccessRules, actualAccessRule =>
+                {
+                    int count = expectedAccessRules.Count(expectedAccessRule => AreAccessRulesEqual(expectedAccessRule, actualAccessRule));
+                    Assert.True(count > 0);
+                });
+            }
+        }
+
+        protected bool AreAccessRulesEqual(PipeAccessRule expectedRule, PipeAccessRule actualRule)
+        {
+            return
+                expectedRule.AccessControlType == actualRule.AccessControlType &&
+                expectedRule.PipeAccessRights  == actualRule.PipeAccessRights &&
+                expectedRule.InheritanceFlags  == actualRule.InheritanceFlags &&
+                expectedRule.PropagationFlags  == actualRule.PropagationFlags;
+        }
+    }
+}

--- a/src/libraries/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/tests/System.IO.Pipes.AccessControl.Tests.csproj
@@ -6,8 +6,10 @@
     <AssembliesBeingTested Include="System.IO.Pipes" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AnonymousPipeTests\AnonymousPipeServerStreamAclTests.cs" />
     <Compile Include="AnonymousPipeTests\AnonymousPipeTest.AclExtensions.cs" />
     <Compile Include="NamedPipeTests\NamedPipeTest.AclExtensions.cs" />
+    <Compile Include="PipeServerStreamAclTestBase.cs" />
     <Compile Include="PipeTest.AclExtensions.cs" />
     <Compile Include="..\..\System.IO.Pipes\tests\PipeTestBase.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.Pipes/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.IO.Pipes/src/MatchingRefApiCompatBaseline.txt
@@ -1,4 +1,5 @@
 # Exposed public in System.IO.Pipes.AccessControl but implemented in System.IO.Pipes
+TypesMustExist : Type 'System.IO.Pipes.AnonymousPipeServerStreamAcl' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.IO.Pipes.PipeAccessRights' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.IO.Pipes.PipeAccessRule' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.IO.Pipes.PipeAuditRule' does not exist in the reference but it does exist in the implementation.

--- a/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -18,120 +18,47 @@
     <Compile Include="System\IO\Pipes\PipeState.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.cs" />
     <Compile Include="System\IO\Pipes\PipeTransmissionMode.cs" />
-    <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs">
-      <Link>System\IO\StreamHelpers.CopyValidation.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs">
-      <Link>System\Threading\Tasks\TaskToApm.cs</Link>
-    </Compile>
+    <Compile Include="$(CoreLibSharedDir)System\IO\StreamHelpers.CopyValidation.cs" Link="Common\CoreLib\System\IO\StreamHelpers.CopyValidation.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Threading\Tasks\TaskToApm.cs" Link="Common\CoreLib\System\Threading\Tasks\TaskToApm.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs">
-      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs">
-      <Link>Common\Interop\Windows\Interop.CloseHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
-      <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs">
-      <Link>Common\Interop\Windows\Interop.FormatMessage.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Interop\Windows\Interop.FreeLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs">
-      <Link>Interop\Windows\Interop.SecurityOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Microsoft\Win32\SafeLibraryHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs">
-      <Link>Interop\Windows\Interop.BOOL.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
-      <Link>Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs">
-      <Link>Common\Interop\Windows\Interop.GenericOperations.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs">
-      <Link>Common\Interop\Windows\Interop.HandleOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PipeOptions.cs">
-      <Link>Common\Interop\Windows\Interop.PipeOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs">
-      <Link>Common\Interop\Windows\Interop.FileOperations.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs">
-      <Link>Interop\Windows\Interop.FileTypes.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.GetCurrentProcess.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.DuplicateHandle_IntPtr.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs">
-      <Link>Interop\Windows\Interop.GetFileType.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreatePipe_SafePipeHandle.cs">
-      <Link>Common\Interop\Windows\Interop.CreatePipe_SafePipeHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ConnectNamedPipe.cs">
-      <Link>Common\Interop\Windows\Interop.ConnectNamedPipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitNamedPipe.cs">
-      <Link>Common\Interop\Windows\Interop.WaitNamedPipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs">
-      <Link>Common\Interop\Windows\Interop.GetNamedPipeHandleState.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeInfo.cs">
-      <Link>Common\Interop\Windows\Interop.GetNamedPipeInfo.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetNamedPipeHandleState.cs">
-      <Link>Common\Interop\Windows\Interop.SetNamedPipeHandleState.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
-      <Link>Common\Interop\Windows\Interop.CancelIoEx.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FlushFileBuffers.cs">
-      <Link>Common\Interop\Windows\Interop.FlushFileBuffers.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.ReadFile_IntPtr.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_NativeOverlapped.cs">
-      <Link>Common\Interop\Windows\Interop.ReadFile_NativeOverlapped.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs">
-      <Link>Common\Interop\Windows\Interop.WriteFile_IntPtr.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs">
-      <Link>Common\Interop\Windows\Interop.WriteFile_NativeOverlapped.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DisconnectNamedPipe.cs">
-      <Link>Common\Interop\Windows\Interop.DisconnectNamedPipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipe.cs">
-      <Link>Common\Interop\Windows\Interop.CreateNamedPipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MaxLengths.cs">
-      <Link>Common\Interop\Windows\Interop.MaxLengths.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RevertToSelf.cs">
-      <Link>Common\Interop\Windows\Interop.RevertToSelf.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ImpersonateNamedPipeClient.cs">
-      <Link>Common\Interop\Windows\Interop.ImpersonateNamedPipeClient.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs">
-      <Link>System\IO\Win32Marshal.cs</Link>
-    </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CloseHandle.cs" Link="Common\Interop\Windows\Interop.CloseHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs" Link="Common\Interop\Windows\Interop.FormatMessage.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FreeLibrary.cs" Link="Common\CoreLib\Interop\Windows\Interop.FreeLibrary.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs" Link="Common\CoreLib\Interop\Windows\Interop.SecurityOptions.cs" />
+    <Compile Include="$(CoreLibSharedDir)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" Link="Common\CoreLib\Microsoft\Win32\SafeLibraryHandle.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs" Link="Common\CoreLib\Interop\Windows\Interop.BOOL.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" Link="Common\CoreLib\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.HandleOptions.cs" Link="Common\Interop\Windows\Interop.HandleOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.PipeOptions.cs" Link="Common\Interop\Windows\Interop.PipeOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Interop.FileOperations.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs" Link="Common\CoreLib\Interop\Windows\Interop.FileTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetCurrentProcess_IntPtr.cs" Link="Common\Interop\Windows\Interop.GetCurrentProcess.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DuplicateHandle_IntPtr.cs" Link="Common\Interop\Windows\Interop.DuplicateHandle_IntPtr.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs" Link="Common\CoreLib\Interop\Windows\Interop.GetFileType.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreatePipe_SafePipeHandle.cs" Link="Common\Interop\Windows\Interop.CreatePipe_SafePipeHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.ConnectNamedPipe.cs" Link="Common\Interop\Windows\Interop.ConnectNamedPipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitNamedPipe.cs" Link="Common\Interop\Windows\Interop.WaitNamedPipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeHandleState.cs" Link="Common\Interop\Windows\Interop.GetNamedPipeHandleState.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetNamedPipeInfo.cs" Link="Common\Interop\Windows\Interop.GetNamedPipeInfo.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SetNamedPipeHandleState.cs" Link="Common\Interop\Windows\Interop.SetNamedPipeHandleState.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CancelIoEx.cs" Link="Common\Interop\Windows\Interop.CancelIoEx.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FlushFileBuffers.cs" Link="Common\Interop\Windows\Interop.FlushFileBuffers.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs" Link="Common\Interop\Windows\Interop.ReadFile_IntPtr.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_NativeOverlapped.cs" Link="Common\Interop\Windows\Interop.ReadFile_NativeOverlapped.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs" Link="Common\Interop\Windows\Interop.WriteFile_IntPtr.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_NativeOverlapped.cs" Link="Common\Interop\Windows\Interop.WriteFile_NativeOverlapped.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.DisconnectNamedPipe.cs" Link="Common\Interop\Windows\Interop.DisconnectNamedPipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipe.cs" Link="Common\Interop\Windows\Interop.CreateNamedPipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MaxLengths.cs" Link="Common\Interop\Windows\Interop.MaxLengths.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.RevertToSelf.cs" Link="Common\Interop\Windows\Interop.RevertToSelf.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ImpersonateNamedPipeClient.cs" Link="Common\Interop\Windows\Interop.ImpersonateNamedPipeClient.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\IO\Win32Marshal.cs" Link="Common\CoreLib\System\IO\Win32Marshal.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafePipeHandle.Windows.cs" />
+    <Compile Include="System\IO\Pipes\AnonymousPipeServerStreamAcl.cs" />
     <Compile Include="System\IO\Pipes\AnonymousPipeServerStream.Windows.cs" />
     <Compile Include="System\IO\Pipes\ConnectionCompletionSource.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeClientStream.Windows.cs" />
@@ -147,12 +74,8 @@
   </ItemGroup>
   <!-- Windows : Win32 only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipeClient.cs">
-      <Link>Common\Interop\Windows\Interop.CreateNamedPipeClient.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Interop\Windows\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateNamedPipeClient.cs" Link="Common\Interop\Windows\Interop.CreateNamedPipeClient.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs" Link="Common\CoreLib\Interop\Windows\Interop.LoadLibraryEx.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.Win32.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
@@ -161,81 +84,31 @@
     <Compile Include="System\IO\Pipes\NamedPipeClientStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.Unix.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.Unix.cs" />
-    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs">
-      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs">
-      <Link>Interop\Unix\Interop.Errors.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs">
-      <Link>Interop\Unix\Interop.IOErrors.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs">
-      <Link>Common\Interop\Unix\Interop.Close.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs">
-      <Link>Common\Interop\Unix\Interop.Fcntl.Pipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs">
-      <Link>Common\Interop\Unix\Interop.Fcntl.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.FLock.cs">
-      <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs">
-      <Link>Common\Interop\Unix\Interop.GetHostName.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerUserName.cs">
-      <Link>Common\Interop\Unix\Interop.GetPeerUserName.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs">
-      <Link>Common\Interop\Unix\Interop.MkDir.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Open.cs">
-      <Link>Common\Interop\Unix\Interop.Open.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.OpenFlags.cs">
-      <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Permissions.cs">
-      <Link>Common\Interop\Unix\Interop.Permissions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs">
-      <Link>Common\Interop\Unix\Interop.Pipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs">
-      <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Read.Pipe.cs">
-      <Link>Common\Interop\Unix\Interop.Read.Pipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Unlink.cs">
-      <Link>Common\Interop\Unix\Interop.Unlink.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Write.Pipe.cs">
-      <Link>Common\Interop\Unix\Interop.Write.Pipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs">
-      <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.Pipe.cs">
-      <Link>Common\Interop\Unix\Interop.Stat.Pipe.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerID.cs">
-      <Link>Common\Interop\Unix\Interop.GetPeerID.cs</Link>
-    </Compile>
-    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs">
-      <Link>Common\Interop\Unix\Interop.GetEUid.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetEUid.cs">
-      <Link>Common\Interop\Unix\Interop.SetEUid.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)System\Threading\Tasks\ForceAsyncAwaiter.cs">
-      <Link>Common\System\Threading\Tasks\ForceAsyncAwaiter.cs</Link>
-    </Compile>
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFileHandleHelper.Unix.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs" Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.Errors.cs" Link="Common\CoreLib\Interop\Unix\Interop.Errors.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\Interop.IOErrors.cs" Link="Common\CoreLib\Interop\Unix\Interop.IOErrors.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Close.cs" Link="Common\Interop\Unix\Interop.Close.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs" Link="Common\Interop\Unix\Interop.Fcntl.Pipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs" Link="Common\Interop\Unix\Interop.Fcntl.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.FLock.cs" Link="Common\Interop\Unix\Interop.FLock.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetHostName.cs" Link="Common\Interop\Unix\Interop.GetHostName.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerUserName.cs" Link="Common\Interop\Unix\Interop.GetPeerUserName.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs" Link="Common\Interop\Unix\Interop.MkDir.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Open.cs" Link="Common\Interop\Unix\Interop.Open.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.OpenFlags.cs" Link="Common\Interop\Unix\Interop.OpenFlags.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Permissions.cs" Link="Common\Interop\Unix\Interop.Permissions.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs" Link="Common\Interop\Unix\Interop.Pipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Poll.cs" Link="Common\Interop\Unix\Interop.Poll.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Read.Pipe.cs" Link="Common\Interop\Unix\Interop.Read.Pipe.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Unlink.cs" Link="Common\Interop\Unix\Interop.Unlink.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Write.Pipe.cs" Link="Common\Interop\Unix\Interop.Write.Pipe.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.Stat.cs" Link="Common\Interop\Unix\Interop.Stat.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.Pipe.cs" Link="Common\Interop\Unix\Interop.Stat.Pipe.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerID.cs" Link="Common\Interop\Unix\Interop.GetPeerID.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Unix\System.Native\Interop.GetEUid.cs" Link="Common\Interop\Unix\Interop.GetEUid.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SetEUid.cs" Link="Common\Interop\Unix\Interop.SetEUid.cs" />
+    <Compile Include="$(CommonPath)System\Threading\Tasks\ForceAsyncAwaiter.cs" Link="Common\System\Threading\Tasks\ForceAsyncAwaiter.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeClientStream.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Security;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO.Pipes
 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Unix.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
-using System.Security;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO.Pipes
 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Security;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO.Pipes
 {
@@ -15,13 +13,27 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class AnonymousPipeServerStream : PipeStream
     {
-        // Creates the anonymous pipe.
+        internal AnonymousPipeServerStream(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
+            : base(direction, bufferSize)
+        {
+            if (direction == PipeDirection.InOut)
+            {
+                throw new NotSupportedException(SR.NotSupported_AnonymousPipeUnidirectional);
+            }
+
+            if (inheritability < HandleInheritability.None || inheritability > HandleInheritability.Inheritable)
+            {
+                throw new ArgumentOutOfRangeException(nameof(inheritability), SR.ArgumentOutOfRange_HandleInheritabilityNoneOrInheritable);
+            }
+
+            Create(direction, inheritability, bufferSize, pipeSecurity);
+        }
+
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize)
         {
             Create(direction, inheritability, bufferSize, null);
         }
 
-        // Creates the anonymous pipe. This overload is used in Mono to implement public constructors.
         private void Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
         {
             Debug.Assert(direction != PipeDirection.InOut, "Anonymous pipe direction shouldn't be InOut");

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics.CodeAnalysis;
-using System.Security;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO.Pipes
 {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStreamAcl.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStreamAcl.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO.Pipes
+{
+    public static class AnonymousPipeServerStreamAcl
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="AnonymousPipeServerStream" /> class with the specified pipe direction, inheritability mode, buffer size, and pipe security.
+        /// </summary>
+        /// <param name="direction">One of the enumeration values that determines the direction of the pipe. Anonymous pipes can only be in one direction, so direction cannot be set to <see cref="PipeDirection.InOut" />.</param>
+        /// <param name="inheritability">One of the enumeration values that determines whether the underlying handle can be inherited by child processes.</param>
+        /// <param name="bufferSize">The size of the buffer. This value must be greater than or equal to 0.</param>
+        /// <param name="pipeSecurity">An object that determines the access control and audit security for the pipe.</param>
+        /// <returns>A new anonymous pipe server stream instance.</returns>
+        /// <remarks>Setting <paramref name="pipeSecurity" /> to <see langword="null" /> is equivalent to calling the `System.IO.Pipes.AnonymousPipeServerStream(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize)` constructor directly.</remarks>
+        /// <exception cref="NotSupportedException"><paramref name="direction" /> is <see cref="PipeDirection.InOut" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="inheritability" /> is not set to a valid <see cref="HandleInheritability" /> enum value.</exception>
+        public static AnonymousPipeServerStream Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
+        {
+            return new AnonymousPipeServerStream(direction, inheritability, bufferSize, pipeSecurity);
+        }
+    }
+}

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -139,9 +139,7 @@ namespace System.Security.AccessControl
                     }
                     else if (error == Interop.Errors.ERROR_INVALID_NAME)
                     {
-                        exception = new ArgumentException(
-                             SR.Argument_InvalidName,
-nameof(name));
+                        exception = new ArgumentException(SR.Argument_InvalidName, nameof(name));
                     }
                     else if (error == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     {


### PR DESCRIPTION
The original corefx PR was already signed off, but the CI did not finish on time before the 5pm deadline: https://github.com/dotnet/corefx/pull/42392

Approved API proposal: https://github.com/dotnet/corefx/issues/41657

We don't currently have a way to create a pipe with a given ACL in .NET Core. We can modify the ACL, but it would be more secure to have the proper ACL on the pipe from the start.

This PR adds a new static class and method that can create an AnonymousPipeServerStream taking a PipeSecurity object, reusing code that can already perform this task.