### PR TITLE
Fixed Base64 EncodeToUtf8 / DecodeFromUtf8 return states (Done | NeedMoreData)

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -29,7 +29,7 @@ namespace System.Buffers.Text
         /// Set to <see langword="false"/> if this method is being called in a loop and if more input data may follow.
         /// At the end of the loop, call this (potentially with an empty source buffer) passing <see langword="true"/>.</param>
         /// <returns>It returns the OperationStatus enum values:
-        /// - Done - on successful processing of the entire input span (also when <paramref name="isFinalBlock"/> is set to <see langword="false"/>)
+        /// - Done - on successful processing of the entire input span
         /// - DestinationTooSmall - if there is not enough space in the output span to fit the decoded input
         /// - NeedMoreData - only if <paramref name="isFinalBlock"/> is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
         /// - InvalidData - if the input contains bytes outside of the expected base64 range, or if it contains invalid/more than two padding characters,

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -123,6 +123,10 @@ namespace System.Buffers.Text
                 {
                     if (isFinalBlock)
                         goto InvalidDataExit;
+
+                    if (src == srcBytes + utf8.Length)
+                        goto DoneExit;
+
                     goto NeedMoreDataExit;
                 }
 

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -17,21 +17,23 @@ namespace System.Buffers.Text
     public static partial class Base64
     {
         /// <summary>
-        /// Decode the span of UTF-8 encoded text represented as base 64 into binary data.
+        /// Decode the span of UTF-8 encoded text represented as base64 into binary data.
         /// If the input is not a multiple of 4, it will decode as much as it can, to the closest multiple of 4.
         /// </summary>
-        /// <param name="utf8">The input span which contains UTF-8 encoded text in base 64 that needs to be decoded.</param>
+        /// <param name="utf8">The input span which contains UTF-8 encoded text in base64 that needs to be decoded.</param>
         /// <param name="bytes">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
         /// <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
         /// <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
-        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to decode.
-        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <param name="isFinalBlock"><see langword="true"/> (default) when the input span contains the entire data to encode.
+        /// Set to <see langword="true"/> when the source buffer contains the entirety of the data to encode.
+        /// Set to <see langword="false"/> if this method is being called in a loop and if more input data may follow.
+        /// At the end of the loop, call this (potentially with an empty source buffer) passing <see langword="true"/>.</param>
         /// <returns>It returns the OperationStatus enum values:
-        /// - Done - on successful processing of the entire input span
+        /// - Done - on successful processing of the entire input span (also when <paramref name="isFinalBlock"/> is set to <see langword="false"/>)
         /// - DestinationTooSmall - if there is not enough space in the output span to fit the decoded input
-        /// - NeedMoreData - only if isFinalBlock is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
-        /// - InvalidData - if the input contains bytes outside of the expected base 64 range, or if it contains invalid/more than two padding characters,
-        ///   or if the input is incomplete (i.e. not a multiple of 4) and isFinalBlock is true.
+        /// - NeedMoreData - only if <paramref name="isFinalBlock"/> is false and the input is not a multiple of 4, otherwise the partial input would be considered as InvalidData
+        /// - InvalidData - if the input contains bytes outside of the expected base64 range, or if it contains invalid/more than two padding characters,
+        ///   or if the input is incomplete (i.e. not a multiple of 4) and <paramref name="isFinalBlock"/> is <see langword="true"/>.
         /// </returns>
         public static unsafe OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
         {

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -30,7 +30,7 @@ namespace System.Buffers.Text
         /// Set to <see langword="false"/> if this method is being called in a loop and if more input data may follow.
         /// At the end of the loop, call this (potentially with an empty source buffer) passing <see langword="true"/>.</param>
         /// <returns>It returns the OperationStatus enum values:
-        /// - Done - on successful processing of the entire input span (also when <paramref name="isFinalBlock"/> is set to <see langword="false"/>)
+        /// - Done - on successful processing of the entire input span
         /// - DestinationTooSmall - if there is not enough space in the output span to fit the encoded input
         /// - NeedMoreData - only if <paramref name="isFinalBlock"/> is <see langword="false"/>, otherwise the output is padded if the input is not a multiple of 3
         /// It does not return InvalidData since that is not possible for base64 encoding.

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -100,7 +100,12 @@ namespace System.Buffers.Text
                     goto DestinationTooSmallExit;
 
                 if (!isFinalBlock)
+                {
+                    if (src == srcEnd)
+                        goto DoneExit;
+
                     goto NeedMoreData;
+                }
 
                 if (src + 1 == srcEnd)
                 {

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -19,19 +19,21 @@ namespace System.Buffers.Text
     public static partial class Base64
     {
         /// <summary>
-        /// Encode the span of binary data into UTF-8 encoded text represented as base 64.
+        /// Encode the span of binary data into UTF-8 encoded text represented as base64.
         /// </summary>
         /// <param name="bytes">The input span which contains binary data that needs to be encoded.</param>
-        /// <param name="utf8">The output span which contains the result of the operation, i.e. the UTF-8 encoded text in base 64.</param>
+        /// <param name="utf8">The output span which contains the result of the operation, i.e. the UTF-8 encoded text in base64.</param>
         /// <param name="bytesConsumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
         /// <param name="bytesWritten">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
-        /// <param name="isFinalBlock">True (default) when the input span contains the entire data to encode.
-        /// Set to false only if it is known that the input span contains partial data with more data to follow.</param>
+        /// <param name="isFinalBlock"><see langword="true"/> (default) when the input span contains the entire data to encode.
+        /// Set to <see langword="true"/> when the source buffer contains the entirety of the data to encode.
+        /// Set to <see langword="false"/> if this method is being called in a loop and if more input data may follow.
+        /// At the end of the loop, call this (potentially with an empty source buffer) passing <see langword="true"/>.</param>
         /// <returns>It returns the OperationStatus enum values:
-        /// - Done - on successful processing of the entire input span
+        /// - Done - on successful processing of the entire input span (also when <paramref name="isFinalBlock"/> is set to <see langword="false"/>)
         /// - DestinationTooSmall - if there is not enough space in the output span to fit the encoded input
-        /// - NeedMoreData - only if isFinalBlock is false, otherwise the output is padded if the input is not a multiple of 3
-        /// It does not return InvalidData since that is not possible for base 64 encoding.
+        /// - NeedMoreData - only if <paramref name="isFinalBlock"/> is <see langword="false"/>, otherwise the output is padded if the input is not a multiple of 3
+        /// It does not return InvalidData since that is not possible for base64 encoding.
         /// </returns>
         public static unsafe OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
         {

--- a/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -45,23 +45,17 @@ namespace System.Buffers.Text.Tests
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
-        public static readonly byte s_encodingPad = (byte)'=';              // '=', for padding
-
-        public static readonly sbyte s_invalidByte = -1;                    // Designating -1 for invalid bytes in the decoding map
+        public const byte EncodingPad = (byte)'=';      // '=', for padding
+        public const sbyte InvalidByte = -1;            // Designating -1 for invalid bytes in the decoding map
 
         public static byte[] InvalidBytes
         {
             get
             {
-                int[] indices = s_decodingMap.FindAllIndexOf(s_invalidByte);
-                // Workaroudn for indices.Cast<byte>().ToArray() since it throws
+                int[] indices = s_decodingMap.FindAllIndexOf(InvalidByte);
+                // Workaround for indices.Cast<byte>().ToArray() since it throws
                 // InvalidCastException: Unable to cast object of type 'System.Int32' to type 'System.Byte'
-                byte[] bytes = new byte[indices.Length];
-                for (int i = 0; i < indices.Length; i++)
-                {
-                    bytes[i] = (byte)indices[i];
-                }
-                return bytes;
+                return indices.Select(i => (byte)i).ToArray();
             }
         }
 
@@ -101,7 +95,7 @@ namespace System.Buffers.Text.Tests
             sbyte[] data = new sbyte[256]; // 0 to byte.MaxValue (255)
             for (int i = 0; i < data.Length; i++)
             {
-                data[i] = s_invalidByte;
+                data[i] = InvalidByte;
             }
             for (int i = 0; i < s_characters.Length; i++)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography
                 ThrowHelper.ThrowCryptographicException();
             }
 
-            Debug.Assert(status == OperationStatus.NeedMoreData);
+            Debug.Assert(status == OperationStatus.Done);
             Debug.Assert(consumed == InputBlockSize);
 
             return written;


### PR DESCRIPTION
Migrated from https://github.com/dotnet/corefx/pull/42395

---

Fixes https://github.com/dotnet/corefx/issues/42245
See also https://github.com/dotnet/corefx/issues/42236

Adapted test according the table in https://github.com/dotnet/corefx/issues/42245#issuecomment-548359376 and fixed the implementation.