### PR TITLE
Fix friend class declaration

### DIFF
--- a/src/coreclr/src/pal/src/include/pal/thread.hpp
+++ b/src/coreclr/src/pal/src/include/pal/thread.hpp
@@ -93,6 +93,13 @@ namespace CorUnix
         );
 
     PAL_ERROR
+    InternalSetThreadDescription(
+        CPalThread *,
+        HANDLE,
+        PCWSTR
+        );
+
+    PAL_ERROR
     CreateThreadData(
         CPalThread **ppThread
         );


### PR DESCRIPTION
[ 27%] Building CXX object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/signalhandlerhelper.cpp.o
coreclr/src/pal/src/thread/thread.cpp:1613:1: error: ‘CorUnix::PAL_ERROR CorUnix::InternalSetThreadDescription(CorUnix::CPalThread*, HANDLE, PCWSTR)’ has not been declared within CorUnix [-Werror]
 CorUnix::InternalSetThreadDescription(
 ^~~~~~~
In file included from coreclr/src/pal/src/include/pal/dbgmsg.h:160:0,
                 from coreclr/src/pal/src/thread/thread.cpp:21:
coreclr/src/pal/src/include/pal/thread.hpp:204:13: note: only here as a friend
             InternalSetThreadDescription(