### PR TITLE
Special-Case Ascending Value Types for System.Linq.OrderBy

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -326,7 +326,7 @@ namespace System.Linq
 
         internal int[] Sort(TElement[] elements, int count)
         {
-            // check that we can use the layered sort. This adds (as a first level approximation) O(N) comparisons
+            // Check that we can use the layered sort. This adds (as a first level approximation) O(N) comparisons
             // to the sort, but this is offset by simpler comparers (i.e. removes a level of indirection),
             // Array.Sort optimizations (for primitives), removes level of indirection from objects (i.e. accessing
             // directly in array by sort, rather than an index into another array) and increases caching affects

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -281,8 +281,6 @@ namespace System.Linq
 
         bool IsAscending { get; }
 
-        void InitializeSortByLayer(int size);
-
         void SortByLayer(TElement[] elements, int[] indexes, int startIdx, int count);
     }
 
@@ -299,13 +297,10 @@ namespace System.Linq
         public bool IsAscending => true;
 
         public void SortByLayer(TElement[] elements, int[] indexes, int startIdx, int count) => Array.Sort(indexes, startIdx, count);
-
-        public void InitializeSortByLayer(int size) { }
     }
 
     internal abstract class EnumerableSorter<TElement> : IEnumerableSorter<TElement>
     {
-        public abstract void InitializeSortByLayer(int size);
         public abstract void SortByLayer(TElement[] elements, int[] indexes, int startIdx, int count);
         public abstract void ComputeKeys(TElement[] elements, int count);
         public abstract int CompareAnyKeys(int index1, int index2);
@@ -338,7 +333,6 @@ namespace System.Linq
             // due to location in array.
             if (IsValueType && IsAscending)
             {
-                InitializeSortByLayer(count);
                 int[] map = ComputeMap(count);
                 SortByLayer(elements, map, 0, count);
                 return map;
@@ -399,16 +393,14 @@ namespace System.Linq
 
         public override bool IsAscending => !_descending && _next.IsAscending;
 
-        public override void InitializeSortByLayer(int size)
-        {
-            _keys = new TKey[size];
-            _next.InitializeSortByLayer(size);
-        }
-
         public override void SortByLayer(TElement[] data, int[] indexes, int startIdx, int count)
         {
-            Debug.Assert(_keys != null);
             Debug.Assert(_next != null);
+
+            if (_keys == null)
+            {
+                _keys = new TKey[data.Length];
+            }
 
             int exclusiveEndIdx = startIdx + count;
 


### PR DESCRIPTION
2nd of n optimizations lifted from my exploration of an alternative `System.Linq` implementation [`Cistern.Linq`](https://github.com/manofstick/Cistern.Linq). There are lots more goodies there, but only so many that will survive the transfer to `System.Linq`!

([_Previous corefx optimization_](https://github.com/dotnet/corefx/pull/42286))

This one (to a first order approximation) *adds* O(N) operations to the sort (huh?) and also forces dual arrays to be sorted (via `Array.Sort(keys, elements, ...)`) so that doesn't sound very good now does it? (Of course it remains a stable sort)

But...

- Simplifies comparer (uses provided one directly, rather than wrapping and accessing keys indirectly via array indexing)
- Uses Array.Sort directly with provided comparer, which is optimized for the default comparer for primitives (and possibly [get an extra kick in the pants](https://bits.houmus.org/2019-08-18/decimating-arraysort-with-avx2-pt1) - come on @damageboy !)
- Benefits from better localization of data, thus better caching

Anyway, here are some results from a [slightly modified performance test](https://github.com/manofstick/performance/blob/fed264dddf888a19452a1796f71df522230ba640/src/benchmarks/micro/corefx/System.Linq/Perf.OrderBy.cs#L130-L131) that just uses a variety of sorting sizes gives the following results:

| Slower                                                                  | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ----------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_OrderBy.OrderByString(NumberOfPeople: 1)         |      1.09 |           205.93 |           224.48 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByString(NumberOfPeople: 2)         |      1.09 |           320.09 |           347.86 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 1) |      1.05 |           189.73 |           200.04 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByString(NumberOfPeople: 4)         |      1.05 |           616.64 |           648.56 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 2) |      1.05 |           275.59 |           289.65 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 8) |      1.04 |          1121.75 |          1164.04 |         |

| Faster                                                                    | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 256)      |      2.84 |         26344.39 |          9262.66 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 128)      |      2.44 |         11127.33 |          4561.05 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 64)       |      2.14 |          4858.36 |          2271.90 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 16)       |      1.80 |          1287.39 |           713.56 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 32)       |      1.77 |          2087.83 |          1180.17 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 128) |      1.21 |         39562.96 |         32765.85 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 8)        |      1.19 |           466.95 |           392.36 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 256) |      1.16 |         81546.65 |         70346.17 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 2)        |      1.06 |           226.88 |           213.39 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 32)  |      1.06 |          6137.20 |          5775.37 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 0)        |      1.05 |            77.19 |            73.31 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 16)  |      1.05 |          2973.10 |          2841.96 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 0)   |      1.04 |            75.35 |            72.18 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByCustomComparer(NumberOfPeople: 64)  |      1.03 |         15992.17 |         15479.79 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByValueType(NumberOfPeople: 1)        |      1.03 |           171.79 |           167.52 |         |

So there is some degraded performance for non-value types for *very small* collections, but these are minor, and only for < 10 elements - due to additional overhead of checking type, etc., but the performance of a known value type (`DateTime`) is significant - ~35% of the time for 256 elements. 

A value type which has a custom comparer also benefits (although by a much more modest amount). (i.e. not just limited to the case of Array Sort optimizing the primitive types)

But!! If the comparer was significantly complex then this could slow it down (due to the additional O(N) operations) but as N increases, the ~O(N log N) will drown this out.

... and this really isn't *just* for value types as N grows it overcomes the additional O(N) and has faster results on reference types (well I tried it with the name strings as per `System.Linq.Tests.Perf_OrderBy.OrderByString` and around the few hundred items it was faster). *But the current state of this PR is just for value types.*