### PR TITLE
Fix crossgen2 ArgIterator for SystemV Amd64 Unix ABI

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2524,13 +2524,12 @@ namespace Internal.JitInterface
         private byte* findNameOfToken(CORINFO_MODULE_STRUCT_* moduleHandle, mdToken token, byte* szFQName, UIntPtr FQNameCapacity)
         { throw new NotImplementedException("findNameOfToken"); }
 
-        SystemVStructClassificator _systemVStructClassificator = new SystemVStructClassificator();
-
         private bool getSystemVAmd64PassStructInRegisterDescriptor(CORINFO_CLASS_STRUCT_* structHnd, SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structPassInRegDescPtr)
         {
             TypeDesc typeDesc = HandleToObject(structHnd);
 
-            return _systemVStructClassificator.getSystemVAmd64PassStructInRegisterDescriptor(typeDesc, structPassInRegDescPtr);
+            SystemVStructClassificator.GetSystemVAmd64PassStructInRegisterDescriptor(typeDesc, out *structPassInRegDescPtr);
+            return true;
         }
 
         private uint getThreadTLSIndex(ref void* ppIndirection)

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -41,6 +41,8 @@ namespace ReadyToRun.SuperIlc
             new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef", crossgen2Only: true),
+            
+            new FrameworkExclusion("System.Runtime.Serialization.Formatters", "Assert in JIT on Linux", crossgen2Only: true)
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -269,8 +269,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // ReportPointersFromValueTypeArg
             if (argDest.IsStructPassedInRegs())
             {
-                // ReportPointersFromStructPassedInRegs
-                throw new NotImplementedException();
+                argDest.ReportPointersFromStructInRegisters(type, delta, frame);
+                return;
             }
             // ReportPointersFromValueType
             if (type.IsByRefLike)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -361,7 +361,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// <summary>
         /// X64 properties common to Windows and Unix ABI.
         /// </summary>
-        private abstract class X64TransitionBlock : TransitionBlock
+        internal abstract class X64TransitionBlock : TransitionBlock
         {
             public override TargetArchitecture Architecture => TargetArchitecture.X64;
             public override int PointerSize => 8;
@@ -398,9 +398,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override int EnregisteredReturnTypeIntegerMaxSize => 8;
         }
 
-        private sealed class X64UnixTransitionBlock : X64TransitionBlock
+        internal sealed class X64UnixTransitionBlock : X64TransitionBlock
         {
             public static readonly TransitionBlock Instance = new X64UnixTransitionBlock();
+
+            public override bool IsX64UnixABI => true;
 
             public const int NUM_FLOAT_ARGUMENT_REGISTERS = 8;
 
@@ -414,6 +416,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override int OffsetOfFloatArgumentRegisters => SizeOfM128A * NUM_FLOAT_ARGUMENT_REGISTERS;
             public override int EnregisteredParamTypeMaxSize => 16;
             public override int EnregisteredReturnTypeIntegerMaxSize => 16;
+            public override bool IsArgPassedByRef(TypeHandle th) => false;
         }
 
         private sealed class Arm32TransitionBlock : TransitionBlock


### PR DESCRIPTION
The ArgIterator was missing proper handling of the SystemV amd64 struct classification.
There were also several minor issues.
The state with this fix should match the native version.

To successfully compile framework with SuperILC, I had to disable System.Runtime.Serialization.Formatters for now, as we hit an assert in JIT when trying to compile it. 