### PR TITLE
Skip compilation for methods with BypassReadyToRun attribute

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -195,6 +195,11 @@ namespace Internal.JitInterface
                 // Special methods on delegate types
                 return true;
             }
+            if (method.HasCustomAttribute("System.Runtime", "BypassReadyToRunAttribute"))
+            {
+                // This is a quick workaround to opt specific methods out of ReadyToRun compilation to work around bugs.
+                return true;
+            }
 
             return false;
         }
@@ -635,6 +640,7 @@ namespace Internal.JitInterface
         {
             if (fIsTailPrefix)
             {
+                // FUTURE: Delay load fixups for tailcalls
                 throw new RequiresRuntimeJitException(nameof(fIsTailPrefix));
             }
 


### PR DESCRIPTION
Matches behavior in crossgen1

cc @dotnet/crossgen-contrib 