### PR TITLE
Run app that has a directory that ends in a dot

### DIFF
--- a/src/coreclr/src/pal/src/file/path.cpp
+++ b/src/coreclr/src/pal/src/file/path.cpp
@@ -586,8 +586,7 @@ Function:
 Abstract:
   Change a DOS path to a Unix path.
 
-  Replaces '\' by '/', removes any trailing dots on directory/filenames,
-  and changes '*.*' to be equal to '*'
+  Replaces '\' by '/', removes and changes '*.*' to be equal to '*'
 
 Parameter:
   IN/OUT lpPath: path to be modified
@@ -616,79 +615,24 @@ FILEDosToUnixPathA(
             *p = '/';
         }
 
-        if (pPointAtDot)
+        if (*p == '*')
         {
-            /* If pPointAtDot is not NULL, it is pointing at the first encountered
-               dot.  If we encountered a \, that means it could be a trailing dot */
-            if (*p == '/')
+            if ((p - lpPath) >= 3)
             {
-                /* If char before the first dot is a '\' or '.' (special case if the
-                   dot is the first char in the path) , then we leave it alone,
-                   because it is either . or .., otherwise it is a trailing dot
-                   pattern and will be truncated */
-                if (charBeforeFirstDot != '.' && charBeforeFirstDot != '/')
+                /* At this point, we know that there is 1 or more dots and
+                then a star.  AND we know the size of our string at this
+                point is at least 3 (so we can go backwards from our pointer
+                safely AND there could possilby be two characters back)
+                So lets check if there is a '*' and a '.' before, if there
+                is, replace just a '*'.  Otherwise, reset pPointAtDot to NULL
+                and do nothing */
+                if (p[-2] == '*' &&
+                    p[-1] == '.' &&
+                    p[0] == '*')
                 {
-                    memmove(pPointAtDot,p,(strlen(p)*sizeof(char))+1);
-                    p = pPointAtDot;
-                }
-                pPointAtDot = NULL; /* Need to reset this */
-            }
-            else if (*p == '*')
-            {
-                /* Check our size before doing anything with our pointers */
-                if ((p - lpPath) >= 3)
-                {
-                    /* At this point, we know that there is 1 or more dots and
-                       then a star.  AND we know the size of our string at this
-                       point is at least 3 (so we can go backwards from our pointer
-                       safely AND there could possilby be two characters back)
-                       So lets check if there is a '*' and a '.' before, if there
-                       is, replace just a '*'.  Otherwise, reset pPointAtDot to NULL
-                       and do nothing */
-                    if (p[-2] == '*' &&
-                        p[-1] == '.' &&
-                        p[0] == '*')
-                    {
-                        memmove(&(p[-2]),p,(strlen(p)*sizeof(char))+1);
-                    }
-
-                    pPointAtDot  = NULL;
+                    memmove(&(p[-2]),p,(strlen(p)*sizeof(char))+1);
                 }
             }
-            else if (*p != '.')
-            {
-                /* If we are here, that means that this is NOT a trailing dot,
-                   some other character is here, so forget our pointer */
-                pPointAtDot = NULL;
-            }
-        }
-        else
-        {
-            if (*p == '.')
-            {
-                /* If pPointAtDot is NULL, and we encounter a dot, save the pointer */
-                pPointAtDot = p;
-                if (pPointAtDot != lpPath)
-                {
-                    charBeforeFirstDot = p[-1];
-                }
-                else
-                {
-                    charBeforeFirstDot = lpPath[0];
-                }
-            }
-        }
-    }
-
-    /* If pPointAtDot still points at anything, then we still have trailing dots.
-       Truncate at pPointAtDot, unless the dots are path specifiers (. or ..) */
-    if (pPointAtDot)
-    {
-        /* make sure the trailing dots don't follow a '/', and that they aren't
-           the only thing in the name */
-        if(pPointAtDot != lpPath && *(pPointAtDot-1) != '/')
-        {
-            *pPointAtDot = '\0';
         }
     }
 

--- a/src/coreclr/src/pal/src/file/path.cpp
+++ b/src/coreclr/src/pal/src/file/path.cpp
@@ -596,8 +596,6 @@ FILEDosToUnixPathA(
        LPSTR lpPath)
 {
     LPSTR p;
-    LPSTR pPointAtDot=NULL;
-    char charBeforeFirstDot='\0';
 
     TRACE("Original DOS path = [%s]\n", lpPath);
 

--- a/src/coreclr/src/pal/src/file/path.cpp
+++ b/src/coreclr/src/pal/src/file/path.cpp
@@ -586,7 +586,7 @@ Function:
 Abstract:
   Change a DOS path to a Unix path.
 
-  Replaces '\' by '/', removes and changes '*.*' to be equal to '*'
+  Replaces '\' by '/'
 
 Parameter:
   IN/OUT lpPath: path to be modified
@@ -606,31 +606,10 @@ FILEDosToUnixPathA(
 
     for (p = lpPath; *p; p++)
     {
-        /* Make the \\ to / switch first */
+        /* Replace \ with / */
         if (*p == '\\')
         {
-            /* Replace \ with / */
             *p = '/';
-        }
-
-        if (*p == '*')
-        {
-            if ((p - lpPath) >= 3)
-            {
-                /* At this point, we know that there is 1 or more dots and
-                then a star.  AND we know the size of our string at this
-                point is at least 3 (so we can go backwards from our pointer
-                safely AND there could possilby be two characters back)
-                So lets check if there is a '*' and a '.' before, if there
-                is, replace just a '*'.  Otherwise, reset pPointAtDot to NULL
-                and do nothing */
-                if (p[-2] == '*' &&
-                    p[-1] == '.' &&
-                    p[0] == '*')
-                {
-                    memmove(&(p[-2]),p,(strlen(p)*sizeof(char))+1);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
This change fixes [#16162](https://github.com/dotnet/coreclr/issues/16162) by removing unnecessary period trimming from `FILEDosToUnixPathA`, which was causing `dotnet run` to crash whenever the path to the assembly contained a trailing dot.