### PR TITLE
Prevent nullptr dereference in GenTree::IsLclVarUpdateTree

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16046,14 +16046,14 @@ unsigned GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps* pOper)
     {
         GenTree* lhs = AsOp()->gtOp1;
         GenTree* rhs = AsOp()->gtOp2;
-        if ((lhs->OperGet() == GT_LCL_VAR) && (rhs->OperIsBinary()))
+        if ((lhs->OperGet() == GT_LCL_VAR) && rhs->OperIsBinary())
         {
             unsigned lhsLclNum = lhs->AsLclVarCommon()->GetLclNum();
             GenTree* rhsOp1    = rhs->AsOp()->gtOp1;
             GenTree* rhsOp2    = rhs->AsOp()->gtOp2;
 
             // Some operators, such as HWINTRINSIC, are currently declared as binary but
-            // do not have two operands. We must check that both operands actually exist.
+            // may not have two operands. We must check that both operands actually exist.
             if ((rhsOp1 != nullptr) && (rhsOp2 != nullptr) && (rhsOp1->OperGet() == GT_LCL_VAR) &&
                 (rhsOp1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
             {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16052,7 +16052,7 @@ unsigned GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps* pOper)
             GenTree* rhsOp1    = rhs->AsOp()->gtOp1;
             GenTree* rhsOp2    = rhs->AsOp()->gtOp2;
 
-            // Some operators, such as HWINTRINSIC, are currently decalred as binary but
+            // Some operators, such as HWINTRINSIC, are currently declared as binary but
             // do not have two operands. We must check that both operands actually exist.
             if ((rhsOp1 != nullptr) && (rhsOp2 != nullptr) && (rhsOp1->OperGet() == GT_LCL_VAR) &&
                 (rhsOp1->AsLclVarCommon()->GetLclNum() == lhsLclNum))

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16049,13 +16049,16 @@ unsigned GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps* pOper)
         if ((lhs->OperGet() == GT_LCL_VAR) && (rhs->OperIsBinary()))
         {
             unsigned lhsLclNum = lhs->AsLclVarCommon()->GetLclNum();
-            GenTree* rhsop1    = rhs->AsOp()->gtOp1;
-            GenTree* rhsop2    = rhs->AsOp()->gtOp2;
-            if ((rhsop1 != nullptr) && (rhsop2 != nullptr) && (rhsop1->OperGet() == GT_LCL_VAR) &&
-                (rhsop1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
+            GenTree* rhsOp1    = rhs->AsOp()->gtOp1;
+            GenTree* rhsOp2    = rhs->AsOp()->gtOp2;
+
+            // Some operators, such as HWINTRINSIC, are currently decalred as binary but
+            // do not have two operands. We must check that both operands actually exist.
+            if ((rhsOp1 != nullptr) && (rhsOp2 != nullptr) && (rhsOp1->OperGet() == GT_LCL_VAR) &&
+                (rhsOp1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
             {
                 lclNum      = lhsLclNum;
-                *pOtherTree = rhsop2;
+                *pOtherTree = rhsOp2;
                 *pOper      = rhs->OperGet();
             }
         }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16045,16 +16045,18 @@ unsigned GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps* pOper)
     if (OperIs(GT_ASG))
     {
         GenTree* lhs = AsOp()->gtOp1;
-        if (lhs->OperGet() == GT_LCL_VAR)
+        GenTree* rhs = AsOp()->gtOp2;
+        if ((lhs->OperGet() == GT_LCL_VAR) && (rhs->OperIsBinary()))
         {
             unsigned lhsLclNum = lhs->AsLclVarCommon()->GetLclNum();
-            GenTree* rhs       = AsOp()->gtOp2;
-            if (rhs->OperIsBinary() && (rhs->AsOp()->gtOp1->gtOper == GT_LCL_VAR) &&
-                (rhs->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
+            GenTree* rhsop1    = rhs->AsOp()->gtOp1;
+            GenTree* rhsop2    = rhs->AsOp()->gtOp2;
+            if ((rhsop1 != nullptr) && (rhsop2 != nullptr) && (rhsop1->OperGet() == GT_LCL_VAR) &&
+                (rhsop1->AsLclVarCommon()->GetLclNum() == lhsLclNum))
             {
                 lclNum      = lhsLclNum;
-                *pOtherTree = rhs->AsOp()->gtOp2;
-                *pOper      = rhs->gtOper;
+                *pOtherTree = rhsop2;
+                *pOper      = rhs->OperGet();
             }
         }
     }

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test27937.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
@@ -27,11 +27,13 @@ class Test27937
         } while (pb < eb);
     }
 
-    static unsafe void Main()
+    static unsafe int Main()
     {
         float* a = stackalloc float[16];
         float* b = stackalloc float[16];
 
         calc(a, b);
+
+        return 100;
     }
 }

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/test27937.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Runtime.Intrinsics;
+
+class Test27937
+{
+    static unsafe void calc(float* fa, float* fb)
+    {
+        float* pb = fb;
+        float* eb = pb + 16;
+
+        do
+        {
+            float* pa = fa;
+            float* ea = pa + 16;
+            var va = Vector128<float>.Zero;
+
+            do
+            {
+                *pa = va.ToScalar();
+
+                pa += Vector128<float>.Count;
+                pb += Vector128<float>.Count;
+            } while (pa < ea);
+
+        } while (pb < eb);
+    }
+
+    static unsafe void Main()
+    {
+        float* a = stackalloc float[16];
+        float* b = stackalloc float[16];
+
+        calc(a, b);
+    }
+}


### PR DESCRIPTION
As explained by @mikedn in https://github.com/dotnet/coreclr/issues/27937#issuecomment-558157580, some binary gentrees are actually other types, so not all actually have 2 operands.  This change prevents a nullptr dereference when a non-binary binary gentree appears on the rhs in `IsLclVarUpdateTree`.

Fixes https://github.com/dotnet/coreclr/issues/27937
