### PR TITLE
Set installer.tasks.csproj to Platform AnyCPU for arch-agnostic output path

### DIFF
--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -7,6 +7,8 @@
     <!-- Duplicating the assembly path here as CoreClr current overrides the Configuration property. -->
     <InstallerTasksAssemblyPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(IntermediateOutputPath)netstandard2.0\installer.tasks.dll</InstallerTasksAssemblyPath>
     <InstallerTasksAssemblyPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(IntermediateOutputPath)net46\installer.tasks.dll</InstallerTasksAssemblyPath>
+    <!-- Set platform to AnyCPU (not TargetArchitecture) to avoid arch-specific output path. -->
+    <Platform>AnyCPU</Platform>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This applies the workaround here, which is lost due to the installer project being shuffled outside `src/installer`:

https://github.com/dotnet/runtime/blob/3a2dc0f8429b922fa254a1ba6f751b79259275b1/src/installer/Directory.Build.props#L24-L26

I'm not sure if this helps with (or interferes with) https://github.com/dotnet/runtime/pull/122... I hit some issues trying to run the installer build in https://github.com/dotnet/runtime/pull/55 and this change seemed to help there. Haven't personally got a build through with this. Will need your help to tell if this change makes sense.