### PR TITLE
JIT: optimize more array covariant store checks in the importer

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4130,7 +4130,7 @@ private:
         OPCODE curOpcode, const BYTE* codeAddrOfNextOpcode, const BYTE* codeEnd, int prefixFlags, bool isRecursive);
 
     bool impIsClassExact(CORINFO_CLASS_HANDLE classHnd);
-    bool impCanSkipCovariantStoreCheck(GenTree* arrayNodeFrom, GenTree* arrayNodeTo);
+    bool impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array);
 
     CORINFO_RESOLVED_TOKEN* impAllocateToken(const CORINFO_RESOLVED_TOKEN& token);
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4130,6 +4130,7 @@ private:
         OPCODE curOpcode, const BYTE* codeAddrOfNextOpcode, const BYTE* codeEnd, int prefixFlags, bool isRecursive);
 
     bool impIsClassExact(CORINFO_CLASS_HANDLE classHnd);
+    bool impCanSkipCovariantStoreCheck(GenTree* arrayNodeFrom, GenTree* arrayNodeTo);
 
     CORINFO_RESOLVED_TOKEN* impAllocateToken(const CORINFO_RESOLVED_TOKEN& token);
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4129,6 +4129,8 @@ private:
     bool impIsImplicitTailCallCandidate(
         OPCODE curOpcode, const BYTE* codeAddrOfNextOpcode, const BYTE* codeEnd, int prefixFlags, bool isRecursive);
 
+    bool impIsClassExact(CORINFO_CLASS_HANDLE classHnd);
+
     CORINFO_RESOLVED_TOKEN* impAllocateToken(const CORINFO_RESOLVED_TOKEN& token);
 
     /*

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -17290,6 +17290,24 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
             break;
         }
 
+        case CORINFO_HELP_NEWARR_1_DIRECT:
+        case CORINFO_HELP_NEWARR_1_OBJ:
+        case CORINFO_HELP_NEWARR_1_VC:
+        case CORINFO_HELP_NEWARR_1_ALIGN8:
+        case CORINFO_HELP_NEWARR_1_R2R_DIRECT:
+        case CORINFO_HELP_READYTORUN_NEWARR_1:
+        {
+            CORINFO_CLASS_HANDLE arrayHnd = (CORINFO_CLASS_HANDLE)call->compileTimeHelperArgumentHandle;
+
+            if (arrayHnd != NO_CLASS_HANDLE)
+            {
+                objClass    = arrayHnd;
+                *pIsExact   = true;
+                *pIsNonNull = true;
+            }
+            break;
+        }
+
         default:
             break;
     }

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -11816,7 +11816,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 arrayNodeFrom = impStackTop().val;
 
                 // Is this a case where we can skip the covariant store check?
-                if (opts.IsOptimizationEnabled() && impCanSkipCovariantStoreCheck(arrayNodeFrom, arrayNodeTo))
+                if (opts.OptimizationEnabled() && impCanSkipCovariantStoreCheck(arrayNodeFrom, arrayNodeTo))
                 {
                     lclTyp = TYP_REF;
                     goto ARR_ST_POST_VERIFY;
@@ -20710,7 +20710,7 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
 bool Compiler::impCanSkipCovariantStoreCheck(GenTree* arrayNodeFrom, GenTree* arrayNodeTo)
 {
     // We should only call this when optimizing.
-    assert(!opts.OptimizationEnabled());
+    assert(opts.OptimizationEnabled());
 
     // Check for assignment to same array, ie. arrLcl[i] = arrLcl[j]
     if (arrayNodeFrom->OperIs(GT_INDEX) && arrayNodeTo->OperIs(GT_LCL_VAR))

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -11816,7 +11816,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 arrayNodeFrom = impStackTop().val;
 
                 // Is this a case where we can skip the covariant store check?
-                if (impCanSkipCovariantStoreCheck(arrayNodeFrom, arrayNodeTo))
+                if (opts.IsOptimizationEnabled() && impCanSkipCovariantStoreCheck(arrayNodeFrom, arrayNodeTo))
                 {
                     lclTyp = TYP_REF;
                     goto ARR_ST_POST_VERIFY;
@@ -20709,10 +20709,8 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
 //
 bool Compiler::impCanSkipCovariantStoreCheck(GenTree* arrayNodeFrom, GenTree* arrayNodeTo)
 {
-    if (!opts.OptimizationEnabled())
-    {
-        return false;
-    }
+    // We should only call this when optimizing.
+    assert(!opts.OptimizationEnabled());
 
     // Check for assignment to same array, ie. arrLcl[i] = arrLcl[j]
     if (arrayNodeFrom->OperIs(GT_INDEX) && arrayNodeTo->OperIs(GT_LCL_VAR))

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8332,7 +8332,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
     // Morph stelem.ref helper call to store a null value, into a store into an array without the helper.
     // This needs to be done after the arguments are morphed to ensure constant propagation has already taken place.
-    if ((call->gtCallType == CT_HELPER) && (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ARRADDR_ST)))
+    if (opts.OptimizationEnabled() && (call->gtCallType == CT_HELPER) &&
+        (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ARRADDR_ST)))
     {
         GenTree* value = gtArgEntryByArgNum(call, 2)->GetNode();
         if (value->IsIntegralConst(0))


### PR DESCRIPTION
The importer was already optimizing away some array covariant store checks,
for cases where the value being stored was null, or the value being stored
came from the same array.

Change this to only optimize array covariant store checks in the importer
when optimization is enabled. For minopts, invoking the store helper produces
smaller code.

Update `gtGetClassHandle` to obtain the array handle from array newobjs,
and use this to also optimize cases where the destination array is exactly
`object[]` or is `T[]` where `T` is final and not itself subject to special
casting logic. In particular this gets the common case where `T` is `string`.

Closes dotnet/coreclr#6537.