### PR TITLE
Current user identity in added to HttpConnectionKey

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -243,6 +243,7 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\CurrentUserIdentityProvider.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\ContextFlagsAdapterPal.Unix.cs">
       <Link>Common\System\Net\ContextFlagsAdapterPal.Unix.cs</Link>
     </Compile>
@@ -330,6 +331,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpWindowsProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\CurrentUserIdentityProvider.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>
@@ -631,6 +633,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Security.Claims" Condition="'$(TargetsWindows)' == 'true'" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Csp" />
     <Reference Include="System.Security.Cryptography.Encoding" />

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -639,6 +639,7 @@
     <Reference Include="System.Security.Cryptography.Encoding" />
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Security.Cryptography.X509Certificates" />
+    <Reference Include="System.Security.Principal" Condition="'$(TargetsWindows)' == 'true'" />
     <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Unix.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Unix.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal static class CurrentUserIdentityProvider
+    {
+        public static string GetIdentity()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Principal;
+
+namespace System.Net.Http
+{
+    internal static class CurrentUserIdentityProvider
+    {
+        public static string GetIdentity()
+        {
+            return WindowsIdentity.GetCurrent().Name;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CurrentUserIdentityProvider.Windows.cs
@@ -10,7 +10,8 @@ namespace System.Net.Http
     {
         public static string GetIdentity()
         {
-            return WindowsIdentity.GetCurrent().Name;
+            using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            return identity.Name;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -165,7 +165,7 @@ namespace System.Net.Http
         private HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
-            bool defaultCredentialsUsed = _settings._credentials == CredentialCache.DefaultCredentials || _settings._defaultProxyCredentials == CredentialCache.DefaultCredentials || _proxy?.Credentials == CredentialCache.DefaultCredentials;
+            bool defaultCredentialsUsed = _settings._credentials == _settings._defaultCredentials|| _settings._defaultProxyCredentials == _settings._defaultCredentials || _proxy?.Credentials == _settings._defaultCredentials;
             string identity = defaultCredentialsUsed ? CurrentUserIdentityProvider.GetIdentity() : string.Empty;
 
             if (isProxyConnect)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -162,14 +162,16 @@ namespace System.Net.Http
             return hostHeader;
         }
 
-        private static HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
+        private HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri proxyUri, bool isProxyConnect)
         {
             Uri uri = request.RequestUri;
+            bool defaultCredentialsUsed = _settings._credentials == CredentialCache.DefaultCredentials || _settings._defaultProxyCredentials == CredentialCache.DefaultCredentials || _proxy?.Credentials == CredentialCache.DefaultCredentials;
+            string identity = defaultCredentialsUsed ? CurrentUserIdentityProvider.GetIdentity() : string.Empty;
 
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri);
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri, identity);
             }
 
             string sslHostName = null;
@@ -195,29 +197,29 @@ namespace System.Net.Http
                     if (HttpUtilities.IsNonSecureWebSocketScheme(uri.Scheme))
                     {
                         // Non-secure websocket connection through proxy to the destination.
-                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, uri.IdnHost, uri.Port, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.ProxyTunnel, uri.IdnHost, uri.Port, null, proxyUri, identity);
                     }
                     else
                     {
                         // Standard HTTP proxy usage for non-secure requests
                         // The destination host and port are ignored here, since these connections
                         // will be shared across any requests that use the proxy.
-                        return new HttpConnectionKey(HttpConnectionKind.Proxy, null, 0, null, proxyUri);
+                        return new HttpConnectionKey(HttpConnectionKind.Proxy, null, 0, null, proxyUri, identity);
                     }
                 }
                 else
                 {
                     // Tunnel SSL connection through proxy to the destination.
-                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, uri.IdnHost, uri.Port, sslHostName, proxyUri);
+                    return new HttpConnectionKey(HttpConnectionKind.SslProxyTunnel, uri.IdnHost, uri.Port, sslHostName, proxyUri, identity);
                 }
             }
             else if (sslHostName != null)
             {
-                return new HttpConnectionKey(HttpConnectionKind.Https, uri.IdnHost, uri.Port, sslHostName, null);
+                return new HttpConnectionKey(HttpConnectionKind.Https, uri.IdnHost, uri.Port, sslHostName, null, identity);
             }
             else
             {
-                return new HttpConnectionKey(HttpConnectionKind.Http, uri.IdnHost, uri.Port, null, null);
+                return new HttpConnectionKey(HttpConnectionKind.Http, uri.IdnHost, uri.Port, null, null, identity);
             }
         }
 
@@ -415,21 +417,23 @@ namespace System.Net.Http
             public readonly int Port;
             public readonly string SslHostName;     // null if not SSL
             public readonly Uri ProxyUri;
+            public readonly string Identity;
 
-            public HttpConnectionKey(HttpConnectionKind kind, string host, int port, string sslHostName, Uri proxyUri)
+            public HttpConnectionKey(HttpConnectionKind kind, string host, int port, string sslHostName, Uri proxyUri, string identity)
             {
                 Kind = kind;
                 Host = host;
                 Port = port;
                 SslHostName = sslHostName;
                 ProxyUri = proxyUri;
+                Identity = identity;
             }
 
             // In the common case, SslHostName (when present) is equal to Host.  If so, don't include in hash.
             public override int GetHashCode() =>
                 (SslHostName == Host ?
-                    HashCode.Combine(Kind, Host, Port, ProxyUri) :
-                    HashCode.Combine(Kind, Host, Port, SslHostName, ProxyUri));
+                    HashCode.Combine(Kind, Host, Port, ProxyUri, Identity) :
+                    HashCode.Combine(Kind, Host, Port, SslHostName, ProxyUri, Identity));
 
             public override bool Equals(object obj) =>
                 obj != null &&
@@ -441,7 +445,8 @@ namespace System.Net.Http
                 Host == other.Host &&
                 Port == other.Port &&
                 ProxyUri == other.ProxyUri &&
-                SslHostName == other.SslHostName;
+                SslHostName == other.SslHostName &&
+                Identity == other.Identity;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -169,7 +169,7 @@ namespace System.Net.Http
             if (isProxyConnect)
             {
                 Debug.Assert(uri == proxyUri);
-                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri, GetIdentityIfDefaultCredentialsUsed(_settings._defaultSystemCredentialsUsedForProxy));
+                return new HttpConnectionKey(HttpConnectionKind.ProxyConnect, uri.IdnHost, uri.Port, null, proxyUri, GetIdentityIfDefaultCredentialsUsed(_settings._defaultCredentialsUsedForProxy));
             }
 
             string sslHostName = null;
@@ -187,7 +187,7 @@ namespace System.Net.Http
                 }
             }
 
-            string identity = GetIdentityIfDefaultCredentialsUsed(proxyUri != null ? _settings._defaultSystemCredentialsUsedForProxy : _settings._defaultSystemCredentialsUsedForServer);
+            string identity = GetIdentityIfDefaultCredentialsUsed(proxyUri != null ? _settings._defaultCredentialsUsedForProxy : _settings._defaultCredentialsUsedForServer);
 
             if (proxyUri != null)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -23,8 +23,8 @@ namespace System.Net.Http
         internal bool _useProxy = HttpHandlerDefaults.DefaultUseProxy;
         internal IWebProxy _proxy;
         internal ICredentials _defaultProxyCredentials;
-        internal bool _defaultSystemCredentialsUsedForProxy;
-        internal bool _defaultSystemCredentialsUsedForServer;
+        internal bool _defaultCredentialsUsedForProxy;
+        internal bool _defaultCredentialsUsedForServer;
 
         internal bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         internal ICredentials _credentials;
@@ -55,8 +55,8 @@ namespace System.Net.Http
             bool allowHttp2 = AllowHttp2;
             _maxHttpVersion = allowHttp2 ? HttpVersion.Version20 : HttpVersion.Version11;
             _allowUnencryptedHttp2 = allowHttp2 && AllowUnencryptedHttp2;
-            _defaultSystemCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials);
-            _defaultSystemCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials;
+            _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials);
+            _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials;
         }
 
         /// <summary>Creates a copy of the settings but with some values normalized to suit the implementation.</summary>
@@ -76,8 +76,8 @@ namespace System.Net.Http
                 _connectTimeout = _connectTimeout,
                 _credentials = _credentials,
                 _defaultProxyCredentials = _defaultProxyCredentials,
-                _defaultSystemCredentialsUsedForProxy = _defaultSystemCredentialsUsedForProxy,
-                _defaultSystemCredentialsUsedForServer = _defaultSystemCredentialsUsedForServer,
+                _defaultCredentialsUsedForProxy = _defaultCredentialsUsedForProxy,
+                _defaultCredentialsUsedForServer = _defaultCredentialsUsedForServer,
                 _expect100ContinueTimeout = _expect100ContinueTimeout,
                 _maxAutomaticRedirections = _maxAutomaticRedirections,
                 _maxConnectionsPerServer = _maxConnectionsPerServer,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -23,6 +23,7 @@ namespace System.Net.Http
         internal bool _useProxy = HttpHandlerDefaults.DefaultUseProxy;
         internal IWebProxy _proxy;
         internal ICredentials _defaultProxyCredentials;
+        internal ICredentials _defaultCredentials = CredentialCache.DefaultCredentials;
 
         internal bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         internal ICredentials _credentials;
@@ -72,6 +73,7 @@ namespace System.Net.Http
                 _connectTimeout = _connectTimeout,
                 _credentials = _credentials,
                 _defaultProxyCredentials = _defaultProxyCredentials,
+                _defaultCredentials = _defaultCredentials,
                 _expect100ContinueTimeout = _expect100ContinueTimeout,
                 _maxAutomaticRedirections = _maxAutomaticRedirections,
                 _maxConnectionsPerServer = _maxConnectionsPerServer,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -23,7 +23,8 @@ namespace System.Net.Http
         internal bool _useProxy = HttpHandlerDefaults.DefaultUseProxy;
         internal IWebProxy _proxy;
         internal ICredentials _defaultProxyCredentials;
-        internal ICredentials _defaultCredentials = CredentialCache.DefaultCredentials;
+        internal bool _defaultSystemCredentialsUsedForProxy;
+        internal bool _defaultSystemCredentialsUsedForServer;
 
         internal bool _preAuthenticate = HttpHandlerDefaults.DefaultPreAuthenticate;
         internal ICredentials _credentials;
@@ -54,6 +55,8 @@ namespace System.Net.Http
             bool allowHttp2 = AllowHttp2;
             _maxHttpVersion = allowHttp2 ? HttpVersion.Version20 : HttpVersion.Version11;
             _allowUnencryptedHttp2 = allowHttp2 && AllowUnencryptedHttp2;
+            _defaultSystemCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials);
+            _defaultSystemCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials;
         }
 
         /// <summary>Creates a copy of the settings but with some values normalized to suit the implementation.</summary>
@@ -73,7 +76,8 @@ namespace System.Net.Http
                 _connectTimeout = _connectTimeout,
                 _credentials = _credentials,
                 _defaultProxyCredentials = _defaultProxyCredentials,
-                _defaultCredentials = _defaultCredentials,
+                _defaultSystemCredentialsUsedForProxy = _defaultSystemCredentialsUsedForProxy,
+                _defaultSystemCredentialsUsedForServer = _defaultSystemCredentialsUsedForServer,
                 _expect100ContinueTimeout = _expect100ContinueTimeout,
                 _maxAutomaticRedirections = _maxAutomaticRedirections,
                 _maxConnectionsPerServer = _maxConnectionsPerServer,

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpConnectionKeyTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpConnectionKeyTest.cs
@@ -26,7 +26,6 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(KeyComponents))]
         public void Equals_DifferentParameters_ReturnsTrueIfAllEqual(string kindString, string host, int port, string sslHostName, Uri proxyUri, string identity, bool expected)
         {
-            Debugger.Launch();
             Assembly assembly = typeof(HttpClientHandler).Assembly;
             Type connectionKindType = assembly.GetTypes().Where(t => t.Name == "HttpConnectionKind").First();
             Type poolManagerType = assembly.GetTypes().Where(t => t.Name == "HttpConnectionPoolManager").First();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpConnectionKeyTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpConnectionKeyTest.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpConnectionKeyTest
+    {
+        public static IEnumerable<object[]> KeyComponents()
+        {
+            yield return new object[] { "Https", "localhost", 80, "localhost-ssl", new Uri("http://localhost"), "domain1/userA", false};
+            yield return new object[] { "Http", "localhost1", 80, "localhost-ssl", new Uri("http://localhost"), "domain1/userA", false };
+            yield return new object[] { "Http", "localhost", 81, "localhost-ssl", new Uri("http://localhost"), "domain1/userA", false };
+            yield return new object[] { "Http", "localhost", 80, "localhost-ssl1", new Uri("http://localhost"), "domain1/userA", false };
+            yield return new object[] { "Http", "localhost", 80, "localhost-ssl", new Uri("http://localhost1"), "domain1/userA", false };
+            yield return new object[] { "Http", "localhost", 80, "localhost-ssl", new Uri("http://localhost"), "domain1/userB", false };
+            yield return new object[] { "Http", "localhost", 80, "localhost-ssl", new Uri("http://localhost"), "domain1/userA", true };
+        }
+
+        [Theory, MemberData(nameof(KeyComponents))]
+        public void Equals_DifferentParameters_ReturnsTrueIfAllEqual(string kindString, string host, int port, string sslHostName, Uri proxyUri, string identity, bool expected)
+        {
+            Debugger.Launch();
+            Assembly assembly = typeof(HttpClientHandler).Assembly;
+            Type connectionKindType = assembly.GetTypes().Where(t => t.Name == "HttpConnectionKind").First();
+            Type poolManagerType = assembly.GetTypes().Where(t => t.Name == "HttpConnectionPoolManager").First();
+            Type keyType = poolManagerType.GetNestedType("HttpConnectionKey", BindingFlags.NonPublic);
+            dynamic referenceKey = Activator.CreateInstance(keyType, Enum.Parse(connectionKindType, "Http"), "localhost", 80, "localhost-ssl", new Uri("http://localhost"), "domain1/userA");
+            dynamic actualKey = Activator.CreateInstance(keyType, Enum.Parse(connectionKindType, kindString), host, port, sslHostName, proxyUri, identity);
+            Assert.Equal(expected, referenceKey.Equals(actualKey));
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpClientEKUTest.cs" />
     <Compile Include="HttpClient.SelectedSitesTest.cs" />
+    <Compile Include="HttpConnectionKeyTest.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />


### PR DESCRIPTION
On retrieving a connection from a pool, HttpConnectionPoolManager adds the current user identity to the HttpConnectionKey for direct and proxy connections when the default credentials is used on Windows platform. Since on Unix there is not the concept of a user identity on the thread, the identity component in the key is always set to string.Empty.

Fixes https://github.com/dotnet/runtime/issues/30307