### PR TITLE
Fix tracing rundown tests with optimizations and large version bubble

### DIFF
--- a/src/coreclr/tests/src/tracing/tracevalidation/rundown/Rundown.cs
+++ b/src/coreclr/tests/src/tracing/tracevalidation/rundown/Rundown.cs
@@ -22,6 +22,7 @@ namespace Tracing.Tests
                 "Common",
                 "Rundown", // this assembly
                 "System.Runtime",
+                "Microsoft.Diagnostics.Tracing.TraceEvent",
                 "System.Private.CoreLib"
             };
 
@@ -68,13 +69,6 @@ namespace Tracing.Tests
                 {
                     Assert.True($"Assembly {expected} in loaded assemblies", assembliesLoaded.Any(loaded => String.Equals(loaded, expected, StringComparison.OrdinalIgnoreCase)));
                 }
-
-                // In R2R, depending on whether the test was built with or without large version bubble enabled for the test and the runtime, one or both of the following assemblies 
-                // will be present
-                Assert.True("Assembly System.Diagnostics.Tracing or Microsoft.Diagnostics.Tracing.TraceEvent expected in loaded assemblies", 
-                            assembliesLoaded.Any(loaded => String.Equals(loaded, "System.Diagnostics.Tracing", StringComparison.OrdinalIgnoreCase)) ||
-                            assembliesLoaded.Any(loaded => String.Equals(loaded, "Microsoft.Diagnostics.Tracing.TraceEvent", StringComparison.OrdinalIgnoreCase)));
-
                 Assert.Equal(nameof(nonMatchingEventCount), nonMatchingEventCount, 0);
             }
 

--- a/src/coreclr/tests/src/tracing/tracevalidation/rundown/Rundown.cs
+++ b/src/coreclr/tests/src/tracing/tracevalidation/rundown/Rundown.cs
@@ -22,7 +22,6 @@ namespace Tracing.Tests
                 "Common",
                 "Rundown", // this assembly
                 "System.Runtime",
-                "System.Diagnostics.Tracing",
                 "System.Private.CoreLib"
             };
 
@@ -69,6 +68,13 @@ namespace Tracing.Tests
                 {
                     Assert.True($"Assembly {expected} in loaded assemblies", assembliesLoaded.Any(loaded => String.Equals(loaded, expected, StringComparison.OrdinalIgnoreCase)));
                 }
+
+                // In R2R, depending on whether the test was built with or without large version bubble enabled for the test and the runtime, one or both of the following assemblies 
+                // will be present
+                Assert.True("Assembly System.Diagnostics.Tracing or Microsoft.Diagnostics.Tracing.TraceEvent expected in loaded assemblies", 
+                            assembliesLoaded.Any(loaded => String.Equals(loaded, "System.Diagnostics.Tracing", StringComparison.OrdinalIgnoreCase)) ||
+                            assembliesLoaded.Any(loaded => String.Equals(loaded, "Microsoft.Diagnostics.Tracing.TraceEvent", StringComparison.OrdinalIgnoreCase)));
+
                 Assert.Equal(nameof(nonMatchingEventCount), nonMatchingEventCount, 0);
             }
 


### PR DESCRIPTION
The test is failing when compiled with crossgen2 with optimizations and 
large version bubble enabled due to the fact that it didn't find 
System.Diagnostics.Tracing loaded. The reason is that due to cross module 
inlining, the System.Diagnostics.Tracing was not needed anymore.
I have fixed it by checking for presence of either the
Microsoft.Diagnostics.Tracing.TraceEvent or the
System.Diagnostics.Tracing. This works in all compilation modes.
In some compilation modes, one of the two is missing.