### PR TITLE
Fix SmtpClient handling exceptions as timeouts

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -721,10 +721,6 @@ namespace System.Net.Mail
                     }
 
                     Abort();
-                    if (_timedOut)
-                    {
-                        throw new SmtpException(SR.net_timeout);
-                    }
 
                     if (e is SecurityException ||
                         e is AuthenticationException ||


### PR DESCRIPTION
This is a bug fix.

Only non-async calls on SmtpClient can timeout, but the flag is checked in the async path as well.

As the flag is not reset in the async path, it could already be set and SmtpClient would swallow any real exception and instead throw a timeout.

CC @dotnet/ncl 