### PR TITLE
Fix double expansion of AggregateException.Flatten message

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AggregateException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AggregateException.cs
@@ -377,7 +377,7 @@ namespace System
             while (exceptionsToFlatten.Count > nDequeueIndex)
             {
                 // dequeue one from exceptionsToFlatten
-                IList<Exception> currentInnerExceptions = exceptionsToFlatten[nDequeueIndex++].InnerExceptions;
+                ReadOnlyCollection<Exception> currentInnerExceptions = exceptionsToFlatten[nDequeueIndex++].InnerExceptions;
 
                 for (int i = 0; i < currentInnerExceptions.Count; i++)
                 {
@@ -401,8 +401,7 @@ namespace System
                 }
             }
 
-
-            return new AggregateException(Message, flattenedExceptions);
+            return new AggregateException(GetType() == typeof(AggregateException) ? base.Message : Message, flattenedExceptions);
         }
 
         /// <summary>Gets a message that describes the exception.</summary>

--- a/src/libraries/System.Threading.Tasks/tests/AggregateExceptionTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/AggregateExceptionTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
@@ -103,7 +101,9 @@ namespace System.Threading.Tasks.Tests
             Exception exceptionB = new Exception("B");
             Exception exceptionC = new Exception("C");
 
-            AggregateException aggExceptionBase = new AggregateException(exceptionA, exceptionB, exceptionC);
+            AggregateException aggExceptionBase = new AggregateException("message", exceptionA, exceptionB, exceptionC);
+
+            Assert.Equal("message (A) (B) (C)", aggExceptionBase.Message);
 
             // Verify flattening one with another.
             // > Flattening (no recursion)...
@@ -114,15 +114,17 @@ namespace System.Threading.Tasks.Tests
             };
 
             Assert.Equal(expected1, flattened1.InnerExceptions);
+            Assert.Equal("message (A) (B) (C)", flattened1.Message);
 
             // Verify flattening one with another, accounting for recursion.
-            AggregateException aggExceptionRecurse = new AggregateException(aggExceptionBase, aggExceptionBase);
+            AggregateException aggExceptionRecurse = new AggregateException("message", aggExceptionBase, aggExceptionBase);
             AggregateException flattened2 = aggExceptionRecurse.Flatten();
             Exception[] expected2 = new Exception[] {
                 exceptionA, exceptionB, exceptionC, exceptionA, exceptionB, exceptionC,
             };
 
             Assert.Equal(expected2, flattened2.InnerExceptions);
+            Assert.Equal("message (A) (B) (C) (A) (B) (C)", flattened2.Message);
         }
     }
 }


### PR DESCRIPTION
A by-product of fixing https://github.com/dotnet/corefx/issues/5364 was that `AggregateException.Flatten()` will construct a new exception using the expanded message from the existing exception which will be expanded again when used.

The test diff for this change would have been the following:
```diff
-Assert.Equal("message (A) (B) (C) (A) (B) (C)", flattened1.Message);
+Assert.Equal("message (A) (B) (C)", flattened1.Message);
-Assert.Equal("message (message (A) (B) (C)) (message (A) (B) (C)) (A) (B) (C) (A) (B) (C)", flattened2.Message);
+Assert.Equal("message (A) (B) (C) (A) (B) (C)", flattened2.Message);
```
@stephentoub Is the check for exact type match OK or too much?