### PR TITLE
Fix ReflectionTypeLoadException nullable annotations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ReflectionTypeLoadException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ReflectionTypeLoadException.cs
@@ -2,35 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 
 namespace System.Reflection
 {
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ReflectionTypeLoadException : SystemException, ISerializable
     {
-        public ReflectionTypeLoadException(Type[]? classes, Exception?[]? exceptions)
-            : base(null)
+        public ReflectionTypeLoadException(Type?[]? classes, Exception?[]? exceptions) :
+            this(classes, exceptions, null)
         {
-            Types = classes;
-            LoaderExceptions = exceptions;
-            HResult = HResults.COR_E_REFLECTIONTYPELOAD;
         }
 
-        public ReflectionTypeLoadException(Type[]? classes, Exception?[]? exceptions, string? message)
+        public ReflectionTypeLoadException(Type?[]? classes, Exception?[]? exceptions, string? message)
             : base(message)
         {
-            Types = classes;
-            LoaderExceptions = exceptions;
+            Types = classes ?? Type.EmptyTypes;
+            LoaderExceptions = exceptions ?? Array.Empty<Exception>();
             HResult = HResults.COR_E_REFLECTIONTYPELOAD;
         }
 
         private ReflectionTypeLoadException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            LoaderExceptions = (Exception[]?)(info.GetValue("Exceptions", typeof(Exception[])));
+            Types = Type.EmptyTypes;
+            LoaderExceptions = (Exception?[]?)info.GetValue("Exceptions", typeof(Exception[])) ?? Array.Empty<Exception?>();
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -40,9 +39,9 @@ namespace System.Reflection
             info.AddValue("Exceptions", LoaderExceptions, typeof(Exception[]));
         }
 
-        public Type[]? Types { get; }
+        public Type?[] Types { get; }
 
-        public Exception?[]? LoaderExceptions { get; }
+        public Exception?[] LoaderExceptions { get; }
 
         public override string Message => CreateString(isMessage: true);
 
@@ -52,8 +51,8 @@ namespace System.Reflection
         {
             string baseValue = isMessage ? base.Message : base.ToString();
 
-            Exception?[]? exceptions = LoaderExceptions;
-            if (exceptions == null || exceptions.Length == 0)
+            Exception?[] exceptions = LoaderExceptions;
+            if (exceptions.Length == 0)
             {
                 return baseValue;
             }
@@ -63,10 +62,10 @@ namespace System.Reflection
             {
                 if (e != null)
                 {
-                    text.AppendLine();
-                    text.Append(isMessage ? e.Message : e.ToString());
+                    text.AppendLine().Append(isMessage ? e.Message : e.ToString());
                 }
             }
+
             return text.ToString();
         }
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6292,11 +6292,11 @@ namespace System.Reflection
     }
     public sealed partial class ReflectionTypeLoadException : System.SystemException, System.Runtime.Serialization.ISerializable
     {
-        public ReflectionTypeLoadException(System.Type[]? classes, System.Exception?[]? exceptions) { }
-        public ReflectionTypeLoadException(System.Type[]? classes, System.Exception?[]? exceptions, string? message) { }
-        public System.Exception?[]? LoaderExceptions { get { throw null; } }
+        public ReflectionTypeLoadException(System.Type?[]? classes, System.Exception?[]? exceptions) { }
+        public ReflectionTypeLoadException(System.Type?[]? classes, System.Exception?[]? exceptions, string? message) { }
+        public System.Exception?[] LoaderExceptions { get { throw null; } }
         public override string Message { get { throw null; } }
-        public System.Type[]? Types { get { throw null; } }
+        public System.Type?[] Types { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }

--- a/src/libraries/System.Runtime/tests/System/Reflection/ReflectionTypeLoadExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ReflectionTypeLoadExceptionTests.cs
@@ -28,8 +28,8 @@ namespace System.Reflection.Tests
             ReflectionTypeLoadException rtle = new ReflectionTypeLoadException(null, null, "Null arguments");
             Assert.NotNull(rtle.ToString());
             Assert.NotNull(rtle.Message);
-            Assert.Null(rtle.LoaderExceptions);
-            Assert.Null(rtle.Types);
+            Assert.Empty(rtle.LoaderExceptions);
+            Assert.Empty(rtle.Types);
         }
     }
 }


### PR DESCRIPTION
Replaces the approved https://github.com/dotnet/runtime/pull/147, which was created from an old fork.
Fixes dotnet/corefx#42595