### PR TITLE
Fix test build error when .NET Core SDK 5 is installed on the machine

### DIFF
--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -7,6 +7,11 @@
   -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('disableversioncheck.targets', '$(MSBuildThisFileDirectory)../'))" />
 
+  <ItemGroup>
+    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
+  </ItemGroup>
+
   <Target Name="CopyDependencyToCoreRoot"
           DependsOnTargets="ResolveAssemblyReferences">
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/185