### PR TITLE
Replace "corefx" with "libraries" in System.Net tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/config.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/config.ps1
@@ -3,7 +3,7 @@
 # See the LICENSE file in the project root for more information.
 
 #
-# CoreFX - Net configuration
+# Libraries - Net configuration
 #
 
 # -- Machine Information
@@ -21,22 +21,22 @@
 #
 
 # A Windows Server SKU hosting Active Directory services. This machine will become the Domain Controller:
-$COREFX_NET_AD_Machine = ""             #Example: "TESTAD"
-$COREFX_NET_AD_MachineIP = ""           #Example: "192.168.0.1" - must be a Static IPv4 address.
+$LIBRARIES_NET_AD_MACHINE = ""             #Example: "TESTAD"
+$LIBRARIES_NET_AD_MACHINEIP = ""           #Example: "192.168.0.1" - must be a Static IPv4 address.
 
 # A Windows Client or Server SKU hosting the IIS Server. This machine will be joined to the Domain.
-$COREFX_NET_IISSERVER_Machine = ""      #Example: "TESTIIS"
-$COREFX_NET_IISSERVER_MachineIP = ""    #Example: "192.168.0.1" - must be a Static IPv4 address.
+$LIBRARIES_NET_IISSERVER_MACHINE = ""      #Example: "TESTIIS"
+$LIBRARIES_NET_IISSERVER_MACHINEIP = ""    #Example: "192.168.0.1" - must be a Static IPv4 address.
 
-# A Windows Client or Server SKU hosting the corefx repo. This machine will be joined to the Domain.
-$COREFX_NET_CLIENT_Machine = ""         #Example: "TESTCLIENT"
+# A Windows Client or Server SKU hosting the runtime repo. This machine will be joined to the Domain.
+$LIBRARIES_NET_CLIENT_MACHINE = ""         #Example: "TESTCLIENT"
 
 # -- Test Parameters
 
 # For security reasons, it's advisable that the default username/password pairs below are changed regularly.
 
 $script:domainName = "corp.contoso.com"
-$script:domainNetbios = "corefx-net-ad"
+$script:domainNetbios = "libraries-net-ad"
 
 $script:domainUserName = "testaduser"
 $script:domainUserPassword = "Test-ADPassword"
@@ -48,13 +48,13 @@ $script:basicUserPassword = "Test-Basic"
 $script:iisServerFQDN = "testserver.contoso.com"
 
 $script:PreRebootRoles = @(
-    @{Name = "COREFX_NET_AD_CLIENT"; Script = "setup_activedirectory_client.ps1"; MachineName = $COREFX_NET_IISSERVER_Machine},
-    @{Name = "COREFX_NET_AD_CLIENT"; Script = "setup_activedirectory_client.ps1"; MachineName = $COREFX_NET_CLIENT_Machine},
-    @{Name = "COREFX_NET_AD_DC"; Script = "setup_activedirectory_domaincontroller.ps1"; MachineName = $COREFX_NET_AD_Machine; MachineIP = $COREFX_NET_AD_MachineIP}
+    @{Name = "LIBRARIES_NET_AD_CLIENT"; Script = "setup_activedirectory_client.ps1"; MachineName = $LIBRARIES_NET_IISSERVER_MACHINE},
+    @{Name = "LIBRARIES_NET_AD_CLIENT"; Script = "setup_activedirectory_client.ps1"; MachineName = $LIBRARIES_NET_CLIENT_MACHINE},
+    @{Name = "LIBRARIES_NET_AD_DC"; Script = "setup_activedirectory_domaincontroller.ps1"; MachineName = $LIBRARIES_NET_AD_MACHINE; MachineIP = $LIBRARIES_NET_AD_MACHINEIP}
 )
 
 $script:Roles = @(
-    @{Name = "COREFX_NET_IISSERVER"; Script = "setup_iisserver.ps1"; MachineName = $COREFX_NET_IISSERVER_Machine; MachineIP = $COREFX_NET_IISSERVER_MachineIP},
-    @{Name = "COREFX_NET_CLIENT"; Script = "setup_client.ps1"; MachineName = $COREFX_NET_CLIENT_Machine},
-    @{Name = "COREFX_NET_AD_DC"; Script = "setup_activedirectory_domaincontroller.ps1"; MachineName = $COREFX_NET_AD_Machine; MachineIP = $COREFX_NET_AD_MachineIP}
+    @{Name = "LIBRARIES_NET_IISSERVER"; Script = "setup_iisserver.ps1"; MachineName = $LIBRARIES_NET_IISSERVER_MACHINE; MachineIP = $LIBRARIES_NET_IISSERVER_MACHINEIP},
+    @{Name = "LIBRARIES_NET_CLIENT"; Script = "setup_client.ps1"; MachineName = $LIBRARIES_NET_CLIENT_MACHINE},
+    @{Name = "LIBRARIES_NET_AD_DC"; Script = "setup_activedirectory_domaincontroller.ps1"; MachineName = $LIBRARIES_NET_AD_MACHINE; MachineIP = $LIBRARIES_NET_AD_MACHINEIP}
 )

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup.ps1
@@ -92,7 +92,7 @@ Function CreateDestinationPath($s)
 {
     return Invoke-Command -Session $s `
     {
-        $destPath = Join-Path $env:SystemDrive "COREFX_NET_Scripts"
+        $destPath = Join-Path $env:SystemDrive "LIBRARIES_NET_SCRIPTS"
         mkdir $destPath -ErrorAction SilentlyContinue | Out-Null  
         return $destPath  
     }    
@@ -138,7 +138,7 @@ Function InstallRoles
 
 Function Install
 {
-    Write-Host -ForegroundColor Cyan "Install/Update CoreFX Networking multi-machine prerequisites"
+    Write-Host -ForegroundColor Cyan "Install/Update Libraries Networking multi-machine prerequisites"
     Write-Host
     CheckRoles
 
@@ -198,7 +198,7 @@ Function UnistallMachines
 
 Function Uninstall
 {
-    Write-Host -ForegroundColor Cyan "Uninstall CoreFX Networking multi-machine prerequisites"
+    Write-Host -ForegroundColor Cyan "Uninstall Libraries Networking multi-machine prerequisites"
     Write-Host
     CheckRoles
     Write-Host

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_activedirectory_client.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_activedirectory_client.ps1
@@ -15,13 +15,13 @@ Param (
 # Imports:
 . .\setup_common.ps1
 
-$script:COREFX_ROLE_NAME = "COREFX_NET_AD_CLIENT"
+$script:LIBRARIES_ROLE_NAME = "LIBRARIES_NET_AD_CLIENT"
 
 Function ConfigureDNS
 {
     Write-Host -ForegroundColor Cyan "Configuring DNS"
 
-    $dcRole = GetRole "COREFX_NET_AD_DC"
+    $dcRole = GetRole "LIBRARIES_NET_AD_DC"
 
     if (-not (Test-Connection $dcRole.MachineIP))
     {
@@ -48,7 +48,7 @@ Function EnableAD
 
 Function Install
 {
-    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:COREFX_ROLE_NAME)"
+    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)"
 
     CheckPreRebootMachineInfo
     ConfigureDNS
@@ -63,7 +63,7 @@ Function Install
 
 Function Uninstall
 {
-    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:COREFX_ROLE_NAME)."
+    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)."
     
     EnvironmentCheckUninstallRoleStatus
 

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_activedirectory_domaincontroller.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_activedirectory_domaincontroller.ps1
@@ -16,7 +16,7 @@ Param (
 # Import configuration.
 . .\setup_common.ps1
 
-$script:COREFX_ROLE_NAME = "COREFX_NET_AD_DC"
+$script:LIBRARIES_ROLE_NAME = "LIBRARIES_NET_AD_DC"
 
 Function EnableAD
 {
@@ -41,7 +41,7 @@ Function ConfigureDNS
 {
     Write-Host -ForegroundColor Cyan "Configuring DNS."
     
-    $iisServer  = GetRole "COREFX_NET_IISSERVER"
+    $iisServer  = GetRole "LIBRARIES_NET_IISSERVER"
 
     $serverName = ($script:iisServerFQDN).Split('.')[0];
     $zoneName = ($script:iisServerFQDN).Substring($serverName.Length + 1)  
@@ -53,7 +53,7 @@ Function ConfigureDNS
 
 Function Install
 {
-    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:COREFX_ROLE_NAME)."
+    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)."
 
     if ((-not (EnvironmentIsRoleInstalled)) -and (-not (EnvironmentIsRoleRebootPending)))
     {
@@ -69,14 +69,14 @@ Function Install
         ConfigureDNS
         Enable-PSRemoting
         EnvironmentSetInstalledRoleStatus
-        Write-Host -ForegroundColor Cyan "Prerequisites installed for $($script:COREFX_ROLE_NAME)."
+        Write-Host -ForegroundColor Cyan "Prerequisites installed for $($script:LIBRARIES_ROLE_NAME)."
         Write-Host
     }
 }
 
 Function Uninstall
 {
-    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:COREFX_ROLE_NAME)."
+    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)."
 
     EnvironmentCheckUninstallRoleStatus
     EnvironmentRemoveRoleStatus

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_client.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_client.ps1
@@ -10,7 +10,7 @@ Param (
 . .\setup_common.ps1
 . .\setup_certificates.ps1
 
-$script:COREFX_ROLE_NAME = "COREFX_NET_CLIENT"
+$script:LIBRARIES_ROLE_NAME = "LIBRARIES_NET_CLIENT"
 
 Function InstallClientEnvironmentConfiguration
 {
@@ -34,7 +34,7 @@ Function UninstallClientEnvironmentConfiguration
 
 Function Install
 {
-    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:COREFX_ROLE_NAME)."
+    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)."
     CheckMachineInfo
 
     InstallClientCertificates
@@ -45,7 +45,7 @@ Function Install
 
 Function Uninstall
 {
-    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:COREFX_ROLE_NAME)."
+    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)."
     EnvironmentCheckUninstallRoleStatus
 
     RemoveClientCertificates

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_firewall.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_firewall.ps1
@@ -5,10 +5,10 @@
 #Requires -RunAsAdministrator
 
 # Firewall configuration
-$script:firewallGroup = "CoreFX Testing"
+$script:firewallGroup = "Libraries Testing"
 $script:firewallRules = @(
-    @{Name = "CoreFXNet - HTTP 80"; Port = 80},
-    @{Name = "CoreFXNet - HTTP 443"; Port = 443}
+    @{Name = "LibariesNet - HTTP 80"; Port = 80},
+    @{Name = "LibrariesNet - HTTP 443"; Port = 443}
 )
 
 Function InstallServerFirewall

--- a/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_iisserver.ps1
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_iisserver.ps1
@@ -61,7 +61,7 @@ $script:webApps = @(
      }
 )
 
-$script:COREFX_ROLE_NAME = "COREFX_NET_IISSERVER"
+$script:LIBRARIES_ROLE_NAME = "LIBRARIES_NET_IISSERVER"
 
 Function InstallIIS
 {
@@ -162,7 +162,7 @@ Function RemoveServerCode
 
 Function Install
 {
-    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:COREFX_ROLE_NAME)"
+    Write-Host -ForegroundColor Cyan "Installing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)"
     CheckMachineInfo
 
     InstallIIS
@@ -177,7 +177,7 @@ Function Install
 
 Function Uninstall
 {
-    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:COREFX_ROLE_NAME)"
+    Write-Host -ForegroundColor Cyan "Removing prerequisites for test role: $($script:LIBRARIES_ROLE_NAME)"
 
     EnvironmentCheckUninstallRoleStatus
 


### PR DESCRIPTION
This PR addresses #347 
This is a first commit of self contained changes to PowerShell scripts found in the Deployment directory.

Also want to double check that the usage of the term "corefx repo", should be changed to "runtime repo".
