### PR TITLE
Disable incremental linking in coreclr Checked Windows builds

### DIFF
--- a/src/coreclr/configurecompiler.cmake
+++ b/src/coreclr/configurecompiler.cmake
@@ -263,6 +263,7 @@ if (MSVC)
   add_link_options($<$<AND:$<OR:$<CONFIG:DEBUG>,$<CONFIG:CHECKED>>,$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>>:/NOVCFEATURE>)
 
   # Checked build specific flags
+  add_link_options($<$<CONFIG:CHECKED>:/INCREMENTAL:NO>) # prevent "warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:REF' specification"
   add_link_options($<$<CONFIG:CHECKED>:/OPT:REF>)
   add_link_options($<$<CONFIG:CHECKED>:/OPT:NOICF>)
 


### PR DESCRIPTION
We force `/OPT:REF` and this is incompatible with incremental linking
(and yields a warning to that effect). To fix, explicitly disable
incremental linking.

(I couldn't find anyplace where it was explicitly enabled, so I believe
it is enabled by default with the given linker options.)

Another option would be to not force `/OPT:REF` for Checked builds.

Fixes https://github.com/dotnet/runtime/issues/191