### PR TITLE
Add SkipLocalsInitAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -609,6 +609,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeFeature.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeWrappedException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SkipLocalsInitAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SpecialNameAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\StateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\StringFreezingAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false)]
+    public sealed class SkipLocalsInitAttribute : Attribute
+    {
+        public SkipLocalsInitAttribute()
+        {
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -6,17 +6,17 @@ namespace System.Runtime.CompilerServices
 {
     /// <summary>
     /// Used to indicate to the compiler that the <c>.locals init</c> flag should
-    /// not be set in nested method headers when emitting to metadata. This
-    /// attribute is unsafe because it may reveal uninitialized memory to the
-    /// application in certain instances (e.g., reading from uninitialized
+    /// not be set in nested method headers when emitting to metadata.
+    /// </summary>
+    /// <remarks>
+    /// This attribute is unsafe because it may reveal uninitialized memory to
+    /// the application in certain instances (e.g., reading from uninitialized
     /// stackalloc'd memory). If applied to a method directly, the attribute
     /// applies to that method and all nested functions (lambdas, local
     /// functions) below it. If applied to a type or module, it applies to all
-    /// methods nested inside.
-    /// </summary>
-    /// <remarks>
-    /// This attribute is intentionally not permitted on assemblies. Use at the
-    /// module level instead to apply to multiple type declarations.
+    /// methods nested inside. This attribute is intentionally not permitted on
+    /// assemblies. Use at the module level instead to apply to multiple type
+    /// declarations.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Module
         | AttributeTargets.Class

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -4,7 +4,26 @@
 
 namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false)]
+    /// <summary>
+    /// Used to indicate to the compiler that the `.locals init` flag should not
+    /// be set in nested method headers when emitting to metadata. This attribute
+    /// is unsafe because it may reveal uninitialized memory to the application
+    /// in certain instances (e.g., reading from uninitialized stackalloc'd
+    /// memory). If applied to a method directly, the attribute applies to that
+    /// method and all nested functions (lambdas, local functions) below it. If
+    /// applied to a type or module, it applies to all methods nested inside.
+    /// </summary>
+    /// <remarks>
+    /// This attribute is intentionally not permitted on assemblies. Use at the
+    /// module level instead to apply to multiple type declarations.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Module
+        | AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Constructor
+        | AttributeTargets.Method
+        | AttributeTargets.Property
+        | AttributeTargets.Event, Inherited = false)]
     public sealed class SkipLocalsInitAttribute : Attribute
     {
         public SkipLocalsInitAttribute()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -5,13 +5,14 @@
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Used to indicate to the compiler that the `.locals init` flag should not
-    /// be set in nested method headers when emitting to metadata. This attribute
-    /// is unsafe because it may reveal uninitialized memory to the application
-    /// in certain instances (e.g., reading from uninitialized stackalloc'd
-    /// memory). If applied to a method directly, the attribute applies to that
-    /// method and all nested functions (lambdas, local functions) below it. If
-    /// applied to a type or module, it applies to all methods nested inside.
+    /// Used to indicate to the compiler that the <c>.locals init</c> flag should
+    /// not be set in nested method headers when emitting to metadata. This
+    /// attribute is unsafe because it may reveal uninitialized memory to the
+    /// application in certain instances (e.g., reading from uninitialized
+    /// stackalloc'd memory). If applied to a method directly, the attribute
+    /// applies to that method and all nested functions (lambdas, local
+    /// functions) below it. If applied to a type or module, it applies to all
+    /// methods nested inside.
     /// </summary>
     /// <remarks>
     /// This attribute is intentionally not permitted on assemblies. Use at the

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6914,6 +6914,13 @@ namespace System.Runtime.CompilerServices
         public object WrappedException { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [AttributeUsage(AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false)]
+    public sealed class SkipLocalsInitAttribute : Attribute
+    {
+        public SkipLocalsInitAttribute()
+        {
+        }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Struct)]
     public sealed partial class SpecialNameAttribute : System.Attribute
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6914,12 +6914,10 @@ namespace System.Runtime.CompilerServices
         public object WrappedException { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [AttributeUsage(AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false)]
-    public sealed class SkipLocalsInitAttribute : Attribute
+    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Event, Inherited = false)]
+    public sealed partial class SkipLocalsInitAttribute : System.Attribute
     {
-        public SkipLocalsInitAttribute()
-        {
-        }
+        public SkipLocalsInitAttribute() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Struct)]
     public sealed partial class SpecialNameAttribute : System.Attribute

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
@@ -9,6 +9,12 @@ namespace System.Runtime.CompilerServices.Tests
     public static class AttributesTests
     {
         [Fact]
+        public static void SkipLocalsInitAttributeTests()
+        {
+            new SkipLocalsInitAttribute();
+        }
+
+        [Fact]
         public static void AccessedThroughPropertyAttributeTests()
         {
             var attr1 = new AccessedThroughPropertyAttribute(null);


### PR DESCRIPTION
This attribute supports a new compiler feature that allows a user to
specify that they don't want to emit the CLR `.locals init` portion of
the header in methods. This can sometimes produce a performance
improvement but, in some cases, can reveal uninitialized memory to the
application.

Ported from https://github.com/dotnet/coreclr/pull/20093