### PR TITLE
Re-enable CoreLib analyzers

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -3,9 +3,10 @@
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
-    <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0-beta2-final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" />
+    <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <!-- Microsoft.CodeAnalysis.Common brings in external dependencies that CoreLib can't deal with. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Condition="'$(MSBuildProjectName)' != 'System.Private.CoreLib'" Version="3.4.0-beta2-final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -4,8 +4,6 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <!-- Microsoft.CodeAnalysis.Common brings in external dependencies that CoreLib can't deal with. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Condition="'$(MSBuildProjectName)' != 'System.Private.CoreLib'" Version="3.4.0-beta2-final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" PrivateAssets="all" />
   </ItemGroup>

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -63,7 +63,7 @@
     <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <EnableAnalyzers>false</EnableAnalyzers>
+    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <!-- Platform specific properties -->

--- a/src/libraries/restore/analyzers/analyzers.depproj
+++ b/src/libraries/restore/analyzers/analyzers.depproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <!-- 
       Microsoft.CodeAnalysis.Common shouldn't be referenced directly but is needed by the analyzer depproj restore.
-      TODO: Remove when project restore is enabled for non test projects.
+      TODO: Remove when project restore is enabled for non test projects: https://github.com/dotnet/corefx/issues/41512.
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0-beta2-final" PrivateAssets="all" />
   </ItemGroup>

--- a/src/libraries/restore/analyzers/analyzers.depproj
+++ b/src/libraries/restore/analyzers/analyzers.depproj
@@ -5,6 +5,14 @@
     <Language>C#</Language>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- 
+      Microsoft.CodeAnalysis.Common shouldn't be referenced directly but is needed by the analyzer depproj restore.
+      TODO: Remove when project restore is enabled for non test projects.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0-beta2-final" PrivateAssets="all" />
+  </ItemGroup>
+
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 
   <Target Name="GenerateAnalyzersPropsFile"


### PR DESCRIPTION
CoreLib analyzers were unintentionally disabled with
6afe96cc2e950379d13a87efa1fa5a651cbce9bd. This re-enables the analyzers
and conditions one which brings in external dependencies that CoreLib
can't deal with.

Fixes https://github.com/dotnet/runtime/issues/422