### PR TITLE
Fix HashSet.Remove to use provided comparer

### DIFF
--- a/src/libraries/Common/tests/System/Collections/TestBase.NonGeneric.cs
+++ b/src/libraries/Common/tests/System/Collections/TestBase.NonGeneric.cs
@@ -20,6 +20,12 @@ namespace System.Collections.Tests
             yield return new object[] { 75 };
         }
 
+        public static IEnumerable<object[]> ValidPositiveCollectionSizes()
+        {
+            yield return new object[] { 1 };
+            yield return new object[] { 75 };
+        }
+
         public enum EnumerableType
         {
             HashSet,

--- a/src/libraries/Common/tests/System/Collections/TestingTypes.cs
+++ b/src/libraries/Common/tests/System/Collections/TestingTypes.cs
@@ -366,5 +366,23 @@ namespace System.Collections.Tests
         public bool Equals(ValueDelegateEquatable other) => EqualsWorker(other);
     }
 
+    public sealed class TrackingEqualityComparer<T> : IEqualityComparer<T>
+    {
+        public int EqualsCalls;
+        public int GetHashCodeCalls;
+
+        public bool Equals(T x, T y)
+        {
+            EqualsCalls++;
+            return EqualityComparer<T>.Default.Equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            GetHashCodeCalls++;
+            return EqualityComparer<T>.Default.GetHashCode(obj);
+        }
+    }
+
     #endregion
 }

--- a/src/libraries/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -416,7 +416,7 @@ namespace System.Collections.Generic
 
                     for (i = _buckets[bucket] - 1; i >= 0; last = i, i = slots[i].next)
                     {
-                        if (slots[i].hashCode == hashCode && EqualityComparer<T>.Default.Equals(slots[i].value, item))
+                        if (slots[i].hashCode == hashCode && comparer.Equals(slots[i].value, item))
                         {
                             goto ReturnFound;
                         }

--- a/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -626,5 +626,29 @@ namespace System.Collections.Tests
         }
 
         #endregion
+
+        #region Remove
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void Remove_NonDefaultComparer_ComparerUsed(int capacity)
+        {
+            var c = new TrackingEqualityComparer<T>();
+            var set = new HashSet<T>(capacity, c);
+
+            AddToCollection(set, capacity);
+            T first = set.First();
+            c.EqualsCalls = 0;
+            c.GetHashCodeCalls = 0;
+
+            Assert.Equal(capacity, set.Count);
+            set.Remove(first);
+            Assert.Equal(capacity - 1, set.Count);
+
+            Assert.InRange(c.EqualsCalls, 1, int.MaxValue);
+            Assert.InRange(c.GetHashCodeCalls, 1, int.MaxValue);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/42598
cc: @safern, @Tratcher 