### PR TITLE
Remove unused code in app domain

### DIFF
--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -966,15 +966,6 @@ public:
         return NULL;
     }
 
-    void SetDisableInterfaceCache()
-    {
-        m_fDisableInterfaceCache = TRUE;
-    }
-    BOOL GetDisableInterfaceCache()
-    {
-        return m_fDisableInterfaceCache;
-    }
-
 #ifdef FEATURE_COMINTEROP
     MngStdInterfacesInfo * GetMngStdInterfacesInfo()
     {
@@ -1166,7 +1157,6 @@ protected:
     // Used to protect the assembly list. Taken also by GC or debugger thread, therefore we have to avoid
     // triggering GC while holding this lock (by switching the thread to GC_NOTRIGGER while it is held).
     CrstExplicitInit m_crstAssemblyList;
-    BOOL             m_fDisableInterfaceCache;  // RCW COM interface cache
     ListLock         m_ClassInitLock;
     JitListLock      m_JITLock;
     ListLock         m_ILStubGenLock;
@@ -1676,8 +1666,6 @@ public:
     // final assembly cleanup
     void ShutdownFreeLoaderAllocators();
 
-    void ReleaseFiles();
-
     virtual BOOL IsAppDomain() { LIMITED_METHOD_DAC_CONTRACT; return TRUE; }
     virtual PTR_AppDomain AsAppDomain() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_AppDomain>(this); }
 
@@ -2034,7 +2022,6 @@ public:
     PEAssembly* FindCachedFile(AssemblySpec* pSpec, BOOL fThrow = TRUE);
     BOOL IsCached(AssemblySpec *pSpec);
 #endif // DACCESS_COMPILE
-    void CacheStringsForDAC();
 
     BOOL AddFileToCache(AssemblySpec* pSpec, PEAssembly *pFile, BOOL fAllowFailure = FALSE);
     BOOL RemoveFileFromCache(PEAssembly *pFile);
@@ -2132,7 +2119,6 @@ public:
     // Create a quick lookup for classes loaded into this domain based on their GUID.
     //
     void InsertClassForCLSID(MethodTable* pMT, BOOL fForceInsert = FALSE);
-    void InsertClassForCLSID(MethodTable* pMT, GUID *pGuid);
 
 #ifdef FEATURE_COMINTEROP
 private:
@@ -2275,41 +2261,12 @@ public:
 
     static void ExceptionUnwind(Frame *pFrame);
 
-    static void RefTakerAcquire(AppDomain* pDomain)
-    {
-        WRAPPER_NO_CONTRACT;
-        if(!pDomain)
-            return;
-        pDomain->AddRef();
-#ifdef _DEBUG
-        FastInterlockIncrement(&pDomain->m_dwRefTakers);
-#endif
-    }
-
-    static void RefTakerRelease(AppDomain* pDomain)
-    {
-        WRAPPER_NO_CONTRACT;
-        if(!pDomain)
-            return;
-#ifdef _DEBUG
-        _ASSERTE(pDomain->m_dwRefTakers);
-        FastInterlockDecrement(&pDomain->m_dwRefTakers);
-#endif
-        pDomain->Release();
-    }
-
 #ifdef _DEBUG
 
     BOOL IsHeldByIterator()
     {
         LIMITED_METHOD_CONTRACT;
         return m_dwIterHolders>0;
-    }
-
-    BOOL IsHeldByRefTaker()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_dwRefTakers>0;
     }
 
     void IteratorRelease()
@@ -2333,16 +2290,7 @@ public:
 
         return m_Stage >= STAGE_ACTIVE;
     }
-    // Range for normal execution of code in the appdomain, currently used for
-    // appdomain resource monitoring since we don't care to update resource usage
-    // unless it's in these stages (as fields of AppDomain may not be valid if it's
-    // not within these stages)
-    BOOL IsUserActive()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
 
-        return m_Stage >= STAGE_ACTIVE && m_Stage <= STAGE_OPEN;
-    }
     BOOL IsValid()
     {
         LIMITED_METHOD_DAC_CONTRACT;
@@ -2356,36 +2304,6 @@ public:
 #endif
     }
 
-#ifdef _DEBUG
-    BOOL IsBeingCreated()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_dwCreationHolders > 0;
-    }
-
-    void IncCreationCount()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        FastInterlockIncrement(&m_dwCreationHolders);
-        _ASSERTE(m_dwCreationHolders > 0);
-    }
-
-    void DecCreationCount()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        FastInterlockDecrement(&m_dwCreationHolders);
-        _ASSERTE(m_dwCreationHolders > -1);
-    }
-#endif
-    BOOL NotReadyForManagedCode()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_Stage < STAGE_READYFORMANAGEDCODE;
-    }
 
     static void RaiseExitProcessEvent();
     Assembly* RaiseResourceResolveEvent(DomainAssembly* pAssembly, LPCSTR szName);
@@ -2595,8 +2513,6 @@ private:
 
 #ifdef _DEBUG
     Volatile<LONG> m_dwIterHolders;
-    Volatile<LONG> m_dwRefTakers;
-    Volatile<LONG> m_dwCreationHolders;
 #endif
 
     //
@@ -2829,11 +2745,6 @@ public:
     }
 #endif
 };  // class AppDomain
-
-
-// This holder is to be used to take a reference to make sure AppDomain* is still valid
-// Please do not use if you are aleady ADU-safe
-typedef Wrapper<AppDomain*,AppDomain::RefTakerAcquire,AppDomain::RefTakerRelease,NULL> AppDomainRefTaker;
 
 // Just a ref holder
 typedef ReleaseHolder<AppDomain> AppDomainRefHolder;

--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -3339,15 +3339,6 @@ void Module::StartUnload()
 }
 #endif // CROSSGEN_COMPILE
 
-void Module::ReleaseILData(void)
-{
-    WRAPPER_NO_CONTRACT;
-
-    ReleaseISymUnmanagedReader();
-}
-
-
-
 //---------------------------------------------------------------------------------------
 //
 // Simple wrapper around calling IsAfContentType_WindowsRuntime() against the flags
@@ -13225,18 +13216,6 @@ void ReflectionModule::ResumeMetadataCapture()
     CaptureModuleMetaDataToMemory();
 }
 
-void ReflectionModule::ReleaseILData()
-{
-    WRAPPER_NO_CONTRACT;
-
-    if (m_pISymUnmanagedWriter)
-    {
-        m_pISymUnmanagedWriter->Release();
-        m_pISymUnmanagedWriter = NULL;
-    }
-
-    Module::ReleaseILData();
-}
 #endif // !CROSSGEN_COMPILE
 
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/src/vm/ceeload.h
+++ b/src/coreclr/src/vm/ceeload.h
@@ -2053,9 +2053,6 @@ protected:
     // concurrently with other uses of the reader (i.e. not shutdown/unload time)
     void ReleaseISymUnmanagedReader(void);
 
-    virtual void ReleaseILData();
-
-
 #endif // DACCESS_COMPILE
 
     // IL stub cache
@@ -3307,8 +3304,6 @@ public:
     static ReflectionModule *Create(Assembly *pAssembly, PEFile *pFile, AllocMemTracker *pamTracker, LPCWSTR szName, BOOL fIsTransient);
     void Initialize(AllocMemTracker *pamTracker, LPCWSTR szName);
     void Destruct();
-
-    void ReleaseILData();
 #endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
     // Overides functions to access sections

--- a/src/coreclr/src/vm/domainfile.cpp
+++ b/src/coreclr/src/vm/domainfile.cpp
@@ -109,47 +109,6 @@ LoaderAllocator * DomainFile::GetLoaderAllocator()
 
 #ifndef DACCESS_COMPILE
 
-void DomainFile::ReleaseFiles()
-{
-    WRAPPER_NO_CONTRACT;
-    Module* pModule=GetCurrentModule();
-    if(pModule)
-        pModule->StartUnload();
-
-    if (m_pFile)
-        m_pFile->ReleaseIL();
-    if(m_pOriginalFile)
-        m_pOriginalFile->ReleaseIL();
-
-    if(pModule)
-        pModule->ReleaseILData();
-}
-
-BOOL DomainFile::TryEnsureActive()
-{
-    CONTRACT(BOOL)
-    {
-        INSTANCE_CHECK;
-        THROWS;
-        GC_TRIGGERS;
-    }
-    CONTRACT_END;
-
-    BOOL success = TRUE;
-
-    EX_TRY
-      {
-          EnsureActive();
-      }
-    EX_CATCH
-      {
-          success = FALSE;
-      }
-    EX_END_CATCH(RethrowTransientExceptions);
-
-    RETURN success;
-}
-
 // Optimization intended for EnsureLoadLevel only
 #include <optsmallperfcritical.h>
 void DomainFile::EnsureLoadLevel(FileLoadLevel targetLevel)
@@ -1260,22 +1219,6 @@ DomainAssembly::~DomainAssembly()
     {
         delete m_pAssembly;
     }
-}
-
-void DomainAssembly::ReleaseFiles()
-{
-    STANDARD_VM_CONTRACT;
-
-    if(m_pAssembly)
-        m_pAssembly->StartUnload();
-    ModuleIterator i = IterateModules(kModIterIncludeLoading);
-    while (i.Next())
-    {
-        if (i.GetDomainFile() != this)
-             i.GetDomainFile()->ReleaseFiles();
-    }
-
-    DomainFile::ReleaseFiles();
 }
 
 void DomainAssembly::SetAssembly(Assembly* pAssembly)

--- a/src/coreclr/src/vm/domainfile.h
+++ b/src/coreclr/src/vm/domainfile.h
@@ -139,9 +139,6 @@ class DomainFile
     }
 #endif
 
-
-    void ReleaseFiles() DAC_EMPTY();
-
     virtual BOOL IsAssembly() = 0;
 
     DomainAssembly *GetDomainAssembly();
@@ -220,9 +217,6 @@ class DomainFile
         WRAPPER_NO_CONTRACT;
         return EnsureLoadLevel(FILE_LOAD_LOADLIBRARY);
     }
-
-    // This wraps EnsureActive, suppressing non-transient exceptions
-    BOOL TryEnsureActive();
 
     // EnsureLoadLevel is a generic routine used to ensure that the file is not in a delay loaded
     // state (unless it needs to be.)  This should be used when a particular level of loading
@@ -499,10 +493,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_pLoaderAllocator;
     }
-
-#ifndef DACCESS_COMPILE
-    void ReleaseFiles();
-#endif // DACCESS_COMPILE
 
     // Finds only loaded hmods
     DomainFile *FindIJWModule(HMODULE hMod);

--- a/src/coreclr/src/vm/pefile.cpp
+++ b/src/coreclr/src/vm/pefile.cpp
@@ -132,24 +132,6 @@ PEFile::~PEFile()
     }
 }
 
-#ifndef  DACCESS_COMPILE
-void PEFile::ReleaseIL()
-{
-    WRAPPER_NO_CONTRACT;
-    if (m_openedILimage!=NULL )
-    {
-        ReleaseMetadataInterfaces(TRUE, TRUE);
-        if (m_identity != NULL)
-        {
-            m_identity->Release();
-            m_identity=NULL;
-        }
-        m_openedILimage->Release();
-        m_openedILimage = NULL;
-    }
-}
-#endif
-
 /* static */
 PEFile *PEFile::Open(PEImage *image)
 {
@@ -1993,31 +1975,7 @@ PEAssembly::~PEAssembly()
 
 }
 
-#ifndef  DACCESS_COMPILE
-void PEAssembly::ReleaseIL()
-{
-    CONTRACTL
-    {
-        INSTANCE_CHECK;
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    GCX_PREEMP();
-    if (m_creator != NULL)
-    {
-        m_creator->Release();
-        m_creator=NULL;
-    }
-
-    PEFile::ReleaseIL();
-}
-#endif
-
 /* static */
-
 PEAssembly *PEAssembly::OpenSystem(IUnknown * pAppCtx)
 {
     STANDARD_VM_CONTRACT;

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -420,8 +420,6 @@ protected:
 #ifndef DACCESS_COMPILE
     PEFile(PEImage *image);
     virtual ~PEFile();
-
-    virtual void ReleaseIL();
 #else
     virtual ~PEFile() {}
 #endif
@@ -638,10 +636,6 @@ class PEAssembly : public PEFile
     // ------------------------------------------------------------
 
     ULONG HashIdentity();
-
-#ifndef  DACCESS_COMPILE
-    virtual void ReleaseIL();
-#endif
 
     // ------------------------------------------------------------
     // Descriptive strings


### PR DESCRIPTION
`AppDomain::ReleaseFiles` and `AppDomain::SetDisableInterfaceCache` are not called anymore.