### PR TITLE
[skip ci] Fix `optComputeAssertionGen` dump newline.

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -4642,12 +4642,13 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
 #ifdef DEBUG
         if (verbose)
         {
-            printf("\n" FMT_BB " valueGen = %s", block->bbNum, BitVecOps::ToString(apTraits, block->bbAssertionGen));
+            printf(FMT_BB " valueGen = %s", block->bbNum, BitVecOps::ToString(apTraits, block->bbAssertionGen));
             if (block->bbJumpKind == BBJ_COND)
             {
                 printf(" => " FMT_BB " valueGen = %s,", block->bbJumpDest->bbNum,
                        BitVecOps::ToString(apTraits, jumpDestGen[block->bbNum]));
             }
+            printf("\n");
         }
 #endif
     }


### PR DESCRIPTION
Before we were printing it like:
```
In BB03 New Global ArrBnds  Assertion: (0, 0) ($0,$0) [idx: {PhiDef($1, $2, $240)};len: {ARR_LENGTH($200)}] in range  index=#04, mask=0000000000000008
          <- extra new line here.
BB01 valueGen = 0000000000000000
BB02 valueGen = 0000000000000002 => BB06 valueGen = 0000000000000001,
BB03 valueGen = 000000000000000C
BB04 valueGen = 0000000000000000
BB05 valueGen = 0000000000000000
BB06 valueGen = 0000000000000000AssertionPropCallback::StartMerge: BB01 in ->  
0000000000000000 <- no newline here.
```