### PR TITLE
Respect COMPlus_legacyCorruptedStateExceptionsPolicy in the Marshal.StructureToPtr and Marshal.PtrToStructure APIs.

### DIFF
--- a/src/coreclr/src/vm/marshalnative.cpp
+++ b/src/coreclr/src/vm/marshalnative.cpp
@@ -149,6 +149,7 @@ FCIMPL3(VOID, MarshalNative::StructureToPtr, Object* pObjUNSAFE, LPVOID ptr, CLR
     if (pMT->HasInstantiation())
         COMPlusThrowArgumentException(W("structure"), W("Argument_NeedNonGenericObject"));
 
+    AVInRuntimeImplOkayHolder AVOkay;
     if (pMT->IsBlittable())
     {
         memcpyNoGCRefs(ptr, pObj->GetData(), pMT->GetNativeSize());
@@ -204,7 +205,9 @@ FCIMPL3(VOID, MarshalNative::PtrToStructureHelper, LPVOID ptr, Object* pObjIn, C
     {
         COMPlusThrowArgumentException(W("structure"), W("Argument_StructMustNotBeValueClass"));
     }
-    else if (pMT->IsBlittable())
+
+    AVInRuntimeImplOkayHolder AVOkay;
+    if (pMT->IsBlittable())
     {
         memcpyNoGCRefs(pObj->GetData(), ptr, pMT->GetNativeSize());
     }


### PR DESCRIPTION
Respect `COMPlus_legacyCorruptedStateExceptionsPolicy` in the `Marshal.StructureToPtr` and `Marshal.PtrToStructure` APIs.

Fixes https://github.com/dotnet/coreclr/issues/27897

This will work as expected for the OP in https://github.com/dotnet/coreclr/issues/27897.

@jkotas Please let me know if there are any concerns with this change. I spoke with @janvorli and we agreed it probably wasn't worth fixing, but wanted to at least have the conversation.