### PR TITLE
Fix various SuperPMI dumping problems

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -756,7 +756,7 @@ void MethodContext::recGetClassAttribs(CORINFO_CLASS_HANDLE classHandle, DWORD a
 }
 void MethodContext::dmpGetClassAttribs(DWORDLONG key, DWORD value)
 {
-    printf("GetClassAttribs key %016llX, value %u", key, value);
+    printf("GetClassAttribs key %016llX, value %08X (%s)", key, value, SpmiDumpHelper::DumpCorInfoFlag((CorInfoFlag)value).c_str());
 }
 DWORD MethodContext::repGetClassAttribs(CORINFO_CLASS_HANDLE classHandle)
 {
@@ -780,7 +780,7 @@ void MethodContext::recGetMethodAttribs(CORINFO_METHOD_HANDLE methodHandle, DWOR
 }
 void MethodContext::dmpGetMethodAttribs(DWORDLONG key, DWORD value)
 {
-    printf("GetMethodAttribs key %016llX, value %u", key, value);
+    printf("GetMethodAttribs key %016llX, value %08X (%s)", key, value, SpmiDumpHelper::DumpCorInfoFlag((CorInfoFlag)value).c_str());
 }
 DWORD MethodContext::repGetMethodAttribs(CORINFO_METHOD_HANDLE methodHandle)
 {
@@ -1041,11 +1041,11 @@ void MethodContext::recGetMethodNameFromMetadata(CORINFO_METHOD_HANDLE ftn,
 
 void MethodContext::dmpGetMethodNameFromMetadata(Agnostic_CORINFO_METHODNAME_TOKENin key, Agnostic_CORINFO_METHODNAME_TOKENout value)
 {
-    unsigned char* methodName    = (unsigned char*)GetMethodName->GetBuffer(value.methodName);
-    unsigned char* className     = (unsigned char*)GetMethodName->GetBuffer(value.className);
-    unsigned char* namespaceName = (unsigned char*)GetMethodName->GetBuffer(value.namespaceName);
-    unsigned char* enclosingClassName = (unsigned char*)GetMethodName->GetBuffer(value.enclosingClassName);
-    printf("GetMethodNameFromMetadata key - ftn-%016llX classNonNull-%u namespaceNonNull-%u nclosingClassNonNull-%u, value meth-'%s', "
+    unsigned char* methodName    = (unsigned char*)GetMethodNameFromMetadata->GetBuffer(value.methodName);
+    unsigned char* className     = (unsigned char*)GetMethodNameFromMetadata->GetBuffer(value.className);
+    unsigned char* namespaceName = (unsigned char*)GetMethodNameFromMetadata->GetBuffer(value.namespaceName);
+    unsigned char* enclosingClassName = (unsigned char*)GetMethodNameFromMetadata->GetBuffer(value.enclosingClassName);
+    printf("GetMethodNameFromMetadata key - ftn-%016llX classNonNull-%u namespaceNonNull-%u enclosingClassNonNull-%u, value meth-'%s', "
            "class-'%s', namespace-'%s' enclosingClass-'%s'",
            key.ftn, key.className, key.namespaceName, key.enclosingClassName, methodName, className, namespaceName, enclosingClassName);
     GetMethodNameFromMetadata->Unlock();
@@ -1384,7 +1384,7 @@ void MethodContext::dmpGetCallInfo(const Agnostic_GetCallInfo& key, const Agnost
            " ipl{at-%08X hnd-%016llX}"
            " sdi-%08X"
            " excp-%08X"
-           "stubLookup%s",
+           " stubLookup{%s}",
            value.hMethod, value.methodFlags, value.classFlags,
            SpmiDumpHelper::DumpAgnostic_CORINFO_SIG_INFO(value.sig).c_str(),
            SpmiDumpHelper::DumpAgnostic_CORINFO_SIG_INFO(value.verSig).c_str(), value.instParamLookup.accessType,

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -50,7 +50,7 @@ std::string SpmiDumpHelper::DumpAgnostic_CORINFO_CONST_LOOKUP(
     const MethodContext::Agnostic_CORINFO_CONST_LOOKUP& constLookup)
 {
     char buffer[MAX_BUFFER_SIZE];
-    sprintf_s(buffer, MAX_BUFFER_SIZE, "at - %u handle/address-%016llX", constLookup.accessType, constLookup.handle);
+    sprintf_s(buffer, MAX_BUFFER_SIZE, "at-%u handle/address-%016llX", constLookup.accessType, constLookup.handle);
     return std::string(buffer);
 }
 
@@ -93,4 +93,62 @@ std::string SpmiDumpHelper::DumpAgnostic_CORINFO_SIG_INFO(const MethodContext::A
               sigInfo.sigInst_methInstCount, sigInfo.sigInst_methInst_Index, sigInfo.args, sigInfo.scope,
               sigInfo.token);
     return std::string(buffer);
+}
+
+std::string SpmiDumpHelper::DumpCorInfoFlag(CorInfoFlag flags)
+{
+    std::string s("");
+
+#define AddFlag(__name)\
+    if (flags & __name) { s += std::string(" ") + std::string(#__name); flags = (CorInfoFlag)((DWORD)flags & ~(DWORD)__name); }
+
+    AddFlag(CORINFO_FLG_PROTECTED);
+    AddFlag(CORINFO_FLG_STATIC);
+    AddFlag(CORINFO_FLG_FINAL);
+    AddFlag(CORINFO_FLG_SYNCH);
+    AddFlag(CORINFO_FLG_VIRTUAL);
+    AddFlag(CORINFO_FLG_NATIVE);
+    AddFlag(CORINFO_FLG_INTRINSIC_TYPE);
+    AddFlag(CORINFO_FLG_ABSTRACT);
+    AddFlag(CORINFO_FLG_EnC);
+    AddFlag(CORINFO_FLG_FORCEINLINE);
+    AddFlag(CORINFO_FLG_SHAREDINST);
+    AddFlag(CORINFO_FLG_DELEGATE_INVOKE);
+    AddFlag(CORINFO_FLG_PINVOKE);
+    AddFlag(CORINFO_FLG_SECURITYCHECK);
+    AddFlag(CORINFO_FLG_NOGCCHECK);
+    AddFlag(CORINFO_FLG_INTRINSIC);
+    AddFlag(CORINFO_FLG_CONSTRUCTOR);
+    AddFlag(CORINFO_FLG_AGGRESSIVE_OPT);
+    AddFlag(CORINFO_FLG_DISABLE_TIER0_FOR_LOOPS);
+    AddFlag(CORINFO_FLG_NOSECURITYWRAP);
+    AddFlag(CORINFO_FLG_DONT_INLINE);
+    AddFlag(CORINFO_FLG_DONT_INLINE_CALLER);
+    AddFlag(CORINFO_FLG_JIT_INTRINSIC);
+    AddFlag(CORINFO_FLG_VALUECLASS);
+    AddFlag(CORINFO_FLG_VAROBJSIZE);
+    AddFlag(CORINFO_FLG_ARRAY);
+    AddFlag(CORINFO_FLG_OVERLAPPING_FIELDS);
+    AddFlag(CORINFO_FLG_INTERFACE);
+    AddFlag(CORINFO_FLG_CONTEXTFUL);
+    AddFlag(CORINFO_FLG_CUSTOMLAYOUT);
+    AddFlag(CORINFO_FLG_CONTAINS_GC_PTR);
+    AddFlag(CORINFO_FLG_DELEGATE);
+    AddFlag(CORINFO_FLG_MARSHAL_BYREF);
+    AddFlag(CORINFO_FLG_CONTAINS_STACK_PTR);
+    AddFlag(CORINFO_FLG_VARIANCE);
+    AddFlag(CORINFO_FLG_BEFOREFIELDINIT);
+    AddFlag(CORINFO_FLG_GENERIC_TYPE_VARIABLE);
+    AddFlag(CORINFO_FLG_UNSAFE_VALUECLASS);
+
+#undef AddFlag
+
+    if (flags != 0)
+    {
+        char buffer[MAX_BUFFER_SIZE];
+        sprintf_s(buffer, MAX_BUFFER_SIZE, " Unknown flags-%08X", flags);
+        s += std::string(buffer);
+    }
+
+    return s;
 }

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
@@ -27,6 +27,7 @@ public:
         const MethodContext::Agnostic_CORINFO_RUNTIME_LOOKUP& lookup);
     static std::string DumpAgnostic_CORINFO_LOOKUP(const MethodContext::Agnostic_CORINFO_LOOKUP& lookup);
     static std::string DumpAgnostic_CORINFO_SIG_INFO(const MethodContext::Agnostic_CORINFO_SIG_INFO& sigInfo);
+    static std::string DumpCorInfoFlag(CorInfoFlag flags);
 
 private:
     static const int MAX_BUFFER_SIZE = 1000;


### PR DESCRIPTION
1. dmpGetMethodNameFromMetadata was dumping from the wrong map (likely a copy/paste error when it was written)
2. add textual dumping of DumpCorInfoFlag flags
