### PR TITLE
Determinism fixes

### DIFF
--- a/src/coreclr/src/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/src/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 // Managed mirror of NativeFormatWriter.h/.cpp
@@ -2041,13 +2042,9 @@ namespace Internal.NativeFormat
             // we can use the ordering to terminate the lookup prematurely.
             uint mask = ((_nBuckets - 1) << 8) | 0xFF;
 
-            // sort it by hashcode
-            _Entries.Sort(
-                    (a, b) =>
-                    {
-                        return (int)(a.Hashcode & mask) - (int)(b.Hashcode & mask);
-                    }
-                );
+            // Sort by hashcode. This sort must be stable since we need determinism even if two entries have
+            // the same hashcode. This is deterministic if entries are added in a deterministic order.
+            _Entries = _Entries.OrderBy(entry => entry.Hashcode & mask).ToList();
 
             // Start with maximum size entries
             _entryIndexSize = 2;

--- a/src/coreclr/src/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
@@ -97,7 +97,9 @@ namespace Internal.IL
 
             EcmaSignatureParser parser = new EcmaSignatureParser(_module, signatureReader);
             LocalVariableDefinition[] locals = parser.ParseLocalsSignature();
-            return (_locals = locals);
+
+            Interlocked.CompareExchange(ref _locals, locals, null);
+            return _locals;
         }
 
         public override ILExceptionRegion[] GetExceptionRegions()
@@ -131,7 +133,8 @@ namespace Internal.IL
                 }
             }
 
-            return (_ilExceptionRegions = ilExceptionRegions);
+            Interlocked.CompareExchange(ref _ilExceptionRegions, ilExceptionRegions, null);
+            return _ilExceptionRegions;
         }
 
         public override object GetObject(int token)

--- a/src/coreclr/src/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-
+using System.Threading;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -64,20 +64,8 @@ namespace Internal.IL
             if (_ilBytes != null)
                 return _ilBytes;
 
-            // This lock is necessary since the JIT requires that we provide the same address
-            // for the IL buffer each time (it uses the address to detect recursive calls).
-            // Since MethodBodyBlock.GetAllBytes creates a new array each time, if two threads
-            // call this on the same function then it is possible for both to set _ilBytes.
-            // Then, one of the threads will receive the first value on the first call and the
-            // second value on all subsequent calls, and we will not detect the recursive call.
-            lock (this)
-            {
-                if (_ilBytes != null)
-                    return _ilBytes;
-
-                byte[] ilBytes = _methodBody.GetILBytes();
-                return (_ilBytes = ilBytes);
-            }
+            Interlocked.CompareExchange(ref _ilBytes, _methodBody.GetILBytes(), null);
+            return _ilBytes;
         }
 
         public override bool IsInitLocals

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -96,8 +96,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int ModuleToIndex(EcmaModule module)
         {
             AssemblyName assemblyName = module.Assembly.GetName();
-
-            if (!_manifestAssemblies.Contains(assemblyName))
+            int assemblyRefIndex;
+            if (!_assemblyRefToModuleIdMap.TryGetValue(assemblyName.Name, out assemblyRefIndex))
             {
                 if (_emissionCompleted)
                 {
@@ -108,14 +108,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // the verification logic would be broken at runtime.
                 Debug.Assert(_nodeFactory.CompilationModuleGroup.VersionsWithModule(module));
 
+                assemblyRefIndex = _nextModuleId++;
                 _manifestAssemblies.Add(assemblyName);
-                if (!_assemblyRefToModuleIdMap.ContainsKey(assemblyName.Name))
-                    _assemblyRefToModuleIdMap.Add(assemblyName.Name, _nextModuleId);
-
-                _nextModuleId++;
+                _assemblyRefToModuleIdMap.Add(assemblyName.Name, assemblyRefIndex);
             }
-
-            return _assemblyRefToModuleIdMap[assemblyName.Name];
+            return assemblyRefIndex;
         }
 
         public override int ClassCode => 791828335;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -176,9 +176,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                fieldList: MetadataTokens.FieldDefinitionHandle(1),
                methodList: MetadataTokens.MethodDefinitionHandle(1));
 
-            IEnumerable<AssemblyName> manifestAssemblies = _moduleIdToAssemblyNameMap.OrderBy(x => x.Key).Select(x => x.Value);
-            foreach (AssemblyName assemblyName in manifestAssemblies)
+            foreach (var idAndAssemblyName in _moduleIdToAssemblyNameMap.OrderBy(x => x.Key))
             {
+                AssemblyName assemblyName = idAndAssemblyName.Value;
                 AssemblyFlags assemblyFlags = 0;
                 byte[] publicKeyOrToken;
                 if ((assemblyName.Flags & AssemblyNameFlags.PublicKey) != 0)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-	        EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
+	            EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
                 SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
                 dataBuilder.EmitTypeSignature(_arrayType, innerContext);
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-	            EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
+                EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
                 SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
                 dataBuilder.EmitTypeSignature(_arrayType, innerContext);
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -26,11 +26,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
-            dataBuilder.AddSymbol(this);
 
-            EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
-            SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
-            dataBuilder.EmitTypeSignature(_arrayType, innerContext);
+            if (!relocsOnly)
+            {
+                dataBuilder.AddSymbol(this);
+
+	        EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
+                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
+                dataBuilder.EmitTypeSignature(_arrayType, innerContext);
+            }
 
             return dataBuilder.ToObjectData();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
@@ -25,10 +25,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
-            dataBuilder.AddSymbol(this);
 
-            dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.StringHandle, _token.Module, _signatureContext);
-            dataBuilder.EmitUInt(_token.TokenRid);
+            if (!relocsOnly)
+            {
+                dataBuilder.AddSymbol(this);
+
+                dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.StringHandle, _token.Module, _signatureContext);
+                dataBuilder.EmitUInt(_token.TokenRid);
+            }
 
             return dataBuilder.ToObjectData();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Internal.IL;
-using Internal.IL.Stubs;
 using Internal.JitInterface;
 using Internal.TypeSystem;
 
@@ -26,7 +25,7 @@ namespace ILCompiler
         protected readonly NodeFactory _nodeFactory;
         protected readonly Logger _logger;
         private readonly DevirtualizationManager _devirtualizationManager;
-        private ILCache _methodILCache;
+        protected ILCache _methodILCache;
         private readonly HashSet<ModuleDesc> _modulesBeingInstrumented;
 
 
@@ -79,10 +78,8 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
-            // Flush the cache when it grows too big
-            if (_methodILCache.Count > 1000)
-                _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
-
+            // TODO: Remove the ILCache and use the pinned heap for the IL stream once this GC
+            // feature ships (in dotnet5)
             return _methodILCache.GetOrCreateValue(method).MethodIL;
         }
 
@@ -106,7 +103,7 @@ namespace ILCompiler
             return _modulesBeingInstrumented.Contains(module);
         }
 
-        private sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
+        public sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
         {
             public ILProvider ILProvider { get; }
             private readonly CompilationModuleGroup _compilationModuleGroup;
@@ -146,7 +143,7 @@ namespace ILCompiler
                 return new MethodILData() { Method = key, MethodIL = methodIL };
             }
 
-            internal class MethodILData
+            public class MethodILData
             {
                 public MethodDesc Method;
                 public MethodIL MethodIL;
@@ -300,6 +297,11 @@ namespace ILCompiler
                         Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
                     }
                 }
+            }
+
+            if (_methodILCache.Count > 1000)
+            {
+                _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -78,8 +78,6 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
-            // TODO: Remove the ILCache and use the pinned heap for the IL stream once this GC
-            // feature ships (in dotnet5)
             return _methodILCache.GetOrCreateValue(method).MethodIL;
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Internal.IL;
+using Internal.IL.Stubs;
 using Internal.JitInterface;
 using Internal.TypeSystem;
 

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 internal class Program
@@ -17,14 +19,27 @@ internal class Program
     public static int CompareDLLs(string folder1, string folder2)
     {
         int result = 100;
-        foreach (string filepath1 in Directory.EnumerateFiles(folder1, "*.dll"))
+
+        // Check for files that failed compilation with one of the seeds but not the other
+        HashSet<string> uniqueFilenames = new HashSet<string>(Directory.GetFiles(folder1, "*.dll").Select(Path.GetFileName));
+        uniqueFilenames.SymmetricExceptWith(Directory.GetFiles(folder2, "*.dll").Select(Path.GetFileName));
+        foreach (string uniqueFilename in uniqueFilenames)
         {
-            byte[] file1 = File.ReadAllBytes(filepath1);
-            byte[] file2 = File.ReadAllBytes(Path.Combine(folder2, Path.GetFileName(filepath1)));
+            Console.WriteLine($"{uniqueFilename} was found in only one of the output folders.");
+            result = 1;
+        }
+
+        foreach (string filename in Directory.GetFiles(folder1, "*.dll").Select(Path.GetFileName))
+        {
+            if (uniqueFilenames.Contains(filename))
+                continue;
+
+            byte[] file1 = File.ReadAllBytes(Path.Combine(folder1, Path.GetFileName(filename)));
+            byte[] file2 = File.ReadAllBytes(Path.Combine(folder2, Path.GetFileName(filename)));
 
             if (file1.Length != file2.Length)
             {
-                Console.WriteLine(filepath1);
+                Console.WriteLine(filename);
                 Console.WriteLine($"Expected ReadyToRun'd files to be identical but they have different sizes ({file1.Length} and {file2.Length})");
                 result = 1;
             }
@@ -33,7 +48,7 @@ internal class Program
             {
                 if (file1[i] != file2[i] && !IsTimestampByte(i))
                 {
-                    Console.WriteLine(filepath1);
+                    Console.WriteLine(filename);
                     Console.WriteLine($"Difference at non-timestamp byte {i}");
                     result = 1;
                 }
@@ -51,8 +66,12 @@ internal class Program
         string coreRootPath = Environment.GetEnvironmentVariable("Core_Root");
         string superIlcPath = Path.Combine(coreRootPath, "ReadyToRun.SuperIlc", OSExeSuffix("ReadyToRun.SuperIlc"));
 
-
+        Console.WriteLine($"================================== Compiling with seed {seed} ==================================");
         Environment.SetEnvironmentVariable("CoreRT_DeterminismSeed", seed.ToString());
+        if (Directory.Exists(outDir))
+        {
+            Directory.Delete(outDir, true);
+        }
         Directory.CreateDirectory(outDir);
         ProcessStartInfo processStartInfo = new ProcessStartInfo(superIlcPath, $"compile-directory -cr {coreRootPath} -in {coreRootPath} --nojit --noexe --large-bubble --release --nocleanup -out {outDir}");
         Process.Start(processStartInfo).WaitForExit();

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
@@ -63,7 +63,7 @@ internal class Program
 
     public static void CompileWithSeed(int seed, string outDir)
     {
-        string coreRootPath = Environment.GetEnvironmentVariable("Core_Root");
+        string coreRootPath = Environment.GetEnvironmentVariable("CORE_ROOT");
         string superIlcPath = Path.Combine(coreRootPath, "ReadyToRun.SuperIlc", OSExeSuffix("ReadyToRun.SuperIlc"));
 
         Console.WriteLine($"================================== Compiling with seed {seed} ==================================");

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/Program.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+internal class Program
+{
+    public static bool IsTimestampByte(int i)
+    {
+        return i >= 136 && i < 140;
+    }
+
+    public static int CompareDLLs(string folder1, string folder2)
+    {
+        foreach (string filepath1 in Directory.EnumerateFiles(folder1, "*.dll"))
+        {
+            byte[] file1 = File.ReadAllBytes(filepath1);
+            byte[] file2 = File.ReadAllBytes(Path.Combine(folder2, Path.GetFileName(filepath1)));
+
+            if (file1.Length != file2.Length)
+            {
+                Console.WriteLine(filepath1);
+                Console.WriteLine("Expected Crossgen2'd files to be identical but they have different sizes.");
+                return 2;
+            }
+
+            for (int i = 0; i < file1.Length; ++i)
+            {
+                if (file1[i] != file2[i] && !IsTimestampByte(i))
+                {
+                    Console.WriteLine(filepath1);
+                    Console.WriteLine($"Difference at non-timestamp byte {i}");
+                    return 1;
+                }
+            }
+
+            Console.WriteLine($"Files of length {file1.Length} were identical.");
+        }
+        return 100;
+    }
+
+    public static int Main()
+    {
+        return CompareDLLs("seed1", "seed2");
+    }
+}

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -14,30 +14,4 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands>
-  <![CDATA[
-$(CLRTestBatchPreCommands)
-set CoreRT_DeterminismSeed=1
-mkdir seed1
-%CORE_ROOT%\ReadyToRun.SuperIlc\ReadyToRun.SuperIlc.exe compile-directory -cr %CORE_ROOT% -in %CORE_ROOT% --nojit --noexe --large-bubble --release --nocleanup -out seed1
-
-set CoreRT_DeterminismSeed=2
-mkdir seed2
-%CORE_ROOT%\ReadyToRun.SuperIlc\ReadyToRun.SuperIlc.exe compile-directory -cr %CORE_ROOT% -in %CORE_ROOT% --nojit --noexe --large-bubble --release --nocleanup -out seed2
-
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands>
-  <![CDATA[
-$(BashCLRTestPreCommands)
-export CoreRT_DeterminismSeed=1
-mkdir seed1
-$CORE_ROOT/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed1
-
-export CoreRT_DeterminismSeed=2
-mkdir seed2
-$CORE_ROOT/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed2
-
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -32,11 +32,11 @@ mkdir seed2
 $(BashCLRTestPreCommands)
 export CoreRT_DeterminismSeed=1
 mkdir seed1
-%CORE_ROOT%/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed1
+$CORE_ROOT/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed1
 
 export CoreRT_DeterminismSeed=2
 mkdir seed2
-%CORE_ROOT%/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed2
+$CORE_ROOT/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed2
 
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+    <!-- Crossgen2 currently targets only x64 -->
+    <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
+    <!-- Known not to work with GCStress for now: https://github.com/dotnet/coreclr/issues/26633 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This is an explicit crossgen test -->
+    <CrossGenTest>false</CrossGenTest>
+    <OldToolsVersion>2.0</OldToolsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands>
+  <![CDATA[
+$(CLRTestBatchPreCommands)
+set CoreRT_DeterminismSeed=1
+mkdir seed1
+%CORE_ROOT%\ReadyToRun.SuperIlc\ReadyToRun.SuperIlc.exe compile-directory -cr %CORE_ROOT% -in %CORE_ROOT% --nojit --noexe --large-bubble --release --nocleanup -out seed1
+
+set CoreRT_DeterminismSeed=2
+mkdir seed2
+%CORE_ROOT%\ReadyToRun.SuperIlc\ReadyToRun.SuperIlc.exe compile-directory -cr %CORE_ROOT% -in %CORE_ROOT% --nojit --noexe --large-bubble --release --nocleanup -out seed2
+
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+  <![CDATA[
+$(BashCLRTestPreCommands)
+export CoreRT_DeterminismSeed=1
+mkdir seed1
+%CORE_ROOT%/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed1
+
+export CoreRT_DeterminismSeed=2
+mkdir seed2
+%CORE_ROOT%/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.exe compile-directory -cr $CORE_ROOT -in $CORE_ROOT --nojit --noexe --large-bubble --release --nocleanup -out seed2
+
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- NativeFormatWriter's HashTable save now uses OrderBy, so the output deterministic if the values are entered deterministically
- Make GetILBytes in EcmaMethodIL threadsafe so we don't accidentally get two different addresses for the same code
- Fix ManifestMetadataTableNode bug where we were incrementing nextModuleId unnecessarily sometimes. Also added a check that we have finishing sorting the object nodes, since we require that they are sorted to get deterministic output here.
- Do not flush the ILCache before compiling all methods in a batch. This might have caused the same MethodDesc to have two different MethodIL objects.
- Add a determinism test that compiles all of coreroot with two different seeds