### PR TITLE
Fix crossgen2 handling of direct calls to abstract methods

### DIFF
--- a/src/coreclr/src/tools/crossgen2/Common/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/coreclr/src/tools/crossgen2/Common/TypeSystem/Common/ExceptionStringID.cs
@@ -32,6 +32,8 @@ namespace Internal.TypeSystem
         InvalidProgramVararg,
         InvalidProgramCallVirtFinalize,
         InvalidProgramNativeCallable,
+        InvalidProgramCallAbstractMethod,
+        InvalidProgramCallVirtStatic,
 
         // BadImageFormatException
         BadImageFormatGeneric,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -915,7 +915,7 @@ namespace Internal.JitInterface
             // a static method would have never found an instance method.
             if (originalMethod.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
             {
-                throw new RequiresRuntimeJitException("CallVirt to static method");
+                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallVirtStatic, originalMethod);
             }
 
             exactType = type;
@@ -1095,7 +1095,7 @@ namespace Internal.JitInterface
                     // Compensate for always treating delegates as direct calls above
                     !(((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0) && ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0) && !resolvedCallVirt))
                 {
-                    throw new RequiresRuntimeJitException("Direct calls to abstract methods are not allowed");
+                    ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallAbstractMethod, targetMethod);
                 }
 
                 bool allowInstParam = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ALLOWINSTPARAM) != 0;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -915,7 +915,7 @@ namespace Internal.JitInterface
             // a static method would have never found an instance method.
             if (originalMethod.Signature.IsStatic && (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0)
             {
-                throw new BadImageFormatException();
+                throw new RequiresRuntimeJitException("CallVirt to static method");
             }
 
             exactType = type;
@@ -1037,14 +1037,14 @@ namespace Internal.JitInterface
                 // Static methods are always direct calls
                 directCall = true;
             }
+            else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) == 0 || resolvedConstraint)
+            {
+                directCall = true;
+            }
             else if (targetMethod.OwningType.IsInterface && targetMethod.IsAbstract)
             {
                 // Backwards compat: calls to abstract interface methods are treated as callvirt
                 directCall = false;
-            }
-            else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) == 0 || resolvedConstraint)
-            {
-                directCall = true;
             }
             else
             {
@@ -1090,6 +1090,14 @@ namespace Internal.JitInterface
 
             if (directCall)
             {
+                // Direct calls to abstract methods are not allowed
+                if (targetMethod.IsAbstract &&
+                    // Compensate for always treating delegates as direct calls above
+                    !(((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0) && ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0) && !resolvedCallVirt))
+                {
+                    throw new RequiresRuntimeJitException("Direct calls to abstract methods are not allowed");
+                }
+
                 bool allowInstParam = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ALLOWINSTPARAM) != 0;
 
                 if (!allowInstParam && canonMethod.RequiresInstArg())


### PR DESCRIPTION
This change fixes two differences between old and new crossgen in the
getCallInfo method. Direct calls to abstract methods were being compiled
as if they were possible and lead to runtime crash in the call chain
from the PreStubWorker.