### PR TITLE
  Remove strong reference of XNamespace from XName

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -13,7 +13,7 @@ namespace System.Xml.Linq
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Serialization", "CA2229", Justification = "Serialized with custom proxy")]
     public sealed class XName : IEquatable<XName>, ISerializable
     {
-        private readonly XNamespace _ns;
+        private readonly string _namespaceName;
         private readonly string _localName;
         private readonly int _hashCode;
 
@@ -22,7 +22,7 @@ namespace System.Xml.Linq
         /// </summary>
         internal XName(XNamespace ns, string localName)
         {
-            _ns = ns;
+            _namespaceName = ns.NamespaceName;
             _localName = XmlConvert.VerifyNCName(localName);
             _hashCode = ns.GetHashCode() ^ localName.GetHashCode();
         }
@@ -41,7 +41,7 @@ namespace System.Xml.Linq
         /// </summary>
         public XNamespace Namespace
         {
-            get { return _ns; }
+            get { return XNamespace.Get(_namespaceName); }
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace System.Xml.Linq
         /// </summary>
         public string NamespaceName
         {
-            get { return _ns.NamespaceName; }
+            get { return _namespaceName; }
         }
 
         /// <summary>
@@ -57,8 +57,8 @@ namespace System.Xml.Linq
         /// </summary>
         public override string ToString()
         {
-            if (_ns.NamespaceName.Length == 0) return _localName;
-            return "{" + _ns.NamespaceName + "}" + _localName;
+            if (_namespaceName.Length == 0) return _localName;
+            return $"{{{_namespaceName}}}{_localName}";
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -58,7 +58,7 @@ namespace System.Xml.Linq
         public override string ToString()
         {
             if (_namespaceName.Length == 0) return _localName;
-            return $"{{{_namespaceName}}}{_localName}";
+            return "{" + _namespaceName + "}" + _localName;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -13,7 +13,7 @@ namespace System.Xml.Linq
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Serialization", "CA2229", Justification = "Serialized with custom proxy")]
     public sealed class XName : IEquatable<XName>, ISerializable
     {
-        private readonly string _namespaceName;
+        private readonly XNamespace _ns;
         private readonly string _localName;
         private readonly int _hashCode;
 
@@ -22,7 +22,7 @@ namespace System.Xml.Linq
         /// </summary>
         internal XName(XNamespace ns, string localName)
         {
-            _namespaceName = ns.NamespaceName;
+            _ns = ns;
             _localName = XmlConvert.VerifyNCName(localName);
             _hashCode = ns.GetHashCode() ^ localName.GetHashCode();
         }
@@ -41,7 +41,7 @@ namespace System.Xml.Linq
         /// </summary>
         public XNamespace Namespace
         {
-            get { return XNamespace.Get(_namespaceName); }
+            get { return _ns; }
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace System.Xml.Linq
         /// </summary>
         public string NamespaceName
         {
-            get { return _namespaceName; }
+            get { return _ns.NamespaceName; }
         }
 
         /// <summary>
@@ -57,8 +57,8 @@ namespace System.Xml.Linq
         /// </summary>
         public override string ToString()
         {
-            if (_namespaceName.Length == 0) return _localName;
-            return "{" + _namespaceName + "}" + _localName;
+            if (_ns.NamespaceName.Length == 0) return _localName;
+            return "{" + _ns.NamespaceName + "}" + _localName;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
@@ -172,9 +172,9 @@ namespace System.Xml.Linq.Tests
         }
 
         [Fact]
-        public void DifferentNamespaceAndSameNameeProduceDifferentInstance()
+        public void DifferentNamespaceAndSameNameProduceDifferentInstance()
         {
-            XName a = "{A2WVL}A2WVK", b = "{A2WVK}A2WVK";
+            XName a = "{A2WVLA}A2WVKA", b = "{A2WVKA}A2WVKA";
             Assert.NotSame(a.Namespace, b.Namespace);
             Assert.NotSame(a, b);
             Assert.NotSame(a.ToString(), b.ToString());
@@ -184,8 +184,8 @@ namespace System.Xml.Linq.Tests
         [Fact]
         public void DefaultNamespaceSameNameProduceSameInstance()
         {
-            XName a = "A2WVK";
-            var b = new XElement("A2WVK");
+            XName a = "A2WVKB";
+            var b = new XElement("A2WVKB");
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.Same(a, b.Name);
             Assert.Same(XNamespace.None, a.Namespace);
@@ -195,8 +195,8 @@ namespace System.Xml.Linq.Tests
         [Fact]
         public void SameNamespaceDifferentNameProduceDifferentInstance()
         {
-            XName a = "{A2WVL}A2WVK";
-            var b = new XElement("{A2WVL}A2WVL");
+            XName a = "{A2WVLC}A2WVKC";
+            var b = new XElement("{A2WVLC}A2WVLC");
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.NotSame(a, b.Name);
             Assert.Same(a.Namespace.ToString(), b.Name.Namespace.ToString());

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
@@ -172,9 +172,9 @@ namespace System.Xml.Linq.Tests
         }
 
         [Fact]
-        public void DifferentNamespaceAndSameNameProduceDifferentInstance()
+        public void DifferentNamespaceAndSameNameProduceDifferentXNameInstance()
         {
-            XName a = "{A2WVLA}A2WVKA", b = "{A2WVKA}A2WVKA";
+            XName a = "{Namesapce1}Name1", b = "{Namesapce2}Name1";
             Assert.NotSame(a.Namespace, b.Namespace);
             Assert.NotSame(a, b);
             Assert.NotSame(a.ToString(), b.ToString());
@@ -182,10 +182,10 @@ namespace System.Xml.Linq.Tests
         }
 
         [Fact]
-        public void DefaultNamespaceSameNameProduceSameInstance()
+        public void SameDefaultNamespaceSameNameProduceSameXNameInstance()
         {
-            XName a = "A2WVKB";
-            var b = new XElement("A2WVKB");
+            XName a = "Name2";
+            var b = new XElement($"Name2");
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.Same(a, b.Name);
             Assert.Same(XNamespace.None, a.Namespace);
@@ -193,10 +193,21 @@ namespace System.Xml.Linq.Tests
         }
 
         [Fact]
-        public void SameNamespaceDifferentNameProduceDifferentInstance()
+        public void SameNamespaceSameStringDifferentInstanceProduceSameXNameInstance()
         {
-            XName a = "{A2WVLC}A2WVKC";
-            var b = new XElement("{A2WVLC}A2WVLC");
+            XName a = "Name3";
+            var b = new XElement($"Name3{null}");
+            Assert.Same(a.Namespace, b.Name.Namespace);
+            Assert.Same(a, b.Name);
+            Assert.Same(XNamespace.None, a.Namespace);
+            Assert.Same(a.ToString(), b.Name.ToString());
+        }
+
+        [Fact]
+        public void SameNamespaceDifferentNameProduceDifferentXNameInstance()
+        {
+            XName a = "{Namesapce2}Name4";
+            var b = new XElement("{Namesapce2}Name5");
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.NotSame(a, b.Name);
             Assert.Same(a.Namespace.ToString(), b.Name.Namespace.ToString());

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace System.Xml.Linq.Tests
@@ -174,7 +175,7 @@ namespace System.Xml.Linq.Tests
         [Fact]
         public void DifferentNamespaceAndSameNameProduceDifferentXNameInstance()
         {
-            XName a = "{Namesapce1}Name1", b = "{Namesapce2}Name1";
+            XName a = "{Namespace1}Name1", b = "{Namespace2}Name1";
             Assert.NotSame(a.Namespace, b.Namespace);
             Assert.NotSame(a, b);
             Assert.NotSame(a.ToString(), b.ToString());
@@ -195,8 +196,11 @@ namespace System.Xml.Linq.Tests
         [Fact]
         public void SameNamespaceSameStringDifferentInstanceProduceSameXNameInstance()
         {
-            XName a = "Name3";
-            var b = new XElement($"Name3{null}");
+            string instance1 = "Name3";
+            string instance2 = $"Name3{null}"; // different string instance populated
+            XName a = instance1;
+            var b = new XElement(instance2);
+            Assert.NotSame(instance1, instance2);
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.Same(a, b.Name);
             Assert.Same(XNamespace.None, a.Namespace);
@@ -206,11 +210,27 @@ namespace System.Xml.Linq.Tests
         [Fact]
         public void SameNamespaceDifferentNameProduceDifferentXNameInstance()
         {
-            XName a = "{Namesapce2}Name4";
-            var b = new XElement("{Namesapce2}Name5");
+            XName a = "{Namespace2}Name4";
+            var b = new XElement("{Namespace2}Name5");
             Assert.Same(a.Namespace, b.Name.Namespace);
             Assert.NotSame(a, b.Name);
             Assert.Same(a.Namespace.ToString(), b.Name.Namespace.ToString());
+        }
+
+        [Fact]
+        public void SameNamespaceSameNameProduceSameXNameInstanceAfterGC()
+        {
+            XName a = "Name6";
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var b = new XElement($"Name6");
+            Assert.Same(a.Namespace, b.Name.Namespace);
+            Assert.Same(a, b.Name);
+            Assert.Same(XNamespace.None, a.Namespace);
+            Assert.Same(a.ToString(), b.Name.ToString());
         }
     }
 }

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using System.Threading;
 using Xunit;
 
 namespace System.Xml.Linq.Tests

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/XHashtable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace System.Xml.Linq.Tests
@@ -169,6 +170,37 @@ namespace System.Xml.Linq.Tests
             XElement a = new XElement("{A2WVL}A2WVK"), b = new XElement("{A2WVK}A2WVL");
             Assert.NotSame(a.Name.Namespace, b.Name.Namespace);
             Assert.NotSame(a.Name, b.Name);
+        }
+
+        [Fact]
+        public void DifferentNamespaceAndSameNameeProduceDifferentInstance()
+        {
+            XName a = "{A2WVL}A2WVK", b = "{A2WVK}A2WVK";
+            Assert.NotSame(a.Namespace, b.Namespace);
+            Assert.NotSame(a, b);
+            Assert.NotSame(a.ToString(), b.ToString());
+            Assert.Equal(a.LocalName, b.LocalName);
+        }
+
+        [Fact]
+        public void DefaultNamespaceSameNameProduceSameInstance()
+        {
+            XName a = "A2WVK";
+            var b = new XElement("A2WVK");
+            Assert.Same(a.Namespace, b.Name.Namespace);
+            Assert.Same(a, b.Name);
+            Assert.Same(XNamespace.None, a.Namespace);
+            Assert.Same(a.ToString(), b.Name.ToString());
+        }
+
+        [Fact]
+        public void SameNamespaceDifferentNameProduceDifferentInstance()
+        {
+            XName a = "{A2WVL}A2WVK";
+            var b = new XElement("{A2WVL}A2WVL");
+            Assert.Same(a.Namespace, b.Name.Namespace);
+            Assert.NotSame(a, b.Name);
+            Assert.Same(a.Namespace.ToString(), b.Name.Namespace.ToString());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36404
XNamespace has a hashtable of XNames keeping all Names bound to it, also XNames has strong reference back to its XNamespace.When creating lots of XNames within same XNamespace its XNames Hastable grows endlessly until fill out memory. Even XNamespaces are WeakReferences it stays in memory forever because they have strong references to its XNames. With this change removing that strong reference from XName 
