### PR TITLE
no PLT on arm64

### DIFF
--- a/src/coreclr/src/pal/inc/unixasmmacros.inc
+++ b/src/coreclr/src/pal/inc/unixasmmacros.inc
@@ -20,6 +20,8 @@
 
 #if defined(__APPLE__)
 #define C_PLTFUNC(name) _##name
+#elif defined(_ARM64_)
+#define C_PLTFUNC(name) name
 #else
 #define C_PLTFUNC(name) name@PLT
 #endif

--- a/src/coreclr/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/src/pal/inc/unixasmmacrosarm64.inc
@@ -83,7 +83,7 @@ C_FUNC(\Name\()_End):
 
 .macro EPILOG_RESTORE_REG reg, ofs
         ldr \reg, [sp, \ofs]
-        .cfi_restore \reg1
+        .cfi_restore \reg
 .endm
 
 .macro EPILOG_RESTORE_REG_PAIR reg1, reg2, ofs

--- a/src/coreclr/src/vm/arm64/asmhelpers.S
+++ b/src/coreclr/src/vm/arm64/asmhelpers.S
@@ -80,7 +80,7 @@ LEAF_END LazyMachStateCaptureState, _TEXT
     ldr \reg, [x2]
 LOCAL_LABEL(NoRestore_\reg):
 
-.endmacro
+.endm
 
 // EXTERN_C int __fastcall HelperMethodFrameRestoreState(
 // INDEBUG_COMMA(HelperMethodFrame *pFrame)
@@ -197,7 +197,7 @@ LEAF_END ThePreStubPatch, _TEXT
 //
 .macro WRITE_BARRIER_ENTRY name
     LEAF_ENTRY \name, _TEXT
-.endmacro
+.endm
 
 // WRITE_BARRIER_END
 //
@@ -205,7 +205,7 @@ LEAF_END ThePreStubPatch, _TEXT
 //
 .macro WRITE_BARRIER_END name
     LEAF_END_MARKED \name, _TEXT
-.endmacro
+.endm
 
 // ------------------------------------------------------------------
 // Start of the writeable code region
@@ -1025,7 +1025,7 @@ NESTED_END CallEHFilterFunclet, _TEXT
 
     NESTED_END \stub, _TEXT
 
-.endmacro
+.endm
 
 
 // ------------------------------------------------------------------
@@ -1425,7 +1425,7 @@ NESTED_ENTRY \helper\()Naked, _TEXT, NoHandler
     EPILOG_RETURN
 
 NESTED_END \helper\()Naked, _TEXT
-.endmacro
+.endm
 
 GenerateProfileHelper ProfileEnter, PROFILE_ENTER
 GenerateProfileHelper ProfileLeave, PROFILE_LEAVE


### PR DESCRIPTION
Terminate macro with endm

Terminat macro with endm

Fix cfi_restore call

Use name instead of _name

Restore apple