### PR TITLE
Eliminate copy assignment of BigInteger

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -757,6 +757,7 @@ namespace System
                 Debug.Assert(unchecked((uint)(maxResultLength)) <= MaxBlockCount);
 
                 // Zero out result internal blocks.
+                result._length = maxResultLength;
                 Buffer.ZeroMemory((byte*)result.GetBlocksPointer(), (uint)maxResultLength * sizeof(uint));
 
                 int smallIndex = 0;
@@ -793,10 +794,6 @@ namespace System
                 if ((maxResultLength > 0) && (result._blocks[maxResultLength - 1] == 0))
                 {
                     result._length = (maxResultLength - 1);
-                }
-                else
-                {
-                    result._length = maxResultLength;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -685,7 +685,7 @@ namespace System
                 return quotient;
             }
 
-            public static void Multiply(ref BigInteger lhs, uint value, ref BigInteger result)
+            public static void Multiply(ref BigInteger lhs, uint value, out BigInteger result)
             {
                 if (lhs.IsZero() || (value == 1))
                 {
@@ -724,7 +724,7 @@ namespace System
                 }
             }
 
-            public static void Multiply(ref BigInteger lhs, ref BigInteger rhs, ref BigInteger result)
+            public static void Multiply(ref BigInteger lhs, ref BigInteger rhs, out BigInteger result)
             {
                 if (lhs.IsZero() || rhs.IsOne())
                 {
@@ -862,7 +862,7 @@ namespace System
                         fixed (uint* pBigNumEntry = &s_Pow10BigNumTable[s_Pow10BigNumTableIndices[index]])
                         {
                             ref BigInteger rhs = ref *(BigInteger*)(pBigNumEntry);
-                            Multiply(ref lhs, ref rhs, ref product);
+                            Multiply(ref lhs, ref rhs, out product);
                         }
 
                         // Swap to the next temporary
@@ -1023,7 +1023,7 @@ namespace System
 
             public void Multiply(uint value)
             {
-                Multiply(ref this, value, ref this);
+                Multiply(ref this, value, out this);
             }
 
             public void Multiply(ref BigInteger value)
@@ -1038,7 +1038,7 @@ namespace System
                         break;
                     default:
                         SetValue(out BigInteger temp, ref this);
-                        Multiply(ref temp, ref value, ref this);
+                        Multiply(ref temp, ref value, out this);
                         break;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -793,7 +793,7 @@ namespace System
 
                 if ((maxResultLength > 0) && (result._blocks[maxResultLength - 1] == 0))
                 {
-                    result._length = (maxResultLength - 1);
+                    result._length--;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -1039,6 +1039,7 @@ namespace System
                     default:
                         SetValue(out BigInteger temp, ref this);
                         Multiply(ref temp, ref value, ref this);
+                        break;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.BigInteger.cs
@@ -1025,19 +1025,8 @@ namespace System
 
             public void Multiply(ref BigInteger value)
             {
-                switch (value._length)
-                {
-                    case 0:
-                        SetZero(out this);
-                        break;
-                    case 1:
-                        Multiply(value._blocks[0]);
-                        break;
-                    default:
-                        SetValue(out BigInteger temp, ref this);
-                        Multiply(ref temp, ref value, out this);
-                        break;
-                }
+                SetValue(out BigInteger temp, ref this);
+                Multiply(ref temp, ref value, out this);
             }
 
             public void Multiply10()

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
@@ -119,11 +119,11 @@ namespace System
                     // 3) Set the margin value to the loweset mantissa bit's scale.
 
                     // scaledValue      = 2 * 2 * mantissa * 2^exponent
-                    scaledValue = new BigInteger(4 * mantissa);
+                    BigInteger.SetUInt64(out scaledValue, 4 * mantissa);
                     scaledValue.ShiftLeft((uint)(exponent));
 
                     // scale            = 2 * 2 * 1
-                    scale = new BigInteger(4);
+                    BigInteger.SetUInt32(out scale, 4);
 
                     // scaledMarginLow  = 2 * 2^(exponent - 1)
                     BigInteger.Pow2((uint)(exponent), out scaledMarginLow);
@@ -136,16 +136,16 @@ namespace System
                     // In order to track the mantissa data as an integer, we store it as is with a large scale
 
                     // scaledValue      = 2 * 2 * mantissa
-                    scaledValue = new BigInteger(4 * mantissa);
+                    BigInteger.SetUInt64(out scaledValue, 4 * mantissa);
 
                     // scale            = 2 * 2 * 2^(-exponent)
                     BigInteger.Pow2((uint)(-exponent + 2), out scale);
 
                     // scaledMarginLow  = 2 * 2^(-1)
-                    scaledMarginLow = new BigInteger(1);
+                    BigInteger.SetUInt32(out scaledMarginLow, 1);
 
                     // scaledMarginHigh = 2 * 2 * 2^(-1)
-                    optionalMarginHigh = new BigInteger(2);
+                    BigInteger.SetUInt32(out optionalMarginHigh, 2);
                 }
 
                 // The high and low margins are different
@@ -161,11 +161,11 @@ namespace System
                     // 3) Set the margin value to the lowest mantissa bit's scale.
 
                     // scaledValue     = 2 * mantissa*2^exponent
-                    scaledValue = new BigInteger(2 * mantissa);
+                    BigInteger.SetUInt64(out scaledValue, 2 * mantissa);
                     scaledValue.ShiftLeft((uint)(exponent));
 
                     // scale           = 2 * 1
-                    scale = new BigInteger(2);
+                    BigInteger.SetUInt32(out scale, 2);
 
                     // scaledMarginLow = 2 * 2^(exponent-1)
                     BigInteger.Pow2((uint)(exponent), out scaledMarginLow);
@@ -175,13 +175,13 @@ namespace System
                     // In order to track the mantissa data as an integer, we store it as is with a large scale
 
                     // scaledValue     = 2 * mantissa
-                    scaledValue = new BigInteger(2 * mantissa);
+                    BigInteger.SetUInt64(out scaledValue, 2 * mantissa);
 
                     // scale           = 2 * 2^(-exponent)
                     BigInteger.Pow2((uint)(-exponent + 1), out scale);
 
                     // scaledMarginLow = 2 * 2^(-1)
-                    scaledMarginLow = new BigInteger(1);
+                    BigInteger.SetUInt32(out scaledMarginLow, 1);
                 }
 
                 // The high and low margins are equal

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Dragon4.cs
@@ -223,7 +223,7 @@ namespace System
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
-                    BigInteger.Multiply(ref scaledMarginLow, 2, ref *pScaledMarginHigh);
+                    BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
                 }
             }
 
@@ -243,7 +243,7 @@ namespace System
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
-                    BigInteger.Multiply(ref scaledMarginLow, 2, ref *pScaledMarginHigh);
+                    BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
                 }
             }
 
@@ -302,7 +302,7 @@ namespace System
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
-                    BigInteger.Multiply(ref scaledMarginLow, 2, ref *pScaledMarginHigh);
+                    BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
                 }
             }
 
@@ -347,7 +347,7 @@ namespace System
 
                     if (pScaledMarginHigh != &scaledMarginLow)
                     {
-                        BigInteger.Multiply(ref scaledMarginLow, 2, ref *pScaledMarginHigh);
+                        BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
                     }
 
                     digitExponent--;

--- a/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
@@ -108,7 +108,7 @@ namespace System
 
         private static void AccumulateDecimalDigitsIntoBigInteger(ref NumberBuffer number, uint firstIndex, uint lastIndex, out BigInteger result)
         {
-            result = new BigInteger(0);
+            BigInteger.SetZero(out result);
 
             byte* src = number.GetDigitsPointer() + firstIndex;
             uint remaining = lastIndex - firstIndex;


### PR DESCRIPTION
Remove constructors from BigInteger which end up causing copy assignments that copy 464 bytes to the target variable. Instead, default and nontrivial assignments will all be done using SetZero, SetUInt32, SetUInt64, and SetValue to only set the relevant blocks.

Unrelated: I'm not sure why I always encounter problems trying to build! This is a relatively clean install of Windows and Visual Studio 2019, and I'm seeing this issue:
```C:\Program Files\dotnet\sdk\3.0.100\Microsoft.Common.CurrentVersion.targets(1175,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.6 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [C:\dev\dotnet-runtime\tools-local\tasks\installer.tasks\installer.tasks.csproj]```
I have installed the .NET Framework 4.6 targeting pack using Visual Studio Installer, but it still gives the same message.