### PR TITLE
Upgrade global.json to 5.0-alpha1 SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,14 +18,18 @@
   -->
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipImportArcadeSdkFromRoot)' != 'true'" />
 
-  <!-- Common paths -->
-
   <!-- Set these properties early enough for libraries as they import the Arcade SDK not early enough.  -->
   <PropertyGroup Condition="'$(SkipImportArcadeSdkFromRoot)' == 'true'">
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <RepositoryEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'eng'))</RepositoryEngineeringDir>
     <ArtifactsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>
     <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
+  </PropertyGroup>
+
+  <!-- The NetCoreApp TFM to build and test against. -->
+  <PropertyGroup>
+    <NetCoreAppvNextTFMFull>.NETCoreApp,Version=v5.0</NetCoreAppvNextTFMFull>
+    <NetCoreAppvNextTFM>netcoreapp5.0</NetCoreAppvNextTFM>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,8 +28,8 @@
 
   <!-- The NetCoreApp TFM to build and test against. -->
   <PropertyGroup>
-    <NetCoreAppvNextTFMFull>.NETCoreApp,Version=v5.0</NetCoreAppvNextTFMFull>
-    <NetCoreAppvNextTFM>netcoreapp5.0</NetCoreAppvNextTFM>
+    <NetCoreAppCurrentTFMFull>.NETCoreApp,Version=v5.0</NetCoreAppCurrentTFMFull>
+    <NetCoreAppCurrentTFM>netcoreapp5.0</NetCoreAppCurrentTFM>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,8 +28,8 @@
 
   <!-- The NetCoreApp TFM to build and test against. -->
   <PropertyGroup>
-    <NetCoreAppCurrentTFMFull>.NETCoreApp,Version=v5.0</NetCoreAppCurrentTFMFull>
-    <NetCoreAppCurrentTFM>netcoreapp5.0</NetCoreAppCurrentTFM>
+    <NetCoreAppCurrentTargetFrameworkMoniker>.NETCoreApp,Version=v5.0</NetCoreAppCurrentTargetFrameworkMoniker>
+    <NetCoreAppCurrent>netcoreapp5.0</NetCoreAppCurrent>
   </PropertyGroup>
 
   <!--

--- a/eng/configurations/targetgroups.props
+++ b/eng/configurations/targetgroups.props
@@ -100,8 +100,8 @@
     </TargetGroups>
     <!-- netcoreapp is an alias for netcoreapp5.0 -->
     <TargetGroups Include="netcoreapp">
-      <TargetFramework>netcoreapp5.0</TargetFramework>
-      <Imports>netcoreapp5.0</Imports>
+      <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+      <Imports>$(NetCoreAppvNextTFM)</Imports>
       <CompatibleWith>netstandard2.1</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="net45">

--- a/eng/configurations/targetgroups.props
+++ b/eng/configurations/targetgroups.props
@@ -100,8 +100,8 @@
     </TargetGroups>
     <!-- netcoreapp is an alias for netcoreapp5.0 -->
     <TargetGroups Include="netcoreapp">
-      <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
-      <Imports>$(NetCoreAppvNextTFM)</Imports>
+      <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+      <Imports>$(NetCoreAppCurrentTFM)</Imports>
       <CompatibleWith>netstandard2.1</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="net45">

--- a/eng/configurations/targetgroups.props
+++ b/eng/configurations/targetgroups.props
@@ -100,8 +100,8 @@
     </TargetGroups>
     <!-- netcoreapp is an alias for netcoreapp5.0 -->
     <TargetGroups Include="netcoreapp">
-      <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
-      <Imports>$(NetCoreAppCurrentTFM)</Imports>
+      <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+      <Imports>$(NetCoreAppCurrent)</Imports>
       <CompatibleWith>netstandard2.1</CompatibleWith>
     </TargetGroups>
     <TargetGroups Include="net45">

--- a/eng/testing/runtimeConfiguration.targets
+++ b/eng/testing/runtimeConfiguration.targets
@@ -36,7 +36,7 @@
     At that point restore and conflict resolution already happened therefore setting the item here has no side effects.
    -->
   <Target Name="_SetRuntimeFrameworksForTestAssemblies"
-          Condition="'$(SelfContained)' != 'true'"
+          Condition="'$(SelfContained)' != 'true' and '$(MSBuildProjectExtension)' != '.depproj'"
           BeforeTargets="GenerateBuildDependencyFile">
     <ItemGroup>
       <RuntimeFramework Include="Microsoft.NETCore.App" Version="$(ProductVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "3.0.100",
+    "version": "5.0.100-alpha1-015772",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "3.0.100"
+    "dotnet": "5.0.100-alpha1-015772"
   },
   "native-tools": {
     "cmake": "3.14.2",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-alpha1-015772",
+    "version": "3.0.100",
     "allowPrerelease": true,
     "rollForward": "major"
   },

--- a/src/coreclr/src/.nuget/Microsoft.NETCore.Crossgen2/Microsoft.NETCore.Crossgen2.pkgproj
+++ b/src/coreclr/src/.nuget/Microsoft.NETCore.Crossgen2/Microsoft.NETCore.Crossgen2.pkgproj
@@ -19,10 +19,10 @@
     <Crossgen2RuntimeConfigContents>
 {
   "runtimeOptions": {
-    "tfm": "netcoreapp3.0",
+    "tfm": "netcoreapp5.0",
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "5.0.0-alpha1.0"
+      "version": "5.0.100-alpha1-015772"
     }
   }
 }

--- a/src/coreclr/src/.nuget/optdata/optdata.csproj
+++ b/src/coreclr/src/.nuget/optdata/optdata.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Windows_NT' And ('$(BuildArch)' == 'x64' Or '$(BuildArch)' == 'x86')">True</OptimizationDataSupported>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Linux' And '$(BuildArch)' == 'x64'">True</OptimizationDataSupported>

--- a/src/coreclr/src/.nuget/optdata/optdata.csproj
+++ b/src/coreclr/src/.nuget/optdata/optdata.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Windows_NT' And ('$(BuildArch)' == 'x64' Or '$(BuildArch)' == 'x86')">True</OptimizationDataSupported>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Linux' And '$(BuildArch)' == 'x64'">True</OptimizationDataSupported>

--- a/src/coreclr/src/.nuget/optdata/optdata.csproj
+++ b/src/coreclr/src/.nuget/optdata/optdata.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Windows_NT' And ('$(BuildArch)' == 'x64' Or '$(BuildArch)' == 'x86')">True</OptimizationDataSupported>
     <OptimizationDataSupported Condition="'$(BuildOS)' == 'Linux' And '$(BuildArch)' == 'x64'">True</OptimizationDataSupported>

--- a/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/Tools/GenUnicodeProp/GenUnicodeProp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
+++ b/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
+++ b/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
+++ b/src/coreclr/src/tools/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
@@ -81,7 +81,7 @@ namespace ReadyToRun.SuperIlc
                     }
 
                     // This is not a reliable way of building the publish folder
-                    string publishFolder = Path.Combine(appFolder, @"artifacts\Debug\netcoreapp3.0\publish");
+                    string publishFolder = Path.Combine(appFolder, @"artifacts\Debug\netcoreapp5.0\publish");
                     if (!Directory.Exists(publishFolder))
                     {
                         nugetLog.WriteLine($"Could not find folder {publishFolder} containing the published app.");

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>ReadyToRun.SuperIlc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platform>AnyCPU</Platform>
     <OutputPath>$(BinDir)\ReadyToRun.SuperIlc</OutputPath>

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>ReadyToRun.SuperIlc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platform>AnyCPU</Platform>
     <OutputPath>$(BinDir)\ReadyToRun.SuperIlc</OutputPath>

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>ReadyToRun.SuperIlc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platform>AnyCPU</Platform>
     <OutputPath>$(BinDir)\ReadyToRun.SuperIlc</OutputPath>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>crossgen2</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTargets Condition="'$(BuildArch)' != ''">$(BuildArch)</PlatformTargets>

--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>crossgen2</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTargets Condition="'$(BuildArch)' != ''">$(BuildArch)</PlatformTargets>

--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>crossgen2</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTargets Condition="'$(BuildArch)' != ''">$(BuildArch)</PlatformTargets>

--- a/src/coreclr/src/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.csproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>

--- a/src/coreclr/src/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.csproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>

--- a/src/coreclr/src/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.csproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>

--- a/src/coreclr/src/tools/runincontext/runincontext.csproj
+++ b/src/coreclr/src/tools/runincontext/runincontext.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>

--- a/src/coreclr/src/tools/runincontext/runincontext.csproj
+++ b/src/coreclr/src/tools/runincontext/runincontext.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>

--- a/src/coreclr/src/tools/runincontext/runincontext.csproj
+++ b/src/coreclr/src/tools/runincontext/runincontext.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>

--- a/src/coreclr/tests/dir.sdkbuild.props
+++ b/src/coreclr/tests/dir.sdkbuild.props
@@ -6,7 +6,7 @@
        and old-style projects should go in dir.common.props. -->
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Platform>$(BuildArch)</Platform>

--- a/src/coreclr/tests/dir.sdkbuild.props
+++ b/src/coreclr/tests/dir.sdkbuild.props
@@ -6,7 +6,7 @@
        and old-style projects should go in dir.common.props. -->
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Platform>$(BuildArch)</Platform>

--- a/src/coreclr/tests/dir.sdkbuild.props
+++ b/src/coreclr/tests/dir.sdkbuild.props
@@ -6,7 +6,7 @@
        and old-style projects should go in dir.common.props. -->
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
     <Platform>$(BuildArch)</Platform>

--- a/src/coreclr/tests/external/external.csproj
+++ b/src/coreclr/tests/external/external.csproj
@@ -12,9 +12,9 @@
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
     <OutputPath>$(TargetingPackPath)</OutputPath>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <NuGetTargetMoniker>.NETCoreApp,Version=v3.0</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>netcoreapp3.0</NuGetTargetMonikerShort>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
     <XUnitRunnerTargetFramework>netcoreapp2.1</XUnitRunnerTargetFramework>
     <CLRTestKind>SharedLibrary</CLRTestKind>

--- a/src/coreclr/tests/external/external.csproj
+++ b/src/coreclr/tests/external/external.csproj
@@ -12,9 +12,9 @@
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
     <OutputPath>$(TargetingPackPath)</OutputPath>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
-    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
     <XUnitRunnerTargetFramework>netcoreapp2.1</XUnitRunnerTargetFramework>
     <CLRTestKind>SharedLibrary</CLRTestKind>

--- a/src/coreclr/tests/external/external.csproj
+++ b/src/coreclr/tests/external/external.csproj
@@ -12,9 +12,9 @@
          This RID value doesn't really matter, since the assets we are copying are not RID specific, so defaulting to Windows here
     -->
     <OutputPath>$(TargetingPackPath)</OutputPath>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
-    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTargetFrameworkMoniker)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrent)</NuGetTargetMonikerShort>
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
     <XUnitRunnerTargetFramework>netcoreapp2.1</XUnitRunnerTargetFramework>
     <CLRTestKind>SharedLibrary</CLRTestKind>

--- a/src/coreclr/tests/publishdependency.targets
+++ b/src/coreclr/tests/publishdependency.targets
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<Project>
   <ItemGroup>
-    <TestTargetFramework Include=".NETCoreApp,Version=v5.0">
-      <Folder>netcoreapp5.0</Folder>
+    <TestTargetFramework Include="$(NetCoreAppCurrentTargetFrameworkMoniker)">
+      <Folder>$(NetCoreAppCurrent)</Folder>
     </TestTargetFramework>
   </ItemGroup>
 
@@ -34,5 +32,4 @@
              Properties="Language=C#;RuntimeIdentifier=$(TargetRid)" />
 
   </Target>
-
 </Project>

--- a/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -7,11 +7,7 @@
     <DefineConstants>$(DefineConstants);$([System.String]::Copy('$(BuildArch)').ToUpper())</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRunScript>false</GenerateRunScript>
-    <!-- Tests build for netcoreapp3.0, but use the test_dependencies
-         assets file, which has netcoreapp5.0 assets. Therefore the
-         assets file for this project must have netcoreapp5.0 assets,
-         but the project needs to build for 3.0. -->
-    <TargetFramework Condition=" '$(SetTFMForRestore)' == 'true' ">netcoreapp5.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <ProjectAssetsFile>$(SourceDir)Common\CoreCLRTestLibrary\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>$(DefineConstants);$([System.String]::Copy('$(BuildArch)').ToUpper())</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRunScript>false</GenerateRunScript>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <ProjectAssetsFile>$(SourceDir)Common\CoreCLRTestLibrary\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>$(DefineConstants);$([System.String]::Copy('$(BuildArch)').ToUpper())</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRunScript>false</GenerateRunScript>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <ProjectAssetsFile>$(SourceDir)Common\CoreCLRTestLibrary\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
+++ b/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectAssetsFile>$(SourceDir)Common\Coreclr.TestWrapper\obj\project.assets.json</ProjectAssetsFile>
-    <NuGetTargetMoniker>.NETCoreApp,Version=v3.0</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>netcoreapp3.0</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
+++ b/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectAssetsFile>$(SourceDir)Common\Coreclr.TestWrapper\obj\project.assets.json</ProjectAssetsFile>
-    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
+++ b/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectAssetsFile>$(SourceDir)Common\Coreclr.TestWrapper\obj\project.assets.json</ProjectAssetsFile>
-    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTargetFrameworkMoniker)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrent)</NuGetTargetMonikerShort>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(SetTFMForRestore)'=='true'">netcoreapp5.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</AssetTargetFallback>
     <NoWarn>$(NoWarn);NU1603</NoWarn>

--- a/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(SetTFMForRestore)'=='true'">netcoreapp5.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</AssetTargetFallback>
     <NoWarn>$(NoWarn);NU1603</NoWarn>

--- a/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/src/coreclr/tests/src/Common/test_runtime/test_runtime.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <IsTestProject>false</IsTestProject>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</AssetTargetFallback>
     <NoWarn>$(NoWarn);NU1603</NoWarn>

--- a/src/coreclr/tests/src/Directory.Build.props
+++ b/src/coreclr/tests/src/Directory.Build.props
@@ -142,7 +142,7 @@
     <RestoreOutputPath>$(MSBuildProjectDirectory)\obj</RestoreOutputPath>
 
     <!-- Specify the target framework of the common test dependency project.json. -->
-    <NuGetTargetMoniker>.NETCoreApp,Version=v5.0</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>netcoreapp5.0</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/Directory.Build.props
+++ b/src/coreclr/tests/src/Directory.Build.props
@@ -142,7 +142,7 @@
     <RestoreOutputPath>$(MSBuildProjectDirectory)\obj</RestoreOutputPath>
 
     <!-- Specify the target framework of the common test dependency project.json. -->
-    <NuGetTargetMoniker>$(NetCoreAppvNextTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppvNextTFM)</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/Directory.Build.props
+++ b/src/coreclr/tests/src/Directory.Build.props
@@ -142,7 +142,7 @@
     <RestoreOutputPath>$(MSBuildProjectDirectory)\obj</RestoreOutputPath>
 
     <!-- Specify the target framework of the common test dependency project.json. -->
-    <NuGetTargetMoniker>$(NetCoreAppCurrentTFMFull)</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>$(NetCoreAppCurrentTFM)</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>$(NetCoreAppCurrentTargetFrameworkMoniker)</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>$(NetCoreAppCurrent)</NuGetTargetMonikerShort>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/performance/Scenario/JitBench/Utilities/DotNetSetup.cs
+++ b/src/coreclr/tests/src/performance/Scenario/JitBench/Utilities/DotNetSetup.cs
@@ -235,7 +235,11 @@ namespace JitBench
 
         public static string GetTargetFrameworkMonikerForFrameworkVersion(string runtimeVersion)
         {
-            if (runtimeVersion.StartsWith("3.0"))
+            if (runtimeVersion.StartsWith("5.0"))
+            {
+                return "netcoreapp5.0";
+            }
+            else if (runtimeVersion.StartsWith("3.0"))
             {
                 return "netcoreapp3.0";
             }

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -33,7 +33,7 @@
       deb-tool" commands, after depending on InitializeDotnetDebTool target.
     -->
     <DebToolBinDir>$(ArtifactsBinDir)dotnet-deb-tool\</DebToolBinDir>
-    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppvNextTFM)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
+    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppCurrentTFM)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
     <DotnetDebToolSourceDir>$(RepoRoot)tools-local/dotnet-deb-tool/</DotnetDebToolSourceDir>
 
     <IsDebianBasedDistro

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -33,7 +33,7 @@
       deb-tool" commands, after depending on InitializeDotnetDebTool target.
     -->
     <DebToolBinDir>$(ArtifactsBinDir)dotnet-deb-tool\</DebToolBinDir>
-    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\netcoreapp3.0\dotnet-deb-tool.dll</DebtoolAssemblyFile>
+    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppvNextTFM)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
     <DotnetDebToolSourceDir>$(RepoRoot)tools-local/dotnet-deb-tool/</DotnetDebToolSourceDir>
 
     <IsDebianBasedDistro

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -33,7 +33,7 @@
       deb-tool" commands, after depending on InitializeDotnetDebTool target.
     -->
     <DebToolBinDir>$(ArtifactsBinDir)dotnet-deb-tool\</DebToolBinDir>
-    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppCurrentTFM)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
+    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppCurrent)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
     <DotnetDebToolSourceDir>$(RepoRoot)tools-local/dotnet-deb-tool/</DotnetDebToolSourceDir>
 
     <IsDebianBasedDistro

--- a/src/installer/test/Directory.Build.props
+++ b/src/installer/test/Directory.Build.props
@@ -9,7 +9,7 @@
     <TestRestoreNuGetConfigFile>$(ArtifactsObjDir)TestNuGetConfig\NuGet.config</TestRestoreNuGetConfigFile>
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
-    <TestInfraTargetFramework>$(NetCoreAppvNextTFM)</TestInfraTargetFramework>
+    <TestInfraTargetFramework>$(NetCoreAppCurrentTFM)</TestInfraTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/installer/test/Directory.Build.props
+++ b/src/installer/test/Directory.Build.props
@@ -9,7 +9,7 @@
     <TestRestoreNuGetConfigFile>$(ArtifactsObjDir)TestNuGetConfig\NuGet.config</TestRestoreNuGetConfigFile>
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
-    <TestInfraTargetFramework>netcoreapp3.0</TestInfraTargetFramework>
+    <TestInfraTargetFramework>$(NetCoreAppvNextTFM)</TestInfraTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/installer/test/Directory.Build.props
+++ b/src/installer/test/Directory.Build.props
@@ -9,7 +9,7 @@
     <TestRestoreNuGetConfigFile>$(ArtifactsObjDir)TestNuGetConfig\NuGet.config</TestRestoreNuGetConfigFile>
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
-    <TestInfraTargetFramework>$(NetCoreAppCurrentTFM)</TestInfraTargetFramework>
+    <TestInfraTargetFramework>$(NetCoreAppCurrent)</TestInfraTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -8,6 +8,6 @@
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -8,6 +8,6 @@
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -8,6 +8,6 @@
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/libraries/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
@@ -1,8 +1,5 @@
 <Project>
   <ItemGroup>
-    <!-- We can remove this workaround until we retarget corefx to 5.0 -->
-    <IgnoredReference Include="System.Private.CoreLib" />
-
     <!-- Temporary till SDK supports transitive framework references. -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />

--- a/src/libraries/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
@@ -1,5 +1,8 @@
 <Project>
   <ItemGroup>
+    <!-- We can remove this workaround until we retarget corefx to 5.0 -->
+    <IgnoredReference Include="System.Private.CoreLib" />
+
     <!-- Temporary till SDK supports transitive framework references. -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />

--- a/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
@@ -1,35 +1,8 @@
 <Project>
-  <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
-    <NETCoreAppMaximumVersion>5.0</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
-    <!-- This should be enabled once we have updating assembly versions in our targeting pack. -->
-    <ShouldVerifyClosure>false</ShouldVerifyClosure>
-  </PropertyGroup>
-
   <ItemGroup>
-    <!-- Since we don't have an SDK that knows about 5.0 framework, we should specify it manually. -->
-    <KnownFrameworkReference Update="Microsoft.NETCore.App"
-                            TargetFramework="$(TargetFramework)"
-                            RuntimeFrameworkName="Microsoft.NETCore.App"
-                            DefaultRuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
-                            LatestRuntimeFrameworkVersion="$(RuntimeFrameworkVersion)"
-                            TargetingPackName="Microsoft.NETCore.App.Ref"
-                            TargetingPackVersion="$(RuntimeFrameworkVersion)"
-                            RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
-                            RuntimePackRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-                            PackagesToReference="Microsoft.NETCore.App/$(RuntimeFrameworkVersion)"
-                            IsTrimmable="true"
-                            />
-
-    <KnownAppHostPack Update="Microsoft.NETCore.App"
-                      TargetFramework="$(TargetFramework)"
-                      AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
-                      AppHostPackVersion="$(RuntimeFrameworkVersion)"
-                      AppHostRuntimeIdentifiers="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"
-                      />
-
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WPF" />
+    <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />
   </ItemGroup>
 </Project>

--- a/src/libraries/restore/netcoreapp/netcoreapp.depproj
+++ b/src/libraries/restore/netcoreapp/netcoreapp.depproj
@@ -11,6 +11,17 @@
     <PackageReference Update="Microsoft.NETCore.App" IsImplicitlyDefined="false" PrivateAssets="None" />
   </ItemGroup>
 
+  <!-- Mark framework references from previous netcoreapp tfms >= 3.0 as copy-local. -->
+  <Target Name="_FrameworkReferencesToPrivate"
+          Condition="'$(TargetsNetCoreApp)' == 'true' and !$(TargetFramework.StartsWith('netcoreapp2.')) and '$(TargetFramework)' != '$(NetCoreAppCurrent)'"
+          AfterTargets="_HandlePackageFileConflicts">
+    <ItemGroup>
+      <_referencePrivate Include="@(Reference)" Private="true" />
+      <Reference Remove="@(Reference)" />
+      <Reference Include="@(_referencePrivate)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- for all configurations this project provides refs for that configuration -->
     <BinPlaceConfiguration Include="$(Configuration)" RefPath="$(RefPath)" />

--- a/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
+++ b/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
     <AssemblyName>dotnet-deb-tool</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
+++ b/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppvNextTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
     <AssemblyName>dotnet-deb-tool</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
+++ b/tools-local/dotnet-deb-tool/dotnet-deb-tool.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrentTFM)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AssemblyName>dotnet-deb-tool</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
We need the 5.0 SDK to use new VSTest features and we should start using it anyway. Opening this PR to test what will eventually break.