### PR TITLE
Update error on failure to execute when SDK could not be resolved

### DIFF
--- a/src/installer/corehost/cli/fxr/fx_muxer.h
+++ b/src/installer/corehost/cli/fxr/fx_muxer.h
@@ -54,5 +54,6 @@ private:
     static int handle_cli(
         const host_startup_info_t& host_info,
         int argc,
-        const pal::char_t* argv[]);
+        const pal::char_t* argv[],
+        const pal::string_t& app_candidate);
 };

--- a/src/installer/corehost/cli/fxr/sdk_resolver.h
+++ b/src/installer/corehost/cli/fxr/sdk_resolver.h
@@ -40,7 +40,9 @@ public:
 
     pal::string_t const& global_file_path() const;
 
-    pal::string_t resolve(const pal::string_t& dotnet_root) const;
+    pal::string_t resolve(const pal::string_t& dotnet_root, bool print_errors = true) const;
+
+    void print_resolution_error(const pal::string_t& dotnet_root, const pal::char_t *prefix) const;
 
     static sdk_resolver from_nearest_global_file(bool allow_prerelease = true);
 

--- a/src/installer/test/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/test/HostActivation.Tests/DotnetArgValidation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Cli.Build;
 using System;
 using System.IO;
 using Xunit;
@@ -12,22 +13,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
     {
         private SharedTestState sharedTestState;
 
-        public DotnetArgValidation(DotnetArgValidation.SharedTestState fixture)
+        public DotnetArgValidation(DotnetArgValidation.SharedTestState sharedState)
         {
-            sharedTestState = fixture;
+            sharedTestState = sharedState;
         }
 
         [Fact]
-        public void Muxer_Exec_With_Missing_App_Assembly_Fails()
+        public void MuxerExec_MissingAppAssembly_Fails()
         {
-            var fixture = sharedTestState.PortableAppFixture
-                .Copy();
-
-            var dotnet = fixture.BuiltDotnet;
-
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.dll");
-
-            dotnet.Exec("exec", assemblyName)
+            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
@@ -36,16 +31,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void Muxer_Exec_With_Missing_App_Assembly_And_Bad_Extension_Fails()
+        public void MuxerExec_MissingAppAssembly_BadExtension_Fails()
         {
-            var fixture = sharedTestState.PortableAppFixture
-                .Copy();
-
-            var dotnet = fixture.BuiltDotnet;
-
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.xzy");
-
-            dotnet.Exec("exec", assemblyName)
+            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
@@ -54,19 +43,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void Muxer_Exec_With_Bad_Extension_Fails()
+        public void MuxerExec_BadExtension_Fails()
         {
-            var fixture = sharedTestState.PortableAppFixture
-                .Copy();
-
-            var dotnet = fixture.BuiltDotnet;
-
             // Get a valid file name, but not exe or dll
-            string fxDir = Path.Combine(fixture.SdkDotnet.BinPath, "shared", "Microsoft.NETCore.App");
+            string fxDir = Path.Combine(sharedTestState.RepoDirectories.DotnetSDK, "shared", "Microsoft.NETCore.App");
             fxDir = new DirectoryInfo(fxDir).GetDirectories()[0].FullName;
             string assemblyName = Path.Combine(fxDir, "Microsoft.NETCore.App.deps.json");
 
-            dotnet.Exec("exec", assemblyName)
+            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
@@ -75,14 +59,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void Detect_Missing_Argument_Value()
+        public void MissingArgumentValue_Fails()
         {
-            var fixture = sharedTestState.PortableAppFixture
-                .Copy();
-
-            var dotnet = fixture.BuiltDotnet;
-
-            dotnet.Exec("--fx-version")
+            sharedTestState.BuiltDotNet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
@@ -90,29 +69,51 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdErrContaining($"Failed to parse supported options or their values:");
         }
 
+        [Fact]
+        public void InvalidFileOrCommand_NoSDK_ListsPossibleIssues()
+        {
+            string fileName = "NonExistent";
+            sharedTestState.BuiltDotNet.Exec(fileName)
+                .WorkingDirectory(sharedTestState.BaseDirectory)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should().Fail()
+                .And.HaveStdErrContaining($"The application '{fileName}' does not exist")
+                .And.HaveStdErrContaining($"It was not possible to find any installed .NET Core SDKs");
+        }
+
         // Return a non-exisitent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()
         {
-            return Path.Combine(sharedTestState.PortableAppFixture.SdkDotnet.BinPath, @"x\y/");
+            return Path.Combine(sharedTestState.RepoDirectories.DotnetSDK, @"x\y/");
         }
 
         public class SharedTestState : IDisposable
         {
             public RepoDirectoriesProvider RepoDirectories { get; }
-            public TestProjectFixture PortableAppFixture { get; }
+
+            public DotNetCli BuiltDotNet { get; }
+            public string BaseDirectory { get; }
 
             public SharedTestState()
             {
                 RepoDirectories = new RepoDirectoriesProvider();
+                BuiltDotNet = new DotNetCli(RepoDirectories.BuiltDotnet);
 
-                PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                    .EnsureRestored(RepoDirectories.CorehostPackages)
-                    .BuildProject();
+                BaseDirectory = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "argValidation"));
+
+                // Create an empty global.json file
+                Directory.CreateDirectory(BaseDirectory);
+                File.WriteAllText(Path.Combine(BaseDirectory, "global.json"), "{}");
             }
 
             public void Dispose()
             {
-                PortableAppFixture.Dispose();
+                if (!TestArtifact.PreserveTestRuns() && Directory.Exists(BaseDirectory))
+                {
+                    Directory.Delete(BaseDirectory, true);
+                }
             }
         }
     }

--- a/src/installer/test/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/test/HostActivation.Tests/SDKLookup.cs
@@ -388,7 +388,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("It was not possible to find any installed .NET Core SDKs")
-                .And.HaveStdErrContaining("Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from");
+                .And.HaveStdErrContaining("Install a .NET Core SDK from");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.4");
@@ -423,7 +423,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void SdkLookup_Must_Pick_The_Highest_Semantic_Version()
         {
             WriteEmptyGlobalJson();
-            
+
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0", "9999.0.3-dummy.9", "9999.0.3-dummy.10");
 
@@ -1291,7 +1291,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             File.WriteAllText(Path.Combine(_currentWorkingDir, "global.json"), contents);
         }
-        
+
         private void WriteEmptyGlobalJson() => WriteGlobalJson("{}");
     }
 }


### PR DESCRIPTION
Update error message to include possible reasons for execution failure when SDK couldn't be resolved.

When executing, if the app/command could not be run, we fall back to forwarding to the SDK. If no SDK could be resolved, the error messaging assumed that the intent was to run an SDK command, which may not be the case.

Fixes dotnet/core-setup#3490

Example output for `dotnet dne.dll` where `dne.dll` does not exist

Before (no SDK):
```
  It was not possible to find any installed .NET Core SDKs
  Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from:
      https://aka.ms/dotnet-download
```
After (no SDK):
```
Could not execute because the application was not found or a compatible .NET Core SDK is not installed.
Possible reasons for this include:
  * You intended to execute a .NET Core program:
      The application 'dne.dll' does not exist.
  * You intended to execute a .NET Core SDK command:
      It was not possible to find any installed .NET Core SDKs.
      Install a .NET Core SDK from:
        https://aka.ms/dotnet-download
```

Before (no compatible SDK):
```
A compatible installed .NET Core SDK for global.json version [3.0.100] from [D:\test\global.json] was not found
Install the [3.0.100] .NET Core SDK or update [D:\test\global.json] with an installed .NET Core SDK:
  3.0.100-rc2-014256 [D:\dotnet-test\sdk]
```
After (no compatible SDK):
```
Could not execute because the application was not found or a compatible .NET Core SDK is not installed.
Possible reasons for this include:
  * You intended to execute a .NET Core program:
      The application 'dne.dll' does not exist.
  * You intended to execute a .NET Core SDK command:
      A compatible installed .NET Core SDK for global.json version [3.0.100] from [D:\test\global.json] was not found.
      Install the [3.0.100] .NET Core SDK or update [D:\test\global.json] with an installed .NET Core SDK:
        3.0.100-rc2-014256 [D:\dotnet-test\sdk]
```

The new message is more in line with the error that would come from a resolved SDK:
```
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET Core program, but dotnet-dne.dll does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```
