### PR TITLE
Fixing Dragon4 to take unbiased rounding into account.

### DIFF
--- a/src/libraries/Common/tests/System/RealFormatterTestsBase.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/RealFormatterTestsBase.netcoreapp.cs
@@ -15,6 +15,10 @@ namespace System.Tests
         protected abstract string InvariantToStringSingle(float f, string format);
 
         [Theory]
+        [InlineData(1.23E+22, "1.23E+22")] // corefx#42576
+        public void TestFormatterDouble_Shortest(double value, string expectedResult) => TestFormatterDouble_Standard(value, "R", expectedResult);
+
+        [Theory]
         [InlineData(double.Epsilon, "\u00A40.00")]
         [InlineData(double.MaxValue, "\u00A4179,769,313,486,231,570,814,527,423,731,704,356,798,070,567,525,844,996,598,917,476,803,157,260,780,028,538,760,589,558,632,766,878,171,540,458,953,514,382,464,234,321,326,889,464,182,768,467,546,703,537,516,986,049,910,576,551,282,076,245,490,090,389,328,944,075,868,508,455,133,942,304,583,236,903,222,948,165,808,559,332,123,348,274,797,826,204,144,723,168,738,177,180,919,299,881,250,404,026,184,124,858,368.00")]
         [InlineData(Math.E, "\u00A42.72")]


### PR DESCRIPTION
The Dragon4 implementation was not taking unbiased rounding into account and so it would generate longer than necessary (but still correct) strings. This is only needed when generating the shortest possible string and doesn't need to be accounted for when generating strings of a specific digit length.