### PR TITLE
Re-enable testing and switch back to the correct queues

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -50,14 +50,15 @@ jobs:
     # Linux musl arm64
     - ${{ if eq(parameters.platform, 'Linux_musl_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
+        - (Alpine.38.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Alpine.38.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
+        - (Alpine.38.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
 
     # Linux rhel6 x64
     - ${{ if eq(parameters.platform, 'Linux_rhel6_x64') }}:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - RedHat.6.Amd64.Open
+      # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/runtime/issues/168 is resolved
+      # - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      #   - RedHat.6.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - RedHat.6.Amd64
 

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -123,9 +123,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/more_tailcalls/*">
             <Issue>Unix does not support tailcall helper</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/**/*">
-            <Issue>168</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm32 All OS -->


### PR DESCRIPTION
Rhel 6 testing should be re-enabled when #168 is addressed.