### PR TITLE
improve renegotiation ssl tests

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -61,7 +61,7 @@ namespace System.Net.Security.Tests
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
                 // Renegotiation will trigger another validation callback/
-                Assert.True(validationCount > 1);
+                Assert.InRange(validationCount, 2, int.MaxValue);
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -23,10 +23,18 @@ namespace System.Net.Security.Tests
         [OuterLoop] // Test hits external azure server.
         public async Task SslStream_AllowRenegotiation_True_Succeeds()
         {
+            int validationCount = 0;
+
+            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            {
+                validationCount++;
+                return true;
+            });
+
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
             using (NetworkStream ns = new NetworkStream(s))
-            using (SslStream ssl = new SslStream(ns, true))
+            using (SslStream ssl = new SslStream(ns, true, validationCallback))
             {
                 X509CertificateCollection certBundle = new X509CertificateCollection();
                 certBundle.Add(Configuration.Certificates.GetClientCertificate());
@@ -52,8 +60,8 @@ namespace System.Net.Security.Tests
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
-                // There's no good way to ensure renegotiation happened in the test.
-                // Under the debugger, we can see this test hits the renegotiation codepath.
+                // Renegotiation will trigger another validation callback/
+                Assert.True(validationCount > 1);
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -161,8 +161,7 @@ namespace System.Net.Security.Tests
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
                 // renegotiation will trigger validation callback again.
-                Assert.True(validationCount > 1);
-
+                Assert.InRange(validationCount, 2, int.MaxValue);
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -132,10 +132,18 @@ namespace System.Net.Security.Tests
         [OuterLoop] // Test hits external azure server.
         public async Task SslStream_NetworkStream_Renegotiation_Succeeds()
         {
+            int validationCount = 0;
+
+            var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+            {
+                validationCount++;
+                return true;
+            });
+
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             await s.ConnectAsync(Configuration.Security.TlsRenegotiationServer, 443);
             using (NetworkStream ns = new NetworkStream(s))
-            using (SslStream ssl = new SslStream(ns, true))
+            using (SslStream ssl = new SslStream(ns, true, validationCallback))
             {
                 X509CertificateCollection certBundle = new X509CertificateCollection();
                 certBundle.Add(Configuration.Certificates.GetClientCertificate());
@@ -152,8 +160,9 @@ namespace System.Net.Security.Tests
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
-                // There's no good way to ensure renegotiation happened in the test.
-                // Under the debugger, we can see this test hits the renegotiation codepath.
+                // renegotiation will trigger validation callback again.
+                Assert.True(validationCount > 1);
+
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }


### PR DESCRIPTION
Improve test to make sure we actually do renegotiation. 
It is curious that we actually never set _pendingReHandshake to true in production code. 

I will address it as part of #453