### PR TITLE
Fix devirtualization in crossgen2

### DIFF
--- a/src/coreclr/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
@@ -82,11 +82,16 @@ namespace ILCompiler
             else
             {
                 impl = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
-                if ((impl != null) && (impl != declMethod ) && impl.IsNewSlot)
+                if (impl != null && (impl != declMethod))
                 {
-                    // We cannot resolve virtual method in case the impl is a new slot since in such case,
-                    // the real target may be on a type derived from the implType.
-                    impl = null;
+                    MethodDesc slotDefiningMethodImpl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(impl);
+                    MethodDesc slotDefiningMethodDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(declMethod);
+
+                    if (slotDefiningMethodImpl != slotDefiningMethodDecl)
+                    {
+                        // We cannot resolve virtual method in case the impl is a different slot from the declMethod
+                        impl = null;
+                    }
                 }
             }
 

--- a/src/coreclr/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
@@ -82,6 +82,12 @@ namespace ILCompiler
             else
             {
                 impl = implType.FindVirtualFunctionTargetMethodOnObjectType(declMethod);
+                if ((impl != null) && (impl != declMethod ) && impl.IsNewSlot)
+                {
+                    // We cannot resolve virtual method in case the impl is a new slot since in such case,
+                    // the real target may be on a type derived from the implType.
+                    impl = null;
+                }
             }
 
             return impl;


### PR DESCRIPTION
In some casesi that are only expressible in IL, devirtualization is
choosing a wrong virtual method. This causes a failure of the
JIT\Regression\JitBlue\GitHub_19222 test.

The test uses the following class hierarchy:
```C#
class A
{
    public virtual void f() {}
}

class B : A
{
    public override void f() {}
}

class C : B
{
    public new void f() {}
}

class D : C
{
    public new void f() {}
}
```
Then there is a local of type C to which we assign a reference to D.
After that the following virtual call is made:
```IL
callvirt instance int32 modopt([mscorlib]System.Runtime.CompilerServices.IsLong) A::f()
```
Devirtualization will choose C.f to call instead of the D.f.

This change disables devirtualization in such cases. Old crossgen does
the same thing.