### PR TITLE
Use static readonly cached delegates in preference to non-capturing lambdas

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -17,7 +17,10 @@ namespace System.Runtime.CompilerServices
     public readonly struct ValueTaskAwaiter : ICriticalNotifyCompletion, IStateMachineBoxAwareAwaiter
     {
         /// <summary>Shim used to invoke an <see cref="Action"/> passed as the state argument to a <see cref="Action{Object}"/>.</summary>
-        internal static readonly Action<object?> s_invokeActionDelegate = state =>
+        internal static readonly Action<object?> s_invokeActionDelegate = default(ValueTaskAwaiter).InvokeAction;
+
+        // We use an instance method as delegates to instance methods are faster than delegates to static methods.
+        private void InvokeAction(object? state)
         {
             if (!(state is Action action))
             {
@@ -26,7 +29,8 @@ namespace System.Runtime.CompilerServices
             }
 
             action();
-        };
+        }
+
         /// <summary>The value being awaited.</summary>
         private readonly ValueTask _value;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs
@@ -36,11 +36,14 @@ namespace System.Threading
         private readonly CancellationTokenSource? _source;
         // !! warning. If more fields are added, the assumptions in CreateLinkedToken may no longer be valid
 
-        private static readonly Action<object?> s_actionToActionObjShunt = obj =>
+        private static readonly Action<object?> s_actionToActionObjShunt = default(CancellationToken).InvokeAction;
+
+        // We use an instance method as delegates to instance methods are faster than delegates to static methods.
+        private void InvokeAction(object? obj)
         {
             Debug.Assert(obj is Action, $"Expected {typeof(Action)}, got {obj}");
             ((Action)obj)();
-        };
+        }
 
         /// <summary>
         /// Returns an empty CancellationToken value.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2351,12 +2351,15 @@ namespace System.Threading.Tasks
             }
         }
 
-        private static readonly ContextCallback s_ecCallback = obj =>
+        private static readonly ContextCallback s_ecCallback = s_cachedCompleted.InvokeContextCallback;
+
+        // We use an instance method as delegates to instance methods are faster than delegates to static methods.
+        private void InvokeContextCallback(object? obj)
         {
             Debug.Assert(obj is Task);
             // Only used privately to pass directly to EC.Run
             Unsafe.As<Task>(obj).InnerInvoke();
-        };
+        }
 
         /// <summary>
         /// The actual code which invokes the body of the task. This can be overridden in derived types.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -601,11 +601,13 @@ namespace System.Threading.Tasks
         public override int MaximumConcurrencyLevel => 1;
 
         // preallocated SendOrPostCallback delegate
-        private static readonly SendOrPostCallback s_postCallback = s =>
+        private static readonly SendOrPostCallback s_postCallback = PostCallback;
+
+        private static void PostCallback(object? state)
         {
-            Debug.Assert(s is Task);
-            ((Task)s).ExecuteEntry(); // with double-execute check because SC could be buggy
-        };
+            Debug.Assert(state is Task);
+            ((Task)state).ExecuteEntry(); // with double-execute check because SC could be buggy
+        }
     }
 
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -30,11 +30,13 @@ namespace System.Threading.Tasks
         }
 
         // static delegate for threads allocated to handle LongRunning tasks.
-        private static readonly ParameterizedThreadStart s_longRunningThreadWork = s =>
+        private static readonly ParameterizedThreadStart s_longRunningThreadWork = StartThread;
+
+        private static void StartThread(object? state)
         {
-            Debug.Assert(s is Task);
-            ((Task)s).ExecuteEntryUnsafe(threadPoolThread: null);
-        };
+            Debug.Assert(state is Task);
+            ((Task)state).ExecuteEntryUnsafe(threadPoolThread: null);
+        }
 
         /// <summary>
         /// Schedules a task to the ThreadPool.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -201,7 +201,10 @@ namespace System.Threading.Tasks
         /// <summary>Type used to create a <see cref="Task"/> to represent a <see cref="IValueTaskSource"/>.</summary>
         private sealed class ValueTaskSourceAsTask : Task
         {
-            private static readonly Action<object?> s_completionAction = state =>
+            private static readonly Action<object?> s_completionAction = new ValueTaskSourceAsTask().InvokeCompletion;
+
+            // We use an instance method as delegates to instance methods are faster than delegates to static methods.
+            private void InvokeCompletion(object? state)
             {
                 if (!(state is ValueTaskSourceAsTask vtst) ||
                     !(vtst._source is IValueTaskSource source))
@@ -238,7 +241,7 @@ namespace System.Threading.Tasks
                         vtst.TrySetException(exc);
                     }
                 }
-            };
+            }
 
             /// <summary>The associated <see cref="IValueTaskSource"/>.</summary>
             private IValueTaskSource? _source;
@@ -250,6 +253,11 @@ namespace System.Threading.Tasks
                 _token = token;
                 _source = source;
                 source.OnCompleted(s_completionAction, this, token, ValueTaskSourceOnCompletedFlags.None);
+            }
+
+            private ValueTaskSourceAsTask()
+            {
+                // Used for cached static delegate s_completionAction
             }
         }
 
@@ -593,7 +601,10 @@ namespace System.Threading.Tasks
         /// <summary>Type used to create a <see cref="Task{TResult}"/> to represent a <see cref="IValueTaskSource{TResult}"/>.</summary>
         private sealed class ValueTaskSourceAsTask : Task<TResult>
         {
-            private static readonly Action<object?> s_completionAction = state =>
+            private static readonly Action<object?> s_completionAction = new ValueTaskSourceAsTask().InvokeCompletion;
+
+            // We use an instance method as delegates to instance methods are faster than delegates to static methods.
+            private void InvokeCompletion(object? state)
             {
                 if (!(state is ValueTaskSourceAsTask vtst) ||
                     !(vtst._source is IValueTaskSource<TResult> source))
@@ -629,7 +640,7 @@ namespace System.Threading.Tasks
                         vtst.TrySetException(exc);
                     }
                 }
-            };
+            }
 
             /// <summary>The associated <see cref="IValueTaskSource"/>.</summary>
             private IValueTaskSource<TResult>? _source;
@@ -641,6 +652,11 @@ namespace System.Threading.Tasks
                 _source = source;
                 _token = token;
                 source.OnCompleted(s_completionAction, this, token, ValueTaskSourceOnCompletedFlags.None);
+            }
+
+            private ValueTaskSourceAsTask()
+            {
+                // Used for cached static delegate s_completionAction
             }
         }
 


### PR DESCRIPTION
Lambdas show up horribly in stack traces

Changes
```csharp
<>c:<.cctor>b__4_0(Object):this
<>c:<ExecuteCallbackHandlers>b__44_0(Object):this
<>c:<.cctor>b__10_0(Object):this
<>c:<.cctor>b__8_0(Object):this
<>c:<WaitForCallbackToCompleteAsync>b__50_0(Object):this
<>c:<.cctor>b__23_0(Object):this
<>c:<.cctor>b__56_0(Object):this
<>c:<.cctor>b__6_0(QueueUserWorkItemCallback):this 
<>c:<.cctor>b__26_0(Object):this
<>c:<.cctor>b__17_0(Object):this
<>c:<.cctor>b__274_0(Object):this
<>c:<.cctor>b__17_1(Action):this
<>c:.ctor():this
```
To
```csharp
ValueTaskSourceAsTask:InvokeCompletion(Object):this
CancellationTokenSource:ExecuteNodeCallback(Object):this
ThreadPoolWorkQueue:InvokeAsyncStateMachineBox(Object):this
ValueTaskAwaiter:InvokeAction(Object):this
CancellationTokenSource:WhenCallbackCompletes(Object):this
Timer:InvokeCallback(Object):this
CancellationTokenSource:InvokeCallback(Object):this
CancellationTokenSource:LinkedTokenCancel(Object):this
QueueUserWorkItemCallback:InvokeCallback(QueueUserWorkItemCallback):this
ThreadPoolTaskScheduler:StartThread(Object)
SynchronizationContextTaskScheduler:PostCallback(Object)
CancellationToken:InvokeAction(Object):this
AwaitTaskContinuation:InvokeContextCallback(Object):this
Task:InvokeContextCallback(Object):this
AwaitTaskContinuation:InvokeAction(Action):this
```

The IEnumerator `FilterTasksFromWorkItems` gets renumbered so it shows up in regressions & improvements
```
Total bytes of diff: -530 (-0.02% of base)
    diff is an improvement.

Total byte diff includes 134 bytes from reconciling methods
        Base had   22 unique methods,     1828 unique bytes
        Diff had   31 unique methods,     1962 unique bytes

Top file improvements by size (bytes):
        -530 : System.Private.CoreLib.dasm (-0.02% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions by size (bytes):
         609 (     8 of base) : System.Private.CoreLib.dasm - ValueTaskSourceAsTask:InvokeCompletion(Object):this (0 base, 2 diff methods)
         342 (     8 of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__7:MoveNext():bool:this (0 base, 1 diff methods)
         137 (     8 of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__7:System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task>.GetEnumerator():IEnumerator`1:this (0 base, 1 diff methods)
          78 (     8 of base) : System.Private.CoreLib.dasm - CancellationTokenSource:ExecuteNodeCallback(Object):this (0 base, 1 diff methods)
          76 (40.86% of base) : System.Private.CoreLib.dasm - CancellationTokenSource:.cctor()
          59 (     8 of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__7:System.IDisposable.Dispose():this (0 base, 1 diff methods)
          54 (     8 of base) : System.Private.CoreLib.dasm - ThreadPoolWorkQueue:InvokeAsyncStateMachineBox(Object):this (0 base, 1 diff methods)
          52 (     8 of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__7:.ctor(int):this (0 base, 1 diff methods)
          51 (     8 of base) : System.Private.CoreLib.dasm - AwaitTaskContinuation:.ctor():this (0 base, 1 diff methods)
          44 (16.30% of base) : System.Private.CoreLib.dasm - ValueTaskSourceAsTask:.cctor() (4 methods)

Top method improvements by size (bytes):
        -695 (-100.00% of base) : System.Private.CoreLib.dasm - <>c:<.cctor>b__4_0(Object):this (4 base, 0 diff methods)
        -667 (-22.89% of base) : System.Private.CoreLib.dasm - <>c:.cctor() (63 base, 48 diff methods)
        -342 (-100.00% of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__6:MoveNext():bool:this (1 base, 0 diff methods)
        -137 (-100.00% of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__6:System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task>.GetEnumerator():IEnumerator`1:this (1 base, 0 diff methods)
         -82 (-7.84% of base) : System.Private.CoreLib.dasm - CancellationTokenSource:ExecuteCallbackHandlers(bool):this
         -78 (-100.00% of base) : System.Private.CoreLib.dasm - <>c:<ExecuteCallbackHandlers>b__44_0(Object):this (1 base, 0 diff methods)
         -75 (-100.00% of base) : System.Private.CoreLib.dasm - <>c:<.cctor>b__10_0(Object):this (2 base, 0 diff methods)
         -59 (-100.00% of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__6:System.IDisposable.Dispose():this (1 base, 0 diff methods)
         -56 (-100.00% of base) : System.Private.CoreLib.dasm - <>c:<.cctor>b__8_0(Object):this (2 base, 0 diff methods)
         -52 (-100.00% of base) : System.Private.CoreLib.dasm - <FilterTasksFromWorkItems>d__6:.ctor(int):this (1 base, 0 diff methods)
```