### PR TITLE
Fix xml doc comment on FlushResult.IsCompleted

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/FlushResult.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/FlushResult.cs
@@ -35,7 +35,7 @@ namespace System.IO.Pipelines
         public bool IsCanceled => (_resultFlags & ResultFlags.Canceled) != 0;
 
         /// <summary>
-        /// True if the <see cref="PipeWriter"/> is complete otherwise false
+        /// Gets a value that indicates the reader is no longer reading data written to the <see cref="PipeWriter" />.
         /// </summary>
         public bool IsCompleted => (_resultFlags & ResultFlags.Completed) != 0;
     }


### PR DESCRIPTION
This brings it into conformity with behavior and the [published documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.pipelines.flushresult.iscompleted?view=dotnet-plat-ext-3.0).