### PR TITLE
Make Crossgen2 tests run daily

### DIFF
--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+- cron: "0 6 * * *"
+  displayName: Mon through Sun at 10:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 #
 # Checkout repository


### PR DESCRIPTION
Eventually (when all tests start passing) we should enable running them on each commit. But for now, to keep track of the progress, the tests will run only once a day.
