### PR TITLE
Improve Regex performance (mainly interpreted)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -205,23 +205,6 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        private bool MatchPattern(string text, int index)
-        {
-            if (CaseInsensitive)
-            {
-                if (text.Length - index < Pattern.Length)
-                {
-                    return false;
-                }
-
-                return (0 == string.Compare(Pattern, 0, text, index, Pattern.Length, CaseInsensitive, _culture));
-            }
-            else
-            {
-                return (0 == string.CompareOrdinal(Pattern, 0, text, index, Pattern.Length));
-            }
-        }
-
         /// <summary>
         /// When a regex is anchored, we can do a quick IsMatch test instead of a Scan
         /// </summary>
@@ -231,16 +214,21 @@ namespace System.Text.RegularExpressions
             {
                 if (index < beglimit || endlimit - index < Pattern.Length)
                     return false;
-
-                return MatchPattern(text, index);
             }
             else
             {
                 if (index > endlimit || index - beglimit < Pattern.Length)
                     return false;
 
-                return MatchPattern(text, index - Pattern.Length);
+                index -= Pattern.Length;
             }
+
+            if (CaseInsensitive)
+            {
+                return string.Compare(Pattern, 0, text, index, Pattern.Length, ignoreCase: true, _culture) == 0;
+            }
+
+            return Pattern.AsSpan().SequenceEqual(text.AsSpan(index, Pattern.Length));
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -732,7 +732,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static char SingletonChar(string set)
         {
-            Debug.Assert(IsSingleton(set) || IsSingletonInverse(set), "Tried to get the singleton char out of a non singleton character class");
+            Debug.Assert(IsSingletonInverse(set), "Tried to get the singleton char out of a non singleton character class");
             return set[SetStartIndex];
         }
 
@@ -746,14 +746,6 @@ namespace System.Text.RegularExpressions
             charClass[SetLengthIndex] == 0 &&
             !IsNegated(charClass) &&
             !IsSubtraction(charClass);
-
-        /// <summary><c>true</c> if the set contains a single character only</summary>
-        public static bool IsSingleton(string set) =>
-            set[CategoryLengthIndex] == 0 &&
-            set[SetLengthIndex] == 2 &&
-            !IsNegated(set) &&
-            !IsSubtraction(set) &&
-            (set[SetStartIndex] == LastChar || set[SetStartIndex] + 1 == set[SetStartIndex + 1]);
 
         public static bool IsSingletonInverse(string set) =>
             set[CategoryLengthIndex] == 0 &&

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 
 namespace System.Text.RegularExpressions
 {
@@ -813,6 +814,68 @@ namespace System.Text.RegularExpressions
                 default:
                     return ch == ZeroWidthJoiner || ch == ZeroWidthNonJoiner;
             }
+        }
+
+        public static bool CharInClass(char ch, string set, ref int[]? asciiResultCache)
+        {
+            // The int[] contains 8 ints, or 256 bits.  These are laid out as pairs, where the first bit ("known") in the pair
+            // says whether the second bit ("value") in the pair has already been computed.  Once a value is computed, it's never
+            // changed, so since Int32s are written/read atomically, we can trust the value bit if we see that the known bit
+            // has been set.  If the known bit hasn't been set, then we proceed to look it up, and then swap in the result.
+            const int CacheArrayLength = 8;
+            Debug.Assert(asciiResultCache is null || asciiResultCache.Length == CacheArrayLength, "set lookup should be able to store two bits for each of the first 128 characters");
+
+            if (ch < 128)
+            {
+                // Lazily-initialize the cache for this set.
+                if (asciiResultCache is null)
+                {
+                    Interlocked.CompareExchange(ref asciiResultCache, new int[CacheArrayLength], null);
+                }
+
+                // Determine which int in the lookup array contains the known and value bits for this character,
+                // and compute their bit numbers.
+                ref int slot = ref asciiResultCache[ch >> 4];
+                int knownBit = 1 << ((ch & 0xF) << 1);
+                int valueBit = knownBit << 1;
+
+                // If the value for this bit has already been computed, use it.
+                int current = slot;
+                if ((current & knownBit) != 0)
+                {
+                    return (current & valueBit) != 0;
+                }
+
+                // (After warm-up, we should find ourselves rarely getting here.)
+
+                // Otherwise, compute it normally.
+                bool isInClass = CharInClass(ch, set);
+
+                // Determine which bits to write back to the array.
+                int bitsToSet = knownBit;
+                if (isInClass)
+                {
+                    bitsToSet |= valueBit;
+                }
+
+                // "or" the bits back in a thread-safe manner.
+                while (true)
+                {
+                    int oldValue = Interlocked.CompareExchange(ref slot, current | bitsToSet, current);
+                    if (oldValue == current)
+                    {
+                        break;
+                    }
+
+                    current = oldValue;
+                }
+
+                // Return the computed value.
+                return isInClass;
+            }
+
+            // Non-ASCII.  Fall back to computing the answer.
+            return CharInClassRecursive(ch, set, 0);
         }
 
         public static bool CharInClass(char ch, string set) =>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -18,7 +18,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
@@ -91,10 +90,12 @@ namespace System.Text.RegularExpressions
 
         public readonly int[] Codes;                     // the code
         public readonly string[] Strings;                // the string/set table
+        public readonly int[]?[] StringsAsciiLookup;     // the ASCII lookup table optimization for the sets in Strings
         public readonly int TrackCount;                  // how many instructions use backtracking
         public readonly Hashtable? Caps;                 // mapping of user group numbers -> impl group slots
         public readonly int CapSize;                     // number of impl group slots
         public readonly RegexPrefix? FCPrefix;           // the set of candidate first characters (may be null)
+        public int[]? FCPrefixAsciiLookup;               // the ASCII lookup table optimization for the set of candidate first characters if there are any
         public readonly RegexBoyerMoore? BMPrefix;       // the fixed prefix string as a Boyer-Moore machine (may be null)
         public readonly int Anchors;                     // the set of zero-length start anchors (RegexFCD.Bol, etc)
         public readonly bool RightToLeft;                // true if right to left
@@ -109,6 +110,7 @@ namespace System.Text.RegularExpressions
 
             Codes = codes;
             Strings = stringlist.ToArray();
+            StringsAsciiLookup = new int[Strings.Length][];
             TrackCount = trackcount;
             Caps = caps;
             CapSize = capsize;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1163,29 +1163,14 @@ namespace System.Text.RegularExpressions
                     CallToLower();
                 }
 
-                if (!RegexCharClass.IsSingleton(_fcPrefix.GetValueOrDefault().Prefix))
-                {
-                    EmitCallCharInClass(_fcPrefix.GetValueOrDefault().Prefix, charInClassV);
-                    BrtrueFar(l2);
-                }
-                else
-                {
-                    Ldc(RegexCharClass.SingletonChar(_fcPrefix.GetValueOrDefault().Prefix));
-                    Beq(l2);
-                }
+                EmitCallCharInClass(_fcPrefix.GetValueOrDefault().Prefix, charInClassV);
+                BrtrueFar(l2);
 
                 MarkLabel(l5);
 
                 Ldloc(cV);
                 Ldc(0);
-                if (!RegexCharClass.IsSingleton(_fcPrefix.GetValueOrDefault().Prefix))
-                {
-                    BgtFar(l1);
-                }
-                else
-                {
-                    Bgt(l1);
-                }
+                BgtFar(l1);
 
                 Ldc(0);
                 BrFar(l3);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -171,6 +171,7 @@ namespace System.Text.RegularExpressions
             _codepos = newpos;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetOperator(int op)
         {
             _caseInsensitive = (0 != (op & RegexCode.Ci));

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -430,7 +430,7 @@ namespace System.Text.RegularExpressions
                     // left-to-right, case-sensitive
                     for (int i = 0; i < span.Length; i++)
                     {
-                        if (RegexCharClass.CharInClass(span[i], set))
+                        if (RegexCharClass.CharInClass(span[i], set, ref _code.FCPrefixAsciiLookup))
                         {
                             runtextpos += i;
                             return true;
@@ -442,8 +442,8 @@ namespace System.Text.RegularExpressions
                     // left-to-right, case-insensitive
                     TextInfo ti = _culture.TextInfo;
                     for (int i = 0; i < span.Length; i++)
-                        {
-                        if (RegexCharClass.CharInClass(ti.ToLower(span[i]), set))
+                    {
+                        if (RegexCharClass.CharInClass(ti.ToLower(span[i]), set, ref _code.FCPrefixAsciiLookup))
                         {
                             runtextpos += i;
                             return true;
@@ -458,7 +458,7 @@ namespace System.Text.RegularExpressions
                     // right-to-left, case-sensitive
                     for (int i = runtextpos - 1; i >= runtextbeg; i--)
                     {
-                        if (RegexCharClass.CharInClass(runtext![i], set))
+                        if (RegexCharClass.CharInClass(runtext![i], set, ref _code.FCPrefixAsciiLookup))
                         {
                             runtextpos = i + 1;
                             return true;
@@ -471,7 +471,7 @@ namespace System.Text.RegularExpressions
                     TextInfo ti = _culture.TextInfo;
                     for (int i = runtextpos - 1; i >= runtextbeg; i--)
                     {
-                        if (RegexCharClass.CharInClass(ti.ToLower(runtext![i]), set))
+                        if (RegexCharClass.CharInClass(ti.ToLower(runtext![i]), set, ref _code.FCPrefixAsciiLookup))
                         {
                             runtextpos = i + 1;
                             return true;
@@ -924,8 +924,14 @@ namespace System.Text.RegularExpressions
                         continue;
 
                     case RegexCode.Set:
-                        if (Forwardchars() < 1 || !RegexCharClass.CharInClass(Forwardcharnext(), _code.Strings[Operand(0)]))
+                        if (Forwardchars() < 1)
                             break;
+
+                        {
+                            int operand = Operand(0);
+                            if (!RegexCharClass.CharInClass(Forwardcharnext(), _code.Strings[operand], ref _code.StringsAsciiLookup[operand]))
+                                break;
+                        }
 
                         advance = 1;
                         continue;
@@ -999,7 +1005,9 @@ namespace System.Text.RegularExpressions
                             if (Forwardchars() < c)
                                 break;
 
-                            string set = _code.Strings[Operand(0)];
+                            int operand0 = Operand(0);
+                            string set = _code.Strings[operand0];
+                            ref int[]? setLookup = ref _code.StringsAsciiLookup[operand0];
 
                             while (c-- > 0)
                             {
@@ -1011,7 +1019,7 @@ namespace System.Text.RegularExpressions
                                     CheckTimeout();
                                 }
 
-                                if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
+                                if (!RegexCharClass.CharInClass(Forwardcharnext(), set, ref setLookup))
                                     goto BreakBackward;
                             }
 
@@ -1078,7 +1086,9 @@ namespace System.Text.RegularExpressions
                             if (c > Forwardchars())
                                 c = Forwardchars();
 
-                            string set = _code.Strings[Operand(0)];
+                            int operand0 = Operand(0);
+                            string set = _code.Strings[operand0];
+                            ref int[]? setLookup = ref _code.StringsAsciiLookup[operand0];
                             int i;
 
                             for (i = c; i > 0; i--)
@@ -1091,7 +1101,7 @@ namespace System.Text.RegularExpressions
                                     CheckTimeout();
                                 }
 
-                                if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
+                                if (!RegexCharClass.CharInClass(Forwardcharnext(), set, ref setLookup))
                                 {
                                     Backwardnext();
                                     break;
@@ -1207,7 +1217,8 @@ namespace System.Text.RegularExpressions
                             int pos = TrackPeek(1);
                             Textto(pos);
 
-                            if (!RegexCharClass.CharInClass(Forwardcharnext(), _code.Strings[Operand(0)]))
+                            int operand0 = Operand(0);
+                            if (!RegexCharClass.CharInClass(Forwardcharnext(), _code.Strings[operand0], ref _code.StringsAsciiLookup[operand0]))
                                 break;
 
                             int i = TrackPeek();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -7,6 +7,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions
 {
@@ -83,36 +84,61 @@ namespace System.Text.RegularExpressions
 
         private void TrackPush(int I1)
         {
-            runtrack![--runtrackpos] = I1;
-            runtrack[--runtrackpos] = _codepos;
+            int[] localruntrack = runtrack!;
+            int localruntrackpos = runtrackpos;
+
+            localruntrack[--localruntrackpos] = I1;
+            localruntrack[--localruntrackpos] = _codepos;
+
+            runtrackpos = localruntrackpos;
         }
 
         private void TrackPush(int I1, int I2)
         {
-            runtrack![--runtrackpos] = I1;
-            runtrack[--runtrackpos] = I2;
-            runtrack[--runtrackpos] = _codepos;
+            int[] localruntrack = runtrack!;
+            int localruntrackpos = runtrackpos;
+
+            localruntrack[--localruntrackpos] = I1;
+            localruntrack[--localruntrackpos] = I2;
+            localruntrack[--localruntrackpos] = _codepos;
+
+            runtrackpos = localruntrackpos;
         }
 
         private void TrackPush(int I1, int I2, int I3)
         {
-            runtrack![--runtrackpos] = I1;
-            runtrack[--runtrackpos] = I2;
-            runtrack[--runtrackpos] = I3;
-            runtrack[--runtrackpos] = _codepos;
+            int[] localruntrack = runtrack!;
+            int localruntrackpos = runtrackpos;
+
+            localruntrack[--localruntrackpos] = I1;
+            localruntrack[--localruntrackpos] = I2;
+            localruntrack[--localruntrackpos] = I3;
+            localruntrack[--localruntrackpos] = _codepos;
+
+            runtrackpos = localruntrackpos;
         }
 
         private void TrackPush2(int I1)
         {
-            runtrack![--runtrackpos] = I1;
-            runtrack[--runtrackpos] = -_codepos;
+            int[] localruntrack = runtrack!;
+            int localruntrackpos = runtrackpos;
+
+            localruntrack[--localruntrackpos] = I1;
+            localruntrack[--localruntrackpos] = -_codepos;
+
+            runtrackpos = localruntrackpos;
         }
 
         private void TrackPush2(int I1, int I2)
         {
-            runtrack![--runtrackpos] = I1;
-            runtrack[--runtrackpos] = I2;
-            runtrack[--runtrackpos] = -_codepos;
+            int[] localruntrack = runtrack!;
+            int localruntrackpos = runtrackpos;
+
+            localruntrack[--localruntrackpos] = I1;
+            localruntrack[--localruntrackpos] = I2;
+            localruntrack[--localruntrackpos] = -_codepos;
+
+            runtrackpos = localruntrackpos;
         }
 
         private void Backtrack()
@@ -186,8 +212,13 @@ namespace System.Text.RegularExpressions
 
         private void StackPush(int I1, int I2)
         {
-            runstack![--runstackpos] = I1;
-            runstack[--runstackpos] = I2;
+            int[] localrunstack = runstack!;
+            int localrunstackpos = runstackpos;
+
+            localrunstack[--localrunstackpos] = I1;
+            localrunstack[--localrunstackpos] = I2;
+
+            runstackpos = localrunstackpos;
         }
 
         private void StackPop()
@@ -278,8 +309,9 @@ namespace System.Text.RegularExpressions
             }
             else
             {
+                TextInfo ti = _culture.TextInfo;
                 while (c != 0)
-                    if (str[--c] != _culture.TextInfo.ToLower(runtext![--pos]))
+                    if (str[--c] != ti.ToLower(runtext![--pos]))
                         return false;
             }
 
@@ -325,8 +357,9 @@ namespace System.Text.RegularExpressions
             }
             else
             {
+                TextInfo ti = _culture.TextInfo;
                 while (c-- != 0)
-                    if (_culture.TextInfo.ToLower(runtext![--cmpos]) != _culture.TextInfo.ToLower(runtext[--pos]))
+                    if (ti.ToLower(runtext![--cmpos]) != ti.ToLower(runtext[--pos]))
                         return false;
             }
 
@@ -1031,8 +1064,9 @@ namespace System.Text.RegularExpressions
                         {
                             int c = Operand(1);
 
-                            if (c > Forwardchars())
-                                c = Forwardchars();
+                            int fc = Forwardchars();
+                            if (c > fc)
+                                c = fc;
 
                             char ch = (char)Operand(0);
                             int i;
@@ -1057,8 +1091,9 @@ namespace System.Text.RegularExpressions
                         {
                             int c = Operand(1);
 
-                            if (c > Forwardchars())
-                                c = Forwardchars();
+                            int fc = Forwardchars();
+                            if (c > fc)
+                                c = fc;
 
                             char ch = (char)Operand(0);
                             int i;
@@ -1083,8 +1118,9 @@ namespace System.Text.RegularExpressions
                         {
                             int c = Operand(1);
 
-                            if (c > Forwardchars())
-                                c = Forwardchars();
+                            int fc = Forwardchars();
+                            if (c > fc)
+                                c = fc;
 
                             int operand0 = Operand(0);
                             string set = _code.Strings[operand0];
@@ -1151,8 +1187,9 @@ namespace System.Text.RegularExpressions
                         {
                             int c = Operand(1);
 
-                            if (c > Forwardchars())
-                                c = Forwardchars();
+                            int fc = Forwardchars();
+                            if (c > fc)
+                                c = fc;
 
                             if (c > 0)
                                 TrackPush(c - 1, Textpos());
@@ -1165,8 +1202,9 @@ namespace System.Text.RegularExpressions
                         {
                             int c = Operand(1);
 
-                            if (c > Forwardchars())
-                                c = Forwardchars();
+                            int fc = Forwardchars();
+                            if (c > fc)
+                                c = fc;
 
                             if (c > 0)
                                 TrackPush(c - 1, Textpos());

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -279,8 +279,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Simple optimization. If a set is a singleton, an inverse singleton,
-        /// or empty, it's transformed accordingly.
+        /// Simple optimization. If a set is an inverse singleton or empty, it's transformed accordingly.
         /// </summary>
         private RegexNode ReduceSet()
         {
@@ -292,12 +291,6 @@ namespace System.Text.RegularExpressions
             {
                 NType = Nothing;
                 Str = null;
-            }
-            else if (RegexCharClass.IsSingleton(Str))
-            {
-                Ch = RegexCharClass.SingletonChar(Str);
-                Str = null;
-                NType += (One - Set);
             }
             else if (RegexCharClass.IsSingletonInverse(Str))
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -342,9 +342,12 @@ namespace System.Text.RegularExpressions
         /// </summary>
         protected void EnsureStorage()
         {
-            if (runstackpos < runtrackcount * 4)
+            int limit = runtrackcount * 4;
+
+            if (runstackpos < limit)
                 DoubleStack();
-            if (runtrackpos < runtrackcount * 4)
+
+            if (runtrackpos < limit)
                 DoubleTrack();
         }
 
@@ -382,9 +385,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         protected void DoubleTrack()
         {
-            int[] newtrack;
-
-            newtrack = new int[runtrack!.Length * 2];
+            int[] newtrack = new int[runtrack!.Length * 2];
 
             Array.Copy(runtrack, 0, newtrack, runtrack.Length, runtrack.Length);
             runtrackpos += runtrack.Length;
@@ -397,9 +398,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         protected void DoubleStack()
         {
-            int[] newstack;
-
-            newstack = new int[runstack!.Length * 2];
+            int[] newstack = new int[runstack!.Length * 2];
 
             Array.Copy(runstack, 0, newstack, runstack.Length, runstack.Length);
             runstackpos += runstack.Length;
@@ -411,9 +410,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         protected void DoubleCrawl()
         {
-            int[] newcrawl;
-
-            newcrawl = new int[runcrawl!.Length * 2];
+            int[] newcrawl = new int[runcrawl!.Length * 2];
 
             Array.Copy(runcrawl, 0, newcrawl, runcrawl.Length, runcrawl.Length);
             runcrawlpos += runcrawl.Length;
@@ -456,11 +453,9 @@ namespace System.Text.RegularExpressions
         {
             if (end < start)
             {
-                int T;
-
-                T = end;
+                int t = end;
                 end = start;
-                start = T;
+                start = t;
             }
 
             Crawl(capnum);
@@ -474,22 +469,17 @@ namespace System.Text.RegularExpressions
         /// </summary>
         protected void TransferCapture(int capnum, int uncapnum, int start, int end)
         {
-            int start2;
-            int end2;
-
-            // these are the two intervals that are cancelling each other
+            // these are the two intervals that are canceling each other
 
             if (end < start)
             {
-                int T;
-
-                T = end;
+                int t = end;
                 end = start;
-                start = T;
+                start = t;
             }
 
-            start2 = MatchIndex(uncapnum);
-            end2 = start2 + MatchLength(uncapnum);
+            int start2 = MatchIndex(uncapnum);
+            int end2 = start2 + MatchLength(uncapnum);
 
             // The new capture gets the innermost defined interval
 


### PR DESCRIPTION
This is a follow-on to https://github.com/dotnet/runtime/pull/271, which improved the performance of Regex, mainly for compiled regular expressions.  This PR improves the throughput of interpreted Regexes, those without the RegexOptions.Compiled option.

The primary change here is similar in nature to the primary change for Compiled: generating a fast lookup for ASCII values rather than having to parse/analyze the character class description for each character matched against it.  In the Compiled case, we took the time to analyze the first 128 characters and emit a static lookup to make it fast to find the answer for any character < 128.  But generating such a lookup table takes time.  For Compiled, we're willing to pay that time, because signing up for Compiled is done when you want to maximize throughput at the expense of such upfront costs.  We don't have that luxury for non-compiled.  Instead, we throw a small additional amount of memory at the problem.  Instead of storing 128 bits per character class (one for each character), we store 256 bits per character class: for each character a bit indicating whether we've evaluated it and a bit indicating the result.  The first time we encounter a character, we do the more costly evaluation, and then we store back both that we evaluated it and the result; subsequent accesses will see that it was already evaluated and just use the cached result.

A few other, smaller opportunistic changes were also made here based on profiling, including improving some of the codegen around repeated array accesses and inlining a function on a hot path where doing so made an impactful difference.  Also a tiny bit of code cleanup as I was touching the relevant functions.

|      Method | Toolchain |       Mean |    Error |   StdDev | Ratio | Allocated |
|------------ |---------- |-----------:|---------:|---------:|------:|----------:|
|       Email | New       |   465.6 ns |  1.26 ns |  1.12 ns |  0.78 |         - |
|       Email | Old       |   600.5 ns |  2.97 ns |  2.78 ns |  1.00 |         - |
|             |           |            |          |          |       |           |
|        Date | New       |   242.7 ns |  0.43 ns |  0.40 ns |  0.59 |         - |
|        Date | Old       |   414.6 ns |  0.52 ns |  0.49 ns |  1.00 |         - |
|             |           |            |          |          |       |           |
|          IP | New       | 1,975.4 ns |  3.46 ns |  3.07 ns |  0.77 |         - |
|          IP | Old       | 2,573.9 ns |  8.53 ns |  7.13 ns |  1.00 |         - |
|             |           |            |          |          |       |           |
|         Uri | New       |   311.8 ns | 24.92 ns | 39.53 ns |  0.63 |         - |
|         Uri | Old       |   508.8 ns |  1.31 ns |  1.16 ns |  1.00 |         - |
|             |           |            |          |          |       |           |
| EmailStatic | New       |   517.3 ns |  2.28 ns |  2.13 ns |  0.80 |     104 B |
| EmailStatic | Old       |   650.2 ns |  2.03 ns |  1.69 ns |  1.00 |     104 B |
|             |           |            |          |          |       |           |
|  DateStatic | New       |   303.4 ns |  0.44 ns |  0.39 ns |  0.66 |     104 B |
|  DateStatic | Old       |   458.3 ns |  1.95 ns |  1.83 ns |  1.00 |     104 B |
|             |           |            |          |          |       |           |
|    IPStatic | New       | 2,038.7 ns |  2.53 ns |  2.37 ns |  0.75 |     104 B |
|    IPStatic | Old       | 2,702.2 ns | 22.82 ns | 19.05 ns |  1.00 |     104 B |
|             |           |            |          |          |       |           |
|   UriStatic | New       |   341.6 ns |  0.55 ns |  0.43 ns |  0.62 |     104 B |
|   UriStatic | Old       |   551.8 ns |  1.36 ns |  1.13 ns |  1.00 |     104 B |
|             |           |            |          |          |       |           |
|        Ctor | New       | 5,568.8 ns | 15.11 ns | 12.62 ns |  0.99 |    9792 B |
|        Ctor | Old       | 5,641.3 ns | 41.50 ns | 38.81 ns |  1.00 |    9712 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);
}

[MemoryDiagnoser]
public class Regexes
{
    [Params(RegexOptions.None)] //, RegexOptions.Compiled)]
    public RegexOptions Options { get; set; }

    private Regex _email, _date, _ip, _uri;

    private const string EmailPattern = @"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$";
    private const string DatePattern = @"\b(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{2,4})\b";
    private const string IPPattern = @"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])";
    private const string UriPattern = @"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?";

    [GlobalSetup]
    public void Setup()
    {
        _email = new Regex(EmailPattern, Options);
        _date = new Regex(DatePattern, Options);
        _ip = new Regex(IPPattern, Options);
        _uri = new Regex(UriPattern, Options);
    }

    [Benchmark] public void Email() => _email.IsMatch("yay.performance@dot.net");
    [Benchmark] public void Date() => _date.IsMatch("Today is 11/18/2019");
    [Benchmark] public void IP() => _ip.IsMatch("012.345.678.910");
    [Benchmark] public void Uri() => _uri.IsMatch("http://example.org");

    [Benchmark] public void EmailStatic() => Regex.IsMatch("yay.performance@dot.net", EmailPattern, Options);
    [Benchmark] public void DateStatic() => Regex.IsMatch("Today is 11/18/2019", DatePattern, Options);
    [Benchmark] public void IPStatic() => Regex.IsMatch("012.345.678.910", IPPattern, Options);
    [Benchmark] public void UriStatic() => Regex.IsMatch("http://example.org", UriPattern, Options);

    [Benchmark] public void Ctor() => new Regex(@"(^(.*)(\(([0-9]+),([0-9]+)\)): )(error|warning) ([A-Z]+[0-9]+) ?: (.*)", Options);
}
```

cc: @danmosemsft, @ViktorHofer, @davidwrighton, @eerhardt 