### PR TITLE
Fix EH handling in PInvoke stubs and remove workaround

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -6394,7 +6394,7 @@ bool Compiler::impCanPInvokeInlineCallSite(BasicBlock* block)
     if (block->hasTryIndex())
     {
         if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) &&
-            opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM))
+            !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM))
         {
             // This does not apply to the actual pinvoke call that is inside the pinvoke
             // ILStub, when the secret parameter is not used. In this case, we have to inline

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -6393,6 +6393,15 @@ bool Compiler::impCanPInvokeInlineCallSite(BasicBlock* block)
     //   jit\jit64\ebvts\mcpp\sources2\ijw\__clrcall\vector_ctor_dtor.02\deldtor_clr.exe
     if (block->hasTryIndex())
     {
+        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) &&
+            opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM))
+        {
+            // This does not apply to the actual pinvoke call that is inside the pinvoke
+            // ILStub, when the secret parameter is not used. In this case, we have to inline
+            // the raw pinvoke call into the stub, otherwise we would end up with a stub that
+            // recursively calls itself, and end up with a stack overflow.
+            return true;
+        }
         return false;
     }
 #endif // _TARGET_64BIT_

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -6393,15 +6393,13 @@ bool Compiler::impCanPInvokeInlineCallSite(BasicBlock* block)
     //   jit\jit64\ebvts\mcpp\sources2\ijw\__clrcall\vector_ctor_dtor.02\deldtor_clr.exe
     if (block->hasTryIndex())
     {
-        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) &&
-            !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM))
-        {
-            // This does not apply to the actual pinvoke call that is inside the pinvoke
-            // ILStub, when the secret parameter is not used. In this case, we have to inline
-            // the raw pinvoke call into the stub, otherwise we would end up with a stub that
-            // recursively calls itself, and end up with a stack overflow.
+        // This does not apply to the raw pinvoke call that is inside the pinvoke
+        // ILStub. In this case, we have to inline the raw pinvoke call into the stub,
+        // otherwise we would end up with a stub that recursively calls itself, and end
+        // up with a stack overflow.
+        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) && opts.ShouldUsePInvokeHelpers())
             return true;
-        }
+
         return false;
     }
 #endif // _TARGET_64BIT_

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
@@ -76,13 +76,6 @@ namespace Internal.IL.Stubs
 
         private MethodIL EmitIL()
         {
-            // Temp workaround to disable PInvoke stubs that require marshalling.
-            // https://github.com/dotnet/runtime/issues/248
-            {
-                if (Marshaller.IsMarshallingRequired(_targetMethod))
-                    throw new NotSupportedException();
-            }
-
             if (!_importMetadata.Flags.PreserveSig)
                 throw new NotSupportedException();
 
@@ -95,13 +88,11 @@ namespace Internal.IL.Stubs
             ILCodeStream unmarshallingCodestream = pInvokeILCodeStreams.UnmarshallingCodestream;
             ILCodeStream cleanupCodestream = pInvokeILCodeStreams.CleanupCodeStream;
 
-            /* Temp workaround: disable EH blocks because of https://github.com/dotnet/runtime/issues/248
-
             // Marshalling is wrapped in a finally block to guarantee cleanup
             ILExceptionRegionBuilder tryFinally = emitter.NewFinallyRegion();
 
             marshallingCodestream.BeginTry(tryFinally);
-            cleanupCodestream.BeginHandler(tryFinally);*/
+            cleanupCodestream.BeginHandler(tryFinally);
 
             // Marshal the arguments
             for (int i = 0; i < _marshallers.Length; i++)
@@ -112,12 +103,11 @@ namespace Internal.IL.Stubs
             EmitPInvokeCall(pInvokeILCodeStreams);
 
             ILCodeLabel lReturn = emitter.NewCodeLabel();
-            /* Temp workaround: disable EH blocks because of https://github.com/dotnet/runtime/issues/248
             unmarshallingCodestream.Emit(ILOpcode.leave, lReturn);
             unmarshallingCodestream.EndTry(tryFinally);
 
             cleanupCodestream.Emit(ILOpcode.endfinally);
-            cleanupCodestream.EndHandler(tryFinally);*/
+            cleanupCodestream.EndHandler(tryFinally);
 
             cleanupCodestream.EmitLabel(lReturn);
 


### PR DESCRIPTION
Fix for https://github.com/dotnet/runtime/issues/248
Reverts workaround from https://github.com/dotnet/runtime/pull/249

The fix in the JIT is to inline the raw PInvoke call if:
1) We are compiling a PInvoke IL Stub
2) We are compiling the stub without a secret parameter

In crossgen1/jit, the raw pinvoke call is a calli operation that uses the secret parameter passed to the stub, and gets inlined by-design (we don't even call `impCanPInvokeInlineCallSite` for it). 

With crossgen2, the secret parameter is not used and we have a separate pinvoke stub for each pinvoke. Each pinvoke IL stub generated by crossgen2 will have some marshaling operations if applicable, and a call to the raw pinvoke target (which gets wrapped by calls to JIT_PInvokeBegin/End helpers). This raw pinvoke call has to be inlined for IL stubs, even in the presence of EH blocks due to marshaling, otherwise we would get an IL stub that infinitely recursively calls itself because it can't inline the actual pinvoke call.

cc @dotnet/crossgen-contrib @dotnet/jit-contrib 