### PR TITLE
Port CoreRT changes

### DIFF
--- a/src/coreclr/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -18,7 +18,11 @@ namespace Internal.TypeSystem.Ecma
         private EcmaModule _module;
         private BlobReader _reader;
 
+#if TYPE_LOADER_IMPLEMENTATION
+        private LowLevelStack<int> _indexStack;
+#else
         private Stack<int> _indexStack;
+#endif
         private List<EmbeddedSignatureData> _embeddedSignatureDataList;
 
 
@@ -226,7 +230,11 @@ namespace Internal.TypeSystem.Ecma
         {
             try
             {
+#if TYPE_LOADER_IMPLEMENTATION
+                _indexStack = new LowLevelStack<int>();
+#else
                 _indexStack = new Stack<int>();
+#endif
                 _indexStack.Push(0);
                 _embeddedSignatureDataList = new List<EmbeddedSignatureData>();
                 return ParseMethodSignatureInternal(skipEmbeddedSignatureData: false);


### PR DESCRIPTION
`TYPE_LOADER_IMPLEMENTATION` is never defined in this repo, so this change does absolutely nothing.

All it does is to ensure the file `EcmaSignatureParser.cs` is identical across this repo and CoreRT.
This partially fixes https://github.com/dotnet/coreclr/issues/27845

In order to make them truly identical, I also need to port `NativeTypeKind.SafeArray` support introduced in https://github.com/dotnet/coreclr/pull/27673 to CoreRT.