### PR TITLE
Enabling index check

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -29,7 +29,6 @@
     <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
-    <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">

--- a/src/libraries/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/src/libraries/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -238,6 +238,15 @@
         "wp8": "8.0.0.0"
       }
     },
+    "Microsoft.Private.CoreFx.OOB": {
+      "InboxOn": {}
+    },
+    "Microsoft.Private.PackageBaseline": {
+      "StableVersions": [
+        "1.0.0"
+      ],
+      "InboxOn": {}
+    },
     "Microsoft.VisualBasic": {
       "StableVersions": [
         "10.0.0",
@@ -373,6 +382,17 @@
         "4.0.1.0": "4.6.0",
         "5.0.0.0": "5.0.0"
       }
+    },
+    "Microsoft.Windows.Compatibility": {
+      "StableVersions": [
+        "2.0.0",
+        "2.0.1",
+        "2.1.0",
+        "2.1.1",
+        "3.0.0",
+        "3.0.1"
+      ],
+      "InboxOn": {}
     },
     "Microsoft.Windows.Compatibility.Shims": {
       "StableVersions": [


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/39489

We disabled the index check while moving the package version to 5.0.0 https://github.com/dotnet/corefx/pull/39503


I think the reason behind disabling was that we needed to publish those packages with new versions before we consume them.

cc @wtgodbe 