### PR TITLE
Fix printing switching to MinOpts or Optimized

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -3577,11 +3577,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
         if (compSwitchedToOptimized)
         {
-            printf("OPTIONS: Tier-0 compilation, switched to FullOpts");
+            printf("OPTIONS: Tier-0 compilation, switched to FullOpts\n");
         }
         if (compSwitchedToMinOpts)
         {
-            printf("OPTIONS: Tier-1/FullOpts compilation, switched to MinOpts");
+            printf("OPTIONS: Tier-1/FullOpts compilation, switched to MinOpts\n");
         }
 
         printf("OPTIONS: compCodeOpt = %s\n",

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -5855,6 +5855,9 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 #endif
     }
 
+    compSwitchedToOptimized = false;
+    compSwitchedToMinOpts   = false;
+
     // compInitOptions will set the correct verbose flag.
 
     compInitOptions(compileFlags);
@@ -5946,9 +5949,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
     info.compTotalHotCodeSize  = 0;
     info.compTotalColdCodeSize = 0;
 
-    compHasBackwardJump     = false;
-    compSwitchedToOptimized = false;
-    compSwitchedToMinOpts   = false;
+    compHasBackwardJump = false;
 
 #ifdef DEBUG
     compCurBB = nullptr;

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4266,13 +4266,14 @@ void Compiler::fgSwitchToOptimized()
     JITDUMP("****\n**** JIT Tier0 jit request switching to Tier1 because of loop\n****\n");
     assert(opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0));
     opts.jitFlags->Clear(JitFlags::JIT_FLAG_TIER0);
+
+    // Leave a note for jit diagnostics
+    compSwitchedToOptimized = true;
+
     compInitOptions(opts.jitFlags);
 
     // Notify the VM of the change
     info.compCompHnd->setMethodAttribs(info.compMethodHnd, CORINFO_FLG_SWITCHED_TO_OPTIMIZED);
-
-    // And leave a note for jit diagnostics too
-    compSwitchedToOptimized = true;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
`compSwitchedToOptimized` and `compSwitchedToMinOpts`should be initialized before calling to `compInitOptions` since the function output is based on the value of these fields.

@AndyAyersMS PTAL
cc @dotnet/jit-contrib 