### PR TITLE
Avoid allocating Regex when using static methods

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
@@ -10,7 +10,7 @@ namespace System.Text.RegularExpressions
         /// Searches the input string for one or more occurrences of the text supplied in the given pattern.
         /// </summary>
         public static bool IsMatch(string input, string pattern) =>
-            new Regex(pattern, addToCache: true).IsMatch(input);
+            RegexCache.GetOrAdd(pattern).IsMatch(input);
 
         /// <summary>
         /// Searches the input string for one or more occurrences of the text
@@ -18,10 +18,10 @@ namespace System.Text.RegularExpressions
         /// parameter.
         /// </summary>
         public static bool IsMatch(string input, string pattern, RegexOptions options) =>
-            IsMatch(input, pattern, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).IsMatch(input);
 
         public static bool IsMatch(string input, string pattern, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, addToCache: true).IsMatch(input);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).IsMatch(input);
 
         /*
          * Returns true if the regex finds a match within the specified string
@@ -59,7 +59,7 @@ namespace System.Text.RegularExpressions
         /// supplied in the pattern parameter.
         /// </summary>
         public static Match Match(string input, string pattern) =>
-            new Regex(pattern, addToCache: true).Match(input);
+            RegexCache.GetOrAdd(pattern).Match(input);
 
         /// <summary>
         /// Searches the input string for one or more occurrences of the text
@@ -67,10 +67,10 @@ namespace System.Text.RegularExpressions
         /// string.
         /// </summary>
         public static Match Match(string input, string pattern, RegexOptions options) =>
-            Match(input, pattern, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Match(input);
 
         public static Match Match(string input, string pattern, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, addToCache: true).Match(input);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Match(input);
 
         /*
          * Finds the first match for the regular expression starting at the beginning
@@ -123,16 +123,16 @@ namespace System.Text.RegularExpressions
         /// Returns all the successful matches as if Match were called iteratively numerous times.
         /// </summary>
         public static MatchCollection Matches(string input, string pattern) =>
-            new Regex(pattern, addToCache: true).Matches(input);
+            RegexCache.GetOrAdd(pattern).Matches(input);
 
         /// <summary>
         /// Returns all the successful matches as if Match were called iteratively numerous times.
         /// </summary>
         public static MatchCollection Matches(string input, string pattern, RegexOptions options) =>
-            Matches(input, pattern, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Matches(input);
 
         public static MatchCollection Matches(string input, string pattern, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, addToCache: true).Matches(input);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Matches(input);
 
         /*
          * Finds the first match for the regular expression starting at the beginning

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -20,7 +20,7 @@ namespace System.Text.RegularExpressions
         /// the first character in the input string.
         /// </summary>
         public static string Replace(string input, string pattern, string replacement) =>
-            new Regex(pattern, addToCache: true).Replace(input, replacement);
+            RegexCache.GetOrAdd(pattern).Replace(input, replacement);
 
         /// <summary>
         /// Replaces all occurrences of
@@ -28,10 +28,10 @@ namespace System.Text.RegularExpressions
         /// pattern, starting at the first character in the input string.
         /// </summary>
         public static string Replace(string input, string pattern, string replacement, RegexOptions options) =>
-            Replace(input, pattern, replacement, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, replacement);
 
         public static string Replace(string input, string pattern, string replacement, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, true).Replace(input, replacement);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, replacement);
 
         /// <summary>
         /// Replaces all occurrences of the previously defined pattern with the
@@ -83,17 +83,17 @@ namespace System.Text.RegularExpressions
         /// replacement pattern.
         /// </summary>
         public static string Replace(string input, string pattern, MatchEvaluator evaluator) =>
-            new Regex(pattern, addToCache: true).Replace(input, evaluator);
+            RegexCache.GetOrAdd(pattern).Replace(input, evaluator);
 
         /// <summary>
         /// Replaces all occurrences of the <paramref name="pattern"/> with the recent
         /// replacement pattern, starting at the first character.
         /// </summary>
         public static string Replace(string input, string pattern, MatchEvaluator evaluator, RegexOptions options) =>
-            Replace(input, pattern, evaluator, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, evaluator);
 
         public static string Replace(string input, string pattern, MatchEvaluator evaluator, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, addToCache: true).Replace(input, evaluator);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, evaluator);
 
         /// <summary>
         /// Replaces all occurrences of the previously defined pattern with the recent

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -13,16 +13,16 @@ namespace System.Text.RegularExpressions
         /// by <paramref name="pattern"/>.
         /// </summary>
         public static string[] Split(string input, string pattern) =>
-            new Regex(pattern, addToCache: true).Split(input);
+            RegexCache.GetOrAdd(pattern).Split(input);
 
         /// <summary>
         /// Splits the <paramref name="input "/>string at the position defined by <paramref name="pattern"/>.
         /// </summary>
         public static string[] Split(string input, string pattern, RegexOptions options) =>
-            Split(input, pattern, options, s_defaultMatchTimeout);
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Split(input);
 
         public static string[] Split(string input, string pattern, RegexOptions options, TimeSpan matchTimeout) =>
-            new Regex(pattern, options, matchTimeout, addToCache: true).Split(input);
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Split(input);
 
         /// <summary>
         /// Splits the <paramref name="input"/> string at the position defined by a

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -36,26 +36,6 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public TimeSpan MatchTimeout => internalMatchTimeout;
 
-        // Note: "&lt;" is the XML entity for smaller ("<").
-        /// <summary>
-        /// Validates that the specified match timeout value is valid.
-        /// The valid range is <code>TimeSpan.Zero &lt; matchTimeout &lt;= Regex.MaximumMatchTimeout</code>.
-        /// </summary>
-        /// <param name="matchTimeout">The timeout value to validate.</param>
-        /// <exception cref="ArgumentOutOfRangeException">If the specified timeout is not within a valid range.
-        /// </exception>
-        protected internal static void ValidateMatchTimeout(TimeSpan matchTimeout)
-        {
-            if (InfiniteMatchTimeout == matchTimeout)
-                return;
-
-            // Change this to make sure timeout is not longer then Environment.Ticks cycle length:
-            if (TimeSpan.Zero < matchTimeout && matchTimeout <= s_maximumMatchTimeout)
-                return;
-
-            throw new ArgumentOutOfRangeException(nameof(matchTimeout));
-        }
-
         /// <summary>
         /// Specifies the default RegEx matching timeout value (i.e. the timeout that will be used if no
         /// explicit timeout is specified).

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Cache.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Cache.Tests.cs
@@ -139,7 +139,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             return (int)typeof(Regex).Assembly
                 .GetType("System.Text.RegularExpressions.RegexCache")
-                .GetField("s_cacheCount", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .GetField("s_cacheCount", BindingFlags.NonPublic | BindingFlags.Static)
                 .GetValue(null);
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Cache.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Cache.Tests.cs
@@ -137,8 +137,9 @@ namespace System.Text.RegularExpressions.Tests
 
         private int GetCachedItemsNum()
         {
-            return (int)typeof(Regex)
-                .GetField("s_cacheCount", BindingFlags.NonPublic | BindingFlags.Static)
+            return (int)typeof(Regex).Assembly
+                .GetType("System.Text.RegularExpressions.RegexCache")
+                .GetField("s_cacheCount", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
                 .GetValue(null);
         }
     }


### PR DESCRIPTION
Regex supports a cache that's meant to be used for the static methods, e.g. the static Regex.IsMatch.  However, currently that cache isn't caching the actual Regex class, but rather a sub object that stores some of the state from the Regex and then is used to rehydrate a new Regex instance.  This means we allocate a new Regex object when these static methods are used, even if the data is found in the cache.  This means an operation like the static Regex.IsMatch is never allocation-free.  There's also weirdness around this caching, in that when a new Regex instance is constructed, it checks the cache (paying the relevant lookup costs) even though it doesn't add back to the cache, so the only way it would ever find something in the cache is if the same set of inputs (e.g. pattern, options, timeout, etc.) are used with both the Regex ctor and with the static methods, where the static methods would populate the cache that's then consulted by the ctor.  This adds unnecessary expense on the common path for a very uncommon situation; it also complicates the code non-trivially.

This commit changes things to cleanly separate the cache from Regex, and to actually cache the Regex instance itself.

Running the "Regex*Static" perf tests:

|      Method |        Toolchain |  Options |       Mean |     Error | Ratio | Allocated |
|------------ |----------------- |--------- |-----------:|----------:|------:|----------:|
| EmailStatic | new              |     None |   487.9 ns |   5.22 ns |  0.97 |         - |
| EmailStatic | old              |     None |   500.9 ns |   3.57 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|  DateStatic | new              |     None |   272.1 ns |   2.02 ns |  0.88 |         - |
|  DateStatic | old              |     None |   309.9 ns |   0.20 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|    IPStatic | new              |     None | 2,233.4 ns | 377.74 ns |  0.94 |         - |
|    IPStatic | old              |     None | 2,384.4 ns | 330.49 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|   UriStatic | new              |     None |   307.6 ns |   0.49 ns |  0.89 |         - |
|   UriStatic | old              |     None |   347.3 ns |   6.86 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
| EmailStatic | new              | Compiled |   191.9 ns |   0.80 ns |  0.92 |         - |
| EmailStatic | old              | Compiled |   209.0 ns |   1.49 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|  DateStatic | new              | Compiled |   134.3 ns |   0.79 ns |  0.83 |         - |
|  DateStatic | old              | Compiled |   161.1 ns |   0.97 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|    IPStatic | new              | Compiled |   410.5 ns |   2.21 ns |  0.92 |         - |
|    IPStatic | old              | Compiled |   445.7 ns |   4.37 ns |  1.00 |     104 B |
|             |                  |          |            |           |       |           |
|   UriStatic | new              | Compiled |   129.4 ns |   0.52 ns |  0.83 |         - |
|   UriStatic | old              | Compiled |   156.7 ns |   0.37 ns |  1.00 |     104 B |

cc: @eerhardt, @danmosemsft, @ViktorHofer 