### PR TITLE
Address new nullable warnings from compiler [MaybeNull] updates

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
@@ -16,7 +17,10 @@ namespace System.Collections.Generic
         internal sealed class TreeSubSet : SortedSet<T>, ISerializable, IDeserializationCallback
         {
             private readonly SortedSet<T> _underlying;
-            private readonly T _min, _max;
+            [MaybeNull, AllowNull]
+            private readonly T _min;
+            [MaybeNull, AllowNull]
+            private readonly T _max;
             // keeps track of whether the count variable is up to date
             // up to date -> _countVersion = _underlying.version
             // not up to date -> _countVersion < _underlying.version
@@ -35,7 +39,7 @@ namespace System.Collections.Generic
             }
 #endif
 
-            public TreeSubSet(SortedSet<T> Underlying, T Min, T Max, bool lowerBoundActive, bool upperBoundActive)
+            public TreeSubSet(SortedSet<T> Underlying, [AllowNull] T Min, [AllowNull] T Max, bool lowerBoundActive, bool upperBoundActive)
                 : base(Underlying.Comparer)
             {
                 _underlying = Underlying;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -757,9 +757,9 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        internal Node? FindRange(T from, T to) => FindRange(from, to, lowerBoundActive: true, upperBoundActive: true);
+        internal Node? FindRange([AllowNull] T from, [AllowNull]  T to) => FindRange(from, to, lowerBoundActive: true, upperBoundActive: true);
 
-        internal Node? FindRange(T from, T to, bool lowerBoundActive, bool upperBoundActive)
+        internal Node? FindRange([AllowNull] T from, [AllowNull] T to, bool lowerBoundActive, bool upperBoundActive)
         {
             Node? current = root;
             while (current != null)
@@ -1561,7 +1561,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue)
+        public virtual SortedSet<T> GetViewBetween([AllowNull] T lowerValue, [AllowNull] T upperValue)
         {
             if (Comparer.Compare(lowerValue, upperValue) > 0)
             {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/AggregationMinMaxHelpers.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/AggregationMinMaxHelpers.cs
@@ -32,7 +32,7 @@ namespace System.Linq
             Func<Pair<bool, T>, T> resultSelector = MakeResultSelectorFunction();
 
             AssociativeAggregationOperator<T, Pair<bool, T>, T> aggregation =
-                new AssociativeAggregationOperator<T, Pair<bool, T>, T>(source, new Pair<bool, T>(false, default), null,
+                new AssociativeAggregationOperator<T, Pair<bool, T>, T>(source, new Pair<bool, T>(false, default!), null,
                                                                         true, intermediateReduce, finalReduce, resultSelector, default(T)! != null, QueryAggregationOptions.AssociativeCommutative);
 
             return aggregation.Aggregate();

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Parallel
                 if (_source.MoveNext(ref current!, ref keyUnused))
                 {
                     currentElement = new Pair<TInputOutput, THashKey>(
-                        current, _keySelector == null ? default : _keySelector(current));
+                        current, _keySelector == null ? default! : _keySelector(current));
                     return true;
                 }
                 return false;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -115,7 +115,7 @@ namespace System.Linq.Parallel
                 if (_source.MoveNext(ref current!, ref currentKey))
                 {
                     currentElement = new Pair<TInputOutput, THashKey>(
-                        current, _keySelector == null ? default : _keySelector(current));
+                        current, _keySelector == null ? default! : _keySelector(current));
                     return true;
                 }
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ConcatQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ConcatQueryOperator.cs
@@ -297,7 +297,9 @@ namespace System.Linq.Parallel
 
     internal struct ConcatKey<TLeftKey, TRightKey>
     {
+        [MaybeNull, AllowNull]
         private readonly TLeftKey _leftKey;
+        [MaybeNull, AllowNull]
         private readonly TRightKey _rightKey;
         private readonly bool _isLeft;
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperatorEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperatorEnumerator.cs
@@ -65,6 +65,6 @@ namespace System.Linq.Parallel
             return false;
         }
 
-        protected abstract bool MoveNextCore(ref TIntermediate currentElement);
+        protected abstract bool MoveNextCore([MaybeNullWhen(false), AllowNull] ref TIntermediate currentElement);
     }
 }

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -49,7 +49,7 @@ namespace System.Linq.Parallel
         // Check whether value is in set
         internal bool TryGetValue(TKey key, [MaybeNullWhen(false), AllowNull] ref TValue value)
         {
-            return Find(key, false, false, ref value);
+            return Find(key, false, false, ref value!);
         }
 
         internal TValue this[TKey key]
@@ -77,7 +77,7 @@ namespace System.Linq.Parallel
                     comparer.Equals(key1, key2));
         }
 
-        private bool Find(TKey key, bool add, bool set, ref TValue value)
+        private bool Find(TKey key, bool add, bool set, [MaybeNullWhen(false)] ref TValue value)
         {
             int hashCode = GetKeyHashCode(key);
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Pair.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Pair.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Parallel
         // A simple constructor that initializes the first/second fields.
         //
 
-        public Pair(T first, [MaybeNull, AllowNull] U second)
+        public Pair(T first, U second)
         {
             _first = first;
             _second = second;

--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -21,7 +21,7 @@ namespace System.Linq
                 TSource element = partition.TryGetElementAt(index, out bool found);
                 if (found)
                 {
-                    return element;
+                    return element!;
                 }
             }
             else

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -17,7 +17,7 @@ namespace System.Linq
                 ThrowHelper.ThrowNoElementsException();
             }
 
-            return first;
+            return first!;
         }
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -28,7 +28,7 @@ namespace System.Linq
                 ThrowHelper.ThrowNoMatchException();
             }
 
-            return first;
+            return first!;
         }
 
         [return: MaybeNull]

--- a/src/libraries/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Iterator.cs
@@ -4,7 +4,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq
 {
@@ -34,8 +33,7 @@ namespace System.Linq
         {
             private readonly int _threadId;
             internal int _state;
-            [MaybeNull, AllowNull]
-            internal TSource _current = default; // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/37138
+            internal TSource _current = default!;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Iterator{TSource}"/> class.
@@ -67,7 +65,7 @@ namespace System.Linq
             /// </remarks>
             public virtual void Dispose()
             {
-                _current = default;
+                _current = default!;
                 _state = -1;
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -17,7 +17,7 @@ namespace System.Linq
                 ThrowHelper.ThrowNoElementsException();
             }
 
-            return last;
+            return last!;
         }
 
         public static TSource Last<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -28,7 +28,7 @@ namespace System.Linq
                 ThrowHelper.ThrowNoMatchException();
             }
 
-            return last;
+            return last!;
         }
 
         [return: MaybeNull]

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -572,7 +572,7 @@ namespace System.Linq
                 bool sourceFound;
                 TSource input = _source.TryGetElementAt(index, out sourceFound);
                 found = sourceFound;
-                return sourceFound ? _selector(input) : default!;
+                return sourceFound ? _selector(input!) : default!;
             }
 
             [return: MaybeNull]
@@ -581,7 +581,7 @@ namespace System.Linq
                 bool sourceFound;
                 TSource input = _source.TryGetFirst(out sourceFound);
                 found = sourceFound;
-                return sourceFound ? _selector(input) : default!;
+                return sourceFound ? _selector(input!) : default!;
             }
 
             [return: MaybeNull]
@@ -590,7 +590,7 @@ namespace System.Linq
                 bool sourceFound;
                 TSource input = _source.TryGetLast(out sourceFound);
                 found = sourceFound;
-                return sourceFound ? _selector(input) : default!;
+                return sourceFound ? _selector(input!) : default!;
             }
 
             private TResult[] LazyToArray()

--- a/src/libraries/System.Linq/src/System/Linq/Set.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Set.cs
@@ -125,7 +125,7 @@ namespace System.Linq
                     }
 
                     _slots[i]._hashCode = -1;
-                    _slots[i]._value = default;
+                    _slots[i]._value = default!;
                     _slots[i]._next = -1;
                     return true;
                 }
@@ -235,7 +235,6 @@ namespace System.Linq
             /// <summary>
             /// The item held by this slot.
             /// </summary>
-            [MaybeNull, AllowNull]
             internal TElement _value;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -544,7 +544,7 @@ namespace System.Collections.Concurrent
             }
 
             // Return the value from the slot.
-            return segment._slots[i].Item;
+            return segment._slots[i].Item!;
         }
 
         private IEnumerator<T> Enumerate(ConcurrentQueueSegment<T> head, int headHead, ConcurrentQueueSegment<T> tail, int tailTail)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -160,7 +160,7 @@ namespace System.Collections.Concurrent
                     {
                         // Successfully reserved the slot.  Note that after the above CompareExchange, other threads
                         // trying to dequeue from this slot will end up spinning until we do the subsequent Write.
-                        item = slots[slotsIndex].Item;
+                        item = slots[slotsIndex].Item!;
                         if (!Volatile.Read(ref _preservedForObservation))
                         {
                             // If we're preserving, though, we don't zero out the slot, as we need it for
@@ -230,7 +230,7 @@ namespace System.Collections.Concurrent
                 int diff = sequenceNumber - (currentHead + 1);
                 if (diff == 0)
                 {
-                    result = resultUsed ? slots[slotsIndex].Item : default!;
+                    result = resultUsed ? slots[slotsIndex].Item! : default!;
                     return true;
                 }
                 else if (diff < 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
@@ -525,6 +525,7 @@ namespace System
         public bool IsValueCreated => _lazy.IsValueCreated;
 
         /// <summary>Returns the value of the Lazy object.</summary>
+        [MaybeNull]
         public T Value => _lazy.ValueForDebugDisplay;
 
         /// <summary>Returns the execution mode of the Lazy object</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/AsyncLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/AsyncLocal.cs
@@ -98,8 +98,8 @@ namespace System.Threading
 
         internal AsyncLocalValueChangedArgs([AllowNull] T previousValue, [AllowNull] T currentValue, bool contextChanged)
         {
-            PreviousValue = previousValue;
-            CurrentValue = currentValue;
+            PreviousValue = previousValue!;
+            CurrentValue = currentValue!;
             ThreadContextChanged = contextChanged;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -140,7 +140,7 @@ namespace System.Threading
             // Fast path.
             if (Volatile.Read(ref initialized))
             {
-                return target;
+                return target!;
             }
 
             return EnsureInitializedCore(ref target, ref initialized, ref syncLock);
@@ -177,7 +177,7 @@ namespace System.Threading
                 }
             }
 
-            return target;
+            return target!;
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace System.Threading
             // Fast path.
             if (Volatile.Read(ref initialized))
             {
-                return target;
+                return target!;
             }
 
             return EnsureInitializedCore(ref target, ref initialized, ref syncLock, valueFactory);
@@ -230,7 +230,7 @@ namespace System.Threading
                 }
             }
 
-            return target;
+            return target!;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -60,7 +60,7 @@ namespace System.Threading.Tasks
     public class Task<TResult> : Task
     {
         // The value itself, if set.
-        [MaybeNull] internal TResult m_result = default!;
+        [MaybeNull, AllowNull] internal TResult m_result = default!;
 
         private static readonly TaskFactory<TResult> s_Factory = new TaskFactory<TResult>();
 
@@ -439,7 +439,7 @@ namespace System.Threading.Tasks
         public TResult Result =>
             IsWaitNotificationEnabledOrNotRanToCompletion ?
                 GetResultCore(waitCompletionNotification: true) :
-                m_result;
+                m_result!;
 
         /// <summary>
         /// Gets the result value of this <see cref="Task{TResult}"/> once the task has completed successfully.
@@ -454,7 +454,7 @@ namespace System.Threading.Tasks
             {
                 Debug.Assert(!IsWaitNotificationEnabledOrNotRanToCompletion,
                     "Should only be used when the task completed successfully and there's no wait notification enabled");
-                return m_result;
+                return m_result!;
             }
         }
 
@@ -473,7 +473,7 @@ namespace System.Threading.Tasks
             // We shouldn't be here if the result has not been set.
             Debug.Assert(IsCompletedSuccessfully, "Task<T>.Result getter: Expected result to have been set.");
 
-            return m_result;
+            return m_result!;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -805,6 +805,7 @@ namespace System.Threading
         public bool IsValueCreated => _tlocal.IsValueCreated;
 
         /// <summary>Returns the value of the ThreadLocal object.</summary>
+        [MaybeNull]
         public T Value => _tlocal.ValueForDebugDisplay;
 
         /// <summary>Return all values for all threads that have accessed this instance.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
@@ -56,7 +56,7 @@ namespace System
         {
             // Call the worker method that has more performant but less user friendly signature.
             T o = this.Target;
-            target = o;
+            target = o!;
             return o != null;
         }
 

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -163,7 +163,7 @@ namespace System.Threading.Channels
             }
 
             error?.Throw();
-            return result;
+            return result!;
         }
 
         /// <summary>Gets the result of the operation.</summary>

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -215,7 +215,7 @@ namespace System.Threading.Channels
                         VoidAsyncOperationWithData<T> w = parent._blockedWriters.DequeueHead();
                         if (w.TrySetResult(default))
                         {
-                            parent._items.EnqueueTail(w.Item);
+                            parent._items.EnqueueTail(w.Item!);
                             return item;
                         }
                     }


### PR DESCRIPTION
The compiler is updating its handling of maybe-null values (https://github.com/dotnet/roslyn/pull/39778), and in doing so we're getting a bunch of new warnings.  We've not yet ingested the new compiler, but this proactively addresses the warnings for when we do.

cc: @safern, @buyaa-n, @cston, @jaredpar 