### PR TITLE
Two more fixes for crossgen2

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -83,7 +83,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             for (int methodIndex = 0; methodIndex < _methods.Count; methodIndex++)
             {
                 IMethodNode methodNode = _methods[methodIndex];
-                if (methodNode == null || (methodNode is MethodWithGCInfo methodWithGCInfo && methodWithGCInfo.IsEmpty))
+                if (methodNode == null || (methodNode is LocalMethodImport localMethod && localMethod.MethodCodeNode.IsEmpty))
                 {
                     // Flush an empty GC ref map block to prevent
                     // the indexed records from falling out of sync with methods

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -69,7 +69,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen2/crossgen2" -r:$CORE_ROOT/*.dll --targetarch=x64 -O --inputbubble -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
+          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen2/crossgen2" -r:$CORE_ROOT/*.dll -r:$PWD/*.dll --targetarch=x64 -O --inputbubble -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
           echo $__Command
           $__Command
           __cg2ExitCode=$?
@@ -130,7 +130,7 @@ if defined RunCrossGen2 (
             mkdir IL
             copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
             ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble -r:!CORE_ROOT!\*.dll
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble -r:!CORE_ROOT!\*.dll -r:%25cd%25\*.dll
             echo "!__Command!"
             call !__Command!
             set CrossGen2Status=!ERRORLEVEL!


### PR DESCRIPTION
Fix 1: reference assemblies in the test working directory for crossgen2 test runs
Fix 2: Fix GCRefMapBuilder to correctly detect "empty" methods and not emit GC info for methods that were never compiled, and crash due to missing assembly references causing TypeSystem exceptions.

. @dotnet/crossgen-contrib 