### PR TITLE
Update libraries pr/ci build to use live coreclr

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -112,30 +112,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux rhel6 x64
-
-- ${{ if or(containsValue(parameters.platforms, 'Linux_rhel6_x64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      osGroup: Linux
-      osSubgroup: _rhel6
-      archType: x64
-      platform: Linux_rhel6_x64
-      container:
-        image: centos-6-f39df28-20191023143802
-        registry: mcr
-      jobParameters:
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ if ne(parameters.managedOsxBuild, true) }}:
-          managedTestBuildOsGroup: Linux_rhel
-        ${{ if eq(parameters.managedOsxBuild, true) }}:
-          managedTestBuildOsGroup: OSX
-        ${{ insert }}: ${{ parameters.jobParameters }}
-
 # Linux x64
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -41,7 +41,6 @@ jobs:
     - Linux_arm64
     - Linux_musl_arm64
     - Linux_musl_x64
-    - Linux_rhel6_x64
     - Linux_x64
     - OSX_x64
     - Windows_NT_arm
@@ -117,7 +116,6 @@ jobs:
     - Linux_arm64
     - Linux_musl_x64
     - Linux_musl_arm64
-    - Linux_rhel6_x64
     - Linux_x64
     - OSX_x64
     - Windows_NT_x64

--- a/eng/pipelines/coreclr/internal.yml
+++ b/eng/pipelines/coreclr/internal.yml
@@ -70,7 +70,6 @@ stages:
         - build_Linux_arm64_release
         - build_Linux_musl_x64_release
         - build_Linux_musl_arm64_release
-        - build_Linux_rhel6_x64_release
         - build_Linux_x64_release
         - build_OSX_x64_release
         - build_Windows_NT_x64_release

--- a/eng/pipelines/coreclr/pr.yml
+++ b/eng/pipelines/coreclr/pr.yml
@@ -72,7 +72,6 @@ jobs:
     platforms:
     - Linux_arm64
     - Linux_musl_x64
-    - Linux_rhel6_x64
     - OSX_x64
     - Windows_NT_arm
     - Windows_NT_arm64

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -51,12 +51,6 @@ jobs:
     - ${{ if eq(parameters.buildConfig, 'Release') }}:
       - name: stripSymbolsArg
         value: '-stripsymbols'
-    - name: portableBuildArg
-      value: ''
-    # Ensure that we produce os-specific packages for the following distros:
-    - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.osSubgroup, '_rhel6')) }}:
-      - name: portableBuildArg
-        value: '-portablebuild=false'
     - name: clangArg
       value: ''
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
@@ -190,7 +184,7 @@ jobs:
           SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Build packages
-    - script: $(coreClrRepoRootDir)build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) $(portableBuildArg) -ci
+    - script: $(coreClrRepoRootDir)build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) -ci
       displayName: Build packages
 
     # Publish official build

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -54,14 +54,6 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Alpine.38.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
 
-    # Linux rhel6 x64
-    - ${{ if eq(parameters.platform, 'Linux_rhel6_x64') }}:
-      # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/runtime/issues/168 is resolved
-      # - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      #   - RedHat.6.Amd64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - RedHat.6.Amd64
-
     # Linux x64
     - ${{ if eq(parameters.platform, 'Linux_x64') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:

--- a/eng/pipelines/installer/azure-pipelines.yml
+++ b/eng/pipelines/installer/azure-pipelines.yml
@@ -151,14 +151,6 @@ stages:
       portableBuild: true
       targetArchitecture: x64
 
-  - template: ${{ variables['pipelinesPath'] }}/jobs/bash-build.yml
-    parameters:
-      additionalMSBuildArgs: /p:OutputRid=rhel.6-x64
-      name: Linux_x64_Rhel6
-      dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-50f0d02-20190918213956
-      portableBuild: false
-      targetArchitecture: x64
-
   # -------- Build OSX (macOS) leg --------
   - template: ${{ variables['pipelinesPath'] }}/jobs/osx-build.yml
     parameters:

--- a/eng/pipelines/libraries/.azure-ci.yml
+++ b/eng/pipelines/libraries/.azure-ci.yml
@@ -61,6 +61,29 @@ variables:
 jobs:
   - template: /eng/pipelines/common/checkout-job.yml
 
+  #
+  # CoreCLR builds.
+  #
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      buildConfig: release
+      platforms:
+      - OSX_x64
+      - Windows_NT_x64
+      - Windows_NT_x86
+      - Linux_rhel6_x64
+      - Linux_x64
+      - Linux_arm
+      - Linux_arm64
+      - Linux_musl_x64
+      - Linux_musl_arm64
+      jobParameters:
+        testGroup: innerloop
+
+  #
+  # Libraries builds.
+  #
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/libraries/build-job.yml
@@ -84,6 +107,7 @@ jobs:
         ${{ if eq(variables['isOfficialBuild'], false) }}:
           runTests: true
           testScope: innerloop
+          liveCoreClrBuildConfig: release
   
   - ${{ if eq(variables['isFullMatrix'], false) }}:
     - template: /eng/pipelines/common/platform-matrix.yml
@@ -102,6 +126,7 @@ jobs:
           testScope: innerloop
           framework: netcoreapp
           runTests: true
+          liveCoreClrBuildConfig: release
   
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -119,6 +144,7 @@ jobs:
       jobParameters:
         isOfficialBuild: ${{ variables['isOfficialBuild'] }}
         framework: netcoreapp
+        liveCoreClrBuildConfig: release
   
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -149,5 +175,6 @@ jobs:
       jobParameters:
         isOfficialBuild: ${{ variables['isOfficialBuild'] }}
         framework: allConfigurations
+        liveCoreClrBuildConfig: release
         ${{ if eq(variables['isOfficialBuild'], false) }}:
           runTests: true

--- a/eng/pipelines/libraries/.azure-ci.yml
+++ b/eng/pipelines/libraries/.azure-ci.yml
@@ -72,7 +72,6 @@ jobs:
       - OSX_x64
       - Windows_NT_x64
       - Windows_NT_x86
-      - Linux_rhel6_x64
       - Linux_x64
       - Linux_arm
       - Linux_arm64
@@ -89,7 +88,6 @@ jobs:
       jobTemplate: /eng/pipelines/libraries/build-job.yml
       buildConfig: Release
       platforms:
-      - Linux_rhel6_x64
       - Windows_NT_x86
       - ${{ if eq(variables['isFullMatrix'], true) }}:
         - OSX_x64

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -28,7 +28,7 @@ jobs:
 
       enableTelemetry: ${{ parameters.isOfficialBuild }} # TODO: figure out if it's needed
       container: ${{ parameters.container }}
-      condition: ${{ parameters.condition }}
+      condition: and(succeeded(), ${{ parameters.condition }})
       helixRepo: dotnet/runtime
       pool: ${{ parameters.pool }}
       variables:

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -38,7 +38,6 @@ jobs:
         - _msbuildCommonParameters: ''
         - _stripSymbolsArg: ''
         - _runtimeOSArg: ''
-        - _portableArg: ''
         - _finalFrameworkArg: -framework ${{ parameters.framework }}
         - _buildScript: $(_buildScriptFileName)$(scriptExt)
         - _warnAsErrorArg: ''
@@ -46,10 +45,6 @@ jobs:
 
         - ${{ if ne(parameters.testScope, '') }}:
           - _testScopeArg: -testscope ${{ parameters.testScope }}
-
-        - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.osSubGroup, '_rhel6')) }}:
-          - _runtimeOSArg: /p:RuntimeOS=rhel.6
-          - _portableArg: /p:PortableBuild=false
         
         - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.osSubGroup, '_musl')) }}:
           - _runtimeOSArg: /p:RuntimeOS=linux-musl
@@ -92,7 +87,7 @@ jobs:
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             - _stripSymbolsArg: -stripSymbols
 
-        - _buildArguments: -configuration ${{ parameters.buildConfig }} -ci -arch ${{ parameters.archType }} $(_finalFrameworkArg) $(_stripSymbolsArg) $(_testScopeArg) $(_warnAsErrorArg) $(_runtimeOSArg) $(_portableArg) $(_msbuildCommonParameters) $(_coreClrOverridePathArg)
+        - _buildArguments: -configuration ${{ parameters.buildConfig }} -ci -arch ${{ parameters.archType }} $(_finalFrameworkArg) $(_stripSymbolsArg) $(_testScopeArg) $(_warnAsErrorArg) $(_runtimeOSArg) $(_msbuildCommonParameters) $(_coreClrOverridePathArg)
         - ${{ parameters.variables }}
 
       dependsOn:

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -78,6 +78,10 @@ jobs:
           - _coreClrArtifactName: 'CoreCLRProduct_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveCoreClrBuildConfig }}'
           - _coreClrOverridePathArg: ' /p:CoreCLROverridePath=$(_coreClrDownloadPath)'
 
+          # WebAssembly uses linux implementation detail
+          - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:
+            - _coreClrArtifactName: 'CoreCLRProduct_Linux_x64_${{ parameters.liveCoreClrBuildConfig }}'
+
         # Windows variables
         - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
           - _runtimeOSArg: /p:RuntimeOS=win10

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -41,7 +41,10 @@ jobs:
 
       ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
         dependsOn:
-        - ${{ format('coreclr_product_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveCoreClrBuildConfig) }}
+        - ${{ if ne(parameters.osGroup, 'WebAssembly') }}:
+          - ${{ format('coreclr_product_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveCoreClrBuildConfig) }}
+        - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:
+          - ${{ format('coreclr_product_build_{0}{1}_{2}_{3}', 'linux', parameters.osSubgroup, 'x64', parameters.liveCoreClrBuildConfig) }}
 
       variables:
         - _skipTestRestoreArg: /p:SkipTestRestore=true

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -44,10 +44,6 @@ jobs:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
         - \(Alpine.38.Arm64.Open\)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
 
-    # Linux rhel6 x64
-    - ${{ if eq(parameters.platform, 'Linux_rhel6_x64') }}:
-        - RedHat.6.Amd64.Open
-
     # Linux x64
     - ${{ if eq(parameters.platform, 'Linux_x64') }}:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -24,7 +24,6 @@ jobs:
         - ${{ if eq(variables['isFullMatrix'], true) }}:
           - Windows_NT_x64
       - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
-        - Linux_rhel6_x64
         - ${{ if eq(variables['isFullMatrix'], true) }}:
           - Linux_x64
           - Linux_arm


### PR DESCRIPTION
This change adds coreclr build step into libraries CI and consumes it live using `CoreCLROverridePath`. 

This also includes two extra commits:
- Remove RHEL6 pipelines from all pipelines within the repo
- Fix a bug where libraries jobs conditions that its result was true was always run even if the job we depended on failed. So we need to add `succeeded` to the condition when flowing that value to arcade.

FYI: @stephentoub @jkotas @jaredpar @danmosemsft 