### PR TITLE
Change ArchiveTest reads to ArchiveTests and introduce IgnoreForCI property

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -20,7 +20,7 @@
 
   <!-- Archive test binaries. -->
   <Target Name="ArchiveTests"
-          Condition="'$(ArchiveTests)' == 'true'"
+          Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'"
           AfterTargets="PrepareForRun"
           DependsOnTargets="GenerateRunScript">
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />

--- a/eng/testing/xunit/xunit.console.props
+++ b/eng/testing/xunit/xunit.console.props
@@ -8,14 +8,14 @@
     <PackageReference Condition="'$(TargetsNetFx)' == 'true'" Include="xunit.runner.console" Version="$(XUnitVersion)" />
 
     <!-- Microsoft.Net.Test.Sdk brings a lot of assemblies with it. To reduce helix payload submission size we disable it on CI. -->
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="xunit.runner.visualstudio" Version="$(XUnitVersion)" />
+    <PackageReference Condition="'$(ArchiveTests)' != 'true'" Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Condition="'$(ArchiveTests)' != 'true'" Include="xunit.runner.visualstudio" Version="$(XUnitVersion)" />
     <!--
       Microsoft.Net.Test.Sdk has a dependency on Newtonsoft.Json v9.0.1. We upgrade the dependency version
       with the one used in corefx to have a consistent set of dependency versions. Additionally this works
       around a dupliate type between System.Runtime.Serialization.Formatters and Newtonsoft.Json.
     -->
-    <PackageReference Condition="'$(ArchiveTest)' != 'true'" Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Condition="'$(ArchiveTests)' != 'true'" Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
 
   </ItemGroup>
 </Project>

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -3,7 +3,7 @@
     <RunArguments>$(TargetFileName)</RunArguments>
     <RunArguments>$(RunArguments) -xml $(TestResultsName)</RunArguments>
     <RunArguments>$(RunArguments) -nologo</RunArguments>
-    <RunArguments Condition="'$(ArchiveTest)' == 'true'">$(RunArguments) -nocolor</RunArguments>
+    <RunArguments Condition="'$(ArchiveTests)' == 'true'">$(RunArguments) -nocolor</RunArguments>
 
     <!-- Add local and global options to the argument stack. -->
     <RunArguments Condition="'$(TestDisableParallelization)' == 'true'">$(RunArguments) -maxthreads 1</RunArguments>

--- a/eng/testing/xunit/xunit.targets
+++ b/eng/testing/xunit/xunit.targets
@@ -12,7 +12,7 @@
 
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
     <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
-    <_withoutCategories Condition="'$(ArchiveTest)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
+    <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>
 

--- a/src/libraries/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/System.Data.SqlClient.Stress.Tests.csproj
+++ b/src/libraries/System.Data.SqlClient/tests/StressTests/System.Data.SqlClient.Stress.Tests/System.Data.SqlClient.Stress.Tests.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>Stress.Data.SqlClient</RootNamespace>
     <AssemblyName>System.Data.SqlClient.Stress.Tests</AssemblyName>
     <!-- These should not run in Helix: they produce no outputs and are only run manually -->
-    <ArchiveTest>false</ArchiveTest>
+    <IgnoreForCI>true</IgnoreForCI>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Stress.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/System.Net.Sockets.Async.Stress.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
     <!-- Manual test, don't run on CI -->
-    <ArchiveTest>false</ArchiveTest>
+    <IgnoreForCI>true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SocketPerformanceAsyncTests.cs" />


### PR DESCRIPTION
With 1d5de1533ad35b39f776701c4d22b68a3def2dd8, the ArchiveTest property
was removed. This fixes the remaining places where the old property is
still read. Additionally this introduces a new property `IgnoreForCI`
which is consistent with the xunit trait to skip the whole assembly for
CI testing.

Fixes https://github.com/dotnet/runtime/issues/510