### PR TITLE
Propagate assertions through Exception handlers.

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -4526,6 +4526,12 @@ public:
         BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, pAssertionOut);
     }
 
+    void MergeHandler(BasicBlock* block, BasicBlock* firstTryBlock, BasicBlock* lastTryBlock)
+    {
+        BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, firstTryBlock->bbAssertionIn);
+        BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, lastTryBlock->bbAssertionOut);
+    }
+
     // At the end of the merge store results of the dataflow equations, in a postmerge state.
     bool EndMerge(BasicBlock* block)
     {
@@ -4677,20 +4683,9 @@ ASSERT_TP* Compiler::optInitAssertionDataflowFlags()
 
     // Initially estimate the OUT sets to everything except killed expressions
     // Also set the IN sets to 1, so that we can perform the intersection.
-    // Also, zero-out the flags for handler blocks, as we could be in the
-    // handler due to an exception bypassing the regular program flow which
-    // actually generates assertions along the bbAssertionOut/jumpDestOut
-    // edges.
     for (BasicBlock* block = fgFirstBB; block; block = block->bbNext)
     {
-        if (bbIsHandlerBeg(block))
-        {
-            block->bbAssertionIn = BitVecOps::MakeEmpty(apTraits);
-        }
-        else
-        {
-            block->bbAssertionIn = BitVecOps::MakeCopy(apTraits, apValidFull);
-        }
+        block->bbAssertionIn      = BitVecOps::MakeCopy(apTraits, apValidFull);
         block->bbAssertionGen     = BitVecOps::MakeEmpty(apTraits);
         block->bbAssertionOut     = BitVecOps::MakeCopy(apTraits, apValidFull);
         jumpDestOut[block->bbNum] = BitVecOps::MakeCopy(apTraits, apValidFull);

--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -4526,6 +4526,17 @@ public:
         BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, pAssertionOut);
     }
 
+    //------------------------------------------------------------------------
+    // MergeHandler: Merge assertions into the first exception handler/filter block.
+    //
+    // Arguments:
+    //   block         - the block that is the start of a handler or filter;
+    //   firstTryBlock - the first block of the try for "block" handler;
+    //   lastTryBlock  - the last block of the try for "block" handler;.
+    //
+    // Notes:
+    //   We can jump to the handler from any instruction in the try region.
+    //   It means we can propagate only assertions that are valid for the whole try region.
     void MergeHandler(BasicBlock* block, BasicBlock* firstTryBlock, BasicBlock* lastTryBlock)
     {
         BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, firstTryBlock->bbAssertionIn);

--- a/src/coreclr/src/jit/dataflow.h
+++ b/src/coreclr/src/jit/dataflow.h
@@ -52,6 +52,12 @@ void DataFlow::ForwardAnalysis(TCallback& callback)
         worklist.erase(worklist.begin());
 
         callback.StartMerge(block);
+        if (m_pCompiler->bbIsHandlerBeg(block))
+        {
+            EHblkDsc* ehDsc = m_pCompiler->ehGetBlockHndDsc(block);
+            callback.MergeHandler(block, ehDsc->ebdTryBeg, ehDsc->ebdTryLast);
+        }
+        else
         {
             flowList* preds = m_pCompiler->BlockPredsWithEH(block);
             for (flowList* pred = preds; pred; pred = pred->flNext)

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -1034,6 +1034,11 @@ public:
 #endif // DEBUG
     }
 
+    void MergeHandler(BasicBlock* block, BasicBlock* firstTryBlock, BasicBlock* lastTryBlock)
+    {
+        // TODO CQ: add CSE for handler blocks, CSE_INTO_HANDLERS should be defined.
+    }
+
     // At the end of the merge store results of the dataflow equations, in a postmerge state.
     // We also handle the case where calls conditionally kill CSE availabilty.
     //

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -1034,6 +1034,17 @@ public:
 #endif // DEBUG
     }
 
+    //------------------------------------------------------------------------
+    // MergeHandler: Merge CSE values into the first exception handler/filter block.
+    //
+    // Arguments:
+    //   block         - the block that is the start of a handler or filter;
+    //   firstTryBlock - the first block of the try for "block" handler;
+    //   lastTryBlock  - the last block of the try for "block" handler;.
+    //
+    // Notes:
+    //   We can jump to the handler from any instruction in the try region.
+    //   It means we can propagate only CSE that are valid for the whole try region.
     void MergeHandler(BasicBlock* block, BasicBlock* firstTryBlock, BasicBlock* lastTryBlock)
     {
         // TODO CQ: add CSE for handler blocks, CSE_INTO_HANDLERS should be defined.


### PR DESCRIPTION
for such C# code:
```
int[] array = new int[100];
int i = 0;
while (i < 100)
{
    try
    {
    }
    catch (NullReferenceException arg_16_0)
    {
        array[i] = i; <- that bounds check can't be eliminated without that change.
    }
    array[i] = i; <- that bounds check can't be eliminated without that change.

    i++;
}
```
without that change, we were not able to eliminate bounds/null checks in/after exception handler blocks.

The initial restriction was added because we can jump to the exception handler from any instruction in the try region. So we set `bbAssertionIn` to empty set to guarantee that we don't propagate something that is true only for some points in the try block.

With that change, we calculate assertions that are always valid in the try block as `firstTryBlock->bbAssertionIn & lastTryBlock->bbAssertionOut`.

We always create unique assertions so if we have smth like:
```
null check V01 <- <- assertion01 is created
try 
{ <- assertion01 is alive
    V01 = smth <- assertion01 is killed
    null check V01 <- assertion02 is created
} <- assertion02 is alive
catch <- no asserion is alive, because assertion01 and assertion02 are different assertions.
{}
```
`firstTryBlock->bbAssertionIn & lastTryBlock->bbAssertionOut` will still be valid.


diffs:
System.Private.CoreLib: -114 (-0.00% of base)
21 total methods with Code Size differences (21 improved, 0 regressed), 26848 unchanged.

framework assemblies:  -1111 (-0.00% of base)
207 total methods with Code Size differences (207 improved, 0 regressed), 185568 unchanged.

The improvements look like expected: we eliminate null checks and bounds checks in and after handlers.

I will improve CSE later in a separate PR because it has other pessimizationz as well.