### PR TITLE
Verified the null checking in the extension methods.

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -50,23 +50,43 @@ namespace System.IO
             fileSecurity.Persist(fullPath);
         }
 
+        /// <summary>
+        /// This extension method for FileStream returns a FileSecurity object containing security descriptors from the Access, Owner, and Group AccessControlSections.
+        /// </summary>
+        /// <param name="fileStream">An object that represents the file for retrieving security descriptors from</param>
+        /// <exception cref="ArgumentNullException">is <see langword="null" />.</exception>
+        /// <exception cref="ObjectDisposedException">File is closed.</exception>
         public static FileSecurity GetAccessControl(this FileStream fileStream)
         {
+            if (fileStream == null)
+                throw new ArgumentNullException(nameof(fileStream));
+
             SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
             {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
             }
+
             return new FileSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
+        /// <summary>
+        /// This extension method for FileStream sets the security descriptors for the file using a FileSecurity instance.
+        /// </summary>
+        /// <param name="fileStream">An object that represents the file to apply security changes to.</param>
+        /// <param name="fileSecurity">An object that determines the access control and audit security for the file.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="fileStream" /> or <paramref name="fileSecurity" /> is <see langword="null" />.</exception>
+        /// <exception cref="ObjectDisposedException">File is closed.</exception>
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
-            SafeFileHandle handle = fileStream.SafeFileHandle;
+            if (fileStream == null)
+                throw new ArgumentNullException(nameof(fileStream));
 
             if (fileSecurity == null)
                 throw new ArgumentNullException(nameof(fileSecurity));
 
+
+            SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
             {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
@@ -116,14 +136,10 @@ namespace System.IO
         public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
         {
             if (fileInfo == null)
-            {
                 throw new ArgumentNullException(nameof(fileInfo));
-            }
 
             if (fileSecurity == null)
-            {
                 throw new ArgumentNullException(nameof(fileSecurity));
-            }
 
             // don't include inheritable in our bounds check for share
             FileShare tempshare = share & ~FileShare.Inheritable;

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -54,8 +54,8 @@ namespace System.IO
         /// This extension method for FileStream returns a FileSecurity object containing security descriptors from the Access, Owner, and Group AccessControlSections.
         /// </summary>
         /// <param name="fileStream">An object that represents the file for retrieving security descriptors from</param>
-        /// <exception cref="ArgumentNullException">is <see langword="null" />.</exception>
-        /// <exception cref="ObjectDisposedException">File is closed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="fileStream" /> is <see langword="null" />.</exception>
+        /// <exception cref="ObjectDisposedException">The file stream is closed.</exception>
         public static FileSecurity GetAccessControl(this FileStream fileStream)
         {
             if (fileStream == null)
@@ -76,7 +76,7 @@ namespace System.IO
         /// <param name="fileStream">An object that represents the file to apply security changes to.</param>
         /// <param name="fileSecurity">An object that determines the access control and audit security for the file.</param>
         /// <exception cref="ArgumentNullException"><paramref name="fileStream" /> or <paramref name="fileSecurity" /> is <see langword="null" />.</exception>
-        /// <exception cref="ObjectDisposedException">File is closed.</exception>
+        /// <exception cref="ObjectDisposedException">The file stream is closed.</exception>
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
             if (fileStream == null)

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -24,7 +24,9 @@ namespace System.IO
         public static void SetAccessControl(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
             if (directorySecurity == null)
+            {
                 throw new ArgumentNullException(nameof(directorySecurity));
+            }
 
             string fullPath = Path.GetFullPath(directoryInfo.FullName);
             directorySecurity.Persist(fullPath);
@@ -43,8 +45,9 @@ namespace System.IO
         public static void SetAccessControl(this FileInfo fileInfo, FileSecurity fileSecurity)
         {
             if (fileSecurity == null)
+            {
                 throw new ArgumentNullException(nameof(fileSecurity));
-
+            }
             string fullPath = Path.GetFullPath(fileInfo.FullName);
             // Appropriate security check should be done for us by FileSecurity.
             fileSecurity.Persist(fullPath);
@@ -59,11 +62,15 @@ namespace System.IO
         public static FileSecurity GetAccessControl(this FileStream fileStream)
         {
             if (fileStream == null)
+            {
                 throw new ArgumentNullException(nameof(fileStream));
+            }
 
             SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
+            {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
+            }
 
             return new FileSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
@@ -78,14 +85,20 @@ namespace System.IO
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
             if (fileStream == null)
+            {
                 throw new ArgumentNullException(nameof(fileStream));
+            }
 
             if (fileSecurity == null)
+            {
                 throw new ArgumentNullException(nameof(fileSecurity));
+            }
 
             SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
+            {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
+            }
 
             fileSecurity.Persist(handle, fileStream.Name);
         }
@@ -100,10 +113,14 @@ namespace System.IO
         public static void Create(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
             if (directoryInfo == null)
+            {
                 throw new ArgumentNullException(nameof(directoryInfo));
+            }
 
             if (directorySecurity == null)
+            {
                 throw new ArgumentNullException(nameof(directorySecurity));
+            }
 
             FileSystem.CreateDirectory(directoryInfo.FullName, directorySecurity.GetSecurityDescriptorBinaryForm());
         }
@@ -131,10 +148,14 @@ namespace System.IO
         public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
         {
             if (fileInfo == null)
+            {
                 throw new ArgumentNullException(nameof(fileInfo));
+            }
 
             if (fileSecurity == null)
+            {
                 throw new ArgumentNullException(nameof(fileSecurity));
+            }
 
             // don't include inheritable in our bounds check for share
             FileShare tempshare = share & ~FileShare.Inheritable;
@@ -184,10 +205,12 @@ namespace System.IO
             {
                 access = FileAccess.Read;
             }
+
             if ((rights & FileSystemRights.WriteData) != 0 || ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_WRITE) != 0)
             {
                 access = access == FileAccess.Read ? FileAccess.ReadWrite : FileAccess.Write;
             }
+
             return access;
         }
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -63,9 +63,7 @@ namespace System.IO
 
             SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
-            {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
-            }
 
             return new FileSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
@@ -85,12 +83,9 @@ namespace System.IO
             if (fileSecurity == null)
                 throw new ArgumentNullException(nameof(fileSecurity));
 
-
             SafeFileHandle handle = fileStream.SafeFileHandle;
             if (handle.IsClosed)
-            {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
-            }
 
             fileSecurity.Persist(handle, fileStream.Name);
         }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
@@ -62,11 +62,26 @@ namespace System.IO
 
         public static FileSecurity GetAccessControl(this FileStream fileStream)
         {
+            if (fileStream == null)
+            {
+                throw new ArgumentNullException(nameof(fileStream));
+            }
+
             return fileStream.GetAccessControl();
         }
 
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
+            if (fileStream == null)
+            {
+                throw new ArgumentNullException(nameof(fileStream));
+            }
+
+            if (fileSecurity == null)
+            {
+                throw new ArgumentNullException(nameof(fileSecurity));
+            }
+
             fileStream.SetAccessControl(fileSecurity);
         }
     }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -106,7 +106,7 @@ namespace System.IO
         [Fact]
         public void GetAccessControl_Filestream_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileStream)null));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((FileStream)null));
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace System.IO
         [Fact]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -106,7 +106,7 @@ namespace System.IO
         [Fact]
         public void GetAccessControl_Filestream_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((FileStream)null));
+            Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.GetAccessControl((FileStream)null));
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace System.IO
         [Fact]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));
+            Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));
         }
 
         [Fact]


### PR DESCRIPTION
Fix for issue dotnet/corefx#41907
Reference PR dotnet/corefx/#42682

Added necessary null checks and exceptions to GetAccessControl and SetAccessControl . Removed braces in Create(this FileInfo,..) method.  Changed NullReferenceException to ArgumentNullException, also reflected in test cases.  Comments added to GetAccessControl and SetAccessControl methods.

cc: @carlossanlop @danmosemsft