### PR TITLE
Adjusting `GetCurrentProcessorId` caching to different environments.

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -274,6 +274,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Threading\StackCrawlMark.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\SynchronizationContext.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Thread.CoreCLR.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Threading\ProcessorIdCache.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\ThreadPool.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Timer.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\WaitHandle.CoreCLR.cs" />

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Threading
+{
+    internal static class ProcessorIdCache
+    {
+        // The upper bits of t_currentProcessorIdCache are the currentProcessorId. The lower bits of
+        // the t_currentProcessorIdCache are counting down to get it periodically refreshed.
+        // TODO: Consider flushing the currentProcessorIdCache on Wait operations or similar
+        // actions that are likely to result in changing the executing core
+        [ThreadStatic]
+        private static int t_currentProcessorIdCache;
+
+        private const int ProcessorIdCacheShift = 16;
+        private const int ProcessorIdCacheCountDownMask = (1 << ProcessorIdCacheShift) - 1;
+        // 50 is our best guess.
+        // Based on further calibration it is likley to be adjusted lower.
+        // In relatively rare cases of a slow GetCurrentProcessorNumber, it may be recalibrated to a higher number.
+        private static int s_processorIdRefreshRate = 50;
+        // We will not adjust higher than this though.
+        private const int MaxIdRefreshRate = 5000;
+
+        private static int RefreshCurrentProcessorId()
+        {
+            double[]? calibrationSamples = s_CalibrationSamples;
+            if (calibrationSamples != null)
+                CalibrateOnce(calibrationSamples);
+
+            int currentProcessorId = Thread.GetCurrentProcessorNumber();
+
+            // On Unix, GetCurrentProcessorNumber() is implemented in terms of sched_getcpu, which
+            // doesn't exist on all platforms.  On those it doesn't exist on, GetCurrentProcessorNumber()
+            // returns -1.  As a fallback in that case and to spread the threads across the buckets
+            // by default, we use the current managed thread ID as a proxy.
+            if (currentProcessorId < 0) currentProcessorId = Environment.CurrentManagedThreadId;
+
+            Debug.Assert(s_processorIdRefreshRate <= ProcessorIdCacheCountDownMask);
+
+            // Mask with int.MaxValue to ensure the execution Id is not negative
+            t_currentProcessorIdCache = ((currentProcessorId << ProcessorIdCacheShift) & int.MaxValue) | s_processorIdRefreshRate;
+
+            return currentProcessorId;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetCurrentProcessorId()
+        {
+            if (s_processorIdRefreshRate <= 2)
+                return Thread.GetCurrentProcessorNumber();
+
+            int currentProcessorIdCache = t_currentProcessorIdCache--;
+            if ((currentProcessorIdCache & ProcessorIdCacheCountDownMask) == 0)
+            {
+                return RefreshCurrentProcessorId();
+            }
+
+            return currentProcessorIdCache >> ProcessorIdCacheShift;
+        }
+
+        // We must collect multiple samples to account for irregularities caused by GC and context switches.
+        // Why we keep an array of samples and do not adjust as we go:
+        //   We expect that we will adjust the refresh rate down. If we do that early, we may end up forcing all
+        //   the calibration work to happen much sooner. There is no urgency in being calibrated while the app
+        //   is in start-up mode. That would just add to the "rush hour" traffic.
+        private static int s_CalibrationToDo;
+        private static int s_CalibrationDone;
+        // 10 is chosen to budget the sampling under 5 msec total, assuming 0.5 msec per sample.
+        private const int CalibrationSampleCount = 10;
+        private static double[]? s_CalibrationSamples = new double[CalibrationSampleCount * 2];
+
+        private static void CalibrateOnce(double[] calibrationSamples)
+        {
+            if (s_CalibrationToDo >= CalibrationSampleCount)
+                return;
+
+            int sample = Interlocked.Increment(ref s_CalibrationToDo) - 1;
+            if (sample >= CalibrationSampleCount)
+                return;
+
+            // Actual calibration step. Let's try to fit into ~50 usec.
+            int id = 0;
+            long t1 = 0;
+            long twentyMicrosecond = Stopwatch.Frequency / 50000;
+            int iters = 1;
+
+            // double the sample size until it is 1 msec.
+            // we may spend up to 40 usec in this loop in a worst case.
+            while (t1 < twentyMicrosecond)
+            {
+                iters *= 2;
+                t1 = Stopwatch.GetTimestamp();
+                for (int i = 0; i < iters; i++)
+                {
+                    id = Thread.GetCurrentProcessorNumber();
+                }
+                t1 = Stopwatch.GetTimestamp() - t1;
+            }
+
+            // assuming TLS takes 1/2 of ProcessorNumber time or less, this should take 10 usec or less
+            long t2 = Stopwatch.GetTimestamp();
+            for (int i = 0; i < iters; i++)
+            {
+                UninlinedThreadStatic();
+            }
+            long t3 = Stopwatch.GetTimestamp();
+
+            // if we have useful measurements, record a sample
+            if (id >= 0 && t1 > 0 && t3 - t2 > 0)
+            {
+                calibrationSamples[sample * 2] = (double)t1 / iters;            // ID
+                calibrationSamples[sample * 2 + 1] = (double)(t3 - t2) / iters; // TLS
+            }
+            else
+            {
+                // API is not functional or clock did not go forward.
+                // just pretend it was a very expensive sample with default ratio.
+                calibrationSamples[sample * 2] = (double)Stopwatch.Frequency * 50; // 50 sec;
+                calibrationSamples[sample * 2 + 1] = Stopwatch.Frequency; // 1 sec
+            }
+
+            // If this was the last sample computed, get best times and update the ratio of ID to TLS.
+            if (Interlocked.Increment(ref s_CalibrationDone) == CalibrationSampleCount)
+            {
+                double idMin = double.MaxValue;
+                double tlsMin = double.MaxValue;
+                for (int i = 0; i < CalibrationSampleCount; i++)
+                {
+                    idMin = Math.Min(idMin, calibrationSamples[i * 2]);       //ID
+                    tlsMin = Math.Min(tlsMin, calibrationSamples[i * 2 + 1]); //TLS
+                }
+
+                s_CalibrationSamples = null;
+                s_processorIdRefreshRate = Math.Min(MaxIdRefreshRate, (int)(idMin / tlsMin));
+            }
+        }
+
+        // NoInlining is to make sure JIT does not CSE and to have a better perf proxy for TLS access.
+        // Measuring inlined ThreadStatic in a loop results in underestimates and unnecessary caching.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static int UninlinedThreadStatic()
+        {
+            return t_currentProcessorIdCache;
+        }
+    }
+}

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
@@ -71,7 +71,7 @@ namespace System.Threading
             // also check if API is actually functional (-1 means not supported)
             if (Thread.GetCurrentProcessorNumber() < 0)
             {
-                s_processorIdRefreshRate = int.MaxValue;
+                s_processorIdRefreshRate = ProcessorIdCacheCountDownMask;
                 return false;
             }
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ProcessorIdCache.cs
@@ -183,7 +183,14 @@ namespace System.Threading
             }
 
             // Make sure the result was not negative, which would indicate "Not Supported"
-            return id >= 0;
+            if (id < 0)
+            {
+                return false;
+            }
+
+            // GetCurrentProcessorNumber  is fast, no more checks needed.
+            s_CalibrationSamples = null;
+            return true;
         }
 
         // NoInlining is to make sure JIT does not CSE and to have a better perf proxy for TLS access.

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -484,173 +484,32 @@ namespace System.Threading
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int GetCurrentProcessorNumber();
-
-        private static class CoreIdCache
-        {
-            // The upper bits of t_currentProcessorIdCache are the currentProcessorId. The lower bits of
-            // the t_currentProcessorIdCache are counting down to get it periodically refreshed.
-            // TODO: Consider flushing the currentProcessorIdCache on Wait operations or similar
-            // actions that are likely to result in changing the executing core
-            [ThreadStatic]
-            private static int t_currentProcessorIdCache;
-
-            private const int ProcessorIdCacheShift = 16;
-            private const int ProcessorIdCacheCountDownMask = (1 << ProcessorIdCacheShift) - 1;
-            // 50 is our best guess.
-            // Based on further calibration it is likley to be adjusted lower.
-            // In relatively rare cases of a slow GetCurrentProcessorNumber, it may be recalibrated to a higher number.
-            private static int s_processorIdRefreshRate = 50;
-            // We will not adjust higher than this though.
-            private const int MaxIdRefreshRate = 5000;
-
-            private static int RefreshCurrentProcessorId()
-            {
-                double[]? calibrationSamples = s_CalibrationSamples;
-                if (calibrationSamples != null)
-                    CalibrateOnce(calibrationSamples);
-
-                int currentProcessorId = GetCurrentProcessorNumber();
-
-                // On Unix, GetCurrentProcessorNumber() is implemented in terms of sched_getcpu, which
-                // doesn't exist on all platforms.  On those it doesn't exist on, GetCurrentProcessorNumber()
-                // returns -1.  As a fallback in that case and to spread the threads across the buckets
-                // by default, we use the current managed thread ID as a proxy.
-                if (currentProcessorId < 0) currentProcessorId = Environment.CurrentManagedThreadId;
-
-                Debug.Assert(s_processorIdRefreshRate <= ProcessorIdCacheCountDownMask);
-
-                // Mask with int.MaxValue to ensure the execution Id is not negative
-                t_currentProcessorIdCache = ((currentProcessorId << ProcessorIdCacheShift) & int.MaxValue) | s_processorIdRefreshRate;
-
-                return currentProcessorId;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal static int GetCurrentProcessorId()
-            {
-                if (s_processorIdRefreshRate <= 2)
-                    return GetCurrentProcessorNumber();
-
-                int currentProcessorIdCache = t_currentProcessorIdCache--;
-                if ((currentProcessorIdCache & ProcessorIdCacheCountDownMask) == 0)
-                {
-                    return RefreshCurrentProcessorId();
-                }
-
-                return currentProcessorIdCache >> ProcessorIdCacheShift;
-            }
-
-            // We must collect multiple samples to account for irregularities caused by GC and context switches.
-            // Why we keep an array of samples and do not adjust as we go:
-            //   We expect that we will adjust the refresh rate down. If we do that early, we may end up forcing all
-            //   the calibration work to happen much sooner. There is no urgency in being calibrated while the app
-            //   is in start-up mode. That would just add to the "rush hour" traffic.
-            private static int s_CalibrationToDo;
-            private static int s_CalibrationDone;
-            // 10 is chosen to budget the sampling under 5 msec total, assuming 0.5 msec per sample.
-            private const int CalibrationSampleCount = 10;
-            private static double[]? s_CalibrationSamples = new double[CalibrationSampleCount * 2];
-
-            private static void CalibrateOnce(double[] calibrationSamples)
-            {
-                if (s_CalibrationToDo >= CalibrationSampleCount)
-                    return;
-
-                int sample = Interlocked.Increment(ref s_CalibrationToDo) - 1;
-                if (sample >= CalibrationSampleCount)
-                    return;
-
-                // Actual calibration step. Let's try to fit into ~50 usec.
-                int id = 0;
-                long t1 = 0;
-                long twentyMicrosecond = Stopwatch.Frequency / 50000;
-                int iters = 1;
-
-                // double the sample size until it is 1 msec.
-                // we may spend up to 40 usec in this loop in a worst case.
-                while (t1 < twentyMicrosecond)
-                {
-                    iters *= 2;
-                    t1 = Stopwatch.GetTimestamp();
-                    for (int i = 0; i < iters; i++)
-                    {
-                        id = GetCurrentProcessorNumber();
-                    }
-                    t1 = Stopwatch.GetTimestamp() - t1;
-                }
-
-                // assuming TLS takes 1/2 of CoreID time or less, this should take 10 usec or less
-                long t2 = Stopwatch.GetTimestamp();
-                for (int i = 0; i < iters; i++)
-                {
-                    UninlinedThreadStatic();
-                }
-                long t3 = Stopwatch.GetTimestamp();
-
-                // if we have useful measurements, record a sample
-                if (id >= 0 && t1 > 0 && t3 - t2 > 0)
-                {
-                    calibrationSamples[sample * 2] = (double)t1 / iters;            // ID
-                    calibrationSamples[sample * 2 + 1] = (double)(t3 - t2) / iters; // TLS
-                }
-                else
-                {
-                    // API is not functional or clock did not go forward.
-                    // just pretend it was a very expensive sample with default ratio.
-                    calibrationSamples[sample * 2] = (double)Stopwatch.Frequency * 50; // 50 sec;
-                    calibrationSamples[sample * 2 + 1] = Stopwatch.Frequency; // 1 sec
-                }
-
-                // If this was the last sample computed, get best times and update the ratio of ID to TLS.
-                if (Interlocked.Increment(ref s_CalibrationDone) == CalibrationSampleCount)
-                {
-                    double idMin = double.MaxValue;
-                    double tlsMin = double.MaxValue;
-                    for (int i = 0; i < CalibrationSampleCount; i++)
-                    {
-                        idMin = Math.Min(idMin, calibrationSamples[i * 2]);       //ID
-                        tlsMin = Math.Min(tlsMin, calibrationSamples[i * 2 + 1]); //TLS
-                    }
-
-                    s_CalibrationSamples = null;
-                    s_processorIdRefreshRate = Math.Min(MaxIdRefreshRate, (int)(idMin / tlsMin));
-                }
-            }
-
-            // NoInlining is to make sure JIT does not CSE and to have a better perf proxy for TLS access.
-            // Measuring inlined ThreadStatic in a loop results in underestimates and unnecessary caching.
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            internal static int UninlinedThreadStatic()
-            {
-                return t_currentProcessorIdCache;
-            }
-        }
+        internal static extern int GetCurrentProcessorNumber();
 
         // Cached processor id could be used as a hint for which per-core stripe of data to access to avoid sharing.
         // It is periodically refreshed to trail the actual thread core affinity.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetCurrentProcessorId()
         {
-            if (s_isCoreIdReallyFast)
+            if (s_isProcessorNumberReallyFast)
                 return GetCurrentProcessorNumber();
 
-            return CoreIdCache.GetCurrentProcessorId();
+            return ProcessorIdCache.GetCurrentProcessorId();
         }
 
         // do a fast check and record in a readonly static so that it could become a JIT constant
-        private static readonly bool s_isCoreIdReallyFast = SimpleCoreIdSpeedCheck();
+        private static readonly bool s_isProcessorNumberReallyFast = SimpleProcessorNumberSpeedCheck();
 
         // If GetCurrentProcessorNumber takes any nontrivial time (compared to TLS access), return false.
         // Check more than once - to make sure it was not because TLS was delayed by GC or a context switch.
-        private static bool SimpleCoreIdSpeedCheck()
+        private static bool SimpleProcessorNumberSpeedCheck()
         {
             // NOTE: We do not check the frequency of the Stopwatch.
             //       If the resolution, precision or access time to the timer are inadequate for our measures here,
             //       the test will fail anyways.
 
             // warm up the code paths.
-            int id = CoreIdCache.UninlinedThreadStatic() | GetCurrentProcessorNumber();
+            int id = ProcessorIdCache.UninlinedThreadStatic() | GetCurrentProcessorNumber();
             long oneMicrosecond = Stopwatch.Frequency / 1000000;
 
             // this loop should take < 50 usec. limit it to 100 usec just in case.
@@ -676,7 +535,7 @@ namespace System.Threading
                 long t2 = Stopwatch.GetTimestamp();
                 for (int j = 0; j < iters; j++)
                 {
-                    CoreIdCache.UninlinedThreadStatic();
+                    ProcessorIdCache.UninlinedThreadStatic();
                 }
                 long t3 = Stopwatch.GetTimestamp();
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -486,19 +486,31 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern int GetCurrentProcessorNumber();
 
-        // The upper bits of t_currentProcessorIdCache are the currentProcessorId. The lower bits of
-        // the t_currentProcessorIdCache are counting down to get it periodically refreshed.
-        // TODO: Consider flushing the currentProcessorIdCache on Wait operations or similar
-        // actions that are likely to result in changing the executing core
-        [ThreadStatic]
-        private static int t_currentProcessorIdCache;
+        // t_currentProcessorId lives in a separate class to make sure the class is fully initialized by the time we use the field
+        private class CoreIdCache
+        {
+            // The upper bits of t_currentProcessorId are the currentProcessorId. The lower bits of
+            // the t_currentProcessorIdCache are counting down to get it periodically refreshed.
+            // TODO: Consider flushing the currentProcessorIdCache on Wait operations or similar
+            // actions that are likely to result in changing the executing core
+            [ThreadStatic]
+            internal static int t_currentProcessorId;
+        }
 
         private const int ProcessorIdCacheShift = 16;
         private const int ProcessorIdCacheCountDownMask = (1 << ProcessorIdCacheShift) - 1;
-        private const int ProcessorIdRefreshRate = 5000;
+        // 50 is our best guess.
+        // Based on further calibration it is likley to be adjusted lower.
+        // In relatively rare cases of a slow GetCurrentProcessorNumber, it may be recalibrated to a higher number.
+        private static int ProcessorIdRefreshRate = 50;
+        // We will not adjust higher than this though.
+        private const int MaxIdRefreshRate = 5000;
 
         private static int RefreshCurrentProcessorId()
         {
+            if (sCalibrationSamples != null)
+                CalibrateOnce();
+
             int currentProcessorId = GetCurrentProcessorNumber();
 
             // On Unix, GetCurrentProcessorNumber() is implemented in terms of sched_getcpu, which
@@ -507,29 +519,165 @@ namespace System.Threading
             // by default, we use the current managed thread ID as a proxy.
             if (currentProcessorId < 0) currentProcessorId = Environment.CurrentManagedThreadId;
 
-            // Add offset to make it clear that it is not guaranteed to be 0-based processor number
-            currentProcessorId += 100;
-
             Debug.Assert(ProcessorIdRefreshRate <= ProcessorIdCacheCountDownMask);
 
             // Mask with int.MaxValue to ensure the execution Id is not negative
-            t_currentProcessorIdCache = ((currentProcessorId << ProcessorIdCacheShift) & int.MaxValue) | ProcessorIdRefreshRate;
+            CoreIdCache.t_currentProcessorId = ((currentProcessorId << ProcessorIdCacheShift) & int.MaxValue) | ProcessorIdRefreshRate;
 
             return currentProcessorId;
         }
 
-        // Cached processor id used as a hint for which per-core stack to access. It is periodically
-        // refreshed to trail the actual thread core affinity.
+        // Cached processor id could be used as a hint for which per-core stripe of data to access to avoid sharing.
+        // It is periodically refreshed to trail the actual thread core affinity.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetCurrentProcessorId()
         {
-            int currentProcessorIdCache = t_currentProcessorIdCache--;
+            if (IsCoreIdReallyFast || ProcessorIdRefreshRate <= 2)
+                return GetCurrentProcessorNumber();
+
+            int currentProcessorIdCache = CoreIdCache.t_currentProcessorId--;
             if ((currentProcessorIdCache & ProcessorIdCacheCountDownMask) == 0)
             {
                 return RefreshCurrentProcessorId();
             }
 
             return currentProcessorIdCache >> ProcessorIdCacheShift;
+        }
+
+        // do a fast check and record in a readonly static so that it could become a JIT constant
+        internal static readonly bool IsCoreIdReallyFast = SimpleCoreIdSpeedCheck();
+
+        // If GetCurrentProcessorNumber takes any nontrivial time (compared to TLS access), return false.
+        // Check more than once - to make sure it was not because TLS was delayed by GC or a context switch.
+        private static bool SimpleCoreIdSpeedCheck()
+        {
+            // warm up the code paths.
+            int id = UninlinedThreadStatic() | GetCurrentProcessorNumber();
+            long _05usec = Stopwatch.Frequency / 1000000;
+
+            // limit quick test to 100 microseconds.
+            // If we are on slow hardware, we should calibrate anyways.
+            long limit = Stopwatch.Frequency / 10000 + Stopwatch.GetTimestamp();
+            for (int i = 0; i < 10; i++)
+            {
+                int iters = 1;
+                long t1 = 0;
+                // double the sample size until it is 0.5 usec.
+                while (t1 < _05usec)
+                {
+                    iters *= 2;
+                    t1 = Stopwatch.GetTimestamp();
+                    for (int j = 0; j < iters; j++)
+                    {
+                        id = GetCurrentProcessorNumber();
+                    }
+                    t1 = Stopwatch.GetTimestamp() - t1;
+                }
+
+                // assuming TLS cannot be a lot slower than getting ID, this should take 1-5 usec
+                long t2 = Stopwatch.GetTimestamp();
+                for (int j = 0; j < iters; j++)
+                {
+                    UninlinedThreadStatic();
+                }
+                long t3 = Stopwatch.GetTimestamp();
+
+                // if getting ID took longer than 2x TLS access, we should consider caching.
+                if (t3 > limit || (t3 - t2) * 2 < t1)
+                {
+                    return false;
+                }
+            }
+
+            // Make sure the result was not negative, which would indicate "Not Supported"
+            return id >= 0;
+        }
+
+        // NoInlining is to make sure JIT does not CSE and to have a better perf proxy for TLS access.
+        // Measuring inlined ThreadStatic in a loop results in underestimates and unnecessary caching.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int UninlinedThreadStatic()
+        {
+            return CoreIdCache.t_currentProcessorId;
+        }
+
+        // We must collect multiple samples to account for irregularities caused by GC and context switches.
+        // Why we keep an array of samples and do not adjust as we go:
+        //   We expect that we will adjust the refresh rate down. If we do that early, we may end up forcing all
+        //   the calibration work to happen much sooner. There is no urgency in being calibrated while the app
+        //   is in start-up mode. That would just add to the "rush hour" traffic.
+        private static int sCalibrationToDo;
+        private static int sCalibrationDone;
+        // 25 is chosen to budget the sampling under 100 msec total, assuming 4 msec per sample.
+        private const int CalibrationSamples = 25;
+        private static double[] sCalibrationSamples = new double[CalibrationSamples * 2];
+
+        private static void CalibrateOnce()
+        {
+            if (sCalibrationToDo >= CalibrationSamples)
+                return;
+
+            int sample = Interlocked.Increment(ref sCalibrationToDo) - 1;
+            if (sample >= CalibrationSamples)
+                return;
+
+            // Actual calibration step. Let's try to fit into ~4 msec.
+            double[] calibrationState = sCalibrationSamples;
+
+            int id = 0;
+            long t1 = 0;
+            long _1msec = Stopwatch.Frequency / 1000;
+            int iters = 1;
+
+            // double the sample size until it is 1 msec.
+            // we may spend up to 3 msec in this loop in a worst case.
+            while (t1 < _1msec)
+            {
+                iters *= 2;
+                t1 = Stopwatch.GetTimestamp();
+                for (int i = 0; i < iters; i++)
+                {
+                    id = GetCurrentProcessorNumber();
+                }
+                t1 = Stopwatch.GetTimestamp() - t1;
+            }
+
+            // assuming TLS cannot be a lot slower than ID, this should take 1 msec
+            long t2 = Stopwatch.GetTimestamp();
+            for (int i = 0; i < iters; i++)
+            {
+                UninlinedThreadStatic();
+            }
+            long t3 = Stopwatch.GetTimestamp();
+
+            // if we have useful measurements, record a sample
+            if (id >= 0 && t1 > 0 && t3 - t2 > 0)
+            {
+                calibrationState[sample * 2] = (double)t1 / iters;            // ID
+                calibrationState[sample * 2 + 1] = (double)(t3 - t2) / iters; // TLS
+            }
+            else
+            {
+                // API is not functional or clock did not go forward.
+                // just pretend it was a very expensive sample with default ratio.
+                calibrationState[sample * 2] = (double)Stopwatch.Frequency * 50; // 50 sec;
+                calibrationState[sample * 2 + 1] = Stopwatch.Frequency; // 1 sec
+            }
+
+            // If this was the last sample computed, get best times and update the ratio of ID to TLS.
+            if (Interlocked.Increment(ref sCalibrationDone) == CalibrationSamples)
+            {
+                double idMin = double.MaxValue;
+                double tlsMin = double.MaxValue;
+                for (int i = 0; i < CalibrationSamples; i++)
+                {
+                    idMin = Math.Min(idMin, calibrationState[i * 2]);       //ID
+                    tlsMin = Math.Min(tlsMin, calibrationState[i * 2 + 1]); //TLS
+                }
+
+                sCalibrationSamples = null!;
+                ProcessorIdRefreshRate = Math.Min(MaxIdRefreshRate, (int)(idMin / tlsMin));
+            }
         }
 
         internal void ResetThreadPoolThread()

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -497,7 +497,8 @@ namespace System.Threading
             return ProcessorIdCache.GetCurrentProcessorId();
         }
 
-        // do a fast check and record in a readonly static so that it could become a JIT constant
+        // a speed check will determine refresh rate of the cache and will report if caching is not advisable.
+        // we will record that in a readonly static so that it could become a JIT constant and bypass caching entirely.
         private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.ProcessorNumberSpeedCheck();
 
         internal void ResetThreadPoolThread()

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -498,7 +498,7 @@ namespace System.Threading
         }
 
         // do a fast check and record in a readonly static so that it could become a JIT constant
-        private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.ProcessorNumberSpeedCheck() <= 3;
+        private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.ProcessorNumberSpeedCheck();
 
         internal void ResetThreadPoolThread()
         {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -498,7 +498,7 @@ namespace System.Threading
         }
 
         // do a fast check and record in a readonly static so that it could become a JIT constant
-        private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.SimpleProcessorNumberSpeedCheck();
+        private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.ProcessorNumberSpeedCheck() <= 3;
 
         internal void ResetThreadPoolThread()
         {


### PR DESCRIPTION
`GetProcessorNumber` has a big range of possible implementations and performance characteristics. The slowest implementations can be 100x times slower than the fast ones, and we may not have seen all the range. Even on the same hardware performance may vary (i.e. x86 WOW process will have noticeably slower support than x64 on the same machine/OS). 

At sub-context-switch times the result of `GetProcessorNumber` is fairly stable. Most OSs would try to keep the thread from “wandering” to other cores. As such it is possible to amortize the expenses of this API by thread-static caching. However the context switches do happen and the cached result has diminishing utility as the time passes.

The good news is that this API is fast on recent hardware/OS-es and is getting faster. It is not uncommon now to see systems where the call is fast enough that caching is not necessary or, in fact, may make it slower. There are systems where this API is actually faster than a standalone `ThreadStatic` access. (for example when RDPID instruction is available and OS uses it).

The goal of this change is to use **as little caching as possible** while not falling into perf cliffs on systems where API happens to be slow.

== In this change:

There are two on-demand checks that estimate the performance of `GetProcessorNumber` with a standalone `ThreadStatic` access used as a base reference. There is still a cache, but the caching strategy is adjusted accordingly to those checks.

1)	On the first access to the `GetCurrentProcessorId` a quick and conservative check is performed to detect “definitely fast” systems. 
On such systems no caching is required and no further checks are necessary. We get out of the way. Cache is bypassed.
2)	Systems that do not pass the first check, will operate with default cache settings (refresh every 50 accesses). 
At the time of cache refresh a calibration sample would be collected. 
When enough samples are collected, a more precise refresh rate is computed. Typically it will be smaller than 50x. Sometimes it may be larger. 
The total cost of calibration has upper bound and is not high. The impact is further mitigated by spreading out the measurements which makes calibration pay-for-play, takes it away from start-up and has dilutionary effect. As a result calibration is generally hardly noticeable in profiler.




