### PR TITLE
Removed test scripts platform conditions

### DIFF
--- a/src/coreclr/tests/src/CLRTest.Execute.targets
+++ b/src/coreclr/tests/src/CLRTest.Execute.targets
@@ -58,8 +58,8 @@ This file contains the logic for providing Execution Script generation.
   -->
   
   <ItemGroup>
-    <ExecutionScriptKind Include="Batch" Condition="'$(BuildOS)' == 'Windows_NT'" />
-    <ExecutionScriptKind Include="Bash" Condition="'$(BuildOS)' != 'Windows_NT'" />
+    <ExecutionScriptKind Include="Batch" />
+    <ExecutionScriptKind Include="Bash" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Under `coreclr/tests/src/CLRTest.Execute.targets`, there were a couple conditionals that checked whether the current platform was any _Windows_ flavor. If so, then a `.cmd` wrapper script was generated for the tests. Otherwise, a `.sh` one was created instead.

As the first step in the upcoming test build optimizations and include/exclude filters, we require that both wrappers are generated, so this commit removes the conditionals to always have both wrappers, regardless of platform or test restrictions.