### PR TITLE
Fix race in installer tasks build

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -79,8 +79,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(RepoTaskProjects)"
-             Properties="RepoRoot=$(RepoRoot)"
-             Targets="Restore;Build;CreateHostMachineInfoFile"/>
+             Targets="Restore;Build"/>
 
     <WriteLinesToFile File="$(RepoTasksOutputFile)"
                       Lines="$(RepoTasksOutputFile)"
@@ -94,7 +93,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <RepoTasksSrc Include="$(RepoTasksDir)**\*.cs" />
+      <RepoTasksSrc Include="$(RepoTasksDir)**\*.cs*" />
     </ItemGroup>
   </Target>
 

--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net46</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- Duplicating the assembly path here as CoreClr current overrides the Configuration property. -->
+    <InstallerTasksAssemblyPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(IntermediateOutputPath)netstandard2.0\installer.tasks.dll</InstallerTasksAssemblyPath>
+    <InstallerTasksAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(IntermediateOutputPath)net46\installer.tasks.dll</InstallerTasksAssemblyPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,8 +40,10 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
-  <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(InstallerTasksAssemblyPath)" />
-  <Target Name="CreateHostMachineInfoFile">
+  <UsingTask TaskName="GetTargetMachineInfo"
+             AssemblyFile="$(InstallerTasksAssemblyPath)" />
+  <Target Name="CreateHostMachineInfoFile"
+          AfterTargets="DispatchToInnerBuilds">
     <GetTargetMachineInfo>
       <Output PropertyName="HostMachineRid" TaskParameter="RuntimeIdentifier" />
     </GetTargetMachineInfo>


### PR DESCRIPTION
I couldn't find the place where CoreClr is fiddling with the Configuration property but this change is general goodness (by making the tools-local logic more general purpose)

cc @ivdiazsa @jashook 
