### PR TITLE
Use MaxExpansionFactorWhileTranscoding instead of counting bytes

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -50,13 +50,13 @@ namespace System.Text.Json
                 return false;
             }
 
-            int length = JsonReaderHelper.GetUtf8ByteCount(source);
+            int maxLength = checked(source.Length * JsonConstants.MaxExpansionFactorWhileTranscoding);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+            Span<byte> bytes = maxLength <= JsonConstants.StackallocThreshold
                 ? stackalloc byte[JsonConstants.StackallocThreshold]
-                : new byte[length];
+                : new byte[maxLength];
 
-            JsonReaderHelper.GetUtf8FromText(source, bytes);
+            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }
@@ -69,13 +69,13 @@ namespace System.Text.Json
                 return false;
             }
 
-            int length = JsonReaderHelper.GetUtf8ByteCount(source);
+            int maxLength = checked(source.Length * JsonConstants.MaxExpansionFactorWhileTranscoding);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+            Span<byte> bytes = maxLength <= JsonConstants.StackallocThreshold
                 ? stackalloc byte[JsonConstants.StackallocThreshold]
-                : new byte[length];
+                : new byte[maxLength];
 
-            JsonReaderHelper.GetUtf8FromText(source, bytes);
+            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }

--- a/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -229,6 +229,10 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"199\\u0037-07\\u002d16T1\\u0039:20:30.4555555+\\u002dZ\"" };
             // Proper format but invalid calendar date, time, or time zone designator fields 1997-00-16
             yield return new object[] { "\"\\u0031\\u0039\\u0039\\u0037\\u002d\\u0030\\u0030\\u002d\\u0031\\u0036\"" };
+
+            // High byte expansion - parsing fails early at 254 characters.
+            yield return new object[] { "\"" + new string('\u20AC', 250) + "\"" };
+            yield return new object[] { "\"" + new string('\u20AC', 260) + "\"" };
         }
 
         public static IEnumerable<object[]> DateTimeFractionTrimBaseTests()

--- a/src/libraries/System.Text.Json/tests/JsonStringTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonStringTests.cs
@@ -110,6 +110,21 @@ namespace System.Text.Json.Tests
             Assert.Equal(dateTimeOffset, dateTimeOffset2);
         }
 
+        [Theory]
+        [MemberData(nameof(JsonDateTimeTestData.InvalidISO8601Tests), MemberType = typeof(JsonDateTimeTestData))]
+        public static void TestInvalidDateTime(string testStr)
+        {
+            var jsonString = new JsonString(testStr);
+
+            Assert.False(jsonString.TryGetDateTime(out DateTime dateTimeVal));
+            Assert.Equal(default, dateTimeVal);
+            Assert.False(jsonString.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffsetVal));
+            Assert.Equal(default, dateTimeOffsetVal);
+
+            Assert.Throws<FormatException>(() => jsonString.GetDateTime());
+            Assert.Throws<FormatException>(() => jsonString.GetDateTimeOffset());
+        }
+
         [Fact]
         public static void TestChangingValue()
         {


### PR DESCRIPTION
dotnet/runtime version of https://github.com/dotnet/corefx/pull/42574.

// @ahsonkhan 