### PR TITLE
Remove System.ComponentModel.TypeConverter exclusion from SuperILC

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -41,9 +41,6 @@ namespace ReadyToRun.SuperIlc
             new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef", crossgen2Only: true),
-
-            // TODO (TRylek): problem related to devirtualization of method without IL - System.Enum.Equals(object)
-            new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL", crossgen2Only: true),
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;


### PR DESCRIPTION
It turns out it is not needed anymore, the assembly compiles fine