### PR TITLE
Fix crossgen2 compilation with reverse pinvoke

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -601,6 +601,8 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE_MAYBENULL:
                 case CorInfoHelpFunc.CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_MAYBENULL:
                 case CorInfoHelpFunc.CORINFO_HELP_GETREFANY:
+                case CorInfoHelpFunc.CORINFO_HELP_JIT_REVERSE_PINVOKE_ENTER:
+                case CorInfoHelpFunc.CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT:
                     throw new RequiresRuntimeJitException(ftnNum.ToString());
 
                 default:


### PR DESCRIPTION
Crossgen2 is failing to compile assemblies that contain reverse pinvoke
helpers with NotImplementedException.
This change fixes it by throwing RequiresRuntimeJit exception instead
for CORINFO_HELP_JIT_REVERSE_PINVOKE_ENTER and
CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT. 
That way, we just don't compile the related method, but the rest of the assembly 
is still compiled.