### PR TITLE
Support Write-Thru of EH variables in LSRA

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -401,7 +401,6 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_FeatureSIMD, W("FeatureSIMD"), EXTERNAL_Fea
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_SIMD16ByteOnly, W("SIMD16ByteOnly"), 0, "Limit maximum SIMD vector length to 16 bytes (used by x64_arm64_altjit)")
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableAVX, W("EnableAVX"), EXTERNAL_JitEnableAVX_Default, "Enable AVX instruction set for wide operations as default", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_TrackDynamicMethodDebugInfo, W("TrackDynamicMethodDebugInfo"), 0, "Specifies whether debug info should be generated and tracked for dynamic methods", CLRConfig::REGUTIL_default)
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableEHWriteThru,  W("EnableEHWriteThru"), 0, "Enable enregistration of variables live on EH edges", CLRConfig::REGUTIL_default)
 
 #ifdef FEATURE_MULTICOREJIT
 

--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -401,6 +401,7 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_FeatureSIMD, W("FeatureSIMD"), EXTERNAL_Fea
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_SIMD16ByteOnly, W("SIMD16ByteOnly"), 0, "Limit maximum SIMD vector length to 16 bytes (used by x64_arm64_altjit)")
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableAVX, W("EnableAVX"), EXTERNAL_JitEnableAVX_Default, "Enable AVX instruction set for wide operations as default", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_TrackDynamicMethodDebugInfo, W("TrackDynamicMethodDebugInfo"), 0, "Specifies whether debug info should be generated and tracked for dynamic methods", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableEHWriteThru,  W("EnableEHWriteThru"), 0, "Enable enregistration of variables live on EH edges", CLRConfig::REGUTIL_default)
 
 #ifdef FEATURE_MULTICOREJIT
 

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -504,7 +504,10 @@ void CodeGenInterface::genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bo
     }
     else
     {
-        assert((regSet.GetMaskVars() & regMask) == 0);
+        // If this is going live, the register must not have a variable in it, except
+        // in the case of an exception variable, which may be already treated as live
+        // in the register.
+        assert(varDsc->lvLiveInOutOfHndlr || ((regSet.GetMaskVars() & regMask) == 0));
         regSet.AddMaskVars(regMask);
     }
 }
@@ -681,12 +684,14 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
     unsigned        deadVarIndex = 0;
     while (deadIter.NextElem(&deadVarIndex))
     {
-        unsigned   varNum  = lvaTrackedIndexToLclNum(deadVarIndex);
-        LclVarDsc* varDsc  = lvaGetDesc(varNum);
-        bool       isGCRef = (varDsc->TypeGet() == TYP_REF);
-        bool       isByRef = (varDsc->TypeGet() == TYP_BYREF);
+        unsigned   varNum     = lvaTrackedIndexToLclNum(deadVarIndex);
+        LclVarDsc* varDsc     = lvaGetDesc(varNum);
+        bool       isGCRef    = (varDsc->TypeGet() == TYP_REF);
+        bool       isByRef    = (varDsc->TypeGet() == TYP_BYREF);
+        bool       isInReg    = varDsc->lvIsInReg();
+        bool       isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
 
-        if (varDsc->lvIsInReg())
+        if (isInReg)
         {
             // TODO-Cleanup: Move the code from compUpdateLifeVar to genUpdateRegLife that updates the
             // gc sets
@@ -701,8 +706,8 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             }
             codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
-        // This isn't in a register, so update the gcVarPtrSetCur.
-        else if (isGCRef || isByRef)
+        // Update the gcVarPtrSetCur if it is in memory.
+        if (isInMemory && (isGCRef || isByRef))
         {
             VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, deadVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
@@ -724,13 +729,16 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 
         if (varDsc->lvIsInReg())
         {
-#ifdef DEBUG
-            if (VarSetOps::IsMember(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex))
+            if (!varDsc->lvLiveInOutOfHndlr)
             {
-                JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", varNum);
-            }
+#ifdef DEBUG
+                if (VarSetOps::IsMember(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex))
+                {
+                    JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", varNum);
+                }
 #endif // DEBUG
-            VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
+                VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
+            }
             codeGen->genUpdateRegLife(varDsc, true /*isBorn*/, false /*isDying*/ DEBUGARG(nullptr));
             regMaskTP regMask = varDsc->lvRegMask();
             if (isGCRef)
@@ -3269,6 +3277,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                           // 1 means the first part of a register argument
                           // 2, 3 or 4  means the second,third or fourth part of a multireg argument
         bool stackArg;    // true if the argument gets homed to the stack
+        bool writeThru;   // true if the argument gets homed to both stack and register
         bool processed;   // true after we've processed the argument (and it is in its final location)
         bool circular;    // true if this register participates in a circular dependency loop.
 
@@ -3605,6 +3614,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
             }
 
             regArgTab[regArgNum + i].processed = false;
+            regArgTab[regArgNum + i].writeThru = (varDsc->lvIsInReg() && varDsc->lvLiveInOutOfHndlr);
 
             /* mark stack arguments since we will take care of those first */
             regArgTab[regArgNum + i].stackArg = (varDsc->lvIsInReg()) ? false : true;
@@ -3765,9 +3775,9 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
     noway_assert(((regArgMaskLive & RBM_FLTARG_REGS) == 0) &&
                  "Homing of float argument registers with circular dependencies not implemented.");
 
-    /* Now move the arguments to their locations.
-     * First consider ones that go on the stack since they may
-     * free some registers. */
+    // Now move the arguments to their locations.
+    // First consider ones that go on the stack since they may free some registers.
+    // Also home writeThru args, since they're also homed to the stack.
 
     regArgMaskLive = regState->rsCalleeRegArgMaskLiveIn; // reset the live in to what it was at the start
     for (argNum = 0; argNum < argMax; argNum++)
@@ -3805,7 +3815,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
         // If this arg is never on the stack, go to the next one.
         if (varDsc->lvType == TYP_LONG)
         {
-            if (regArgTab[argNum].slot == 1 && !regArgTab[argNum].stackArg)
+            if (regArgTab[argNum].slot == 1 && !regArgTab[argNum].stackArg && !regArgTab[argNum].writeThru)
             {
                 continue;
             }
@@ -3839,7 +3849,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 
         noway_assert(varDsc->lvIsParam);
         noway_assert(varDsc->lvIsRegArg);
-        noway_assert(varDsc->lvIsInReg() == false ||
+        noway_assert(varDsc->lvIsInReg() == false || varDsc->lvLiveInOutOfHndlr ||
                      (varDsc->lvType == TYP_LONG && varDsc->GetOtherReg() == REG_STK && regArgTab[argNum].slot == 2));
 
         var_types storeType = TYP_UNDEF;
@@ -3906,13 +3916,15 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif // USING_SCOPE_INFO
         }
 
-        /* mark the argument as processed */
+        // Mark the argument as processed.
+        if (!regArgTab[argNum].writeThru)
+        {
+            regArgTab[argNum].processed = true;
+            regArgMaskLive &= ~genRegMask(srcRegNum);
+        }
 
-        regArgTab[argNum].processed = true;
-        regArgMaskLive &= ~genRegMask(srcRegNum);
-
-#if defined(TARGET_ARM)
-        if (storeType == TYP_DOUBLE)
+#if defined(_TARGET_ARM_)
+        if ((storeType == TYP_DOUBLE) && !regArgTab[argNum].writeThru)
         {
             regArgTab[argNum + 1].processed = true;
             regArgMaskLive &= ~genRegMask(REG_NEXT(srcRegNum));
@@ -4618,7 +4630,7 @@ void CodeGen::genCheckUseBlockInit()
                     {
                         if (!varDsc->lvRegister)
                         {
-                            if (!varDsc->lvIsInReg())
+                            if (!varDsc->lvIsInReg() || varDsc->lvLiveInOutOfHndlr)
                             {
                                 // Var is on the stack at entry.
                                 initStkLclCnt +=
@@ -7233,7 +7245,9 @@ void CodeGen::genFnProlog()
             continue;
         }
 
-        if (varDsc->lvIsInReg())
+        bool isInReg    = varDsc->lvIsInReg();
+        bool isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
+        if (isInReg)
         {
             regMaskTP regMask = genRegMask(varDsc->GetRegNum());
             if (!varDsc->IsFloatRegType())
@@ -7264,7 +7278,7 @@ void CodeGen::genFnProlog()
                 initFltRegs |= regMask;
             }
         }
-        else
+        if (isInMemory)
         {
         INIT_STK:
 

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -3923,7 +3923,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
             regArgMaskLive &= ~genRegMask(srcRegNum);
         }
 
-#if defined(_TARGET_ARM_)
+#if defined(TARGET_ARM)
         if ((storeType == TYP_DOUBLE) && !regArgTab[argNum].writeThru)
         {
             regArgTab[argNum + 1].processed = true;

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1883,7 +1883,7 @@ void CodeGen::genProduceReg(GenTree* tree)
 
             // The GTF_SPILL flag generally means that we need to spill this local.
             // The exception is the case of an EH var that is being "spilled"
-            // to the stack, indicated by aby an EH GT_LCL_VAR use that is marked GTF_SPILL
+            // to the stack, indicated by an EH GT_LCL_VAR use that is marked GTF_SPILL
             // (note that all EH lclVar defs are always "spilled", i.e. write-thru).
             // It is always valid on the stack, but the GTF_SPILL flag records the fact
             // that the register value is going dead.

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1881,12 +1881,13 @@ void CodeGen::genProduceReg(GenTree* tree)
             LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
             assert(!varDsc->lvNormalizeOnStore() || (tree->TypeGet() == genActualType(varDsc->TypeGet())));
 
-            // The GTF_SPILL flag generally means that we need to spill this local.
-            // The exception is the case of an EH var that is being "spilled"
-            // to the stack, indicated by an EH GT_LCL_VAR use that is marked GTF_SPILL
-            // (note that all EH lclVar defs are always "spilled", i.e. write-thru).
-            // It is always valid on the stack, but the GTF_SPILL flag records the fact
-            // that the register value is going dead.
+            // If we reach here, we have a register candidate local that is marked with GTF_SPILL.
+            // This flag generally means that we need to spill this local.
+            // The exception is the case of a use of an EH var use that is being "spilled"
+            // to the stack, indicated by GTF_SPILL (note that all EH lclVar defs are always
+            // spilled, i.e. write-thru).
+            // An EH var use is always valid on the stack (so we don't need to actually spill it),
+            // but the GTF_SPILL flag records the fact that the register value is going dead.
             if (((tree->gtFlags & GTF_VAR_DEF) != 0) || !varDsc->lvLiveInOutOfHndlr)
             {
                 // Store local variable to its home location.

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -239,15 +239,18 @@ void CodeGen::genCodeForBBlist()
                 {
                     newRegByrefSet |= varDsc->lvRegMask();
                 }
-#ifdef DEBUG
-                if (verbose && VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
+                if (!varDsc->lvLiveInOutOfHndlr)
                 {
-                    VarSetOps::AddElemD(compiler, removedGCVars, varIndex);
-                }
+#ifdef DEBUG
+                    if (verbose && VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
+                    {
+                        VarSetOps::AddElemD(compiler, removedGCVars, varIndex);
+                    }
 #endif // DEBUG
-                VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varIndex);
+                    VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varIndex);
+                }
             }
-            else if (compiler->lvaIsGCTracked(varDsc))
+            if ((!varDsc->lvIsInReg() || varDsc->lvLiveInOutOfHndlr) && compiler->lvaIsGCTracked(varDsc))
             {
 #ifdef DEBUG
                 if (verbose && !VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
@@ -823,10 +826,20 @@ void CodeGen::genSpillVar(GenTree* tree)
         var_types lclTyp = genActualType(varDsc->TypeGet());
         emitAttr  size   = emitTypeSize(lclTyp);
 
-        instruction storeIns = ins_Store(lclTyp, compiler->isSIMDTypeLocalAligned(varNum));
-        assert(varDsc->GetRegNum() == tree->GetRegNum());
-        inst_TT_RV(storeIns, size, tree, tree->GetRegNum());
+        // If this is a write-thru variable, we don't actually spill at a use, but we will kill the var in the reg
+        // (below).
+        if (!varDsc->lvLiveInOutOfHndlr)
+        {
+            instruction storeIns = ins_Store(lclTyp, compiler->isSIMDTypeLocalAligned(varNum));
+            assert(varDsc->GetRegNum() == tree->GetRegNum());
+            inst_TT_RV(storeIns, size, tree, tree->GetRegNum());
+        }
 
+        // We should only have both GTF_SPILL (i.e. the flag causing this method to be called) and
+        // GTF_SPILLED on a write-thru def, for which we should not be calling this method.
+        assert((tree->gtFlags & GTF_SPILLED) == 0);
+
+        // Remove the live var from the register.
         genUpdateRegLife(varDsc, /*isBorn*/ false, /*isDying*/ true DEBUGARG(tree));
         gcInfo.gcMarkRegSetNpt(varDsc->lvRegMask());
 
@@ -847,10 +860,19 @@ void CodeGen::genSpillVar(GenTree* tree)
     }
 
     tree->gtFlags &= ~GTF_SPILL;
-    varDsc->SetRegNum(REG_STK);
-    if (varTypeIsMultiReg(tree))
+    // If this is NOT a write-thru, reset the var location.
+    if ((tree->gtFlags & GTF_SPILLED) == 0)
     {
-        varDsc->SetOtherReg(REG_STK);
+        varDsc->SetRegNum(REG_STK);
+        if (varTypeIsMultiReg(tree))
+        {
+            varDsc->SetOtherReg(REG_STK);
+        }
+    }
+    else
+    {
+        // We only have 'GTF_SPILL' and 'GTF_SPILLED' on a def of a write-thru lclVar.
+        assert(varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0));
     }
 
 #ifdef USING_VARIABLE_LIVE_RANGE
@@ -1030,13 +1052,16 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 }
 #endif // USING_VARIABLE_LIVE_RANGE
 
-#ifdef DEBUG
-                if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
+                if (!varDsc->lvLiveInOutOfHndlr)
                 {
-                    JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", lcl->GetLclNum());
-                }
+#ifdef DEBUG
+                    if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
+                    {
+                        JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", lcl->GetLclNum());
+                    }
 #endif // DEBUG
-                VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex);
+                    VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex);
+                }
 
 #ifdef DEBUG
                 if (compiler->verbose)
@@ -1316,14 +1341,14 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
         LclVarDsc*           varDsc = &compiler->lvaTable[lcl->GetLclNum()];
         assert(varDsc->lvLRACandidate);
 
-        if ((tree->gtFlags & GTF_VAR_DEATH) != 0)
-        {
-            gcInfo.gcMarkRegSetNpt(genRegMask(varDsc->GetRegNum()));
-        }
-        else if (varDsc->GetRegNum() == REG_STK)
+        if (varDsc->GetRegNum() == REG_STK)
         {
             // We have loaded this into a register only temporarily
             gcInfo.gcMarkRegSetNpt(genRegMask(tree->GetRegNum()));
+        }
+        else if ((tree->gtFlags & GTF_VAR_DEATH) != 0)
+        {
+            gcInfo.gcMarkRegSetNpt(genRegMask(varDsc->GetRegNum()));
         }
     }
     else
@@ -1852,13 +1877,20 @@ void CodeGen::genProduceReg(GenTree* tree)
 
         if (genIsRegCandidateLocal(tree))
         {
-            // Store local variable to its home location.
-            // Ensure that lclVar stores are typed correctly.
-            unsigned varNum = tree->AsLclVarCommon()->GetLclNum();
-            assert(!compiler->lvaTable[varNum].lvNormalizeOnStore() ||
-                   (tree->TypeGet() == genActualType(compiler->lvaTable[varNum].TypeGet())));
-            inst_TT_RV(ins_Store(tree->gtType, compiler->isSIMDTypeLocalAligned(varNum)), emitTypeSize(tree->TypeGet()),
-                       tree, tree->GetRegNum());
+            unsigned   varNum = tree->AsLclVarCommon()->GetLclNum();
+            LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+            assert(!varDsc->lvNormalizeOnStore() || (tree->TypeGet() == genActualType(varDsc->TypeGet())));
+
+            // First, check for the case of an EH var that is being "spilled" to the stack, indicated
+            // by a non-def GT_LCL_VAR that is marked GTF_SPILL.
+            // This case occurs at the end of a block when its register is going dead.
+            // It is already valid on the stack.
+            if (((tree->gtFlags & GTF_VAR_DEF) != 0) || !varDsc->lvLiveInOutOfHndlr)
+            {
+                // Store local variable to its home location.
+                // Ensure that lclVar stores are typed correctly.
+                inst_TT_RV(ins_Store(tree->gtType, compiler->isSIMDTypeLocalAligned(varNum)), tree, tree->GetRegNum());
+            }
         }
         else
         {

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4522,6 +4522,37 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
 
     EndPhase(PHASE_CLONE_FINALLY);
 
+#if DEBUG
+    if (lvaEnregEHVars)
+    {
+        unsigned methHash   = info.compMethodHash();
+        char*    lostr      = getenv("JitEHWTHashLo");
+        unsigned methHashLo = 0;
+        bool     dump       = false;
+        if (lostr != nullptr)
+        {
+            sscanf_s(lostr, "%x", &methHashLo);
+            dump = true;
+        }
+        char*    histr      = getenv("JitEHWTHashHi");
+        unsigned methHashHi = UINT32_MAX;
+        if (histr != nullptr)
+        {
+            sscanf_s(histr, "%x", &methHashHi);
+            dump = true;
+        }
+        if (methHash < methHashLo || methHash > methHashHi)
+        {
+            lvaEnregEHVars = false;
+        }
+        else if (dump)
+        {
+            printf("Enregistering EH Vars for method %s, hash = 0x%x.\n", info.compFullName, info.compMethodHash());
+            printf(""); // flush
+        }
+    }
+#endif
+
     // Compute bbNum, bbRefs and bbPreds
     //
     JITDUMP("\nRenumbering the basic blocks for fgComputePreds\n");

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -415,6 +415,8 @@ public:
     unsigned char lvDoNotEnregister : 1; // Do not enregister this variable.
     unsigned char lvFieldAccessed : 1;   // The var is a struct local, and a field of the variable is accessed.  Affects
                                          // struct promotion.
+    unsigned char lvLiveInOutOfHndlr : 1; // The variable is live in or out of an exception handler, and therefore must
+                                          // be on the stack (at least at those boundaries.)
 
     unsigned char lvInSsa : 1; // The variable is in SSA form (set by SsaBuilder)
 
@@ -424,9 +426,6 @@ public:
     // also, lvType == TYP_STRUCT prevents enregistration.  At least one of the reasons should be true.
     unsigned char lvVMNeedsStackAddr : 1; // The VM may have access to a stack-relative address of the variable, and
                                           // read/write its value.
-    unsigned char lvLiveInOutOfHndlr : 1; // The variable was live in or out of an exception handler, and this required
-                                          // the variable to be
-                                          // in the stack (at least at those boundaries.)
     unsigned char lvLclFieldExpr : 1;     // The variable is not a struct, but was accessed like one (e.g., reading a
                                           // particular byte from an int).
     unsigned char lvLclBlockOpAddr : 1;   // The variable was written to via a block operation that took its address.
@@ -3005,6 +3004,9 @@ public:
     void lvaSetVarAddrExposed(unsigned varNum);
     void lvaSetVarLiveInOutOfHandler(unsigned varNum);
     bool lvaVarDoNotEnregister(unsigned varNum);
+
+    bool lvaEnregEHVars;
+
 #ifdef DEBUG
     // Reasons why we can't enregister.  Some of these correspond to debug properties of local vars.
     enum DoNotEnregisterReason
@@ -3027,6 +3029,7 @@ public:
         DNER_PinningRef,
 #endif
     };
+
 #endif
     void lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason));
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -2755,6 +2755,13 @@ bool Compiler::gtIsLikelyRegVar(GenTree* tree)
         return false;
     }
 
+    // If this is an EH-live var, return false if it is a def,
+    // as it will have to go to memory.
+    if (varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0))
+    {
+        return false;
+    }
+
     // Be pessimistic if ref counts are not yet set up.
     //
     // Perhaps we should be optimistic though.

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -662,6 +662,7 @@ void CodeGen::inst_TT_RV(instruction ins, emitAttr size, GenTree* tree, regNumbe
 #ifdef DEBUG
     // The tree must have a valid register value.
     assert(reg != REG_STK);
+
     bool isValidInReg = ((tree->gtFlags & GTF_SPILLED) == 0);
     if (!isValidInReg)
     {

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -244,6 +244,9 @@ CONFIG_INTEGER(EnablePOPCNT, W("EnablePOPCNT"), 1)           // Enable POPCNT
 CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)
 #endif                                                       // !defined(TARGET_AMD64) && !defined(TARGET_X86)
 
+CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 0) // Enable the register allocator to support EH-write thru:
+                                                             // partial enregistration of vars exposed on EH boundaries
+
 // clang-format off
 
 #if defined(TARGET_ARM64)

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -1455,6 +1455,8 @@ private:
     VARSET_TP fpCalleeSaveCandidateVars;
     // Set of variables exposed on EH flow edges.
     VARSET_TP exceptVars;
+    // Set of variables exposed on finally edges. These must be zero-init if they are refs or if compInitMem is true.
+    VARSET_TP finallyVars;
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 #if defined(TARGET_AMD64)

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -71,7 +71,7 @@ inline bool registerTypesEquivalent(RegisterType a, RegisterType b)
 }
 
 //------------------------------------------------------------------------
-// registerTypesEquivalent: Get the set of callee-save registers of the given RegisterType
+// calleeSaveRegs: Get the set of callee-save registers of the given RegisterType
 //
 inline regMaskTP calleeSaveRegs(RegisterType rt)
 {
@@ -79,7 +79,7 @@ inline regMaskTP calleeSaveRegs(RegisterType rt)
 }
 
 //------------------------------------------------------------------------
-// registerTypesEquivalent: Get the set of callee-save registers of the given RegisterType
+// callerSaveRegs: Get the set of caller-save registers of the given RegisterType
 //
 inline regMaskTP callerSaveRegs(RegisterType rt)
 {

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -388,10 +388,11 @@ struct LsraBlockInfo
     // 0 for fgFirstBB.
     unsigned int         predBBNum;
     BasicBlock::weight_t weight;
-    bool                 hasCriticalInEdge;
-    bool                 hasCriticalOutEdge;
-    bool                 hasEHBoundaryIn;
-    bool                 hasEHBoundaryOut;
+    bool                 hasCriticalInEdge : 1;
+    bool                 hasCriticalOutEdge : 1;
+    bool                 hasEHBoundaryIn : 1;
+    bool                 hasEHBoundaryOut : 1;
+    bool                 hasEHPred : 1;
 
 #if TRACK_LSRA_STATS
     // Per block maintained LSRA statistics.

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -1181,18 +1181,22 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
                 {
                     interval->preferCalleeSave = true;
                 }
-                regMaskTP newPreferences = allRegs(interval->registerType) & (~killMask);
 
-                if (newPreferences != RBM_NONE)
+                if (!interval->isWriteThru || !isCallKill)
                 {
-                    interval->updateRegisterPreferences(newPreferences);
-                }
-                else
-                {
-                    // If there are no callee-saved registers, the call could kill all the registers.
-                    // This is a valid state, so in that case assert should not trigger. The RA will spill in order to
-                    // free a register later.
-                    assert(compiler->opts.compDbgEnC || (calleeSaveRegs(varDsc->lvType)) == RBM_NONE);
+                    regMaskTP newPreferences = allRegs(interval->registerType) & (~killMask);
+
+                    if (newPreferences != RBM_NONE)
+                    {
+                        interval->updateRegisterPreferences(newPreferences);
+                    }
+                    else
+                    {
+                        // If there are no callee-saved registers, the call could kill all the registers.
+                        // This is a valid state, so in that case assert should not trigger. The RA will spill in order
+                        // to free a register later.
+                        assert(compiler->opts.compDbgEnC || (calleeSaveRegs(varDsc->lvType)) == RBM_NONE);
+                    }
                 }
             }
         }
@@ -2101,49 +2105,74 @@ void LinearScan::buildIntervals()
                 currentLoc = 1;
             }
 
-            // Any lclVars live-in to a block are resolution candidates.
-            VarSetOps::UnionD(compiler, resolutionCandidateVars, currentLiveVars);
+            // Handle special cases for live-in.
+            // If this block hasEHBoundaryIn, then we will mark the recentRefPosition of each EH Var preemptively as
+            // spillAfter, since we don't want them to remain in registers.
+            // Otherwise, determine if we need any DummyDefs.
+            // We need DummyDefs for cases where "predBlock" isn't really a predecessor.
+            // Note that it's possible to have uses of unitialized variables, in which case even the first
+            // block may require DummyDefs, which we are not currently adding - this means that these variables
+            // will always be considered to be in memory on entry (and reloaded when the use is encountered).
+            // TODO-CQ: Consider how best to tune this.  Currently, if we create DummyDefs for uninitialized
+            // variables (which may actually be initialized along the dynamically executed paths, but not
+            // on all static paths), we wind up with excessive liveranges for some of these variables.
 
-            if (!blockInfo[block->bbNum].hasEHBoundaryIn)
+            if (blockInfo[block->bbNum].hasEHBoundaryIn)
             {
-                // Determine if we need any DummyDefs.
-                // We need DummyDefs for cases where "predBlock" isn't really a predecessor.
-                // Note that it's possible to have uses of unitialized variables, in which case even the first
-                // block may require DummyDefs, which we are not currently adding - this means that these variables
-                // will always be considered to be in memory on entry (and reloaded when the use is encountered).
-                // TODO-CQ: Consider how best to tune this.  Currently, if we create DummyDefs for uninitialized
-                // variables (which may actually be initialized along the dynamically executed paths, but not
-                // on all static paths), we wind up with excessive liveranges for some of these variables.
-
-                VARSET_TP newLiveIn(VarSetOps::MakeCopy(compiler, currentLiveVars));
-                if (predBlock != nullptr)
+                VARSET_TP       liveInEHVars(VarSetOps::Intersection(compiler, currentLiveVars, exceptVars));
+                VarSetOps::Iter iter(compiler, liveInEHVars);
+                unsigned        varIndex = 0;
+                while (iter.NextElem(&varIndex))
                 {
-                    // Compute set difference: newLiveIn = currentLiveVars - predBlock->bbLiveOut
-                    VarSetOps::DiffD(compiler, newLiveIn, predBlock->bbLiveOut);
+                    Interval* interval = getIntervalForLocalVar(varIndex);
+                    if (interval->recentRefPosition != nullptr)
+                    {
+                        JITDUMP("  Marking RP #%d of V%02u as spillAfter\n", interval->recentRefPosition->rpNum,
+                                interval->varNum);
+                        interval->recentRefPosition->spillAfter;
+                    }
                 }
-                bool needsDummyDefs = (!VarSetOps::IsEmpty(compiler, newLiveIn) && block != compiler->fgFirstBB);
+            }
+            else
+            {
+                // Any lclVars live-in on a non-EH boundary edge are resolution candidates.
+                VarSetOps::UnionD(compiler, resolutionCandidateVars, currentLiveVars);
+
+                if (block != compiler->fgFirstBB)
+                {
+                    VARSET_TP newLiveIn(VarSetOps::MakeCopy(compiler, currentLiveVars));
+                    if (predBlock != nullptr)
+                    {
+                        // Compute set difference: newLiveIn = currentLiveVars - predBlock->bbLiveOut
+                        VarSetOps::DiffD(compiler, newLiveIn, predBlock->bbLiveOut);
+                    }
 
                 // Create dummy def RefPositions
 
-                if (needsDummyDefs)
-                {
-                    // If we are using locations from a predecessor, we should never require DummyDefs.
-                    assert(!predBlockIsAllocated);
-
-                    JITDUMP("Creating dummy definitions\n");
-                    VarSetOps::Iter iter(compiler, newLiveIn);
-                    unsigned        varIndex = 0;
-                    while (iter.NextElem(&varIndex))
+                    if (!VarSetOps::IsEmpty(compiler, newLiveIn))
                     {
-                        // Add a dummyDef for any candidate vars that are in the "newLiveIn" set.
-                        LclVarDsc* varDsc = compiler->lvaGetDescByTrackedIndex(varIndex);
-                        assert(isCandidateVar(varDsc));
-                        Interval*    interval = getIntervalForLocalVar(varIndex);
-                        RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr,
-                                                          allRegs(interval->registerType));
-                        pos->setRegOptional(true);
+                        // If we are using locations from a predecessor, we should never require DummyDefs.
+                        assert(!predBlockIsAllocated);
+
+                        JITDUMP("Creating dummy definitions\n");
+                        VarSetOps::Iter iter(compiler, newLiveIn);
+                        unsigned        varIndex = 0;
+                        while (iter.NextElem(&varIndex))
+                        {
+                            LclVarDsc* varDsc = compiler->lvaGetDescByTrackedIndex(varIndex);
+                            // Add a dummyDef for any candidate vars that are in the "newLiveIn" set.
+                            // If this is the entry block, don't add any incoming parameters (they're handled with
+                            // ParamDefs).
+                            if (isCandidateVar(varDsc) && (predBlock != nullptr || !varDsc->lvIsParam))
+                            {
+                                Interval*    interval = getIntervalForLocalVar(varIndex);
+                                RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr,
+                                                                  allRegs(interval->registerType));
+                                pos->setRegOptional(true);
+                            }
+                        }
+                        JITDUMP("Finished creating dummy definitions\n\n");
                     }
-                    JITDUMP("Finished creating dummy definitions\n\n");
                 }
             }
         }
@@ -2156,6 +2185,23 @@ void LinearScan::buildIntervals()
         RefPosition* pos = newRefPosition((Interval*)nullptr, currentLoc, RefTypeBB, nullptr, RBM_NONE);
         currentLoc += 2;
         JITDUMP("\n");
+
+        if (firstColdLoc == MaxLocation)
+        {
+            if (block->isRunRarely())
+            {
+                firstColdLoc = currentLoc;
+                JITDUMP("firstColdLoc = %d\n", firstColdLoc);
+            }
+        }
+        else
+        {
+            // TODO: We'd like to assert the following but we don't currently ensure that only
+            // "RunRarely" blocks are contiguous.
+            // (The funclets will generally be last, but we don't follow layout order, so we
+            // don't have to preserve that in the block sequence.)
+            // assert(block->isRunRarely());
+        }
 
         LIR::Range& blockRange = LIR::AsRange(block);
         for (GenTree* node : blockRange.NonPhiNodes())
@@ -2211,85 +2257,80 @@ void LinearScan::buildIntervals()
 
         if (enregisterLocalVars)
         {
-            // We don't need exposed uses for an EH edge, because no lclVars will be kept in
-            // registers across such edges.
-            if (!blockInfo[block->bbNum].hasEHBoundaryOut)
+            // Insert exposed uses for a lclVar that is live-out of 'block' but not live-in to the
+            // next block, or any unvisited successors.
+            // This will address lclVars that are live on a backedge, as well as those that are kept
+            // live at a GT_JMP.
+            //
+            // Blocks ending with "jmp method" are marked as BBJ_HAS_JMP,
+            // and jmp call is represented using GT_JMP node which is a leaf node.
+            // Liveness phase keeps all the arguments of the method live till the end of
+            // block by adding them to liveout set of the block containing GT_JMP.
+            //
+            // The target of a GT_JMP implicitly uses all the current method arguments, however
+            // there are no actual references to them.  This can cause LSRA to assert, because
+            // the variables are live but it sees no references.  In order to correctly model the
+            // liveness of these arguments, we add dummy exposed uses, in the same manner as for
+            // backward branches.  This will happen automatically via expUseSet.
+            //
+            // Note that a block ending with GT_JMP has no successors and hence the variables
+            // for which dummy use ref positions are added are arguments of the method.
+
+            VARSET_TP expUseSet(VarSetOps::MakeCopy(compiler, block->bbLiveOut));
+            VarSetOps::IntersectionD(compiler, expUseSet, registerCandidateVars);
+            BasicBlock* nextBlock = getNextBlock();
+            if (nextBlock != nullptr)
             {
-                // Insert exposed uses for a lclVar that is live-out of 'block' but not live-in to the
-                // next block, or any unvisited successors.
-                // This will address lclVars that are live on a backedge, as well as those that are kept
-                // live at a GT_JMP.
-                //
-                // Blocks ending with "jmp method" are marked as BBJ_HAS_JMP,
-                // and jmp call is represented using GT_JMP node which is a leaf node.
-                // Liveness phase keeps all the arguments of the method live till the end of
-                // block by adding them to liveout set of the block containing GT_JMP.
-                //
-                // The target of a GT_JMP implicitly uses all the current method arguments, however
-                // there are no actual references to them.  This can cause LSRA to assert, because
-                // the variables are live but it sees no references.  In order to correctly model the
-                // liveness of these arguments, we add dummy exposed uses, in the same manner as for
-                // backward branches.  This will happen automatically via expUseSet.
-                //
-                // Note that a block ending with GT_JMP has no successors and hence the variables
-                // for which dummy use ref positions are added are arguments of the method.
-
-                VARSET_TP expUseSet(VarSetOps::MakeCopy(compiler, block->bbLiveOut));
-                VarSetOps::IntersectionD(compiler, expUseSet, registerCandidateVars);
-                BasicBlock* nextBlock = getNextBlock();
-                if (nextBlock != nullptr)
+                VarSetOps::DiffD(compiler, expUseSet, nextBlock->bbLiveIn);
+            }
+            for (BasicBlock* succ : block->GetAllSuccs(compiler))
+            {
+                if (VarSetOps::IsEmpty(compiler, expUseSet))
                 {
-                    VarSetOps::DiffD(compiler, expUseSet, nextBlock->bbLiveIn);
-                }
-                for (BasicBlock* succ : block->GetAllSuccs(compiler))
-                {
-                    if (VarSetOps::IsEmpty(compiler, expUseSet))
-                    {
-                        break;
-                    }
-
-                    if (isBlockVisited(succ))
-                    {
-                        continue;
-                    }
-                    VarSetOps::DiffD(compiler, expUseSet, succ->bbLiveIn);
+                    break;
                 }
 
-                if (!VarSetOps::IsEmpty(compiler, expUseSet))
+                if (isBlockVisited(succ))
                 {
-                    JITDUMP("Exposed uses:");
-                    VarSetOps::Iter iter(compiler, expUseSet);
-                    unsigned        varIndex = 0;
-                    while (iter.NextElem(&varIndex))
-                    {
-                        LclVarDsc* varDsc = compiler->lvaGetDescByTrackedIndex(varIndex);
-                        assert(isCandidateVar(varDsc));
-                        Interval*    interval = getIntervalForLocalVar(varIndex);
-                        regMaskTP    regMask  = allRegs(interval->registerType);
-                        RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, regMask);
-                        pos->setRegOptional(true);
-                        JITDUMP(" V%02u", compiler->lvaTrackedIndexToLclNum(varIndex));
-                    }
-                    JITDUMP("\n");
+                    continue;
                 }
+                VarSetOps::DiffD(compiler, expUseSet, succ->bbLiveIn);
             }
 
-            // Clear the "last use" flag on any vars that are live-out from this block.
+            if (!VarSetOps::IsEmpty(compiler, expUseSet))
             {
-                VARSET_TP       bbLiveDefs(VarSetOps::Intersection(compiler, registerCandidateVars, block->bbLiveOut));
-                VarSetOps::Iter iter(compiler, bbLiveDefs);
+                JITDUMP("Exposed uses:");
+                VarSetOps::Iter iter(compiler, expUseSet);
                 unsigned        varIndex = 0;
                 while (iter.NextElem(&varIndex))
                 {
-                    LclVarDsc* const varDsc = compiler->lvaGetDescByTrackedIndex(varIndex);
+                    unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
+                    LclVarDsc* varDsc = compiler->lvaTable + varNum;
                     assert(isCandidateVar(varDsc));
-                    RefPosition* const lastRP = getIntervalForLocalVar(varIndex)->lastRefPosition;
-                    // We should be able to assert that lastRP is non-null if it is live-out, but sometimes liveness
-                    // lies.
-                    if ((lastRP != nullptr) && (lastRP->bbNum == block->bbNum))
-                    {
-                        lastRP->lastUse = false;
-                    }
+                    Interval*    interval = getIntervalForLocalVar(varIndex);
+                    RefPosition* pos =
+                        newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, allRegs(interval->registerType));
+                    pos->setRegOptional(true);
+                    JITDUMP(" V%02u", varNum);
+                }
+                JITDUMP("\n");
+            }
+
+            // Clear the "last use" flag on any vars that are live-out from this block.
+            VARSET_TP       bbLiveDefs(VarSetOps::Intersection(compiler, registerCandidateVars, block->bbLiveOut));
+            VarSetOps::Iter iter(compiler, bbLiveDefs);
+            unsigned        varIndex = 0;
+            while (iter.NextElem(&varIndex))
+            {
+                unsigned         varNum = compiler->lvaTrackedToVarNum[varIndex];
+                LclVarDsc* const varDsc = &compiler->lvaTable[varNum];
+                assert(isCandidateVar(varDsc));
+                RefPosition* const lastRP = getIntervalForLocalVar(varIndex)->lastRefPosition;
+                // We should be able to assert that lastRP is non-null if it is live-out, but sometimes liveness
+                // lies.
+                if ((lastRP != nullptr) && (lastRP->bbNum == block->bbNum))
+                {
+                    lastRP->lastUse = false;
                 }
             }
 
@@ -2325,6 +2366,62 @@ void LinearScan::buildIntervals()
                 RefPosition* pos =
                     newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, allRegs(interval->registerType));
                 pos->setRegOptional(true);
+            }
+        }
+        // Adjust heuristics for writeThru intervals.
+        if (compiler->compHndBBtabCount > 0)
+        {
+            VarSetOps::Iter iter(compiler, exceptVars);
+            unsigned        varIndex = 0;
+            while (iter.NextElem(&varIndex))
+            {
+                unsigned   varNum   = compiler->lvaTrackedToVarNum[varIndex];
+                LclVarDsc* varDsc   = compiler->lvaTable + varNum;
+                Interval*  interval = getIntervalForLocalVar(varIndex);
+                assert(interval->isWriteThru);
+                BasicBlock::weight_t weight = varDsc->lvRefCntWtd();
+
+                // We'd like to only allocate registers for EH vars that have enough uses
+                // to compensate for the additional registers being live (and for the possibility
+                // that we may have to insert an additional copy).
+                // However, we don't currently have that information available. Instead, we'll
+                // aggressively assume that these vars are defined once, at their first RefPosition.
+                //
+                RefPosition* firstRefPosition = interval->firstRefPosition;
+
+                // Incoming reg args are given an initial weight of 2 * BB_UNITY_WEIGHT
+                // (see lvaComputeRefCounts(); this may be reviewed/changed in future).
+                //
+                BasicBlock::weight_t initialWeight = (firstRefPosition->refType == RefTypeParamDef)
+                                                         ? (2 * BB_UNITY_WEIGHT)
+                                                         : blockInfo[firstRefPosition->bbNum].weight;
+                weight -= initialWeight;
+
+                // If the remaining weight is less than the initial weight, we'd like to allocate it only
+                // opportunistically, but we don't currently have a mechanism to do so.
+                // For now, we'll just avoid using callee-save registers if the weight is too low.
+                if (interval->preferCalleeSave)
+                {
+                    // The benefit of a callee-save register isn't as high as it would be for a normal arg.
+                    // We'll have at least the cost of saving & restoring the callee-save register,
+                    // so we won't break even until we have at least 4 * BB_UNITY_WEIGHT.
+                    // Given that we also don't have a good way to tell whether the variable is live
+                    // across a call in the non-EH code, we'll be extra conservative about this.
+                    // Note that for writeThru intervals we don't update the preferences to be only callee-save.
+                    unsigned calleeSaveCount =
+                        (varTypeIsFloating(interval->registerType)) ? CNT_CALLEE_SAVED_FLOAT : CNT_CALLEE_ENREG;
+                    if ((weight <= (BB_UNITY_WEIGHT * 7)) || varDsc->lvVarIndex >= calleeSaveCount)
+                    {
+                        // If this is relatively low weight, don't prefer callee-save at all.
+                        interval->preferCalleeSave = false;
+                    }
+                    else
+                    {
+                        // In other cases, we'll add in the callee-save regs to the preferences, but not clear
+                        // the non-callee-save regs . We also handle this case specially in tryAllocateFreeReg().
+                        interval->registerPreferences |= calleeSaveRegs(interval->registerType);
+                    }
+                }
             }
         }
 
@@ -3023,7 +3120,20 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
                 srcInterval->assignRelatedInterval(varDefInterval);
             }
         }
-        newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, allRegs(storeLoc->TypeGet()));
+        RefPosition* def =
+            newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, allRegs(storeLoc->TypeGet()));
+        if (varDefInterval->isWriteThru)
+        {
+            // We always make write-thru defs reg-optional, as we can store them if they don't
+            // get a register.
+            def->regOptional = true;
+        }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+        if (varTypeNeedsPartialCalleeSave(varDefInterval->registerType))
+        {
+            varDefInterval->isPartiallySpilled = false;
+        }
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     }
 
     return srcCount;

--- a/src/coreclr/src/jit/treelifeupdater.cpp
+++ b/src/coreclr/src/jit/treelifeupdater.cpp
@@ -96,11 +96,13 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 {
                     compiler->codeGen->genUpdateVarReg(varDsc, tree);
                 }
-                if (varDsc->lvIsInReg() && tree->GetRegNum() != REG_NA)
+                bool isInReg    = varDsc->lvIsInReg() && tree->GetRegNum() != REG_NA;
+                bool isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
+                if (isInReg)
                 {
                     compiler->codeGen->genUpdateRegLife(varDsc, isBorn, isDying DEBUGARG(tree));
                 }
-                else
+                if (isInMemory)
                 {
                     VarSetOps::AddElemD(compiler, stackVarDeltaSet, varDsc->lvVarIndex);
                 }
@@ -131,6 +133,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 if (fldVarDsc->lvTracked)
                 {
                     unsigned fldVarIndex = fldVarDsc->lvVarIndex;
+                    bool     isInReg     = fldVarDsc->lvIsInReg();
+                    bool     isInMemory  = !isInReg || fldVarDsc->lvLiveInOutOfHndlr;
                     noway_assert(fldVarIndex < compiler->lvaTrackedCount);
                     if (!hasDeadTrackedFieldVars)
                     {
@@ -139,7 +143,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                         {
                             // We repeat this call here and below to avoid the VarSetOps::IsMember
                             // test in this, the common case, where we have no deadTrackedFieldVars.
-                            if (fldVarDsc->lvIsInReg())
+                            if (isInReg)
                             {
                                 if (isBorn)
                                 {
@@ -147,7 +151,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                                 }
                                 compiler->codeGen->genUpdateRegLife(fldVarDsc, isBorn, isDying DEBUGARG(tree));
                             }
-                            else
+                            if (isInMemory)
                             {
                                 VarSetOps::AddElemD(compiler, stackVarDeltaSet, fldVarIndex);
                             }
@@ -155,7 +159,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     }
                     else if (ForCodeGen && VarSetOps::IsMember(compiler, varDeltaSet, fldVarIndex))
                     {
-                        if (compiler->lvaTable[i].lvIsInReg())
+                        if (isInReg)
                         {
                             if (isBorn)
                             {
@@ -163,7 +167,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                             }
                             compiler->codeGen->genUpdateRegLife(fldVarDsc, isBorn, isDying DEBUGARG(tree));
                         }
-                        else
+                        if (isInMemory)
                         {
                             VarSetOps::AddElemD(compiler, stackVarDeltaSet, fldVarIndex);
                         }


### PR DESCRIPTION
Mark EH variables (those that are live in or out of exception regions) only as lvLiveInOutOfHndlr, not necessarily lvDoNotEnregister.
During register allocation, mark these as write-thru, and mark all defs as write-thru, ensuring that the stack value is always valid.
Mark those defs with GTF_SPILLED (this the "reload" flag and is not currently used for pure defs) to indicate that it should be kept in the register.
Mark blocks that enter EH regions as having no predecessor, and set the location of all live-in vars to be on the stack.
Change genFnPrologCalleeRegArgs to store EH vars also to the stack if they have a register assignment.