### PR TITLE
Fix missing unbox flag on method handle for struct methods

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -348,6 +348,12 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode CreateMethodHandleHelper(MethodWithToken method, SignatureContext signatureContext)
         {
+            bool useUnboxingStub = method.Method.IsUnboxingThunk();
+            if (useUnboxingStub)
+            {
+                method = new MethodWithToken(method.Method.GetUnboxedMethod(), method.Token, method.ConstrainedType);
+            }
+
             bool useInstantiatingStub = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method.Method;
 
             return new PrecodeHelperImport(
@@ -355,7 +361,7 @@ namespace ILCompiler.DependencyAnalysis
                 _codegenNodeFactory.MethodSignature(
                     ReadyToRunFixupKind.READYTORUN_FIXUP_MethodHandle,
                     method,
-                    isUnboxingStub: false,
+                    isUnboxingStub: useUnboxingStub,
                     isInstantiatingStub: useInstantiatingStub,
                     signatureContext));
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1698,10 +1698,20 @@ namespace Internal.JitInterface
                         break;
 
                     case CorInfoGenericHandleType.CORINFO_HANDLETYPE_METHOD:
-                        symbolNode = _compilation.SymbolNodeFactory.ReadyToRunHelper(
-                            ReadyToRunHelperId.MethodHandle,
-                            new MethodWithToken(HandleToObject(pResolvedToken.hMethod), HandleToModuleToken(ref pResolvedToken), constrainedType: null),
-                            GetSignatureContext());
+                        {
+                            MethodDesc md = HandleToObject(pResolvedToken.hMethod);
+                            TypeDesc td = HandleToObject(pResolvedToken.hClass);
+
+                            if (td.IsValueType)
+                            {
+                                md = _unboxingThunkFactory.GetUnboxingMethod(md);
+                            }
+
+                            symbolNode = _compilation.SymbolNodeFactory.ReadyToRunHelper(
+                                ReadyToRunHelperId.MethodHandle,
+                                new MethodWithToken(md, HandleToModuleToken(ref pResolvedToken), constrainedType: null),
+                                GetSignatureContext());
+                        }
                         break;
 
                     case CorInfoGenericHandleType.CORINFO_HANDLETYPE_FIELD:


### PR DESCRIPTION
Fixes Loader\classloader\generics\regressions\dev10_393447 test runtime
failure when compiled with crossgen2.

This mimicks what old crossgen does.