### PR TITLE
Fix corehost RID generation logic for versionless distros

### DIFF
--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -25,7 +25,7 @@ init_rid_plat()
                 # remove the last version number
                 VERSION_ID=${VERSION_ID%.*}
             fi
-            __rid_plat="$ID.$VERSION_ID"
+            __rid_plat="$ID${VERSION_ID:+.$VERSION_ID}"
             if [[ "$ID" == "alpine" ]]; then
                 __rid_plat="linux-musl"
             fi


### PR DESCRIPTION
The Linux/Bash build script for `corehost` incorrectly assumes that `VERSION_ID` will be set after sourcing `/etc/os-release`, which is not the case on rolling release distributions like Arch Linux. On such systems, calling `init_rid_plat` initializes base Runtime Identifier to values similar to `arch.` which ultimately results in malformed RIDs like `arch.-x64` and breaks the build process further down the line.

With this change, if `VERSION_ID` is unset, then the dot will be omitted and final RID will be more correct `arch-x64`. On distributions with `VERSION_ID` set in `/etc/os-release`, this change doesn't affect the RID computation at all.

Applying this fix allows former `core-setup` repository to correctly build on Arch Linux. Hopefully if this PR is accepted, it will be backported to .NET Core 3.1 too.

(Issue and the fix discovered [here](https://github.com/dotnet/source-build/issues/1310#issuecomment-552856074), see that issue for more background info.)