### PR TITLE
Cleanup warnings for uncompiled methods for some by-design scenarios

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -182,6 +182,20 @@ namespace Internal.JitInterface
             {
                 return true;
             }
+            if (MethodBeingCompiled.IsAbstract)
+            {
+                return true;
+            }
+            if (MethodBeingCompiled.OwningType.IsDelegate && (
+                MethodBeingCompiled.IsConstructor ||
+                MethodBeingCompiled.Name == "BeginInvoke" ||
+                MethodBeingCompiled.Name == "Invoke" ||
+                MethodBeingCompiled.Name == "EndInvoke"))
+            {
+                // Special methods on delegate types
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
With these changes, we will no longer emit a warning that we can't compile:
1) Delegate methods with no IL body (Invoke, BeginInvoke, and EndInvoke)
2) Abstract methods

cc @dotnet/crossgen-contrib 