### PR TITLE
[Arm64] Fix JitDump assertions when emitting ld1

### DIFF
--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -11175,7 +11175,6 @@ void emitter::emitDispIns(
             break;
 
         case IF_LS_2D: // LS_2D   .Q.............. xx.xssnnnnnttttt      Vt Rn
-            assert(insOptsNone(id->idInsOpt()));
             assert(emitGetInsSC(id) == 0);
             emitDispReg(id->idReg1(), emitInsTargetRegSize(id), true);
             emitDispAddrRI(id->idReg2(), id->idInsOpt(), 0);

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -1084,6 +1084,7 @@ emitAttr emitter::emitInsTargetRegSize(instrDesc* id)
         case INS_str:
         case INS_ldur:
         case INS_stur:
+        case INS_ld1:
             result = id->idOpSize();
             break;
 


### PR DESCRIPTION
This fixes assertions in jitdump when a source code contains `AdvSimd.LoadVector64` or `AdvSimd.LoadVector128` intrinsics:

1. Adds a case for `ld1` instruction in `emitter::emitInsTargetRegSize`
2. Removes ` assert(insOptsNone(id->idInsOpt()))` since `ld1` in `LS_2D` format *(LD1 (multiple structures) - No offset)* can have options set (e.g. corresponding to an arrangement specifier)

@briansull @BruceForstall PTAL
cc @dotnet/jit-contrib 