### PR TITLE
Print duplicate files when throwing exception on bundler

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -165,7 +165,7 @@ namespace Microsoft.NET.HostModel.Bundle
             if (duplicateGroups.Any())
             {
                 throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath:"
-                    + string.Join("\n", duplicateGroups.SelectMany(o => o).Select(o => "  " + o.ToString())));
+                    + string.Join("\n", duplicateGroups.SelectMany(o => o)));
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -160,9 +160,12 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException("Invalid input specification: Must specify the host binary");
             }
 
-            if (fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).Any())
+            var duplicateGroups = fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1);
+
+            if (duplicateGroups.Any())
             {
-                throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath");
+                throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath:"
+                    + string.Join("\n", duplicateGroups.SelectMany(o => o).Select(o => "  " + o.BundleRelativePath)));
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -165,7 +165,7 @@ namespace Microsoft.NET.HostModel.Bundle
             if (duplicateGroups.Any())
             {
                 throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath:"
-                    + string.Join("\n", duplicateGroups.SelectMany(o => o).Select(o => "  " + o.BundleRelativePath)));
+                    + string.Join("\n", duplicateGroups.SelectMany(o => o).Select(o => "  " + o.ToString())));
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 return false;
             }
 
-            if (Path.GetExtension(fileRelativePath).ToLowerInvariant().Equals(".pdb"))
+            if (Path.GetExtension(fileRelativePath).Equals(".pdb", StringComparison.InvariantCultureIgnoreCase))
             {
                 return EmbedPDBs;
             }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -165,7 +165,8 @@ namespace Microsoft.NET.HostModel.Bundle
             if (duplicateGroups.Any())
             {
                 throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath:"
-                    + string.Join("\n", duplicateGroups.SelectMany(o => o)));
+                    + Environment.NewLine
+                    + string.Join(Environment.NewLine, duplicateGroups.SelectMany(o => o)));
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/FileSpec.cs
@@ -29,6 +29,11 @@ namespace Microsoft.NET.HostModel.Bundle
             return !string.IsNullOrWhiteSpace(SourcePath) && 
                    !string.IsNullOrWhiteSpace(BundleRelativePath);
         }
+        
+        public override string ToString()
+        {
+            return $"{SourcePath} ({BundleRelativePath})";
+        }
     }
 }
 

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -79,7 +79,11 @@ namespace Microsoft.NET.HostModel.Tests
             fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
 
             Bundler bundler = new Bundler(hostName, bundleDir.FullName);
-            Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
+
+            var argEx = Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
+            Assert.Equal("Invalid input specification: Found multiple entries with the same BundleRelativePath:"
+                + Environment.NewLine
+                + fileSpecs[1], argEx.Message);
         }
 
         [InlineData(true)]


### PR DESCRIPTION
This will greatly help in finding the culprit files when you encounter this exception.