### PR TITLE
Rename mentions of corefx-testdata to runtime-assets

### DIFF
--- a/src/libraries/Common/tests/System/Net/Capability.Security.cs
+++ b/src/libraries/Common/tests/System/Net/Capability.Security.cs
@@ -11,7 +11,7 @@ namespace System.Net.Test.Common
     {
         // Thumbprint for CN = NDX Test Root CA.
         // The certificate is part of the chain at
-        // https://github.com/dotnet/corefx-testdata/blob/master/System.Net.TestData/contoso.com.p7b
+        // https://github.com/dotnet/runtime-assets/blob/master/System.Net.TestData/contoso.com.p7b
         private const string CARootThumbprint = "3B279AD43D6DD459268D3F3A3D72DAAD4BF4D9C6";
 
         private static Lazy<bool> s_trustedCertificateSupport =

--- a/src/libraries/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.Security.cs
@@ -28,7 +28,7 @@ namespace System.Net.Test.Common
 
             public static string TlsRenegotiationServer => GetValue("COREFX_NET_SECURITY_TLSREGOTIATIONSERVER", "corefx-net-tls.azurewebsites.net");
 
-            // This should be set if hostnames for all certificates within corefx-testdata have been set to point to 127.0.0.1.
+            // This should be set if hostnames for all certificates within runtime-assets have been set to point to 127.0.0.1.
             // Example:
             //      127.0.0.1 testservereku.contoso.com
             //      127.0.0.1 testnoeku.contoso.com

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_certificates.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_certificates.ps1
@@ -6,9 +6,9 @@
 
 # Certificate configuration
 
-$script:testDataUri = "https://github.com/dotnet/corefx-testdata/archive/master.zip" 
-$script:testData = "corefx-testdata"
-$script:certificatePath = "$($script:testData)\corefx-testdata-master\System.Net.TestData"
+$script:testDataUri = "https://github.com/dotnet/runtime-assets/archive/master.zip" 
+$script:testData = "runtime-assets"
+$script:certificatePath = "$($script:testData)\runtime-assets-master\System.Net.TestData"
 
 $script:clientPrivateKeyPath = Join-Path $script:certificatePath "testclient1_at_contoso.com.pfx"
 $script:clientPrivateKeyPassword = "testcertificate"


### PR DESCRIPTION
We renamed the dotnet/corefx-testdata repository to dotnet/data.
This PR updates all mentions of the old repositories' name.