### PR TITLE
Fix crossgen2 field signature emission

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -542,15 +542,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             uint fieldSigFlags = 0;
             TypeDesc canonOwnerType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
             TypeDesc ownerType = null;
-            if (canonOwnerType != field.OwningType)
-            {
-                // Convert field to canonical form as this is what the field - module token lookup stores
-                field = field.Context.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)canonOwnerType);
-            }
             if (canonOwnerType.HasInstantiation)
             {
                 ownerType = field.OwningType;
                 fieldSigFlags |= (uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_OwnerType;
+            }
+            if (canonOwnerType != field.OwningType)
+            {
+                // Convert field to canonical form as this is what the field - module token lookup stores
+                field = field.Context.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)canonOwnerType);
             }
 
             ModuleToken fieldToken = context.GetModuleTokenForField(field);


### PR DESCRIPTION
The SignatureBuilder.EmitFieldSignature is incorrectly getting owner
type for generic types as the type converted to canon instead ofthe
original owner type. That results in runtime failures like the one shown
below in two coreclr pri1 tests:

 > Type handle 'GenericHolder\`2' and field handle with declaring type
 'GenericHolder\`2[System.__Canon,System.__Canon]' are incompatible. Get
 RuntimeFieldHandle and declaring RuntimeTypeHandle off the same
 FieldInfo.

This change fixes that by getting the owner type before we perform the
conversion to the Canon version.