### PR TITLE
Fix zero connection timeout issue

### DIFF
--- a/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -220,7 +220,6 @@ namespace System.Data.SqlClient.SNI
                 cts.CancelAfter(timeout);
                 cts.Token.Register(Cancel);
             }
-            
 
             Socket availableSocket = null;
             try

--- a/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -142,7 +142,7 @@ namespace System.Data.SqlClient.SNI
                 }
                 else
                 {
-                    _socket = Connect(serverName, port, ts);
+                    _socket = Connect(serverName, port, ts, isInfiniteTimeOut);
                 }
 
                 if (_socket == null || !_socket.Connected)
@@ -177,7 +177,7 @@ namespace System.Data.SqlClient.SNI
             _status = TdsEnums.SNI_SUCCESS;
         }
 
-        private static Socket Connect(string serverName, int port, TimeSpan timeout)
+        private static Socket Connect(string serverName, int port, TimeSpan timeout, bool isInfiniteTimeout)
         {
             IPAddress[] ipAddresses = Dns.GetHostAddresses(serverName);
             IPAddress serverIPv4 = null;
@@ -197,7 +197,15 @@ namespace System.Data.SqlClient.SNI
             Socket[] sockets = new Socket[2];
 
             CancellationTokenSource cts = new CancellationTokenSource();
-            cts.CancelAfter(timeout);
+            if (isInfiniteTimeout)
+            {
+                cts.CancelAfter(-1);
+            }
+            else
+            {
+                cts.CancelAfter(timeout);
+            }
+
             void Cancel()
             {
                 for (int i = 0; i < sockets.Length; ++i)

--- a/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -216,8 +216,7 @@ namespace System.Data.SqlClient.SNI
 
             if (!isInfiniteTimeout)
             {
-                cts = new CancellationTokenSource();
-                cts.CancelAfter(timeout);
+                cts = new CancellationTokenSource(timeout);
                 cts.Token.Register(Cancel);
             }
 


### PR DESCRIPTION
The original issue is from [dotnet/SqlCLient #58](https://github.com/dotnet/SqlClient/issues/58) .

Backport the [PR#332](https://github.com/dotnet/SqlClient/pull/332) from Microsoft.Data.SqlClient to System.Data.SqlClient.