### PR TITLE
Use SDK from bootstrapped CLI rather than testhost

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -61,6 +61,8 @@ $subsetCategory = $subsetCategory.ToLowerInvariant()
 
 # VS Test Explorer support for libraries
 if ($vs) {
+  . $PSScriptRoot\common\tools.ps1
+
   if (-Not (Test-Path $vs)) {
     $vs = Join-Path "$PSScriptRoot\..\src\libraries" $vs | Join-Path -ChildPath "$vs.sln"
   }
@@ -69,6 +71,9 @@ if ($vs) {
 
   # This tells .NET Core to use the same dotnet.exe that build scripts use
   $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp-Windows_NT-$configuration-$archTestHost";
+
+  # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
+  $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=InitializeDotNetCli -install:$false
 
   # This tells .NET Core not to go looking for .NET Core in other places
   $env:DOTNET_MULTILEVEL_LOOKUP=0;

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -53,7 +53,6 @@
     <ItemGroup>
       <HostFxFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == '$(HostFxrFileName)'" />
       <DotnetExe Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'dotnet'" />
-      <HostSdkFile Include="$(DotNetRoot)sdk\$(DotNetVersion)\**\*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(HostFxFile)"
@@ -67,11 +66,6 @@
           UseHardlinksIfPossible="$(UseHardlink)" />
 
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OS)' != 'Windows_NT'"/>
-
-    <Copy SourceFiles="@(HostSdkFile)"
-          DestinationFolder="$(TestHostRootPath)sdk\$(DotNetVersion)\%(RecursiveDir)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="$(UseHardlink)" />
   </Target>
 
   <Target Name="OverrideRuntime"


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/commit/dd2ad4367bc4e070f3e8ca81ca6421db5733e731

This also removes copying the SDK to the testhost directory
since that is no longer needed.