### PR TITLE
Temp workaround to disable PInvoke ILStubs with EH blocks

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
@@ -76,6 +76,13 @@ namespace Internal.IL.Stubs
 
         private MethodIL EmitIL()
         {
+            // Temp workaround to disable PInvoke stubs that require marshalling.
+            // https://github.com/dotnet/runtime/issues/248
+            {
+                if (Marshaller.IsMarshallingRequired(_targetMethod))
+                    throw new NotSupportedException();
+            }
+
             if (!_importMetadata.Flags.PreserveSig)
                 throw new NotSupportedException();
 
@@ -88,11 +95,13 @@ namespace Internal.IL.Stubs
             ILCodeStream unmarshallingCodestream = pInvokeILCodeStreams.UnmarshallingCodestream;
             ILCodeStream cleanupCodestream = pInvokeILCodeStreams.CleanupCodeStream;
 
+            /* Temp workaround: disable EH blocks because of https://github.com/dotnet/runtime/issues/248
+
             // Marshalling is wrapped in a finally block to guarantee cleanup
             ILExceptionRegionBuilder tryFinally = emitter.NewFinallyRegion();
 
             marshallingCodestream.BeginTry(tryFinally);
-            cleanupCodestream.BeginHandler(tryFinally);
+            cleanupCodestream.BeginHandler(tryFinally);*/
 
             // Marshal the arguments
             for (int i = 0; i < _marshallers.Length; i++)
@@ -103,11 +112,12 @@ namespace Internal.IL.Stubs
             EmitPInvokeCall(pInvokeILCodeStreams);
 
             ILCodeLabel lReturn = emitter.NewCodeLabel();
+            /* Temp workaround: disable EH blocks because of https://github.com/dotnet/runtime/issues/248
             unmarshallingCodestream.Emit(ILOpcode.leave, lReturn);
             unmarshallingCodestream.EndTry(tryFinally);
 
             cleanupCodestream.Emit(ILOpcode.endfinally);
-            cleanupCodestream.EndHandler(tryFinally);
+            cleanupCodestream.EndHandler(tryFinally);*/
 
             cleanupCodestream.EmitLabel(lReturn);
 


### PR DESCRIPTION
Temporary workaround due to https://github.com/dotnet/runtime/issues/248.