### PR TITLE
Fix exception handling in interface method that checks for marshalling requirements

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1979,11 +1979,23 @@ namespace Internal.JitInterface
                     return false;
                 }
 
-                MethodIL stubIL = _compilation.GetMethodIL(method);
-                if (stubIL == null)
+                MethodIL stubIL = null;
+                try
                 {
-                    // This is the case of a PInvoke method that requires marshallers, which we can't use in this compilation
-                    Debug.Assert(!_compilation.NodeFactory.CompilationModuleGroup.GeneratesPInvoke(method));
+                    stubIL = _compilation.GetMethodIL(method);
+                    if (stubIL == null)
+                    {
+                        // This is the case of a PInvoke method that requires marshallers, which we can't use in this compilation
+                        Debug.Assert(!_compilation.NodeFactory.CompilationModuleGroup.GeneratesPInvoke(method));
+                        return true;
+                    }
+                }
+                catch (RequiresRuntimeJitException)
+                {
+                    // The PInvoke IL emitter will throw for known unsupported scenario. We cannot propagate the exception here since
+                    // this interface call might be used to check if a certain pinvoke can be inlined in the caller. Throwing means that the
+                    // caller will not get compiled. Instead, we'll return true to let the JIT know that it cannot inline the pinvoke, and
+                    // the actual pinvoke call will be handled by a stub that we create and compile in the runtime.
                     return true;
                 }
 


### PR DESCRIPTION
When looking at why we were not compiling some methods, it was due to the fact that the JIT was asking if some PInvokes could be inlined, and the stub emitter was returning "false" by throwing an exception.
Not handling the exception and returning false from the JIT interface API causes the exception to propagate, making us not compile the caller methods too.