### PR TITLE
Allow project builds from script

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -94,8 +94,23 @@ if ($null -ne $properties -and $actionPassedIn -ne $true) {
   $actionPassedIn = @(Compare-Object -ReferenceObject $properties -DifferenceObject $actions.ForEach({ "-" + $_ }) -ExcludeDifferent -IncludeEqual).Length -ne 0
 }
 
-if (!$actionPassedIn -or $subsetCategory -ne "libraries") {
+if (!$actionPassedIn) {
   $arguments = "-restore -build"
+}
+
+$possibleDirToBuild = if($properties.Length -gt 0) { $properties[0]; } else { $null }
+
+if ($null -ne $possibleDirToBuild -and $subsetCategory -eq "libraries") {
+  $dtb = $possibleDirToBuild.TrimEnd('\')
+  if (Test-Path $dtb) {
+    $properties[0] = "/p:DirectoryToBuild=$(Resolve-Path $dtb)"
+  }
+  else {
+    $dtb = Join-Path "$PSSCriptRoot\..\src\libraries" $dtb
+    if (Test-Path $dtb) {
+      $properties[0] = "/p:DirectoryToBuild=$(Resolve-Path $dtb)"
+    }
+  }
 }
 
 foreach ($argument in $PSBoundParameters.Keys)

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -52,9 +52,10 @@ extraargs=''
 build=false
 buildtests=false
 subsetCategory=''
+checkedPossibleDirectoryToBuild=false
 
 # Check if an action is passed in
-declare -a actions=("r" "restore" "b" "build" "rebuild" "t" "test" "buildtests")
+declare -a actions=("r" "restore" "b" "build" "buildtests" "rebuild" "t" "test" "pack" "sign" "publish" "clean")
 actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
 
 while [[ $# > 0 ]]; do
@@ -118,6 +119,17 @@ while [[ $# > 0 ]]; do
       ;;
       *)
       ea=$1
+      
+      if [[ $checkedPossibleDirectoryToBuild == false ]] && [[ $subsetCategory == "libraries" ]]; then
+        checkedPossibleDirectoryToBuild=true
+
+        if [[ -d "$1" ]]; then
+          ea="/p:DirectoryToBuild=$1"
+        elif [[ -d "$scriptroot/../src/libraries/$1" ]]; then
+          ea="/p:DirectoryToBuild=$scriptroot/../src/libraries/$1"
+        fi
+      fi
+
       extraargs="$extraargs $ea"
       shift 1
       ;;
@@ -132,7 +144,7 @@ if [[ "$buildtests" == true ]]; then
   fi
 fi
 
-if [ ${#actInt[@]} -eq 0 ] || [ "$subsetCategory" != "libraries" ]; then
+if [ ${#actInt[@]} -eq 0 ]; then
     arguments="-restore -build $arguments"
 fi
 

--- a/eng/pipelines/installer/jobs/bash-build.yml
+++ b/eng/pipelines/installer/jobs/bash-build.yml
@@ -66,7 +66,7 @@ jobs:
       # parameter is empty, AzDO replaces it with empty space without chomping the extra newline.
       # This causes a newline in the arg string that causes failure.
       BuildArguments: >-
-        --ci --test
+        --restore --build --ci --test
         /p:CrossBuild=${{ parameters.crossBuild }}
         /p:DisableCrossgen=${{ parameters.disableCrossgen }}
         /p:PortableBuild=${{ parameters.portableBuild }}

--- a/eng/pipelines/installer/jobs/osx-build.yml
+++ b/eng/pipelines/installer/jobs/osx-build.yml
@@ -26,7 +26,7 @@ jobs:
     - task: NuGetAuthenticate@0
 
   - script: >-
-      $(Build.SourcesDirectory)/$(buildScriptFileName).sh --ci --test
+      $(Build.SourcesDirectory)/$(buildScriptFileName).sh --restore --build --ci --test
       /p:OfficialBuildId=$(OfficialBuildId)
       /p:StripSymbols=true
       $(CommonMSBuildArgs)

--- a/eng/pipelines/installer/jobs/windows-build.yml
+++ b/eng/pipelines/installer/jobs/windows-build.yml
@@ -58,7 +58,7 @@ jobs:
       displayName: Clear NuGet http cache (if exists)
 
     - script: >-
-        $(buildScriptFileName).cmd -ci -test
+        $(buildScriptFileName).cmd -restore -build -ci -test
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
       displayName: Build


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/196

For Installer we need to make the buildtests target work. For CoreClr we want restore and buildtests. We should do this in a subsequent PR.