### PR TITLE
Remove AppDomain::GetFusionContext

### DIFF
--- a/src/coreclr/src/binder/applicationcontext.cpp
+++ b/src/coreclr/src/binder/applicationcontext.cpp
@@ -76,7 +76,6 @@ namespace BINDER_SPACE
         m_pFailureCache = NULL;
         m_contextCS = NULL;
         m_pTrustedPlatformAssemblyMap = nullptr;
-        m_pFileNameHash = nullptr;
     }
 
     ApplicationContext::~ApplicationContext()
@@ -92,11 +91,6 @@ namespace BINDER_SPACE
         if (m_pTrustedPlatformAssemblyMap != nullptr)
         {
             delete m_pTrustedPlatformAssemblyMap;
-        }
-
-        if (m_pFileNameHash != nullptr)
-        {
-            delete m_pFileNameHash;
         }
     }
 
@@ -220,7 +214,6 @@ namespace BINDER_SPACE
         // Parse TrustedPlatformAssemblies
         //
         m_pTrustedPlatformAssemblyMap = new SimpleNameToFileNameMap();
-        m_pFileNameHash = new TpaFileNameHash();
 
         sTrustedPlatformAssemblies.Normalize();
 
@@ -349,10 +342,6 @@ namespace BINDER_SPACE
             }
 
             m_pTrustedPlatformAssemblyMap->AddOrReplace(mapEntry);
-
-            FileNameMapEntry fileNameExistenceEntry;
-            fileNameExistenceEntry.m_wszFileName = wszFileName;
-            m_pFileNameHash->AddOrReplace(fileNameExistenceEntry);
         }
 
         //

--- a/src/coreclr/src/binder/fusionassemblyname.cpp
+++ b/src/coreclr/src/binder/fusionassemblyname.cpp
@@ -482,16 +482,11 @@ CreateAssemblyNameObject(
 
     if (parseDisplayName)
     {
-        hr = pName->Init(NULL, NULL);
-        if (FAILED(hr)) {
-            goto exit;
-        }
-
         hr = pName->Parse((LPWSTR)szAssemblyName);
     }
     else
     {
-        hr = pName->Init(szAssemblyName, NULL);
+        hr = pName->SetName(szAssemblyName);
     }
 
     if (FAILED(hr))
@@ -504,40 +499,6 @@ CreateAssemblyNameObject(
 
 exit:
     END_ENTRYPOINT_NOTHROW;
-    return hr;
-}
-
-// ---------------------------------------------------------------------------
-// CreateAssemblyNameObjectFromMetaData
-// ---------------------------------------------------------------------------
-STDAPI
-CreateAssemblyNameObjectFromMetaData(
-    LPASSEMBLYNAME    *ppAssemblyName,
-    LPCOLESTR          szAssemblyName,
-    ASSEMBLYMETADATA  *pamd)
-{
-
-    HRESULT hr = S_OK;
-    CAssemblyName *pName = NULL;
-
-    pName = NEW(CAssemblyName);
-    if (!pName)
-    {
-        hr = E_OUTOFMEMORY;
-        goto exit;
-    }
-
-    hr = pName->Init(szAssemblyName, pamd);
-
-    if (FAILED(hr))
-    {
-        SAFERELEASE(pName);
-        goto exit;
-    }
-
-    *ppAssemblyName = pName;
-
-exit:
     return hr;
 }
 
@@ -566,50 +527,15 @@ CAssemblyName::~CAssemblyName()
 }
 
 // ---------------------------------------------------------------------------
-// CAssemblyName::Init
+// CAssemblyName::SetName
 // ---------------------------------------------------------------------------
-HRESULT
-CAssemblyName::Init(LPCTSTR pszAssemblyName, ASSEMBLYMETADATA *pamd)
+HRESULT CAssemblyName::SetName(LPCTSTR pszAssemblyName)
 {
-    HRESULT hr = S_OK;
+    if (pszAssemblyName == nullptr)
+        return E_INVALIDARG;
 
-    // Name
-    if (pszAssemblyName)
-    {
-        hr = SetProperty(ASM_NAME_NAME, (LPTSTR) pszAssemblyName,
-            (DWORD)((wcslen(pszAssemblyName)+1) * sizeof(TCHAR)));
-        if (FAILED(hr))
-            goto exit;
-    }
-
-    if (pamd) {
-            // Major version
-        if (FAILED(hr = SetProperty(ASM_NAME_MAJOR_VERSION,
-                &pamd->usMajorVersion, sizeof(WORD)))
-
-            // Minor version
-            || FAILED(hr = SetProperty(ASM_NAME_MINOR_VERSION,
-                &pamd->usMinorVersion, sizeof(WORD)))
-
-            // Revision number
-            || FAILED(hr = SetProperty(ASM_NAME_REVISION_NUMBER,
-                &pamd->usRevisionNumber, sizeof(WORD)))
-
-            // Build number
-            || FAILED(hr = SetProperty(ASM_NAME_BUILD_NUMBER,
-                &pamd->usBuildNumber, sizeof(WORD)))
-
-            // Culture
-            || FAILED(hr = SetProperty(ASM_NAME_CULTURE,
-                pamd->szLocale, pamd->cbLocale * sizeof(WCHAR)))
-                )
-            {
-                goto exit;
-            }
-    }
-
-exit:
-    return hr;
+    return SetProperty(ASM_NAME_NAME, (LPTSTR) pszAssemblyName,
+        (DWORD)((wcslen(pszAssemblyName)+1) * sizeof(TCHAR)));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/coreclr/src/binder/inc/applicationcontext.hpp
+++ b/src/coreclr/src/binder/inc/applicationcontext.hpp
@@ -24,28 +24,6 @@ namespace BINDER_SPACE
 {
     //=============================================================================================
     // Data structures for Simple Name -> File Name hash
-    struct FileNameMapEntry
-    {
-        LPWSTR m_wszFileName;
-    };
-
-    class FileNameHashTraits : public NoRemoveSHashTraits< DefaultSHashTraits< FileNameMapEntry > >
-    {
-     public:
-        typedef PCWSTR key_t;
-        static const FileNameMapEntry Null() { FileNameMapEntry e; e.m_wszFileName = nullptr; return e; }
-        static bool IsNull(const FileNameMapEntry & e) { return e.m_wszFileName == nullptr; }
-        static key_t GetKey(const FileNameMapEntry & e)
-        {
-            key_t key;
-            key = e.m_wszFileName;
-            return key;
-        }
-        static count_t Hash(const key_t &str) { return HashiString(str); }
-        static BOOL Equals(const key_t &lhs, const key_t &rhs) { LIMITED_METHOD_CONTRACT; return (_wcsicmp(lhs, rhs) == 0); }
-    };
-
-    typedef SHash<FileNameHashTraits> TpaFileNameHash;
 
     // Entry in SHash table that maps namespace to list of files
     struct SimpleNameToFileNameMapEntry
@@ -133,7 +111,6 @@ namespace BINDER_SPACE
                                          HRESULT  hrBindResult);
         inline StringArrayList *GetAppPaths();
         inline SimpleNameToFileNameMap *GetTpaList();
-        inline TpaFileNameHash *GetTpaFileNameList();
         inline StringArrayList *GetPlatformResourceRoots();
         inline StringArrayList *GetAppNiPaths();
 
@@ -159,7 +136,6 @@ namespace BINDER_SPACE
         StringArrayList    m_appNiPaths;
 
         SimpleNameToFileNameMap * m_pTrustedPlatformAssemblyMap;
-        TpaFileNameHash    * m_pFileNameHash;
     };
 
 #include "applicationcontext.inl"

--- a/src/coreclr/src/binder/inc/applicationcontext.inl
+++ b/src/coreclr/src/binder/inc/applicationcontext.inl
@@ -69,11 +69,6 @@ SimpleNameToFileNameMap * ApplicationContext::GetTpaList()
     return m_pTrustedPlatformAssemblyMap;
 }
 
-TpaFileNameHash * ApplicationContext::GetTpaFileNameList()
-{
-    return m_pFileNameHash;
-}
-
 StringArrayList * ApplicationContext::GetPlatformResourceRoots()
 {
     return &m_platformResourceRoots;

--- a/src/coreclr/src/binder/inc/fusionassemblyname.hpp
+++ b/src/coreclr/src/binder/inc/fusionassemblyname.hpp
@@ -79,7 +79,7 @@ public:
     CAssemblyName();
     virtual ~CAssemblyName();
 
-    HRESULT Init(LPCTSTR pszAssemblyName, ASSEMBLYMETADATA *pamd);
+    HRESULT SetName(LPCTSTR pszAssemblyName);
     HRESULT Parse(LPCWSTR szDisplayName);
 };
 
@@ -88,12 +88,6 @@ CreateAssemblyNameObject(
     LPASSEMBLYNAME    *ppAssemblyName,
     LPCOLESTR          szAssemblyName,
     bool               parseDisplayName);
-
-STDAPI
-CreateAssemblyNameObjectFromMetaData(
-    LPASSEMBLYNAME    *ppAssemblyName,
-    LPCOLESTR          szAssemblyName,
-    ASSEMBLYMETADATA  *pamd);
 
 namespace fusion
 {

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -966,14 +966,6 @@ public:
         return NULL;
     }
 
-#ifdef FEATURE_COMINTEROP
-    //****************************************************************************************
-    //
-    // This will look up interop data for a method table
-    //
-
-#endif // FEATURE_COMINTEROP
-
     void SetDisableInterfaceCache()
     {
         m_fDisableInterfaceCache = TRUE;
@@ -1141,10 +1133,7 @@ public:
 
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 
-    IUnknown *GetFusionContext() {LIMITED_METHOD_CONTRACT;  return m_pFusionContext; }
-
     CLRPrivBinderCoreCLR *GetTPABinderContext() {LIMITED_METHOD_CONTRACT;  return m_pTPABinderContext; }
-
 
     CrstExplicitInit * GetLoaderAllocatorReferencesLock()
     {
@@ -1157,10 +1146,6 @@ protected:
     //****************************************************************************************
     // Helper method to initialize the large heap handle table.
     void InitLargeHeapHandleTable();
-
-    //****************************************************************************************
-    // Adds an assembly to the domain.
-    void AddAssemblyNoLock(Assembly* assem);
 
     //****************************************************************************************
     //
@@ -1186,11 +1171,6 @@ protected:
     JitListLock      m_JITLock;
     ListLock         m_ILStubGenLock;
 
-    // Fusion context, used for adding assemblies to the is domain. It defines
-    // fusion properties for finding assemblyies such as SharedBinPath,
-    // PrivateBinPath, Application Directory, etc.
-    IUnknown *m_pFusionContext; // Current binding context for the domain
-
     CLRPrivBinderCoreCLR *m_pTPABinderContext; // Reference to the binding context that holds TPA list details
 
     IGCHandleStore* m_handleStore;
@@ -1215,7 +1195,7 @@ protected:
 public:
     // Only call this routine when you can guarantee there are no
     // loads in progress.
-    void ClearFusionContext();
+    void ClearBinderContext();
 
     //****************************************************************************************
     // Synchronization holders.
@@ -2260,7 +2240,7 @@ public:
         return m_tpIndex;
     }
 
-    IUnknown *CreateFusionContext();
+    IUnknown *CreateBinderContext();
 
     void SetIgnoreUnhandledExceptions()
     {
@@ -3015,10 +2995,6 @@ public:
     static void PublishAppDomainAndInformDebugger (AppDomain *pDomain);
 #endif // DEBUGGING_SUPPORTED
 
-    //****************************************************************************************
-    // Helper function to remove a domain from the system
-    BOOL RemoveDomain(AppDomain* pDomain); // Does not decrement the reference
-
 #ifdef PROFILING_SUPPORTED
     //****************************************************************************************
     // Tell profiler about system created domains which are created before the profiler is
@@ -3112,10 +3088,6 @@ public:
     }
 
 private:
-
-    //****************************************************************************************
-    // Helper function to create the single COM domain
-    void CreateDefaultDomain();
 
     //****************************************************************************************
     // Helper function to add a domain to the global list

--- a/src/coreclr/src/vm/assemblyspec.cpp
+++ b/src/coreclr/src/vm/assemblyspec.cpp
@@ -807,7 +807,7 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
             // TPABinder context anyways.
             //
             // Get the reference to the default binding context (this could be the TPABinder context or custom AssemblyLoadContext)
-            pParentAssemblyBinder = static_cast<ICLRPrivBinder*>(pDomain->GetFusionContext());
+            pParentAssemblyBinder = static_cast<ICLRPrivBinder*>(pDomain->GetTPABinderContext());
         }
     }
 
@@ -844,7 +844,7 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
         //
         // In such a case, the parent assembly (semantically) is CoreLibrary and thus, the default binding context should be
         // used as the parent assembly binder.
-        pParentAssemblyBinder = static_cast<ICLRPrivBinder*>(pDomain->GetFusionContext());
+        pParentAssemblyBinder = static_cast<ICLRPrivBinder*>(pDomain->GetTPABinderContext());
     }
 
     return pParentAssemblyBinder;
@@ -1221,7 +1221,7 @@ AssemblySpecBindingCache::AssemblyBinding* AssemblySpecBindingCache::LookupInter
     else
     {
         // For System.Private.Corelib Binding context is either not set or if set then it should be TPA
-        _ASSERTE(pSpec->GetBindingContext() == NULL || pSpec->GetBindingContext() == pSpecDomain->GetFusionContext());
+        _ASSERTE(pSpec->GetBindingContext() == NULL || pSpec->GetBindingContext() == pSpecDomain->GetTPABinderContext());
     }
 
     if (pBinderContextForLookup != NULL)

--- a/src/coreclr/src/vm/clrprivbinderwinrt.h
+++ b/src/coreclr/src/vm/clrprivbinderwinrt.h
@@ -22,9 +22,6 @@
 
 #include "coreclr/corebindresult.h"
 
-// IBindResult maps directly to its one and only implementation on CoreCLR.
-typedef CoreBindResult IBindResult;
-
 //=====================================================================================================================
 // Forward declarations
 class CLRPrivBinderWinRT;
@@ -158,11 +155,6 @@ public:
         IAssemblyName * pIAssemblyName,
         ICLRPrivAssembly ** ppPrivAssembly);
 
-    // Binds WinRT assemblies only.
-    HRESULT BindWinRTAssemblyByName(
-        IAssemblyName * pIAssemblyName,
-        IBindResult ** ppIBindResult);
-
     HRESULT GetAssemblyAndTryFindNativeImage(SString &sWinmdFilename, LPCWSTR pwzSimpleName, BINDER_SPACE::Assembly ** ppAssembly);
     // On Phone the application's APP_PATH CoreCLR hosting config property is used as the app
     // package graph for RoResolveNamespace to find 3rd party WinMDs.  This method wires up
@@ -257,17 +249,10 @@ public:
     CLRPrivAssemblyWinRT(
         CLRPrivBinderWinRT *                         pBinder,
         CLRPrivBinderUtil::CLRPrivResourcePathImpl * pResourceIL,
-        IBindResult *                                pIBindResult,
+        CoreBindResult *                             pBindResult,
         BOOL                                         fShareable);
 
     ~CLRPrivAssemblyWinRT();
-
-    HRESULT GetIBindResult(
-        IBindResult ** ppIBindResult);
-
-    static HRESULT GetIBindResult(
-        ICLRPrivAssembly * pPrivAssembly,
-        IBindResult **     ppIBindResult);
 
     //=============================================================================================
     // IUnknown interface methods
@@ -335,7 +320,7 @@ private:
     ReleaseHolder<CLRPrivBinderUtil::CLRPrivResourcePathImpl> m_pResourceIL;
     // This cannot be a holder as there can be a race to assign to it.
     ICLRPrivResource * m_pIResourceNI;
-    ReleaseHolder<IBindResult> m_pIBindResult;
+    ReleaseHolder<CoreBindResult> m_pBindResult;
     Volatile<DWORD> m_dwImageTypes;
     ReleaseHolder<ICLRPrivBinder> m_FallbackBinder;
 };  // class CLRPrivAssemblyWinRT

--- a/src/coreclr/src/vm/compile.cpp
+++ b/src/coreclr/src/vm/compile.cpp
@@ -165,7 +165,7 @@ HRESULT CEECompileInfo::CreateDomain(ICorCompilationDomain **ppDomain,
     {
         GCX_COOP();
 
-        pCompilationDomain->CreateFusionContext();
+        pCompilationDomain->CreateBinderContext();
 
         pCompilationDomain->SetFriendlyName(W("Compilation Domain"));
         SystemDomain::System()->LoadDomain(pCompilationDomain);

--- a/src/coreclr/src/vm/coreassemblyspec.cpp
+++ b/src/coreclr/src/vm/coreassemblyspec.cpp
@@ -324,20 +324,10 @@ HRESULT BaseAssemblySpec::ParseName()
         _ASSERTE(pDomain);
 
         BINDER_SPACE::ApplicationContext *pAppContext = NULL;
-        IUnknown *pIUnknownBinder = pDomain->GetFusionContext();
-
-        if (pIUnknownBinder != NULL)
+        CLRPrivBinderCoreCLR *pBinder = pDomain->GetTPABinderContext();
+        if (pBinder != NULL)
         {
-#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-            if (pDomain->GetFusionContext() != pDomain->GetTPABinderContext())
-            {
-                pAppContext = (static_cast<CLRPrivBinderAssemblyLoadContext *>(static_cast<ICLRPrivBinder*>(pIUnknownBinder)))->GetAppContext();
-            }
-            else
-#endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-            {
-                pAppContext = (static_cast<CLRPrivBinderCoreCLR *>(pIUnknownBinder))->GetAppContext();
-            }
+            pAppContext = pBinder->GetAppContext();
         }
 
         hr = CCoreCLRBinderHelper::GetAssemblyIdentity(m_pAssemblyName, pAppContext, pAssemblyIdentity);

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -688,7 +688,7 @@ HRESULT CorHost2::_CreateAppDomain(
     if (dwFlags & APPDOMAIN_FORCE_TRIVIAL_WAIT_OPERATIONS)
         pDomain->SetForceTrivialWaitOperations();
 
-    pDomain->CreateFusionContext();
+    pDomain->CreateBinderContext();
 
     {
         GCX_COOP();


### PR DESCRIPTION
It is just the TPA binder context now.

Remove dead code.