### PR TITLE
Fix ZapRequire test hooks for R2R

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -497,14 +497,6 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitConstant, W("SpinLimitConstant"), 
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0xA, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_Monitor_SpinCount, W("Monitor_SpinCount"), 0x1e, "Hex value specifying the maximum number of spin iterations Monitor may perform upon contention on acquiring the lock before waiting.", EEConfig_default)
 
-///
-/// Native Binder
-///
-
-CONFIG_DWORD_INFO(INTERNAL_NgenBind_ZapForbid,             W("NgenBind_ZapForbid"), 0, "Assert if an assembly succeeds in binding to a native image")
-CONFIG_STRING_INFO(INTERNAL_NgenBind_ZapForbidExcludeList, W("NgenBind_ZapForbidExcludeList"), "")
-CONFIG_STRING_INFO(INTERNAL_NgenBind_ZapForbidList,        W("NgenBind_ZapForbidList"), "")
-
 CONFIG_DWORD_INFO_EX(INTERNAL_SymDiffDump, W("SymDiffDump"), 0, "Used to create the map file while binding the assembly. Used by SemanticDiffer", CLRConfig::REGUTIL_default)
 
 ///
@@ -673,17 +665,25 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_DisableWatsonForManagedExceptions, W("DisableW
 ///
 RETAIL_CONFIG_STRING_INFO_EX(INTERNAL_ZapBBInstr, W("ZapBBInstr"), "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_ZapBBInstrDir, W("ZapBBInstrDir"), "")
+
+#ifdef FEATURE_PREJIT
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ZapDisable, W("ZapDisable"), 0, "")
 CONFIG_STRING_INFO_EX(INTERNAL_ZapExclude, W("ZapExclude"), "", CLRConfig::REGUTIL_default)
 CONFIG_STRING_INFO_EX(INTERNAL_ZapOnly, W("ZapOnly"), "", CLRConfig::REGUTIL_default)
-RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_ZapRequire, W("ZapRequire"), "")
-RETAIL_CONFIG_STRING_INFO(EXTERNAL_ZapRequireExcludeList, W("ZapRequireExcludeList"), "")
-RETAIL_CONFIG_STRING_INFO(EXTERNAL_ZapRequireList, W("ZapRequireList"), "")
 RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_ZapSet, W("ZapSet"), "", CLRConfig::REGUTIL_default)
+#endif
 
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ReadyToRun, W("ReadyToRun"), 1, "Enable/disable use of ReadyToRun native code") // On by default for CoreCLR
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_ReadyToRunExcludeList, W("ReadyToRunExcludeList"), "List of assemblies that cannot use Ready to Run images")
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_ReadyToRunLogFile, W("ReadyToRunLogFile"), "Name of file to log success/failure of using Ready to Run images")
+
+RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_ZapRequire, W("ZapRequire"), "Assert if an assembly fails in loading a ReadyToRun image")
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_ZapRequireList, W("ZapRequireList"), "")
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_ZapRequireExcludeList, W("ZapRequireExcludeList"), "")
+
+CONFIG_DWORD_INFO(INTERNAL_ZapForbid, W("ZapForbid"), 0, "Assert if an assembly succeeds in loading a ReadyToRun image")
+CONFIG_STRING_INFO(INTERNAL_ZapForbidList, W("ZapForbidList"), "")
+CONFIG_STRING_INFO(INTERNAL_ZapForbidExcludeList, W("ZapForbidExcludeList"), "")
 
 #if defined(FEATURE_EVENT_TRACE) || defined(FEATURE_EVENTSOURCE_XPLAT)
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableEventLog, W("EnableEventLog"), 0, "Enable/disable use of EnableEventLogging mechanism ") // Off by default

--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -593,10 +593,12 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
         }
 
         StackSString ss;
-        if (m_pReadyToRunInfo != NULL && g_pConfig->ForbidZap(GetSimpleName()))
-            ss.Printf("ZapForbid: ReadyToRun should be forbidden for %s.\n", GetSimpleName());
-        else if(m_pReadyToRunInfo == NULL && g_pConfig->RequireZap(GetSimpleName()))
+        if (m_pReadyToRunInfo == NULL && g_pConfig->RequireZap(GetSimpleName()))
             ss.Printf("ZapRequire: Failed to load ReadyToRun for %s.\n", GetSimpleName());
+#ifdef _DEBUG
+        else if (m_pReadyToRunInfo != NULL && g_pConfig->ForbidZap(GetSimpleName()))
+            ss.Printf("ZapForbid: ReadyToRun should be forbidden for %s.\n", GetSimpleName());
+#endif
 
         if (!ss.IsEmpty())
         {

--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -591,6 +591,24 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
                 GetNativeAssemblyImport(TRUE /* loadAllowed */);
             }
         }
+
+        StackSString ss;
+        if (m_pReadyToRunInfo != NULL && g_pConfig->ForbidZap(GetSimpleName()))
+            ss.Printf("ZapForbid: ReadyToRun should be forbidden for %s.\n", GetSimpleName());
+        else if(m_pReadyToRunInfo == NULL && g_pConfig->RequireZap(GetSimpleName()))
+            ss.Printf("ZapRequire: Failed to load ReadyToRun for %s.\n", GetSimpleName());
+
+        if (!ss.IsEmpty())
+        {
+#if defined(_DEBUG)
+            // Assert as some test may not check their error codes well. So throwing an
+            // exception may not cause a test failure (as it should).
+            StackScratchBuffer scratch;
+            DbgAssertDialog(__FILE__, __LINE__, (char*)ss.GetUTF8(scratch));
+#endif // defined(_DEBUG)
+
+            COMPlusThrowNonLocalized(kFileLoadException, ss.GetUnicode());
+        }
     }
 #endif
 

--- a/src/coreclr/src/vm/eeconfig.h
+++ b/src/coreclr/src/vm/eeconfig.h
@@ -671,13 +671,15 @@ public:
         REQUIRE_ZAPS_COUNT
     };
     RequireZapsType RequireZaps()           const {LIMITED_METHOD_CONTRACT;  return iRequireZaps; }
+
     bool    RequireZap(LPCUTF8 assemblyName) const;
 #ifdef _DEBUG
     bool    ForbidZap(LPCUTF8 assemblyName) const;
 #endif
-    bool    ExcludeReadyToRun(LPCUTF8 assemblyName) const;
 
+#ifdef FEATURE_PREJIT
     LPCWSTR ZapSet()                        const { LIMITED_METHOD_CONTRACT; return pZapSet; }
+#endif
 
     bool    NgenBindOptimizeNonGac()        const { LIMITED_METHOD_CONTRACT; return fNgenBindOptimizeNonGac; }
 
@@ -957,9 +959,6 @@ private: //----------------------------------------------------------------
     // This overrides pRequireZapsList.
     AssemblyNamesList * pRequireZapsExcludeList;
 
-    // Assemblies which cannot use Ready to Run images.
-    AssemblyNamesList * pReadyToRunExcludeList;
-
 #ifdef _DEBUG
     // Exact opposite of require zaps
     BOOL iForbidZaps;
@@ -967,7 +966,9 @@ private: //----------------------------------------------------------------
     AssemblyNamesList * pForbidZapsExcludeList;
 #endif
 
+#ifdef FEATURE_PREJIT
     LPCWSTR pZapSet;
+#endif  // FEATURE_PREJIT
 
     bool fNgenBindOptimizeNonGac;
 
@@ -987,8 +988,10 @@ private: //----------------------------------------------------------------
     int       m_TraceWrapper;
 #endif
 
+#ifdef FEATURE_PREJIT
     // Flag to keep track of memory
     int     m_fFreepZapSet;
+#endif
 
 #ifdef _DEBUG
     // GC Alloc perf flags

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -482,12 +482,6 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
-    if (g_pConfig->ExcludeReadyToRun(pModule->GetSimpleName()))
-    {
-        DoLog("Ready to Run disabled - module on exclusion list");
-        return NULL;
-    }
-
 #ifdef FEATURE_NATIVE_IMAGE_GENERATION
     // Ignore ReadyToRun during NGen
     if (IsCompilationProcess() && !IsNgenPDBCompilationProcess())


### PR DESCRIPTION
Fixed the following:
- ZapRequire
- ZapRequireList
- ZapRequireExcludeList
- ZapForbid (removed the _NgenBind portion from the name)
- ZapForbidExcludeList (removed the _NgenBind portion from the name)
- ZapForbidList (removed the _NgenBind portion from the name)

Moved the following under FEATURE_PREJIT:
- ZapDisable
- ZapExclude
- ZapOnly
- ZapSet