### PR TITLE
Change and or to an and

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -94,7 +94,7 @@ if ($null -ne $properties -and $actionPassedIn -ne $true) {
   $actionPassedIn = @(Compare-Object -ReferenceObject $properties -DifferenceObject $actions.ForEach({ "-" + $_ }) -ExcludeDifferent -IncludeEqual).Length -ne 0
 }
 
-if (!$actionPassedIn -or $subsetCategory -ne "libraries") {
+if (!$actionPassedIn -and $subsetCategory -ne "libraries") {
   $arguments = "-restore -build"
 }
 


### PR DESCRIPTION
I was hitting an issue where build.cmd -buildtest was always failing with:
```
.\build.cmd -buildtests
C:\Users\jukotali\code\runtime\eng\common\build.ps1 : Cannot bind parameter because parameter 'build' is specified more than once. To provide multiple values to parameters that   can accept multiple values, use the array syntax. For example, "-parameter value1,value2,value3".
+ ... ali\code\runtime\eng/common/build.ps1" -restore -build -build /p:Buil ...
+                                                            ~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [build.ps1], ParameterBindingException
    + FullyQualifiedErrorId : ParameterAlreadyBound,build.ps1
```

I think the following should be an -and instead of an -or