### PR TITLE
Turn back on some of the EventPipe tests that were disabled in GCStress

### DIFF
--- a/src/coreclr/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
@@ -8,7 +8,6 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/coreclr/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -8,7 +8,6 @@
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExceptionThrown_V1.cs" />

--- a/src/coreclr/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -8,7 +8,6 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/coreclr/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
After we fixed https://github.com/dotnet/coreclr/pull/26776, we never turned back on some of the EventPipe tests we disabled for GCStress mode. 