### PR TITLE
.dockerignore: remove .git from blacklist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,3 @@
-.git/
-**/syntax: glob
-
 ### VisualStudio ###
 
 # Tool Runtime Dir


### PR DESCRIPTION
Git targets are currently failing because docker builds are blacklisting the `.git` folder.