### PR TITLE
Added tests to cover all branches of JsonNodeOptions

### DIFF
--- a/src/libraries/System.Text.Json/tests/JsonNode.TraversalTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNode.TraversalTests.cs
@@ -279,5 +279,26 @@ namespace System.Text.Json.Tests
             Assert.IsType<JsonArray>(jsonObject["array"]);
             Assert.IsType<JsonNumber>(nestedObject["array"]);
         }
+
+        [Fact]
+        public static void TestInvalidJsonNodeOptions()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                CommentHandling = (JsonCommentHandling)Enum.GetNames(typeof(JsonCommentHandling)).Length
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                MaxDepth = -1
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)Enum.GetNames(typeof(DuplicatePropertyNameHandlingStrategy)).Length
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)(-1)
+            });
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/JsonNode.TraversalTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNode.TraversalTests.cs
@@ -110,23 +110,6 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        public static void TestParseFailsWhenExceedsMaxDepth()
-        {
-            var builder = new StringBuilder();
-            for (int i = 0; i < 100; i++)
-            {
-                builder.Append("[");
-            }
-
-            for (int i = 0; i < 100; i++)
-            {
-                builder.Append("]");
-            }
-
-            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
-        }
-
-        [Fact]
         public static void TestDeepCopyDoesNotStackOverflow()
         {
             var builder = new StringBuilder();
@@ -278,27 +261,6 @@ namespace System.Text.Json.Tests
 
             Assert.IsType<JsonArray>(jsonObject["array"]);
             Assert.IsType<JsonNumber>(nestedObject["array"]);
-        }
-
-        [Fact]
-        public static void TestInvalidJsonNodeOptions()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
-            {
-                CommentHandling = (JsonCommentHandling)Enum.GetNames(typeof(JsonCommentHandling)).Length
-            });
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
-            {
-                MaxDepth = -1
-            });
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
-            {
-                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)Enum.GetNames(typeof(DuplicatePropertyNameHandlingStrategy)).Length
-            });
-            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
-            {
-                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)(-1)
-            });
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.Json.Tests
+{
+    public static partial class JsonNodeOptionsTests
+    {
+        [Fact]
+        public static void TestParseFailsWhenExceedsMaxDepth()
+        {
+            var builder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append("[");
+            }
+
+            for (int i = 0; i < 100; i++)
+            {
+                builder.Append("]");
+            }
+
+            // Test for default MaxDepth
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
+
+            // Test for MaxDepth of 5
+            var options = new JsonNodeOptions { MaxDepth = 5 };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString(), options));
+        }
+
+        [Theory]
+        [InlineData(JsonCommentHandling.Disallow)]
+        [InlineData(JsonCommentHandling.Skip)]
+        public static void TestJsonCommentHandling(JsonCommentHandling jsonCommentHandling)
+        {
+            JsonNodeOptions options = new JsonNodeOptions { CommentHandling = jsonCommentHandling };
+
+            string jsonStringWithComments = @"
+            {
+                // First comment
+                ""firstProperty"": ""first value"", //Second comment
+                ""secondProperty"" : ""second value""// Third comment
+                // Last comment
+            }";
+
+            if (jsonCommentHandling == JsonCommentHandling.Disallow)
+            {
+                Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments, options));
+            }
+            else
+            {
+                JsonObject jsonObject = (JsonObject)JsonNode.Parse(jsonStringWithComments, options);
+
+                Assert.Equal("first value", jsonObject["firstProperty"]);
+                Assert.Equal("second value", jsonObject["secondProperty"]);
+
+                Assert.Equal(2, jsonObject.GetPropertyNames().Count);
+                Assert.Equal(2, jsonObject.GetPropertyValues().Count);
+            }
+        }
+
+        [Fact]
+        public static void TestTrailingCommas()
+        {
+            string jsonStringWithTrailingCommas = @"
+            {
+                ""firstProperty"": ""first value"",
+                ""secondProperty"" : ""second value"",
+            }";
+
+            JsonNodeOptions options = new JsonNodeOptions { AllowTrailingCommas = true };
+            JsonObject jsonObject = (JsonObject) JsonNode.Parse(jsonStringWithTrailingCommas, options);
+
+            Assert.Equal("first value", jsonObject["firstProperty"]);
+            Assert.Equal("second value", jsonObject["secondProperty"]);
+
+            Assert.Equal(2, jsonObject.GetPropertyNames().Count);
+            Assert.Equal(2, jsonObject.GetPropertyValues().Count);
+
+            options = new JsonNodeOptions { AllowTrailingCommas = false };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas, options));
+        }
+
+        [Fact]
+        public static void TestInvalidJsonNodeOptions()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                CommentHandling = (JsonCommentHandling)Enum.GetNames(typeof(JsonCommentHandling)).Length
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                MaxDepth = -1
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)Enum.GetNames(typeof(DuplicatePropertyNameHandlingStrategy)).Length
+            });
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonNodeOptions()
+            {
+                DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)(-1)
+            });
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
@@ -104,5 +104,17 @@ namespace System.Text.Json.Tests
                 DuplicatePropertyNameHandling = (DuplicatePropertyNameHandlingStrategy)(-1)
             });
         }
+
+        [Fact]
+        public static void TestDefaultJsonNodeOptions()
+        {
+            JsonNodeOptions defaultOptions = default;
+            JsonNodeOptions newOptions = new JsonNodeOptions();
+
+            Assert.Equal(defaultOptions.AllowTrailingCommas, newOptions.AllowTrailingCommas);
+            Assert.Equal(defaultOptions.CommentHandling, newOptions.CommentHandling);
+            Assert.Equal(defaultOptions.DuplicatePropertyNameHandling, newOptions.DuplicatePropertyNameHandling);
+            Assert.Equal(defaultOptions.MaxDepth, newOptions.MaxDepth);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
@@ -24,19 +24,17 @@ namespace System.Text.Json.Tests
 
             // Test for default MaxDepth
             Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
+            JsonNodeOptions options = new JsonNodeOptions { MaxDepth = default };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
 
             // Test for MaxDepth of 5
-            var options = new JsonNodeOptions { MaxDepth = 5 };
+            options = new JsonNodeOptions { MaxDepth = 5 };
             Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString(), options));
         }
 
-        [Theory]
-        [InlineData(JsonCommentHandling.Disallow)]
-        [InlineData(JsonCommentHandling.Skip)]
-        public static void TestJsonCommentHandling(JsonCommentHandling jsonCommentHandling)
+        [Fact]
+        public static void TestJsonCommentHandling()
         {
-            JsonNodeOptions options = new JsonNodeOptions { CommentHandling = jsonCommentHandling };
-
             string jsonStringWithComments = @"
             {
                 // First comment
@@ -45,20 +43,20 @@ namespace System.Text.Json.Tests
                 // Last comment
             }";
 
-            if (jsonCommentHandling == JsonCommentHandling.Disallow)
-            {
-                Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments, options));
-            }
-            else
-            {
-                JsonObject jsonObject = (JsonObject)JsonNode.Parse(jsonStringWithComments, options);
+            JsonNodeOptions options = new JsonNodeOptions { CommentHandling = default };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments));
 
-                Assert.Equal("first value", jsonObject["firstProperty"]);
-                Assert.Equal("second value", jsonObject["secondProperty"]);
+            options = new JsonNodeOptions { CommentHandling = JsonCommentHandling.Disallow };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments, options));
 
-                Assert.Equal(2, jsonObject.GetPropertyNames().Count);
-                Assert.Equal(2, jsonObject.GetPropertyValues().Count);
-            }
+            options = new JsonNodeOptions { CommentHandling = JsonCommentHandling.Skip };
+            JsonObject jsonObject = (JsonObject)JsonNode.Parse(jsonStringWithComments, options);
+
+            Assert.Equal("first value", jsonObject["firstProperty"]);
+            Assert.Equal("second value", jsonObject["secondProperty"]);
+
+            Assert.Equal(2, jsonObject.GetPropertyNames().Count);
+            Assert.Equal(2, jsonObject.GetPropertyValues().Count);
         }
 
         [Fact]
@@ -70,7 +68,13 @@ namespace System.Text.Json.Tests
                 ""secondProperty"" : ""second value"",
             }";
 
-            JsonNodeOptions options = new JsonNodeOptions { AllowTrailingCommas = true };
+            JsonNodeOptions options = new JsonNodeOptions { AllowTrailingCommas = default };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas));
+
+            options = new JsonNodeOptions { AllowTrailingCommas = false };
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas, options));
+
+            options = new JsonNodeOptions { AllowTrailingCommas = true };
             JsonObject jsonObject = (JsonObject) JsonNode.Parse(jsonStringWithTrailingCommas, options);
 
             Assert.Equal("first value", jsonObject["firstProperty"]);
@@ -78,9 +82,6 @@ namespace System.Text.Json.Tests
 
             Assert.Equal(2, jsonObject.GetPropertyNames().Count);
             Assert.Equal(2, jsonObject.GetPropertyValues().Count);
-
-            options = new JsonNodeOptions { AllowTrailingCommas = false };
-            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas, options));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
@@ -115,6 +115,11 @@ namespace System.Text.Json.Tests
             Assert.Equal(defaultOptions.CommentHandling, newOptions.CommentHandling);
             Assert.Equal(defaultOptions.DuplicatePropertyNameHandling, newOptions.DuplicatePropertyNameHandling);
             Assert.Equal(defaultOptions.MaxDepth, newOptions.MaxDepth);
+
+            Assert.False(defaultOptions.AllowTrailingCommas);
+            Assert.Equal(JsonCommentHandling.Disallow, defaultOptions.CommentHandling);
+            Assert.Equal(DuplicatePropertyNameHandlingStrategy.Replace, defaultOptions.DuplicatePropertyNameHandling);
+            Assert.Equal(0, defaultOptions.MaxDepth);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNodeOptionsTests.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Tests
             // Test for default MaxDepth
             Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
             JsonNodeOptions options = new JsonNodeOptions { MaxDepth = default };
-            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString()));
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(builder.ToString(), options));
 
             // Test for MaxDepth of 5
             options = new JsonNodeOptions { MaxDepth = 5 };
@@ -44,7 +44,7 @@ namespace System.Text.Json.Tests
             }";
 
             JsonNodeOptions options = new JsonNodeOptions { CommentHandling = default };
-            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments));
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments, options));
 
             options = new JsonNodeOptions { CommentHandling = JsonCommentHandling.Disallow };
             Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithComments, options));
@@ -69,7 +69,7 @@ namespace System.Text.Json.Tests
             }";
 
             JsonNodeOptions options = new JsonNodeOptions { AllowTrailingCommas = default };
-            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas));
+            Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas, options));
 
             options = new JsonNodeOptions { AllowTrailingCommas = false };
             Assert.ThrowsAny<JsonException>(() => JsonNode.Parse(jsonStringWithTrailingCommas, options));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -20,7 +20,6 @@
     <Compile Include="JsonElementWriteTests.cs" />
     <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />
-    <Compile Include="JsonNodeOptionsTests.cs" />
     <Compile Include="JsonNumberTestData.cs" />
     <Compile Include="JsonPropertyTests.cs" />
     <Compile Include="JsonReaderStateAndOptionsTests.cs" />
@@ -131,6 +130,7 @@
     <Compile Include="JsonNode.AsJsonElementTests.cs" />
     <Compile Include="JsonNode.CloneTests.cs" />
     <Compile Include="JsonNode.TraversalTests.cs" />
+    <Compile Include="JsonNodeOptionsTests.cs" />
     <Compile Include="JsonNullTests.cs" />
     <Compile Include="JsonNumberTests.cs" />
     <Compile Include="JsonObjectTests.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="JsonElementWriteTests.cs" />
     <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />
+    <Compile Include="JsonNodeOptionsTests.cs" />
     <Compile Include="JsonNumberTestData.cs" />
     <Compile Include="JsonPropertyTests.cs" />
     <Compile Include="JsonReaderStateAndOptionsTests.cs" />


### PR DESCRIPTION
Added tests to cover all branches of JsonNodeOptions. I am unsure whether JsonNode.TraversalTests was the right place for this test case, but I found no other more suitable place for it, so feedback is welcome. 

Solves [dotnet/corefx #42585](https://github.com/dotnet/corefx/issues/42585).
