### PR TITLE
Fix range check upper limit.

### DIFF
--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -313,9 +313,9 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
     {
         // To determine the lower bound, ask if the loop increases monotonically.
         bool increasing = IsMonotonicallyIncreasing(tree, false);
-        JITDUMP("IsMonotonicallyIncreasing %d", increasing);
         if (increasing)
         {
+            JITDUMP("[%06d] is monotonically increasing.\n", Compiler::dspTreeID(tree));
             GetRangeMap()->RemoveAll();
             *pRange = GetRange(block, tree, true DEBUGARG(0));
         }
@@ -1039,6 +1039,7 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
     }
     GetOverflowMap()->Set(expr, overflows, OverflowMap::Overwrite);
     m_pSearchPath->Remove(expr);
+    JITDUMP("[%06d] %s\n", Compiler::dspTreeID(expr), ((overflows) ? "overflows" : "does not overflow"));
     return overflows;
 }
 

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -1049,7 +1049,8 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
 // but continues to loop, which will happen with phi nodes. We end the looping by calling the
 // value as "dependent" (dep).
 // If the loop is proven to be "monIncreasing", then make liberal decisions while merging phi node.
-// eg.: merge((0, dep), (dep, dep)) = (0, dep)
+// eg.: merge((0, dep), (dep, dep)) = (0, dep), merge((0, 1), (dep, dep)) = (0, dep),
+// merge((0, 5), (dep, 10)) = (0, 10).
 Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreasing DEBUGARG(int indent))
 {
     bool  newlyAdded = !m_pSearchPath->Set(expr, block, SearchPath::Overwrite);

--- a/src/coreclr/src/jit/rangecheck.h
+++ b/src/coreclr/src/jit/rangecheck.h
@@ -293,7 +293,7 @@ struct RangeOps
     }
 
     // Given two ranges "r1" and "r2", do a Phi merge. If "monIncreasing" is true,
-    // then ignore the dependent variables for the lower bound.
+    // then ignore the dependent variables for the lower bound but not for the upper bound.
     static Range Merge(Range& r1, Range& r2, bool monIncreasing)
     {
         Limit& r1lo = r1.LowerLimit();

--- a/src/coreclr/src/jit/rangecheck.h
+++ b/src/coreclr/src/jit/rangecheck.h
@@ -52,7 +52,7 @@
 //  **Step 4. Check if the dependency chain is monotonic.
 //
 //  **Step 5. If monotonic increasing is true, then perform a widening step, where we assume, the
-//  SSA variables that are "dependent" get their values from the definitions in the
+//  SSA variables that are "dependent" get their lower bound values from the definitions in the
 //  dependency loop and their initial values must be the definitions that are not in
 //  the dependency loop, in this case i_0's value which is 0.
 //
@@ -293,7 +293,7 @@ struct RangeOps
     }
 
     // Given two ranges "r1" and "r2", do a Phi merge. If "monIncreasing" is true,
-    // then ignore the dependent variables.
+    // then ignore the dependent variables for the lower bound.
     static Range Merge(Range& r1, Range& r2, bool monIncreasing)
     {
         Limit& r1lo = r1.LowerLimit();
@@ -335,14 +335,7 @@ struct RangeOps
         }
         else if (r1hi.IsDependent() || r2hi.IsDependent())
         {
-            if (monIncreasing)
-            {
-                result.uLimit = r1hi.IsDependent() ? r2hi : r1hi;
-            }
-            else
-            {
-                result.uLimit = Limit(Limit::keDependent);
-            }
+            result.uLimit = Limit(Limit::keDependent);
         }
 
         if (r1lo.IsConstant() && r2lo.IsConstant())
@@ -461,7 +454,7 @@ public:
     // The range of a variable depends on its rhs which in turn depends on its constituent variables.
     // The "path" is the path taken in the search for the rhs' range and its constituents' range.
     // If "monIncreasing" is true, the calculations are made more liberally assuming initial values
-    // at phi definitions.
+    // at phi definitions for the lower bound.
     Range GetRange(BasicBlock* block, GenTree* expr, bool monIncreasing DEBUGARG(int indent));
 
     // Given the local variable, first find the definition of the local and find the range of the rhs.

--- a/src/coreclr/src/jit/rangecheck.h
+++ b/src/coreclr/src/jit/rangecheck.h
@@ -51,7 +51,7 @@
 //
 //  **Step 4. Check if the dependency chain is monotonic.
 //
-//  **Step 5. If monotonic is true, then perform a widening step, where we assume, the
+//  **Step 5. If monotonic increasing is true, then perform a widening step, where we assume, the
 //  SSA variables that are "dependent" get their values from the definitions in the
 //  dependency loop and their initial values must be the definitions that are not in
 //  the dependency loop, in this case i_0's value which is 0.
@@ -292,9 +292,9 @@ struct RangeOps
         return result;
     }
 
-    // Given two ranges "r1" and "r2", do a Phi merge. If "monotonic" is true,
+    // Given two ranges "r1" and "r2", do a Phi merge. If "monIncreasing" is true,
     // then ignore the dependent variables.
-    static Range Merge(Range& r1, Range& r2, bool monotonic)
+    static Range Merge(Range& r1, Range& r2, bool monIncreasing)
     {
         Limit& r1lo = r1.LowerLimit();
         Limit& r1hi = r1.UpperLimit();
@@ -314,7 +314,7 @@ struct RangeOps
         }
         else if (r1lo.IsDependent() || r2lo.IsDependent())
         {
-            if (monotonic)
+            if (monIncreasing)
             {
                 result.lLimit = r1lo.IsDependent() ? r2lo : r1lo;
             }
@@ -335,7 +335,7 @@ struct RangeOps
         }
         else if (r1hi.IsDependent() || r2hi.IsDependent())
         {
-            if (monotonic)
+            if (monIncreasing)
             {
                 result.uLimit = r1hi.IsDependent() ? r2hi : r1hi;
             }
@@ -460,19 +460,19 @@ public:
     // Given the index expression try to find its range.
     // The range of a variable depends on its rhs which in turn depends on its constituent variables.
     // The "path" is the path taken in the search for the rhs' range and its constituents' range.
-    // If "monotonic" is true, the calculations are made more liberally assuming initial values
+    // If "monIncreasing" is true, the calculations are made more liberally assuming initial values
     // at phi definitions.
-    Range GetRange(BasicBlock* block, GenTree* expr, bool monotonic DEBUGARG(int indent));
+    Range GetRange(BasicBlock* block, GenTree* expr, bool monIncreasing DEBUGARG(int indent));
 
     // Given the local variable, first find the definition of the local and find the range of the rhs.
     // Helper for GetRange.
-    Range ComputeRangeForLocalDef(BasicBlock* block, GenTreeLclVarCommon* lcl, bool monotonic DEBUGARG(int indent));
+    Range ComputeRangeForLocalDef(BasicBlock* block, GenTreeLclVarCommon* lcl, bool monIncreasing DEBUGARG(int indent));
 
     // Compute the range, rather than retrieve a cached value. Helper for GetRange.
-    Range ComputeRange(BasicBlock* block, GenTree* expr, bool monotonic DEBUGARG(int indent));
+    Range ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreasing DEBUGARG(int indent));
 
     // Compute the range for the op1 and op2 for the given binary operator.
-    Range ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool monotonic DEBUGARG(int indent));
+    Range ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool monIncreasing DEBUGARG(int indent));
 
     // Merge assertions from AssertionProp's flags, for the corresponding "phiArg."
     // Requires "pRange" to contain range that is computed partially.
@@ -504,8 +504,8 @@ public:
     // Does the current "expr" which is a use involve a definition, that overflows.
     bool DoesOverflow(BasicBlock* block, GenTree* tree);
 
-    // Widen the range by first checking if the induction variable is monotonic. Requires "pRange"
-    // to be partially computed.
+    // Widen the range by first checking if the induction variable is monotonically increasing.
+    // Requires "pRange" to be partially computed.
     void Widen(BasicBlock* block, GenTree* tree, Range* pRange);
 
     // Is the binary operation increasing the value.

--- a/src/coreclr/tests/src/JIT/jit64/opt/osr/osr015.il
+++ b/src/coreclr/tests/src/JIT/jit64/opt/osr/osr015.il
@@ -4192,7 +4192,7 @@ FOR_START:
         stelem.i4
         leave TRY_END_a
     }
-    catch [mscorlib]System.IndexOutOfRangeException
+    catch [mscorlib]System.NullReferenceException
     {
         leave TRY_END_a
     }

--- a/src/coreclr/tests/src/JIT/jit64/opt/osr/osr015.il
+++ b/src/coreclr/tests/src/JIT/jit64/opt/osr/osr015.il
@@ -1485,6 +1485,29 @@ TRY_END_b029:
 TRY_END_b030:
 
 
+	.try
+	{
+		call void test::test_001c()
+		ldstr "Fail: test_001c"
+		call void [System.Console]System.Console::WriteLine(string)
+		ldc.i4 1
+		stloc 0
+		leave TRY_END_c001
+	}
+	catch [mscorlib]System.IndexOutOfRangeException
+	{
+		leave TRY_END_c001
+	}
+	catch [mscorlib]System.Exception
+	{
+		ldstr "Fail: test_001c"
+		call void [System.Console]System.Console::WriteLine(string)
+		call void [System.Console]System.Console::WriteLine(object)
+		ldc.i4 1
+		stloc 0
+		leave TRY_END_c001
+	}
+TRY_END_c001:
 
 
 
@@ -4137,6 +4160,55 @@ FOR_TEST:
 
 
 
+
+  .method public static void test_001c() cil managed
+  {
+// Check for exception
+// use int32
+// Exceed array bounds with greater than
+// with a back branch that goes to a try region
+// so Jit can't clone the loop check and transofm it
+// to a postcondition loop.
+
+
+	.locals init (int32[], int32)
+
+	
+	ldc.i4 100
+	newarr int32
+	stloc 0
+
+
+FOR_START:
+	ldloc 1
+	ldc.i4 100
+	bgt FOR_END
+
+	.try
+	{
+        ldloc 0
+        ldloc 1
+        ldloc 1
+        stelem.i4
+        leave TRY_END_a
+    }
+    catch [mscorlib]System.IndexOutOfRangeException
+    {
+        leave TRY_END_a
+    }
+    TRY_END_a:
+
+	ldloc 1
+	ldc.i4 1
+	add
+	stloc 1
+	br FOR_START
+
+FOR_END:
+
+	ret   
+		
+  }
 
 
 


### PR DESCRIPTION
There was an issue with range calculations in a rare loop form that was exposed by `complus_JitStressBBProf=1` in https://github.com/dotnet/coreclr/issues/27805.

I have added a test that exposes the issue without any stress mode but it relies on the assertion prop optimization that I have added in #160. [New test failures](https://dev.azure.com/dnceng/public/_build/results?buildId=435017&view=ms.vss-test-web.build-test-results-tab&runId=13798066&resultId=100018&paneView=debug).

In the new test case, `fgOptimizeBranch` is blocked by different try regions and we can't copy loop condition as we usually do.
So we keep our original order:
```
while(i < 100)
{
    arr[i] = i;
    ++i;
}
```

Note: usually we tranform it into:
```
if (i < 100)
{
do
{
  arr[i] = i;
  i++;
}
while (i < 100);
}
```

so with the original order when we try to optimize bounds check for `arr[i]` we have two phi nodes, one is `i0=(0, 0)` that is the pre loop value and another is `i1=(dependent, dependent)` that is loop variable:

```
i0 = 0;
LOOP:
i1 = phi(i0, i2);
if (i1 < 100)
{
    
    arr[i1] = i1;
    i2 = i1 + 1;
    goto LOOP;
}
```

so `i1` asks for a range of `i1` and `i2`. When it asks for `i2` it tries to use assertion propagation info, but there is no info about `i2` there. So we end up with `i0=(0, 0), i2=(dependent, dependent)` and the old code was merging it into `i1=(0,0)` that allowed the compiler to incorrectly remove the bounds check.

In the case where we don't have different try regions and create a loop with postcondition assertion propagation has information about `i2` and uses it to modify `i2` range as `(dependent, 100)` so `i1 = (0, 100)`.

`complus_JitStressBBProf=1` was blocking that cloning and exposed the issue on many test cases in that file.


The fix is to use `increasingMonotoning` flag only to set the lower bound.

Note: We can add the same optimization for decreasing iterators later, but they are probably very rare.

Fixes https://github.com/dotnet/coreclr/issues/27805.

Commits:
1860741db2a: add a new test case to osr015.

42398903d28: Improve JitDump output for range checks.

9ef0ca34526: Rename `monotonic` to `monIncreasing`.

396198f7b77: Fix the bug.

`monIncreasing` can be used only to liberally assume the lower bound.