### PR TITLE
Fix coreclr release build on windows to not use unknown switch

### DIFF
--- a/src/coreclr/coreclr.proj
+++ b/src/coreclr/coreclr.proj
@@ -9,7 +9,7 @@
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(Platform)' == 'x86' or '$(Platform)' == 'x64') and '$(Configuration)' == 'Release'" Include="-enforcepgo" />
-      <_CoreClrBuildArg Condition="'$(Configuration)' == 'Release'" Include="-stripsymbols" />
+      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(Configuration)' == 'Release'" Include="-stripsymbols" />
       <_CoreClrBuildArg Condition="'$(OfficialBuildId)' == ''" Include="-officialbuildid=$(OfficialBuildId)" />
     </ItemGroup>
 


### PR DESCRIPTION
if you currently try and build coreclr subset in windows with `-configuration Release` it fails because tries to pass down the `-stripsymbols` switch which only exists for Unix.

```
MSBUILD : error MSB1001: Unknown switch. [E:\repos\runtime\src\coreclr\coreclr.proj]
  Switch: -stripsymbols

  For switch syntax, type "MSBuild -help"
  Build failed.
BUILD : error : Failed to generate version headers. [E:\repos\runtime\src\coreclr\coreclr.proj]
E:\repos\runtime\src\coreclr\coreclr.proj(21,5): error MSB3073: The command ""E:\repos\runtime\src\coreclr\build.cmd" -skiptests -x64 -release -enforcepgo -stripsymbols -officialbuildid=" exited with code 1.

Build FAILED.
```

FYI: @tarekgh (thanks for reporting the issue)