### PR TITLE
Annotate System.IO.FileSystem.Watcher for nullable reference types

### DIFF
--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace System.IO
@@ -74,7 +75,7 @@ namespace System.IO
         /// away from paths during normalization, but if we see such a path at this point it should be
         /// normalized and has retained the final characters. (Typically from one of the *Info classes)
         /// </summary>
-        /// TODO: add atribute [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull("path")]
         internal static string? EnsureExtendedPrefixIfNeeded(string? path)
         {
             if (path != null && (path.Length >= MaxShortPath || EndsWithPeriodOrSpace(path)))

--- a/src/libraries/Common/src/System/Text/ValueUtf8Converter.cs
+++ b/src/libraries/Common/src/System/Text/ValueUtf8Converter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Buffers;
 
 namespace System.Text
@@ -13,7 +14,7 @@ namespace System.Text
     /// </summary>
     internal ref struct ValueUtf8Converter
     {
-        private byte[] _arrayToReturnToPool;
+        private byte[]? _arrayToReturnToPool;
         private Span<byte> _bytes;
 
         public ValueUtf8Converter(Span<byte> initialBuffer)
@@ -40,7 +41,7 @@ namespace System.Text
 
         public void Dispose()
         {
-            byte[] toReturn = _arrayToReturnToPool;
+            byte[]? toReturn = _arrayToReturnToPool;
             if (toReturn != null)
             {
                 _arrayToReturnToPool = null;

--- a/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.cs
@@ -15,10 +15,10 @@ namespace System.IO
     public delegate void ErrorEventHandler(object sender, System.IO.ErrorEventArgs e);
     public partial class FileSystemEventArgs : System.EventArgs
     {
-        public FileSystemEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string name) { }
+        public FileSystemEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string? name) { }
         public System.IO.WatcherChangeTypes ChangeType { get { throw null; } }
         public string FullPath { get { throw null; } }
-        public string Name { get { throw null; } }
+        public string? Name { get { throw null; } }
     }
     public delegate void FileSystemEventHandler(object sender, System.IO.FileSystemEventArgs e);
     public partial class FileSystemWatcher : System.ComponentModel.Component, System.ComponentModel.ISupportInitialize
@@ -33,13 +33,13 @@ namespace System.IO
         public int InternalBufferSize { get { throw null; } set { } }
         public System.IO.NotifyFilters NotifyFilter { get { throw null; } set { } }
         public string Path { get { throw null; } set { } }
-        public override System.ComponentModel.ISite Site { get { throw null; } set { } }
-        public System.ComponentModel.ISynchronizeInvoke SynchronizingObject { get { throw null; } set { } }
-        public event System.IO.FileSystemEventHandler Changed { add { } remove { } }
-        public event System.IO.FileSystemEventHandler Created { add { } remove { } }
-        public event System.IO.FileSystemEventHandler Deleted { add { } remove { } }
-        public event System.IO.ErrorEventHandler Error { add { } remove { } }
-        public event System.IO.RenamedEventHandler Renamed { add { } remove { } }
+        public override System.ComponentModel.ISite? Site { get { throw null; } set { } }
+        public System.ComponentModel.ISynchronizeInvoke? SynchronizingObject { get { throw null; } set { } }
+        public event System.IO.FileSystemEventHandler? Changed { add { } remove { } }
+        public event System.IO.FileSystemEventHandler? Created { add { } remove { } }
+        public event System.IO.FileSystemEventHandler? Deleted { add { } remove { } }
+        public event System.IO.ErrorEventHandler? Error { add { } remove { } }
+        public event System.IO.RenamedEventHandler? Renamed { add { } remove { } }
         public void BeginInit() { }
         protected override void Dispose(bool disposing) { }
         public void EndInit() { }
@@ -55,8 +55,8 @@ namespace System.IO
     {
         public InternalBufferOverflowException() { }
         protected InternalBufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public InternalBufferOverflowException(string message) { }
-        public InternalBufferOverflowException(string message, System.Exception inner) { }
+        public InternalBufferOverflowException(string? message) { }
+        public InternalBufferOverflowException(string? message, System.Exception? inner) { }
     }
     [System.FlagsAttribute]
     public enum NotifyFilters
@@ -72,9 +72,9 @@ namespace System.IO
     }
     public partial class RenamedEventArgs : System.IO.FileSystemEventArgs
     {
-        public RenamedEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string name, string oldName) : base (default(System.IO.WatcherChangeTypes), default(string), default(string)) { }
+        public RenamedEventArgs(System.IO.WatcherChangeTypes changeType, string directory, string? name, string? oldName) : base (default(System.IO.WatcherChangeTypes), default(string), default(string)) { }
         public string OldFullPath { get { throw null; } }
-        public string OldName { get { throw null; } }
+        public string? OldName { get { throw null; } }
     }
     public delegate void RenamedEventHandler(object sender, System.IO.RenamedEventArgs e);
     public partial struct WaitForChangedResult
@@ -82,8 +82,8 @@ namespace System.IO
         private object _dummy;
         private int _dummyPrimitive;
         public System.IO.WatcherChangeTypes ChangeType { readonly get { throw null; } set { } }
-        public string Name { readonly get { throw null; } set { } }
-        public string OldName { readonly get { throw null; } set { } }
+        public string? Name { readonly get { throw null; } set { } }
+        public string? OldName { readonly get { throw null; } set { } }
         public bool TimedOut { readonly get { throw null; } set { } }
     }
     [System.FlagsAttribute]

--- a/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/ref/System.IO.FileSystem.Watcher.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
     <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -10,13 +10,13 @@ namespace System.IO
     public class FileSystemEventArgs : EventArgs
     {
         private readonly WatcherChangeTypes _changeType;
-        private readonly string _name;
+        private readonly string? _name;
         private readonly string _fullPath;
 
         /// <devdoc>
         /// Initializes a new instance of the <see cref='System.IO.FileSystemEventArgs'/> class.
         /// </devdoc>
-        public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string name)
+        public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string? name)
         {
             _changeType = changeType;
             _name = name;
@@ -31,7 +31,7 @@ namespace System.IO
         /// This is like Path.Combine, except without argument validation,
         /// and a separator is used even if the name argument is empty.
         /// </remarks>
-        internal static string Combine(string directoryPath, string name)
+        internal static string Combine(string directoryPath, string? name)
         {
             bool hasSeparator = false;
             if (directoryPath.Length > 0)
@@ -71,7 +71,7 @@ namespace System.IO
         /// <devdoc>
         ///       Gets the name of the affected file or directory.
         /// </devdoc>
-        public string Name
+        public string? Name
         {
             get
             {

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -46,11 +46,11 @@ namespace System.IO
         private bool _disposed;
 
         // Event handlers
-        private FileSystemEventHandler _onChangedHandler = null;
-        private FileSystemEventHandler _onCreatedHandler = null;
-        private FileSystemEventHandler _onDeletedHandler = null;
-        private RenamedEventHandler _onRenamedHandler = null;
-        private ErrorEventHandler _onErrorHandler = null;
+        private FileSystemEventHandler? _onChangedHandler;
+        private FileSystemEventHandler? _onCreatedHandler;
+        private FileSystemEventHandler? _onDeletedHandler;
+        private RenamedEventHandler? _onRenamedHandler;
+        private ErrorEventHandler? _onErrorHandler;
 
         private const int c_notifyFiltersValidMask = (int)(NotifyFilters.Attributes |
                                                            NotifyFilters.CreationTime |
@@ -65,8 +65,10 @@ namespace System.IO
         static FileSystemWatcher()
         {
             int s_notifyFiltersValidMask = 0;
+#pragma warning disable CS8605 // Unboxing a possibly null value
             foreach (int enumValue in Enum.GetValues(typeof(NotifyFilters)))
                 s_notifyFiltersValidMask |= enumValue;
+#pragma warning restore CS8605
             Debug.Assert(c_notifyFiltersValidMask == s_notifyFiltersValidMask, "The NotifyFilters enum has changed. The c_notifyFiltersValidMask must be updated to reflect the values of the NotifyFilters enum.");
         }
 #endif
@@ -265,7 +267,7 @@ namespace System.IO
         /// <devdoc>
         ///    Occurs when a file or directory in the specified <see cref='System.IO.FileSystemWatcher.Path'/> is changed.
         /// </devdoc>
-        public event FileSystemEventHandler Changed
+        public event FileSystemEventHandler? Changed
         {
             add
             {
@@ -280,7 +282,7 @@ namespace System.IO
         /// <devdoc>
         ///    Occurs when a file or directory in the specified <see cref='System.IO.FileSystemWatcher.Path'/> is created.
         /// </devdoc>
-        public event FileSystemEventHandler Created
+        public event FileSystemEventHandler? Created
         {
             add
             {
@@ -295,7 +297,7 @@ namespace System.IO
         /// <devdoc>
         ///    Occurs when a file or directory in the specified <see cref='System.IO.FileSystemWatcher.Path'/> is deleted.
         /// </devdoc>
-        public event FileSystemEventHandler Deleted
+        public event FileSystemEventHandler? Deleted
         {
             add
             {
@@ -310,7 +312,7 @@ namespace System.IO
         /// <devdoc>
         ///    Occurs when the internal buffer overflows.
         /// </devdoc>
-        public event ErrorEventHandler Error
+        public event ErrorEventHandler? Error
         {
             add
             {
@@ -326,7 +328,7 @@ namespace System.IO
         ///    Occurs when a file or directory in the specified <see cref='System.IO.FileSystemWatcher.Path'/>
         ///    is renamed.
         /// </devdoc>
-        public event RenamedEventHandler Renamed
+        public event RenamedEventHandler? Renamed
         {
             add
             {
@@ -417,7 +419,7 @@ namespace System.IO
         private void NotifyRenameEventArgs(WatcherChangeTypes action, ReadOnlySpan<char> name, ReadOnlySpan<char> oldName)
         {
             // filter if there's no handler or neither new name or old name match a specified pattern
-            RenamedEventHandler handler = _onRenamedHandler;
+            RenamedEventHandler? handler = _onRenamedHandler;
             if (handler != null &&
                 (MatchPattern(name) || MatchPattern(oldName)))
             {
@@ -425,7 +427,7 @@ namespace System.IO
             }
         }
 
-        private FileSystemEventHandler GetHandler(WatcherChangeTypes changeType)
+        private FileSystemEventHandler? GetHandler(WatcherChangeTypes changeType)
         {
             switch (changeType)
             {
@@ -446,7 +448,7 @@ namespace System.IO
         /// </summary>
         private void NotifyFileSystemEventArgs(WatcherChangeTypes changeType, ReadOnlySpan<char> name)
         {
-            FileSystemEventHandler handler = GetHandler(changeType);
+            FileSystemEventHandler? handler = GetHandler(changeType);
 
             if (handler != null && MatchPattern(name.IsEmpty ? _directory : name))
             {
@@ -459,7 +461,7 @@ namespace System.IO
         /// </summary>
         private void NotifyFileSystemEventArgs(WatcherChangeTypes changeType, string name)
         {
-            FileSystemEventHandler handler = GetHandler(changeType);
+            FileSystemEventHandler? handler = GetHandler(changeType);
 
             if (handler != null && MatchPattern(string.IsNullOrEmpty(name) ? _directory : name))
             {
@@ -494,11 +496,11 @@ namespace System.IO
             InvokeOn(e, _onDeletedHandler);
         }
 
-        private void InvokeOn(FileSystemEventArgs e, FileSystemEventHandler handler)
+        private void InvokeOn(FileSystemEventArgs e, FileSystemEventHandler? handler)
         {
             if (handler != null)
             {
-                ISynchronizeInvoke syncObj = SynchronizingObject;
+                ISynchronizeInvoke? syncObj = SynchronizingObject;
                 if (syncObj != null && syncObj.InvokeRequired)
                     syncObj.BeginInvoke(handler, new object[] { this, e });
                 else
@@ -512,10 +514,10 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnError(ErrorEventArgs e)
         {
-            ErrorEventHandler handler = _onErrorHandler;
+            ErrorEventHandler? handler = _onErrorHandler;
             if (handler != null)
             {
-                ISynchronizeInvoke syncObj = SynchronizingObject;
+                ISynchronizeInvoke? syncObj = SynchronizingObject;
                 if (syncObj != null && syncObj.InvokeRequired)
                     syncObj.BeginInvoke(handler, new object[] { this, e });
                 else
@@ -529,10 +531,10 @@ namespace System.IO
         [SuppressMessage("Microsoft.Security", "CA2109:ReviewVisibleEventHandlers", MessageId = "0#", Justification = "Changing from protected to private would be a breaking change")]
         protected void OnRenamed(RenamedEventArgs e)
         {
-            RenamedEventHandler handler = _onRenamedHandler;
+            RenamedEventHandler? handler = _onRenamedHandler;
             if (handler != null)
             {
-                ISynchronizeInvoke syncObj = SynchronizingObject;
+                ISynchronizeInvoke? syncObj = SynchronizingObject;
                 if (syncObj != null && syncObj.InvokeRequired)
                     syncObj.BeginInvoke(handler, new object[] { this, e });
                 else
@@ -549,8 +551,8 @@ namespace System.IO
             // none is done here, either.
 
             var tcs = new TaskCompletionSource<WaitForChangedResult>();
-            FileSystemEventHandler fseh = null;
-            RenamedEventHandler reh = null;
+            FileSystemEventHandler? fseh = null;
+            RenamedEventHandler? reh = null;
 
             // Register the event handlers based on what events are desired.  The full framework
             // doesn't register for the Error event, so this doesn't either.
@@ -642,7 +644,7 @@ namespace System.IO
             StartRaisingEvents();
         }
 
-        public override ISite Site
+        public override ISite? Site
         {
             get
             {
@@ -659,7 +661,7 @@ namespace System.IO
             }
         }
 
-        public ISynchronizeInvoke SynchronizingObject { get; set; }
+        public ISynchronizeInvoke? SynchronizingObject { get; set; }
 
         public void BeginInit()
         {

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/InternalBufferOverflowException.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/InternalBufferOverflowException.cs
@@ -24,7 +24,7 @@ namespace System.IO
         /// <devdoc>
         ///    Initializes a new instance of the <see cref='System.IO.InternalBufferOverflowException'/> class with the error message to be displayed specified.
         /// </devdoc>
-        public InternalBufferOverflowException(string message) : base(message)
+        public InternalBufferOverflowException(string? message) : base(message)
         {
             HResult = HResults.InternalBufferOverflow;
         }
@@ -33,7 +33,7 @@ namespace System.IO
         ///    Initializes a new instance of the <see cref='System.IO.InternalBufferOverflowException'/>
         ///    class with the message to be displayed and the generated inner exception specified.
         /// </devdoc>
-        public InternalBufferOverflowException(string message, Exception inner) : base(message, inner)
+        public InternalBufferOverflowException(string? message, Exception? inner) : base(message, inner)
         {
             HResult = HResults.InternalBufferOverflow;
         }

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs
@@ -9,13 +9,13 @@ namespace System.IO
     /// </devdoc>
     public class RenamedEventArgs : FileSystemEventArgs
     {
-        private readonly string _oldName;
+        private readonly string? _oldName;
         private readonly string _oldFullPath;
 
         /// <devdoc>
         ///    Initializes a new instance of the <see cref='System.IO.RenamedEventArgs'/> class.
         /// </devdoc>
-        public RenamedEventArgs(WatcherChangeTypes changeType, string directory, string name, string oldName)
+        public RenamedEventArgs(WatcherChangeTypes changeType, string directory, string? name, string? oldName)
             : base(changeType, directory, name)
         {
             _oldName = oldName;
@@ -36,7 +36,7 @@ namespace System.IO
         /// <devdoc>
         ///    Gets the old name of the affected file or directory.
         /// </devdoc>
-        public string OldName
+        public string? OldName
         {
             get
             {

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/WaitForChangedResult.cs
@@ -6,7 +6,7 @@ namespace System.IO
 {
     public struct WaitForChangedResult
     {
-        internal WaitForChangedResult(WatcherChangeTypes changeType, string name, string oldName, bool timedOut)
+        internal WaitForChangedResult(WatcherChangeTypes changeType, string? name, string? oldName, bool timedOut)
         {
             ChangeType = changeType;
             Name = name;
@@ -18,8 +18,8 @@ namespace System.IO
             new WaitForChangedResult(changeType: 0, name: null, oldName: null, timedOut: true);
 
         public WatcherChangeTypes ChangeType { get; set; }
-        public string Name { get; set; }
-        public string OldName { get; set; }
+        public string? Name { get; set; }
+        public string? OldName { get; set; }
         public bool TimedOut { get; set; }
     }
 }

--- a/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
@@ -5,6 +5,7 @@
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true' and '$(OSGroup)' == 'AnyOS'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
     <DefineConstants>$(DefineConstants);NOSPAN</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
+    <Nullable>annotations</Nullable>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Linux-Debug;netstandard2.0-Linux-Release;netstandard2.0-OSX-Debug;netstandard2.0-OSX-Release;netstandard2.0-Release;netstandard2.0-Windows_NT-Debug;netstandard2.0-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetStandard)' == 'true' and '$(OSGroup)' != 'AnyOS'">


### PR DESCRIPTION
Replaces the already approved https://github.com/dotnet/runtime/pull/237, which was submitted from my old private fork.