### PR TITLE
Crossgen2 determinism fixes

### DIFF
--- a/src/coreclr/src/tools/crossgen2/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 // Managed mirror of NativeFormatWriter.h/.cpp
@@ -2041,13 +2042,9 @@ namespace Internal.NativeFormat
             // we can use the ordering to terminate the lookup prematurely.
             uint mask = ((_nBuckets - 1) << 8) | 0xFF;
 
-            // sort it by hashcode
-            _Entries.Sort(
-                    (a, b) =>
-                    {
-                        return (int)(a.Hashcode & mask) - (int)(b.Hashcode & mask);
-                    }
-                );
+            // Sort by hashcode. This sort must be stable since we need determinism even if two entries have
+            // the same hashcode. This is deterministic if entries are added in a deterministic order.
+            _Entries = _Entries.OrderBy(entry => entry.Hashcode & mask).ToList();
 
             // Start with maximum size entries
             _entryIndexSize = 2;

--- a/src/coreclr/src/tools/crossgen2/Common/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/TypeSystem/IL/EcmaMethodIL.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-
+using System.Threading;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -64,20 +64,8 @@ namespace Internal.IL
             if (_ilBytes != null)
                 return _ilBytes;
 
-            // This lock is necessary since the JIT requires that we provide the same address
-            // for the IL buffer each time (it uses the address to detect recursive calls).
-            // Since MethodBodyBlock.GetAllBytes creates a new array each time, if two threads
-            // call this on the same function then it is possible for both to set _ilBytes.
-            // Then, one of the threads will receive the first value on the first call and the
-            // second value on all subsequent calls, and we will not detect the recursive call.
-            lock (this)
-            {
-                if (_ilBytes != null)
-                    return _ilBytes;
-
-                byte[] ilBytes = _methodBody.GetILBytes();
-                return (_ilBytes = ilBytes);
-            }
+            Interlocked.CompareExchange(ref _ilBytes, _methodBody.GetILBytes(), null);
+            return _ilBytes;
         }
 
         public override bool IsInitLocals

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -96,8 +96,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int ModuleToIndex(EcmaModule module)
         {
             AssemblyName assemblyName = module.Assembly.GetName();
-
-            if (!_manifestAssemblies.Contains(assemblyName))
+            int assemblyRefIndex;
+            if (!_assemblyRefToModuleIdMap.TryGetValue(assemblyName.Name, out assemblyRefIndex))
             {
                 if (_emissionCompleted)
                 {
@@ -108,14 +108,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // the verification logic would be broken at runtime.
                 Debug.Assert(_nodeFactory.CompilationModuleGroup.VersionsWithModule(module));
 
+                assemblyRefIndex = _nextModuleId++;
                 _manifestAssemblies.Add(assemblyName);
-                if (!_assemblyRefToModuleIdMap.ContainsKey(assemblyName.Name))
-                    _assemblyRefToModuleIdMap.Add(assemblyName.Name, _nextModuleId);
-
-                _nextModuleId++;
+                _assemblyRefToModuleIdMap.Add(assemblyName.Name, assemblyRefIndex);
             }
-
-            return _assemblyRefToModuleIdMap[assemblyName.Name];
+            return assemblyRefIndex;
         }
 
         public override int ClassCode => 791828335;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -27,11 +27,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
-            dataBuilder.AddSymbol(this);
 
-            EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
-            SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_NewArray, targetModule, _signatureContext);
-            dataBuilder.EmitTypeSignature(_arrayType, innerContext);
+            if (!relocsOnly)
+            {
+                dataBuilder.AddSymbol(this);
+
+                EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
+                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_NewArray, targetModule, _signatureContext);
+                dataBuilder.EmitTypeSignature(_arrayType, innerContext);
+            }
 
             return dataBuilder.ToObjectData();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
@@ -25,10 +25,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
-            dataBuilder.AddSymbol(this);
 
-            dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_StringHandle, _token.Module, _signatureContext);
-            dataBuilder.EmitUInt(_token.TokenRid);
+            if (!relocsOnly)
+            {
+                dataBuilder.AddSymbol(this);
+
+                dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_StringHandle, _token.Module, _signatureContext);
+                dataBuilder.EmitUInt(_token.TokenRid);
+            }
 
             return dataBuilder.ToObjectData();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Internal.IL;
-using Internal.IL.Stubs;
 using Internal.JitInterface;
 using Internal.TypeSystem;
 
@@ -26,7 +25,7 @@ namespace ILCompiler
         protected readonly NodeFactory _nodeFactory;
         protected readonly Logger _logger;
         private readonly DevirtualizationManager _devirtualizationManager;
-        private ILCache _methodILCache;
+        protected ILCache _methodILCache;
         private readonly HashSet<ModuleDesc> _modulesBeingInstrumented;
 
 
@@ -79,10 +78,8 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
-            // Flush the cache when it grows too big
-            if (_methodILCache.Count > 1000)
-                _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
-
+            // TODO: Remove the ILCache and use the pinned heap for the IL stream once this GC
+            // feature ships (in dotnet5)
             return _methodILCache.GetOrCreateValue(method).MethodIL;
         }
 
@@ -106,7 +103,7 @@ namespace ILCompiler
             return _modulesBeingInstrumented.Contains(module);
         }
 
-        private sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
+        public sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
         {
             public ILProvider ILProvider { get; }
             private readonly CompilationModuleGroup _compilationModuleGroup;
@@ -147,7 +144,7 @@ namespace ILCompiler
                 return new MethodILData() { Method = key, MethodIL = methodIL };
             }
 
-            internal class MethodILData
+            public class MethodILData
             {
                 public MethodDesc Method;
                 public MethodIL MethodIL;
@@ -301,6 +298,11 @@ namespace ILCompiler
                         Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
                     }
                 }
+            }
+
+            if (_methodILCache.Count > 1000)
+            {
+                _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -78,8 +78,6 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
-            // TODO: Remove the ILCache and use the pinned heap for the IL stream once this GC
-            // feature ships (in dotnet5)
             return _methodILCache.GetOrCreateValue(method).MethodIL;
         }
 


### PR DESCRIPTION
* NativeFormatWriter's HashTable save now uses OrderBy, so the output deterministic if the values are entered deterministically
* Lock GetILBytes in EcmaMethodIL so we don't accidentally get two different addresses for the same code
* Revert ManifestMetadataTableNode change to an older version: we don't add the input module's assemblies to manifestAssemblies in the constructor (we add to assemblyRefToIdMap) so some things were failing. The dictionary might also be faster than the List for lookup.
* Do not flush the ILCache before compiling all methods in a batch. This might have caused the same MethodDesc to have two different MethodIL objects.