### PR TITLE
Enable parallelism in Crossgen2 and add flags for it in SuperIlc.

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -28,6 +28,7 @@ namespace ReadyToRun.SuperIlc
         public bool UseFramework { get; set; }
         public bool Release { get; set; }
         public bool LargeBubble { get; set; }
+        public int Crossgen2Parallelism { get; set; }
         public int CompilationTimeoutMinutes { get; set; }
         public int ExecutionTimeoutMinutes { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -44,6 +44,7 @@ namespace ReadyToRun.SuperIlc
                         UseFramework(),
                         Release(),
                         LargeBubble(),
+                        Crossgen2Parallelism(),
                         ReferencePath(),
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
@@ -75,6 +76,7 @@ namespace ReadyToRun.SuperIlc
                         UseFramework(),
                         Release(),
                         LargeBubble(),
+                        Crossgen2Parallelism(),
                         ReferencePath(),
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
@@ -194,6 +196,9 @@ namespace ReadyToRun.SuperIlc
 
             Option LargeBubble() =>
                 new Option(new[] { "--large-bubble" }, "Assume all input files as part of one version bubble", new Argument<bool>());
+
+            Option Crossgen2Parallelism() =>
+                new Option(new[] { "--crossgen2-parallelism" }, "Max number of threads to use in Crossgen2 (default = logical processor count)", new Argument<int>());
 
             Option IssuesPath() =>
                 new Option(new[] { "--issues-path", "-ip" }, "Path to issues.targets", new Argument<FileInfo[]>() { Arity = ArgumentArity.ZeroOrMore });

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -25,7 +25,11 @@ namespace ReadyToRun.SuperIlc
 
         public CpaotRunner(BuildOptions options, IEnumerable<string> referencePaths)
             : base(options, referencePaths)
-        { }
+        {
+            // Set SuperIlc parallelism to a low enough value that ensures that each Crossgen2 invocation gets to use its parallelism
+            if (options.DegreeOfParallelism == 0)
+                options.DegreeOfParallelism = 2;
+        }
 
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
@@ -53,6 +57,11 @@ namespace ReadyToRun.SuperIlc
             if (_options.LargeBubble)
             {
                 yield return "--inputbubble";
+            }
+
+            if (_options.Crossgen2Parallelism != 0)
+            {
+                yield return $"--parallelism={_options.Crossgen2Parallelism}";
             }
 
             foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(Path.GetDirectoryName(assemblyFileName)))

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -194,7 +194,7 @@ namespace ILCompiler
         /// We only need one CorInfoImpl per thread, and we don't want to unnecessarily construct them
         /// because their construction takes a significant amount of time.
         /// </summary>
-        private readonly ConditionalWeakTable<Thread, CorInfoImpl> corInfoImpls;
+        private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corInfoImpls;
 
         /// <summary>
         /// Name of the compilation input MSIL file.
@@ -231,7 +231,7 @@ namespace ILCompiler
 
             _inputFilePath = inputFilePath;
 
-            corInfoImpls = new ConditionalWeakTable<Thread, CorInfoImpl>();
+            _corInfoImpls = new ConditionalWeakTable<Thread, CorInfoImpl>();
             CorInfoImpl.RegisterJITModule(configProvider);
         }
 
@@ -280,8 +280,6 @@ namespace ILCompiler
                 {
                     MaxDegreeOfParallelism = _parallelism
                 };
-                Console.WriteLine("Parallelism");
-                Console.WriteLine(_parallelism);
                 Parallel.ForEach(obj, options, dependency =>
                 {
                     MethodWithGCInfo methodCodeNodeNeedingCode = dependency as MethodWithGCInfo;
@@ -297,7 +295,7 @@ namespace ILCompiler
                     {
                         using (PerfEventSource.StartStopEvents.JitMethodEvents())
                         {
-                            CorInfoImpl corInfoImpl = corInfoImpls.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
+                            CorInfoImpl corInfoImpl = _corInfoImpls.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
                             corInfoImpl.CompileMethod(methodCodeNodeNeedingCode);
                         }
                     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Internal.IL;
 using Internal.IL.Stubs;
@@ -190,11 +191,19 @@ namespace ILCompiler
         private readonly JitConfigProvider _jitConfigProvider;
 
         /// <summary>
+        /// We only need one CorInfoImpl per thread, and we don't want to unnecessarily construct them
+        /// because their construction takes a significant amount of time.
+        /// </summary>
+        private readonly ConditionalWeakTable<Thread, CorInfoImpl> corInfoImpls;
+
+        /// <summary>
         /// Name of the compilation input MSIL file.
         /// </summary>
         private readonly string _inputFilePath;
 
         private bool _resilient;
+
+        private int _parallelism;
 
         public new ReadyToRunCodegenNodeFactory NodeFactory { get; }
 
@@ -210,16 +219,19 @@ namespace ILCompiler
             JitConfigProvider configProvider,
             string inputFilePath,
             IEnumerable<ModuleDesc> modulesBeingInstrumented,
-            bool resilient)
+            bool resilient,
+            int parallelism)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, devirtualizationManager, modulesBeingInstrumented, logger)
         {
             _resilient = resilient;
+            _parallelism = parallelism;
             NodeFactory = nodeFactory;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);
             _jitConfigProvider = configProvider;
 
             _inputFilePath = inputFilePath;
 
+            corInfoImpls = new ConditionalWeakTable<Thread, CorInfoImpl>();
             CorInfoImpl.RegisterJITModule(configProvider);
         }
 
@@ -264,8 +276,13 @@ namespace ILCompiler
         {
             using (PerfEventSource.StartStopEvents.JitEvents())
             {
-                ConditionalWeakTable<Thread, CorInfoImpl> cwt = new ConditionalWeakTable<Thread, CorInfoImpl>();
-                foreach (DependencyNodeCore<NodeFactory> dependency in obj)
+                ParallelOptions options = new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = _parallelism
+                };
+                Console.WriteLine("Parallelism");
+                Console.WriteLine(_parallelism);
+                Parallel.ForEach(obj, options, dependency =>
                 {
                     MethodWithGCInfo methodCodeNodeNeedingCode = dependency as MethodWithGCInfo;
                     MethodDesc method = methodCodeNodeNeedingCode.Method;
@@ -280,7 +297,7 @@ namespace ILCompiler
                     {
                         using (PerfEventSource.StartStopEvents.JitMethodEvents())
                         {
-                            CorInfoImpl corInfoImpl = cwt.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
+                            CorInfoImpl corInfoImpl = corInfoImpls.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
                             corInfoImpl.CompileMethod(methodCodeNodeNeedingCode);
                         }
                     }
@@ -297,7 +314,7 @@ namespace ILCompiler
                     {
                         Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
                     }
-                }
+                });
             }
 
             if (_methodILCache.Count > 1000)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -22,6 +22,7 @@ namespace ILCompiler
         private readonly EcmaModule _inputModule;
         private readonly bool _ibcTuning;
         private readonly bool _resilient;
+        private readonly int _parallelism;
         private string _jitPath;
 
         // These need to provide reasonable defaults so that the user can optionally skip
@@ -29,12 +30,13 @@ namespace ILCompiler
         private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
         private ILProvider _ilProvider = new ReadyToRunILProvider();
 
-        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath, bool ibcTuning, bool resilient)
+        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath, bool ibcTuning, bool resilient, int parallelism)
             : base(context, group, new CoreRTNameMangler())
         {
             _inputFilePath = inputFilePath;
             _ibcTuning = ibcTuning;
             _resilient = resilient;
+            _parallelism = parallelism;
 
             _inputModule = context.GetModuleFromPath(_inputFilePath);
 
@@ -167,7 +169,8 @@ namespace ILCompiler
                 jitConfig,
                 _inputFilePath,
                 new ModuleDesc[] { _inputModule },
-                _resilient);
+                _resilient,
+                _parallelism);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -20,9 +20,9 @@ namespace ILCompiler
     {
         private readonly string _inputFilePath;
         private readonly EcmaModule _inputModule;
-        private readonly bool _ibcTuning;
-        private readonly bool _resilient;
-        private readonly int _parallelism;
+        private bool _ibcTuning;
+        private bool _resilient;
+        private int _parallelism;
         private string _jitPath;
 
         // These need to provide reasonable defaults so that the user can optionally skip
@@ -30,14 +30,10 @@ namespace ILCompiler
         private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
         private ILProvider _ilProvider = new ReadyToRunILProvider();
 
-        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath, bool ibcTuning, bool resilient, int parallelism)
+        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath)
             : base(context, group, new CoreRTNameMangler())
         {
             _inputFilePath = inputFilePath;
-            _ibcTuning = ibcTuning;
-            _resilient = resilient;
-            _parallelism = parallelism;
-
             _inputModule = context.GetModuleFromPath(_inputFilePath);
 
             // R2R field layout needs compilation group information
@@ -85,6 +81,25 @@ namespace ILCompiler
             _jitPath = jitPath;
             return this;
         }
+
+        public ReadyToRunCodegenCompilationBuilder UseIbcTuning(bool ibcTuning)
+        {
+            _ibcTuning = ibcTuning;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder UseResilience(bool resilient)
+        {
+            _resilient = resilient;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder UseParallelism(int parallelism)
+        {
+            _parallelism = parallelism;
+            return this;
+        }
+
 
         public override ICompilation ToCompilation()
         {

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -142,10 +142,9 @@ namespace ILCompiler
                     // We don't need to override arity here as 255 is the maximum number of generic arguments
                     Argument = new Argument<string[]>()
                 },
-                new Option(new[] { "--parallelism" }, "Number of threads to run")
+                new Option(new[] { "--parallelism" }, "Maximum number of threads to use during compilation")
                 { 
-                    // -1 sets no restriction on processor count
-                    Argument = new Argument<int>(() => -1)
+                    Argument = new Argument<int>(() => Environment.ProcessorCount)
                 },
             };
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -31,6 +31,8 @@ namespace ILCompiler
         public bool Tuning { get; set; }
         public bool Partial { get; set; }
         public bool Resilient { get; set; }
+        public int Parallelism { get; set; }
+
 
         public string SingleMethodTypeName { get; set; }
         public string SingleMethodName { get; set; }
@@ -139,6 +141,11 @@ namespace ILCompiler
                 { 
                     // We don't need to override arity here as 255 is the maximum number of generic arguments
                     Argument = new Argument<string[]>()
+                },
+                new Option(new[] { "--parallelism" }, "Number of threads to run")
+                { 
+                    // -1 sets no restriction on processor count
+                    Argument = new Argument<int>(() => -1)
                 },
             };
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -311,11 +311,7 @@ namespace ILCompiler
                         inputFilePath = input.Value;
                         break;
                     }
-                    CompilationBuilder builder = new ReadyToRunCodegenCompilationBuilder(typeSystemContext, compilationGroup, inputFilePath,
-                        ibcTuning: _commandLineOptions.Tuning,
-                        resilient: _commandLineOptions.Resilient,
-                        parallelism: _commandLineOptions.Parallelism);
-
+                    ReadyToRunCodegenCompilationBuilder builder = new ReadyToRunCodegenCompilationBuilder(typeSystemContext, compilationGroup, inputFilePath);
                     string compilationUnitPrefix = "";
                     builder.UseCompilationUnitPrefix(compilationUnitPrefix);
 
@@ -325,6 +321,9 @@ namespace ILCompiler
                         DependencyTrackingLevel.None : (_commandLineOptions.GenerateFullDgmlLog ? DependencyTrackingLevel.All : DependencyTrackingLevel.First);
 
                     builder
+                        .UseIbcTuning(_commandLineOptions.Tuning)
+                        .UseResilience(_commandLineOptions.Resilient)
+                        .UseParallelism(_commandLineOptions.Parallelism)
                         .UseILProvider(ilProvider)
                         .UseJitPath(_commandLineOptions.JitPath)
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -313,7 +313,8 @@ namespace ILCompiler
                     }
                     CompilationBuilder builder = new ReadyToRunCodegenCompilationBuilder(typeSystemContext, compilationGroup, inputFilePath,
                         ibcTuning: _commandLineOptions.Tuning,
-                        resilient: _commandLineOptions.Resilient);
+                        resilient: _commandLineOptions.Resilient,
+                        parallelism: _commandLineOptions.Parallelism);
 
                     string compilationUnitPrefix = "";
                     builder.UseCompilationUnitPrefix(compilationUnitPrefix);


### PR DESCRIPTION
- Add a `parallelism` flag in Crossgen2
- Add a `crossgen2-parallelism` flag in SuperIlc
- Add a low default amount of parallelism for SuperIlc when compiling with Crossgen2

## Perf improvements
These are the results of compiling System.Private.CoreLib.dll with SuperIlc. The SuperIlc build was a debug build, and the crossgen2 build it used was a release build.
```
ReadyToRun.SuperIlc.exe compile-directory -cr C:\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root -in C:\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root --nojit --noexe --measure-perf --large-bubble --release -input-file System.Private.Core* -dop 1 --crossgen2-parallelism {1 or 8}
```

### With 8 threads (5 run average)
Total average compilation time: **9314.74 ms**
Phase breakdown (average):
- Loading time: 687.77
- Graph processing time: 3859.30 ms
  - Added 206711 nodes to mark stack
  - Dependency analysis time: 606.09 ms
  - Wall clock JIT time: 2706.99 ms
  - Total JIT time: 24671.84 ms (sum of all threads)
  - 22680 methods JITed
- Emitting time: 4765.06 ms

### With 1 thread (5 run average)
Total average compilation time: **13954.71 ms**
Phase breakdown (average):
- Loading time: 686.73 ms
- Graph processing time: 8871.62 ms
  - Added 206711 nodes to mark
  - Dependency analysis time: 599.27 ms
  - Wall clock JIT time: 7754.44 ms
  - Total JIT time: 7670.19 ms (sum of all threads)
  - 22680 methods JITed
- Emitting time: 4393.62 ms
