### PR TITLE
Disable autodetection of warnings in CoreCLR subrepo build

### DIFF
--- a/src/coreclr/coreclr.proj
+++ b/src/coreclr/coreclr.proj
@@ -18,7 +18,8 @@
       <_CoreClrBuildScript Condition="!$([MSBuild]::IsOsPlatform(Windows))">build.sh</_CoreClrBuildScript>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" />
+    <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing warning in the native build. -->
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="Restore" />


### PR DESCRIPTION
CoreCLR subrepo build has a known existing warning coming from
pgomgr that Arcade upgrades to an error via WarnAsError. I propose
suppressing autodetection of warnings in CoreCLR build to fix this
spurious bug reproducing in release mode.

Thanks

Tomas

Fixes: #150