### PR TITLE
Start using local address nodes in the JIT frontend

### DIFF
--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -984,7 +984,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     noway_assert(targetType != TYP_STRUCT);
 
     // record the offset
-    unsigned offset = tree->gtLclOffs;
+    unsigned offset = tree->GetLclOffs();
 
     // We must have a stack store with GT_STORE_LCL_FLD
     noway_assert(targetReg == REG_NA);

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1875,7 +1875,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 #endif // FEATURE_SIMD
 
     // record the offset
-    unsigned offset = tree->gtLclOffs;
+    unsigned offset = tree->GetLclOffs();
 
     // We must have a stack store with GT_STORE_LCL_FLD
     noway_assert(targetReg == REG_NA);
@@ -4974,7 +4974,7 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     if (treeNode->OperGet() == GT_STORE_LCL_FLD)
     {
-        offs = treeNode->AsLclFld()->gtLclOffs;
+        offs = treeNode->AsLclFld()->GetLclOffs();
     }
 
     GenTree* op1 = treeNode->AsOp()->gtOp1;

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1758,7 +1758,7 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     assert(targetReg != REG_NA);
 
     emitAttr size   = emitTypeSize(targetType);
-    unsigned offs   = tree->gtLclOffs;
+    unsigned offs   = tree->GetLclOffs();
     unsigned varNum = tree->GetLclNum();
     assert(varNum < compiler->lvaCount);
 
@@ -1966,8 +1966,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
         if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
         {
-            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-            dstOffset = dstAddr->AsLclFld()->gtLclOffs;
+            dstOffset = dstAddr->AsLclFld()->GetLclOffs();
         }
     }
 
@@ -2103,8 +2102,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
         {
-            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-            dstOffset = dstAddr->AsLclFld()->gtLclOffs;
+            dstOffset = dstAddr->AsLclFld()->GetLclOffs();
         }
     }
 
@@ -2121,8 +2119,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         if (src->OperIs(GT_LCL_FLD))
         {
-            assert(src->AsLclFld()->gtLclOffs <= INT32_MAX);
-            srcOffset = static_cast<int>(src->AsLclFld()->gtLclOffs);
+            srcOffset = src->AsLclFld()->GetLclOffs();
         }
     }
     else
@@ -2146,8 +2143,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
             if (srcAddr->OperIs(GT_LCL_FLD_ADDR))
             {
-                assert(srcAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-                srcOffset = static_cast<int>(srcAddr->AsLclFld()->gtLclOffs);
+                srcOffset = srcAddr->AsLclFld()->GetLclOffs();
             }
         }
     }

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1584,7 +1584,7 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
             unsigned int offset = 0;
             if (srcAddr->OperGet() == GT_LCL_FLD_ADDR)
             {
-                offset = srcAddr->AsLclFld()->gtLclOffs;
+                offset = srcAddr->AsLclFld()->GetLclOffs();
             }
             GetEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, srcReg, lclNode->GetLclNum(), offset);
         }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -2966,8 +2966,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
         if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
         {
-            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-            dstOffset = static_cast<int>(dstAddr->AsLclFld()->gtLclOffs);
+            dstOffset = dstAddr->AsLclFld()->GetLclOffs();
         }
     }
 
@@ -3090,7 +3089,7 @@ void CodeGen::genCodeForLoadOffset(instruction ins, emitAttr size, regNumber dst
     {
         if (baseNode->gtOper == GT_LCL_FLD_ADDR)
         {
-            offset += baseNode->AsLclFld()->gtLclOffs;
+            offset += baseNode->AsLclFld()->GetLclOffs();
         }
         emit->emitIns_R_S(ins, size, dst, baseNode->AsLclVarCommon()->GetLclNum(), offset);
     }
@@ -3146,8 +3145,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
         {
-            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-            dstOffset = static_cast<int>(dstAddr->AsLclFld()->gtLclOffs);
+            dstOffset = dstAddr->AsLclFld()->GetLclOffs();
         }
     }
 
@@ -3166,8 +3164,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         if (src->OperIs(GT_LCL_FLD))
         {
-            assert(src->AsLclFld()->gtLclOffs <= INT32_MAX);
-            srcOffset = static_cast<int>(src->AsLclFld()->gtLclOffs);
+            srcOffset = src->AsLclFld()->GetLclOffs();
         }
     }
     else
@@ -3203,8 +3200,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
             if (srcAddr->OperIs(GT_LCL_FLD_ADDR))
             {
-                assert(srcAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
-                srcOffset = static_cast<int>(srcAddr->AsLclFld()->gtLclOffs);
+                srcOffset = srcAddr->AsLclFld()->GetLclOffs();
             }
         }
     }
@@ -4557,7 +4553,7 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     noway_assert(targetType != TYP_STRUCT);
 
     emitAttr size   = emitTypeSize(targetType);
-    unsigned offs   = tree->gtLclOffs;
+    unsigned offs   = tree->GetLclOffs();
     unsigned varNum = tree->GetLclNum();
     assert(varNum < compiler->lvaCount);
 
@@ -7348,13 +7344,9 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
                 }
 
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = srcNode->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->gtLclOffs;
+                    varNum = srcNode->AsLclFld()->GetLclNum();
+                    offset = srcNode->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -8227,7 +8219,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
             srcLclNum = srcAddr->AsLclVarCommon()->GetLclNum();
             if (srcAddr->OperGet() == GT_LCL_FLD_ADDR)
             {
-                srcLclOffset = srcAddr->AsLclFld()->gtLclOffs;
+                srcLclOffset = srcAddr->AsLclFld()->GetLclOffs();
             }
         }
 

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -9819,11 +9819,11 @@ int cLeafIR(Compiler* comp, GenTree* tree)
             comp->gtGetLclVarNameInfo(lclNum, &ilKind, &ilName, &ilNum);
             if (ilName != nullptr)
             {
-                chars += printf("%s+%u", ilName, tree->AsLclFld()->gtLclOffs);
+                chars += printf("%s+%u", ilName, tree->AsLclFld()->GetLclOffs());
             }
             else
             {
-                chars += printf("%s%d+%u", ilKind, ilNum, tree->AsLclFld()->gtLclOffs);
+                chars += printf("%s%d+%u", ilKind, ilNum, tree->AsLclFld()->GetLclOffs());
                 LclVarDsc* varDsc = comp->lvaTable + lclNum;
                 if (comp->dumpIRLocals)
                 {

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2467,6 +2467,7 @@ public:
                                 GenTree*   op2  = nullptr);
 
     GenTreeIntCon* gtNewIconNode(ssize_t value, var_types type = TYP_INT);
+    GenTreeIntCon* gtNewIconNode(unsigned fieldOffset, FieldSeqNode* fieldSeq);
 
     GenTree* gtNewPhysRegNode(regNumber reg, var_types type);
 
@@ -2543,6 +2544,12 @@ public:
 
     GenTree* gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
     GenTree* gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSETX ILoffs = BAD_IL_OFFSET));
+
+    GenTreeLclVar* gtNewLclVarAddrNode(unsigned lclNum, var_types type = TYP_I_IMPL);
+    GenTreeLclFld* gtNewLclFldAddrNode(unsigned      lclNum,
+                                       unsigned      lclOffs,
+                                       FieldSeqNode* fieldSeq,
+                                       var_types     type = TYP_I_IMPL);
 
 #ifdef FEATURE_SIMD
     GenTreeSIMD* gtNewSIMDNode(

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -1456,13 +1456,13 @@ inline void GenTree::ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
             Compiler*     compiler     = JitTls::GetCompiler();
             bool          isZeroOffset = compiler->GetZeroOffsetFieldMap()->Lookup(this, &zeroFieldSeq);
 
-            AsLclFld()->gtLclOffs  = 0;
-            AsLclFld()->gtFieldSeq = FieldSeqStore::NotAField();
+            AsLclFld()->SetLclOffs(0);
+            AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 
             if (zeroFieldSeq != nullptr)
             {
                 // Set the zeroFieldSeq in the GT_LCL_FLD node
-                AsLclFld()->gtFieldSeq = zeroFieldSeq;
+                AsLclFld()->SetFieldSeq(zeroFieldSeq);
                 // and remove the annotation from the ZeroOffsetFieldMap
                 compiler->GetZeroOffsetFieldMap()->Remove(this);
             }

--- a/src/coreclr/src/jit/decomposelongs.cpp
+++ b/src/coreclr/src/jit/decomposelongs.cpp
@@ -361,12 +361,12 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
     else
     {
         loResult->SetOper(GT_LCL_FLD);
-        loResult->AsLclFld()->gtLclOffs  = 0;
-        loResult->AsLclFld()->gtFieldSeq = FieldSeqStore::NotAField();
+        loResult->AsLclFld()->SetLclOffs(0);
+        loResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 
         hiResult->SetOper(GT_LCL_FLD);
-        hiResult->AsLclFld()->gtLclOffs  = 4;
-        hiResult->AsLclFld()->gtFieldSeq = FieldSeqStore::NotAField();
+        hiResult->AsLclFld()->SetLclOffs(4);
+        hiResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
     }
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
@@ -390,7 +390,7 @@ GenTree* DecomposeLongs::DecomposeLclFld(LIR::Use& use)
     GenTreeLclFld* loResult = tree->AsLclFld();
     loResult->gtType        = TYP_INT;
 
-    GenTree* hiResult = m_compiler->gtNewLclFldNode(loResult->GetLclNum(), TYP_INT, loResult->gtLclOffs + 4);
+    GenTree* hiResult = m_compiler->gtNewLclFldNode(loResult->GetLclNum(), TYP_INT, loResult->GetLclOffs() + 4);
     Range().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
@@ -510,7 +510,7 @@ GenTree* DecomposeLongs::DecomposeStoreLclFld(LIR::Use& use)
     loStore->gtFlags |= GTF_VAR_USEASG;
 
     // Create the store for the upper half of the GT_LONG and insert it after the low store.
-    GenTreeLclFld* hiStore = m_compiler->gtNewLclFldNode(loStore->GetLclNum(), TYP_INT, loStore->gtLclOffs + 4);
+    GenTreeLclFld* hiStore = m_compiler->gtNewLclFldNode(loStore->GetLclNum(), TYP_INT, loStore->GetLclOffs() + 4);
     hiStore->SetOper(GT_STORE_LCL_FLD);
     hiStore->gtOp1 = value->gtOp2;
     hiStore->gtFlags |= (GTF_VAR_DEF | GTF_VAR_USEASG);

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3360,12 +3360,9 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             {
                 case GT_LCL_FLD:
                 case GT_STORE_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = memOp->AsLclFld();
-                    varNum                  = lclField->GetLclNum();
-                    offset                  = lclField->gtLclOffs;
+                    varNum = memOp->AsLclFld()->GetLclNum();
+                    offset = memOp->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -1322,8 +1322,8 @@ AGAIN:
                 return true;
 
             case GT_LCL_FLD:
-                if (op1->AsLclFld()->GetLclNum() != op2->AsLclFld()->GetLclNum() ||
-                    op1->AsLclFld()->gtLclOffs != op2->AsLclFld()->gtLclOffs)
+                if ((op1->AsLclFld()->GetLclNum() != op2->AsLclFld()->GetLclNum()) ||
+                    (op1->AsLclFld()->GetLclOffs() != op2->AsLclFld()->GetLclOffs()))
                 {
                     break;
                 }
@@ -1971,7 +1971,7 @@ AGAIN:
                 break;
             case GT_LCL_FLD:
                 hash = genTreeHashAdd(hash, tree->AsLclFld()->GetLclNum());
-                add  = tree->AsLclFld()->gtLclOffs;
+                add  = tree->AsLclFld()->GetLclOffs();
                 break;
 
             case GT_CNS_INT:
@@ -6153,7 +6153,7 @@ GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned
 
     // assert(lnum < lvaCount);
 
-    node->gtFieldSeq = FieldSeqStore::NotAField();
+    node->SetFieldSeq(FieldSeqStore::NotAField());
     return node;
 }
 
@@ -6925,9 +6925,10 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
             // Remember that the LclVar node has been cloned. The flag will be set
             // on 'copy' as well.
             tree->gtFlags |= GTF_VAR_CLONED;
-            copy = new (this, tree->gtOper) GenTreeLclFld(tree->gtOper, tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
-                                                          tree->AsLclFld()->gtLclOffs);
-            copy->AsLclFld()->gtFieldSeq = tree->AsLclFld()->gtFieldSeq;
+            copy = new (this, tree->OperGet())
+                GenTreeLclFld(tree->OperGet(), tree->TypeGet(), tree->AsLclFld()->GetLclNum(),
+                              tree->AsLclFld()->GetLclOffs());
+            copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
             break;
 
         case GT_CLS_VAR:
@@ -7120,9 +7121,9 @@ GenTree* Compiler::gtCloneExpr(
                     // be set on 'copy' as well.
                     tree->gtFlags |= GTF_VAR_CLONED;
                     copy = new (this, GT_LCL_FLD)
-                        GenTreeLclFld(tree->TypeGet(), tree->AsLclFld()->GetLclNum(), tree->AsLclFld()->gtLclOffs);
-                    copy->AsLclFld()->gtFieldSeq = tree->AsLclFld()->gtFieldSeq;
-                    copy->gtFlags                = tree->gtFlags;
+                        GenTreeLclFld(tree->TypeGet(), tree->AsLclFld()->GetLclNum(), tree->AsLclFld()->GetLclOffs());
+                    copy->AsLclFld()->SetFieldSeq(tree->AsLclFld()->GetFieldSeq());
+                    copy->gtFlags = tree->gtFlags;
                 }
                 goto DONE;
 
@@ -10583,8 +10584,8 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
 
             if (isLclFld)
             {
-                printf("[+%u]", tree->AsLclFld()->gtLclOffs);
-                gtDispFieldSeq(tree->AsLclFld()->gtFieldSeq);
+                printf("[+%u]", tree->AsLclFld()->GetLclOffs());
+                gtDispFieldSeq(tree->AsLclFld()->GetFieldSeq());
             }
 
             if (varDsc->lvRegister)
@@ -15820,7 +15821,7 @@ bool GenTree::DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarComm
                 unsigned lclOffset = 0;
                 if (addrArg->OperIsLocalField())
                 {
-                    lclOffset = addrArg->AsLclFld()->gtLclOffs;
+                    lclOffset = addrArg->AsLclFld()->GetLclOffs();
                 }
 
                 if (lclOffset != 0)
@@ -15922,7 +15923,7 @@ bool GenTree::IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, Fie
         if (OperGet() == GT_LCL_FLD)
         {
             // Otherwise, prepend this field to whatever we've already accumulated outside in.
-            *pFldSeq = comp->GetFieldSeqStore()->Append(AsLclFld()->gtFieldSeq, *pFldSeq);
+            *pFldSeq = comp->GetFieldSeqStore()->Append(AsLclFld()->GetFieldSeq(), *pFldSeq);
         }
         return true;
     }
@@ -15972,7 +15973,7 @@ bool GenTree::IsLocalAddrExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree,
             if (addrArg->OperGet() == GT_LCL_FLD)
             {
                 // Otherwise, prepend this field to whatever we've already accumulated outside in.
-                *pFldSeq = comp->GetFieldSeqStore()->Append(addrArg->AsLclFld()->gtFieldSeq, *pFldSeq);
+                *pFldSeq = comp->GetFieldSeqStore()->Append(addrArg->AsLclFld()->GetFieldSeq(), *pFldSeq);
             }
             return true;
         }
@@ -15986,7 +15987,7 @@ bool GenTree::IsLocalAddrExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree,
         *pLclVarTree = this->AsLclVarCommon();
         if (this->OperGet() == GT_LCL_FLD_ADDR)
         {
-            *pFldSeq = comp->GetFieldSeqStore()->Append(this->AsLclFld()->gtFieldSeq, *pFldSeq);
+            *pFldSeq = comp->GetFieldSeqStore()->Append(this->AsLclFld()->GetFieldSeq(), *pFldSeq);
         }
         return true;
     }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1016,6 +1016,17 @@ public:
     void dumpLIRFlags();
 #endif
 
+    bool TypeIs(var_types type) const
+    {
+        return gtType == type;
+    }
+
+    template <typename... T>
+    bool TypeIs(var_types type, T... rest) const
+    {
+        return TypeIs(type) || TypeIs(rest...);
+    }
+
     bool OperIs(genTreeOps oper) const
     {
         return OperGet() == oper;

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3109,22 +3109,44 @@ struct GenTreeLclVar : public GenTreeLclVarCommon
 
 struct GenTreeLclFld : public GenTreeLclVarCommon
 {
-    unsigned gtLclOffs; // offset into the variable to access
+private:
+    uint16_t      m_lclOffs;  // offset into the variable to access
+    FieldSeqNode* m_fieldSeq; // This LclFld node represents some sequences of accesses.
 
-    FieldSeqNode* gtFieldSeq; // This LclFld node represents some sequences of accesses.
-
-    // old/FE style constructor where load/store/addr share same opcode
+public:
     GenTreeLclFld(var_types type, unsigned lclNum, unsigned lclOffs)
-        : GenTreeLclVarCommon(GT_LCL_FLD, type, lclNum), gtLclOffs(lclOffs), gtFieldSeq(nullptr)
+        : GenTreeLclVarCommon(GT_LCL_FLD, type, lclNum), m_lclOffs(static_cast<uint16_t>(lclOffs)), m_fieldSeq(nullptr)
     {
-        assert(sizeof(*this) <= s_gtNodeSizes[GT_LCL_FLD]);
+        assert(lclOffs <= UINT16_MAX);
     }
 
     GenTreeLclFld(genTreeOps oper, var_types type, unsigned lclNum, unsigned lclOffs)
-        : GenTreeLclVarCommon(oper, type, lclNum), gtLclOffs(lclOffs), gtFieldSeq(nullptr)
+        : GenTreeLclVarCommon(oper, type, lclNum), m_lclOffs(static_cast<uint16_t>(lclOffs)), m_fieldSeq(nullptr)
     {
-        assert(sizeof(*this) <= s_gtNodeSizes[GT_LCL_FLD]);
+        assert(lclOffs <= UINT16_MAX);
     }
+
+    uint16_t GetLclOffs() const
+    {
+        return m_lclOffs;
+    }
+
+    void SetLclOffs(unsigned lclOffs)
+    {
+        assert(lclOffs <= UINT16_MAX);
+        m_lclOffs = static_cast<uint16_t>(lclOffs);
+    }
+
+    FieldSeqNode* GetFieldSeq() const
+    {
+        return m_fieldSeq;
+    }
+
+    void SetFieldSeq(FieldSeqNode* fieldSeq)
+    {
+        m_fieldSeq = fieldSeq;
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeLclFld() : GenTreeLclVarCommon()
     {

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -498,13 +498,9 @@ void CodeGen::genHWIntrinsic_R_RM(
             switch (rmOp->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = rmOp->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->gtLclOffs;
+                    varNum = rmOp->AsLclFld()->GetLclNum();
+                    offset = rmOp->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -684,13 +680,9 @@ void CodeGen::genHWIntrinsic_R_R_RM(
             switch (op2->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = op2->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->AsLclFld()->gtLclOffs;
+                    varNum = op2->AsLclFld()->GetLclNum();
+                    offset = op2->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -852,13 +844,9 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
             switch (op2->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = op2->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->AsLclFld()->gtLclOffs;
+                    varNum = op2->AsLclFld()->GetLclNum();
+                    offset = op2->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -1019,13 +1007,9 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
             switch (op2->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = op2->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->AsLclFld()->gtLclOffs;
+                    varNum = op2->AsLclFld()->GetLclNum();
+                    offset = op2->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -1147,13 +1131,9 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
             switch (op3->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = op3->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->AsLclFld()->gtLclOffs;
+                    varNum = op3->AsLclFld()->GetLclNum();
+                    offset = op3->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -583,8 +583,7 @@ AGAIN:
             goto LCL;
 
         case GT_LCL_FLD:
-
-            offs += tree->AsLclFld()->gtLclOffs;
+            offs += tree->AsLclFld()->GetLclOffs();
             goto LCL;
 
         LCL:
@@ -691,7 +690,7 @@ AGAIN:
 
         case GT_LCL_FLD:
         case GT_STORE_LCL_FLD:
-            offs += tree->AsLclFld()->gtLclOffs;
+            offs += tree->AsLclFld()->GetLclOffs();
             goto LCL;
 
         LCL:
@@ -840,7 +839,7 @@ AGAIN:
 
         case GT_LCL_FLD_ADDR:
         case GT_LCL_FLD:
-            offs += tree->AsLclFld()->gtLclOffs;
+            offs += tree->AsLclFld()->GetLclOffs();
             goto LCL;
 
         LCL:
@@ -1131,13 +1130,9 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             switch (rmOp->OperGet())
             {
                 case GT_LCL_FLD:
-                {
-                    GenTreeLclFld* lclField = rmOp->AsLclFld();
-
-                    varNum = lclField->GetLclNum();
-                    offset = lclField->AsLclFld()->gtLclOffs;
+                    varNum = rmOp->AsLclFld()->GetLclNum();
+                    offset = rmOp->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -3611,6 +3611,14 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
         }
     }
 
+    if (tree->OperIsLocalAddr())
+    {
+        LclVarDsc* varDsc = lvaGetDesc(tree->AsLclVarCommon());
+        assert(varDsc->lvAddrExposed);
+        varDsc->incRefCnts(weight, this);
+        return;
+    }
+
     if ((tree->gtOper != GT_LCL_VAR) && (tree->gtOper != GT_LCL_FLD))
     {
         return;

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -7344,7 +7344,7 @@ Compiler::fgWalkResult Compiler::lvaStressLclFldCB(GenTree** pTree, fgWalkData* 
             /* Change lclVar(lclNum) to lclFld(lclNum,padding) */
 
             tree->ChangeOper(GT_LCL_FLD);
-            tree->AsLclFld()->gtLclOffs = padding;
+            tree->AsLclFld()->SetLclOffs(padding);
         }
         else
         {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -4084,8 +4084,7 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
     GenTree* local;
     if (thisPtr->isLclField())
     {
-        local = new (comp, GT_LCL_FLD)
-            GenTreeLclFld(GT_LCL_FLD, thisPtr->TypeGet(), lclNum, thisPtr->AsLclFld()->gtLclOffs);
+        local = new (comp, GT_LCL_FLD) GenTreeLclFld(thisPtr->TypeGet(), lclNum, thisPtr->AsLclFld()->GetLclOffs());
     }
     else
     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -18153,7 +18153,7 @@ private:
         }
 #endif // _TARGET_64BIT_
 
-        // For now use LCL_VAR_ADDR and LCL_FLD_ADDR only as call arguments and assignment sources.
+        // TODO-ADDR: For now use LCL_VAR_ADDR and LCL_FLD_ADDR only as call arguments and assignment sources.
         // Other usages require more changes. For example, a tree like OBJ(ADD(ADDR(LCL_VAR), 4))
         // could be changed to OBJ(LCL_FLD_ADDR) but then DefinesLocalAddr does not recognize
         // LCL_FLD_ADDR (even though it does recognize LCL_VAR_ADDR).
@@ -18336,7 +18336,7 @@ private:
 
         if (varDsc->lvPromoted || varDsc->lvIsStructField || m_compiler->lvaIsImplicitByRefLocal(val.LclNum()))
         {
-            // Ignore promoted and "implict by ref" variables for now,
+            // TODO-ADDR: For now we ignore promoted and "implict by ref" variables,
             // they require additional changes in subsequent phases.
             return;
         }

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -83,8 +83,8 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
         else
         {
             addr->SetOper(GT_LCL_FLD);
-            addr->AsLclFld()->gtLclOffs  = 0;
-            addr->AsLclFld()->gtFieldSeq = FieldSeqStore::NotAField();
+            addr->AsLclFld()->SetLclOffs(0);
+            addr->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
 
             if (((addr->gtFlags & GTF_VAR_DEF) != 0) && (genTypeSize(simdType) < genTypeSize(lclType)))
             {
@@ -291,8 +291,8 @@ static void RewriteAssignmentIntoStoreLclCore(GenTreeOp* assignment,
 
     if (locationOp == GT_LCL_FLD)
     {
-        store->AsLclFld()->gtLclOffs  = var->AsLclFld()->gtLclOffs;
-        store->AsLclFld()->gtFieldSeq = var->AsLclFld()->gtFieldSeq;
+        store->AsLclFld()->SetLclOffs(var->AsLclFld()->GetLclOffs());
+        store->AsLclFld()->SetFieldSeq(var->AsLclFld()->GetFieldSeq());
     }
 
     copyFlags(store, var, GTF_LIVENESS_MASK);

--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -849,7 +849,7 @@ void CodeGen::genSIMDIntrinsicInit(GenTreeSIMD* simdNode)
             }
             else if (op1->OperIsLocalAddr())
             {
-                unsigned offset = (op1->OperGet() == GT_LCL_FLD_ADDR) ? op1->AsLclFld()->gtLclOffs : 0;
+                unsigned offset = op1->OperIs(GT_LCL_FLD_ADDR) ? op1->AsLclFld()->GetLclOffs() : 0;
                 GetEmitter()->emitIns_R_S(ins, emitTypeSize(targetType), targetReg, op1->AsLclVarCommon()->GetLclNum(),
                                           offset);
             }
@@ -2458,7 +2458,7 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
             offset += compiler->lvaFrameAddress(varNum, &isEBPbased);
             if (op1->OperGet() == GT_LCL_FLD)
             {
-                offset += op1->AsLclFld()->gtLclOffs;
+                offset += op1->AsLclFld()->GetLclOffs();
             }
             baseReg = (isEBPbased) ? REG_EBP : REG_ESP;
         }
@@ -2916,7 +2916,7 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     if (treeNode->OperGet() == GT_STORE_LCL_FLD)
     {
-        offs = treeNode->AsLclFld()->gtLclOffs;
+        offs = treeNode->AsLclFld()->GetLclOffs();
     }
 
     GenTree* op1 = treeNode->AsOp()->gtOp1;
@@ -2958,7 +2958,7 @@ void CodeGen::genLoadLclTypeSIMD12(GenTree* treeNode)
 
     if (treeNode->OperGet() == GT_LCL_FLD)
     {
-        offs = treeNode->AsLclFld()->gtLclOffs;
+        offs = treeNode->AsLclFld()->GetLclOffs();
     }
 
     // Need an additional Xmm register that is different from targetReg to read upper 4 bytes.

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6877,7 +6877,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             case GT_LCL_FLD:
             {
                 GenTreeLclFld* lclFld = tree->AsLclFld();
-                assert(!lvaInSsa(lclFld->GetLclNum()) || lclFld->gtFieldSeq != nullptr);
+                assert(!lvaInSsa(lclFld->GetLclNum()) || (lclFld->GetFieldSeq() != nullptr));
                 // If this is a (full) def, then the variable will be labeled with the new SSA number,
                 // which will not have a value.  We skip; it will be handled by one of the assignment-like
                 // forms (assignment, or initBlk or copyBlk).
@@ -6888,7 +6888,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     LclVarDsc* varDsc = &lvaTable[lclNum];
 
                     var_types indType = tree->TypeGet();
-                    if (lclFld->gtFieldSeq == FieldSeqStore::NotAField() || !lvaInSsa(lclFld->GetLclNum()))
+                    if ((lclFld->GetFieldSeq() == FieldSeqStore::NotAField()) || !lvaInSsa(lclFld->GetLclNum()))
                     {
                         // This doesn't represent a proper field access or it's a struct
                         // with overlapping fields that is hard to reason about; return a new unique VN.
@@ -6897,7 +6897,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     else
                     {
                         ValueNumPair lclVNPair = varDsc->GetPerSsaData(ssaNum)->m_vnPair;
-                        tree->gtVNPair         = vnStore->VNPairApplySelectors(lclVNPair, lclFld->gtFieldSeq, indType);
+                        tree->gtVNPair = vnStore->VNPairApplySelectors(lclVNPair, lclFld->GetFieldSeq(), indType);
                     }
                 }
             }
@@ -7169,8 +7169,8 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         else
                         {
                             // We should never have a null field sequence here.
-                            assert(lclFld->gtFieldSeq != nullptr);
-                            if (lclFld->gtFieldSeq == FieldSeqStore::NotAField())
+                            assert(lclFld->GetFieldSeq() != nullptr);
+                            if (lclFld->GetFieldSeq() == FieldSeqStore::NotAField())
                             {
                                 // We don't know what field this represents.  Assign a new VN to the whole variable
                                 // (since we may be writing to an unknown portion of it.)
@@ -7184,7 +7184,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                 // (we looked in a side table above for its "def" identity).  Look up that value.
                                 ValueNumPair oldLhsVNPair =
                                     lvaTable[lclFld->GetLclNum()].GetPerSsaData(lclFld->GetSsaNum())->m_vnPair;
-                                newLhsVNPair = vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, lclFld->gtFieldSeq,
+                                newLhsVNPair = vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, lclFld->GetFieldSeq(),
                                                                                    rhsVNPair, // Pre-value.
                                                                                    lclFld->TypeGet(), compCurBB);
                             }
@@ -7607,7 +7607,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 }
                 else if (arg->OperGet() == GT_LCL_FLD)
                 {
-                    fieldSeq = arg->AsLclFld()->gtFieldSeq;
+                    fieldSeq = arg->AsLclFld()->GetFieldSeq();
                     if (fieldSeq == nullptr)
                     {
                         // Local field with unknown field seq -- not a precise pointer.

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6723,6 +6723,12 @@ void Compiler::fgValueNumberTree(GenTree* tree)
     {
         switch (oper)
         {
+            case GT_LCL_VAR_ADDR:
+            case GT_LCL_FLD_ADDR:
+                assert(lvaVarAddrExposed(tree->AsLclVarCommon()->GetLclNum()));
+                tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
+                break;
+
             case GT_LCL_VAR:
             {
                 GenTreeLclVarCommon* lcl    = tree->AsLclVarCommon();


### PR DESCRIPTION
Small contribution to https://github.com/dotnet/coreclr/issues/19875 to inaugurate the new repo :)

I've been trying to figure out how to handle this, there's no way to completly remove `ADDR` in a single PR. And I think I found a reasonable good starting point - generate some `LCL_VAR|FLD_ADDR` nodes in some specific case that don't require a lot of other changes.

Of course, it would make more sense to generate these nodes directly from the importer. But that's probably going to be an all or nothing kind of thing and require far more changes.

Also, this starts another change that I was considered ever since I added `LocalAddressVisitor` - start taking over the responsibility of morphing indirect/field local variable access from global morph. The current situation is impractical, `LocalAddressVisitor` has its own analysis logic and morph has its own transformation logic. That's redundant and risky, it's hard to say if the two are in sync. Besides, global morph should have been dismantled a long time ago :)