### PR TITLE
Revise perfjitdump

### DIFF
--- a/src/coreclr/src/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/src/pal/src/misc/perfjitdump.cpp
@@ -295,6 +295,7 @@ exit:
                     if (result < item[itemsWritten].iov_len)
                     {
                         item[itemsWritten].iov_len -= result;
+                        item[items].iov_base = (void*)((uint64_t) item[items].iov_base + result);
                         break;
                     }
                     else

--- a/src/coreclr/src/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/src/pal/src/misc/perfjitdump.cpp
@@ -136,7 +136,7 @@ struct PerfJitDumpState
         codeIndex(0)
     {}
 
-    bool enabled;
+    volatile bool enabled;
     int fd;
     void *mmapAddr;
     pthread_mutex_t mutex;
@@ -259,6 +259,7 @@ exit:
             if (!enabled)
                 goto exit;
 
+            // Increment codeIndex while locked
             record.code_index = ++codeIndex;
 
             do

--- a/src/coreclr/src/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/src/pal/src/misc/perfjitdump.cpp
@@ -140,7 +140,7 @@ struct PerfJitDumpState
     int fd;
     void *mmapAddr;
     pthread_mutex_t mutex;
-    uint64_t codeIndex;
+    volatile uint64_t codeIndex;
 
     int FatalError(bool locked)
     {


### PR DESCRIPTION
Remove unnecessary fsync() call
Use writev() instead of write() to reduce OS calls
Handle partial write cases

Fixes dotnet/coreclr#27912 (aka https://github.com/dotnet/runtime/issues/13812)