### PR TITLE
Minor SpanHelpers cleanup

### DIFF
--- a/src/coreclr/src/vm/mscorlib.h
+++ b/src/coreclr/src/vm/mscorlib.h
@@ -731,7 +731,7 @@ DEFINE_METHOD(UNSAFE,               BYREF_ADD,              Add, GM_RefT_Int_Ret
 DEFINE_METHOD(UNSAFE,               BYREF_INTPTR_ADD,       Add, GM_RefT_IntPtr_RetRefT)
 DEFINE_METHOD(UNSAFE,               PTR_ADD,                Add, GM_PtrVoid_Int_RetPtrVoid)
 DEFINE_METHOD(UNSAFE,               BYREF_BYTE_OFFSET,      ByteOffset, NoSig)
-DEFINE_METHOD(UNSAFE,               BYREF_ADD_BYTE_OFFSET,  AddByteOffset, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_ADD_BYTE_OFFSET,  AddByteOffset, GM_RefT_IntPtr_RetRefT)
 DEFINE_METHOD(UNSAFE,               BYREF_ARE_SAME,         AreSame, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_IS_ADDRESS_GREATER_THAN, IsAddressGreaterThan, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_IS_ADDRESS_LESS_THAN, IsAddressLessThan, NoSig)

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -11,15 +11,10 @@ using System.Runtime.Versioning;
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
 #if BIT64
 using nuint = System.UInt64;
-#else
-using nuint = System.UInt32;
-#endif
-#if !CORECLR
-#if BIT64
 using nint = System.Int64;
 #else
+using nuint = System.UInt32;
 using nint = System.Int32;
-#endif
 #endif
 
 //
@@ -152,6 +147,17 @@ namespace Internal.Runtime.CompilerServices
 
         /// <summary>
         /// Adds an element offset to the given reference.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T Add<T>(ref T source, nint elementOffset)
+        {
+            return ref Unsafe.Add(ref source, (IntPtr)(void*)elementOffset);
+        }
+
+        /// <summary>
+        /// Adds an byte offset to the given reference.
         /// </summary>
         [Intrinsic]
         [NonVersionable]
@@ -295,7 +301,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Adds an element offset to the given reference.
+        /// Adds an byte offset to the given reference.
         /// </summary>
         [Intrinsic]
         [NonVersionable]

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -145,6 +145,7 @@ namespace Internal.Runtime.CompilerServices
 #endif
         }
 
+#if BIT64
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
@@ -155,6 +156,7 @@ namespace Internal.Runtime.CompilerServices
         {
             return ref Unsafe.Add(ref source, (IntPtr)(void*)elementOffset);
         }
+#endif
 
         /// <summary>
         /// Adds an byte offset to the given reference.

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -107,7 +107,8 @@ namespace System
                 }
             }
 
-            if (sizeof(UIntPtr) > sizeof(int) && (byte*)minLength >= (byte*)(i + sizeof(int) / sizeof(char)))
+#if BIT64
+            if ((byte*)minLength >= (byte*)(i + sizeof(int) / sizeof(char)))
             {
                 if (Unsafe.ReadUnaligned<int>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref first, i))) ==
                     Unsafe.ReadUnaligned<int>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref second, i))))
@@ -115,6 +116,7 @@ namespace System
                     i += sizeof(int) / sizeof(char);
                 }
             }
+#endif
 
             while ((byte*)i < (byte*)minLength)
             {
@@ -254,15 +256,15 @@ namespace System
             // remaining data that is shorter than a Vector length.
             while (lengthToExamine >= 4)
             {
-                ref char current = ref Add(ref searchSpace, offset);
+                ref char current = ref Unsafe.Add(ref searchSpace, offset);
 
                 if (value == current)
                     goto Found;
-                if (value == Add(ref current, 1))
+                if (value == Unsafe.Add(ref current, 1))
                     goto Found1;
-                if (value == Add(ref current, 2))
+                if (value == Unsafe.Add(ref current, 2))
                     goto Found2;
-                if (value == Add(ref current, 3))
+                if (value == Unsafe.Add(ref current, 3))
                     goto Found3;
 
                 offset += 4;
@@ -271,7 +273,7 @@ namespace System
 
             while (lengthToExamine > 0)
             {
-                if (value == Add(ref searchSpace, offset))
+                if (value == Unsafe.Add(ref searchSpace, offset))
                     goto Found;
 
                 offset++;
@@ -1030,10 +1032,6 @@ namespace System
         {
             return 3 - (BitOperations.LeadingZeroCount(match) >> 4);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref char Add(ref char source, nint elementOffset)
-            => ref Unsafe.Add(ref source, (IntPtr)elementOffset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector<ushort> LoadVector(ref char start, nint offset)


### PR DESCRIPTION
- Use ifdef instead of runtime condition
- Use explicit signature for Unsafe.AddByteOffset in VM. We were getting lucky that the right overload of Unsafe.AddByteOffset was choosen by the VM.