### PR TITLE
Correct integer conversions

### DIFF
--- a/src/coreclr/src/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/src/pal/src/misc/perfjitdump.cpp
@@ -249,7 +249,7 @@ exit:
             };
             size_t itemsCount = sizeof(items) / sizeof(items[0]);
 
-            int itemsWritten = 0;
+            size_t itemsWritten = 0;
 
             result = pthread_mutex_lock(&mutex);
 
@@ -266,7 +266,7 @@ exit:
             {
                 result = writev(fd, items + itemsWritten, itemsCount - itemsWritten);
 
-                if (result == bytesRemaining)
+                if ((size_t)result == bytesRemaining)
                     break;
 
                 if (result == -1)
@@ -278,7 +278,7 @@ exit:
                 }
 
                 // Detect unexpected failure cases.
-                _ASSERTE(bytesRemaining > result);
+                _ASSERTE(bytesRemaining > (size_t)result);
                 _ASSERTE(result > 0);
 
                 // Handle partial write case
@@ -287,7 +287,7 @@ exit:
 
                 do
                 {
-                    if (result < items[itemsWritten].iov_len)
+                    if ((size_t)result < items[itemsWritten].iov_len)
                     {
                         items[itemsWritten].iov_len -= result;
                         items[itemsWritten].iov_base = (void*)((size_t) items[itemsWritten].iov_base + result);


### PR DESCRIPTION
runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp: In member function ‘int PerfJitDumpState::LogMethod(void*, size_t, const char*, void*, void*)’:
runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:269:28: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
                 if (result == bytesRemaining)
                     ~~~~~~~^~~~~~~~~~~~~~~~~
In file included from runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:11:0:
runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:281:41: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
                 _ASSERTE(bytesRemaining > result);
                          ~~~~~~~~~~~~~~~^~~
runtime/src/coreclr/src/pal/src/include/pal/dbgmsg.h:363:35: note: in definition of macro ‘_ASSERTE’
 #define _ASSERTE(expr) do { if (!(expr)) { ASSERT("Expression: " #expr "\n"); } } while(0)
                                   ^~~~
runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:290:32: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
                     if (result < items[itemsWritten].iov_len)
                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:11:0:
runtime/src/coreclr/src/pal/src/misc/perfjitdump.cpp:302:47: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
                         _ASSERTE(itemsWritten < itemsCount);
                                  ~~~~~~~~~~~~~^~~
runtime/src/coreclr/src/pal/src/include/pal/dbgmsg.h:363:35: note: in definition of macro ‘_ASSERTE’
 #define _ASSERTE(expr) do { if (!(expr)) { ASSERT("Expression: " #expr "\n"); } } while(0)
