### PR TITLE
SmtpConnection: fix Socket not getting Disposed when LingerState cannot be set.

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -1080,13 +1080,16 @@ namespace System.Net.Mail
 
         private void Abort()
         {
-            try
-            {
+            // Try-catch commented out to identify exception that is causing
+            // https://github.com/dotnet/corefx/issues/40711.
+
+            // try
+            // {
                 _transport.Abort();
-            }
-            catch
-            {
-            }
+            // }
+            // catch
+            // {
+            // }
         }
 
         public void Dispose()

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -40,9 +40,6 @@ namespace System.Net.Mail
         private readonly ChannelBinding _channelBindingToken = null;
         private bool _enableSsl;
         private X509CertificateCollection _clientCertificates;
-#pragma warning disable CS0414
-        private bool _aborted; // Tracks whether Abort was called, for debugging https://github.com/dotnet/corefx/issues/40711.
-#pragma warning restore CS0414
 
         internal SmtpConnection(SmtpTransport parent, SmtpClient client, ICredentialsByHost credentials, ISmtpAuthenticationModule[] authenticationModules)
         {
@@ -154,8 +151,6 @@ namespace System.Net.Mail
 
         internal void Abort()
         {
-            _aborted = true;
-
             if (!_isClosed)
             {
                 lock (this)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40711