### PR TITLE
JIT: if IR and stack can't provide a ref class handle, use object

### DIFF
--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -2666,7 +2666,7 @@ void Compiler::lvaSetClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool is
 // Notes:
 //    Preferentially uses the tree's type, when available. Since not all
 //    tree kinds can track ref types, the stack type is used as a
-//    fallback.
+//    fallback. If there is no stack type, then the class is set to object.
 
 void Compiler::lvaSetClass(unsigned varNum, GenTree* tree, CORINFO_CLASS_HANDLE stackHnd)
 {
@@ -2681,6 +2681,10 @@ void Compiler::lvaSetClass(unsigned varNum, GenTree* tree, CORINFO_CLASS_HANDLE 
     else if (stackHnd != nullptr)
     {
         lvaSetClass(varNum, stackHnd);
+    }
+    else
+    {
+        lvaSetClass(varNum, impGetObjectClass());
     }
 }
 

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Writer
+{
+    public object Data { get; set; }
+    public int Position { get; set; }
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   Writer()
+   {
+       Data = new int[] { 100, -1, -2, -3 };
+       Position = 4;
+   }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ArraySegment<byte> Test()
+    {
+        var writer = new Writer();
+        object temp = writer.Data;
+        byte[] data = Unsafe.As<object, byte[]>(ref temp);
+        return new ArraySegment<byte>(data, 0, writer.Position);
+    }
+    
+    public static int Main()
+    {
+        var x = Test();
+        return x[0];
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27923/GitHub_27923.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In some cases we may end up in `lvaSetClass` without a valid ref class handle
from either the IR or the stack. Use the handle for `object` as a conservative
fallback.

Closes dotnet/coreclr#27923 (aka #13817)
