### PR TITLE
Optimizations on System.Linq.Enumerable.ToArray

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.SizeOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.SizeOpt.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Linq;
+
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Internal helper functions for working with enumerables.
+    /// </summary>
+    internal static partial class EnumerableHelpers
+    {
+        /// <summary>Converts an enumerable to an array.</summary>
+        /// <param name="source">The enumerable to convert.</param>
+        /// <returns>The resulting array.</returns>
+        internal static T[] ToArray<T>(IEnumerable<T> source)
+        {
+            Debug.Assert(source != null);
+
+            if (source is ICollection<T> collection)
+            {
+                int count = collection.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var result = new T[count];
+                collection.CopyTo(result, arrayIndex: 0);
+                return result;
+            }
+
+            var builder = new LargeArrayBuilder<T>(initialize: true);
+            builder.AddRange(source);
+            return builder.ToArray();
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.SpeedOpt.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Linq;
+
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Internal helper functions for working with enumerables.
+    /// </summary>
+    internal static partial class EnumerableHelpers
+    {
+        /// <summary>Converts an enumerable to an array.</summary>
+        /// <param name="source">The enumerable to convert.</param>
+        /// <returns>The resulting array.</returns>
+        internal static T[] ToArray<T>(IEnumerable<T> source) => ToArrayEnumerable<T>.Instance.ToArray(source);
+    }
+}

--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
@@ -86,30 +86,5 @@ namespace System.Collections.Generic
 
             Debug.Assert(arrayIndex == endIndex);
         }
-
-        /// <summary>Converts an enumerable to an array.</summary>
-        /// <param name="source">The enumerable to convert.</param>
-        /// <returns>The resulting array.</returns>
-        internal static T[] ToArray<T>(IEnumerable<T> source)
-        {
-            Debug.Assert(source != null);
-
-            if (source is ICollection<T> collection)
-            {
-                int count = collection.Count;
-                if (count == 0)
-                {
-                    return Array.Empty<T>();
-                }
-
-                var result = new T[count];
-                collection.CopyTo(result, arrayIndex: 0);
-                return result;
-            }
-
-            var builder = new LargeArrayBuilder<T>(initialize: true);
-            builder.AddRange(source);
-            return builder.ToArray();
-        }
     }
 }

--- a/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
@@ -1,0 +1,354 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace System.Collections.Generic
+{
+    internal abstract class ToArrayBase<T>
+    {
+        private const int maxArraySize = int.MaxValue;
+
+        private const int initialRecursiveDepth = 16;
+        private const int itemsPerRecursion = 4;
+
+        protected const int maxSizeForNoAllocations = initialRecursiveDepth * itemsPerRecursion;
+
+        protected T[] FinishViaAllocations(object source, ref int sourceIdx, Func<T, bool>? predicate, int count)
+        {
+            if (count == maxArraySize)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            T[] result;
+            int bufferSize = (int)Math.Min((uint)maxArraySize, (uint)count * 2) - count;
+            T[] buffer = new T[bufferSize];
+
+            var (index, moveNext) = PopulateBuffer(buffer, source, ref sourceIdx, predicate);
+
+            if (moveNext)
+            {
+                result = FinishViaAllocations(source, ref sourceIdx, predicate, count + index);
+            }
+            else
+            {
+                result = new T[count + index];
+            }
+
+            Array.Copy(buffer, 0, result, count, index);
+            return result;
+        }
+
+        protected abstract (int, bool) PopulateBuffer(T[] buffer, object source, ref int sourceIdx, Func<T, bool>? predicate);
+
+        protected static T[] Allocate(int count)
+        {
+            if (count == 0)
+                return Array.Empty<T>();
+
+            return new T[count];
+        }
+
+        protected static T[] AllocateAndAssign(int count, T item1)
+        {
+            T[] result = new T[count];
+            result[--count] = item1;
+            return result;
+        }
+
+        protected static T[] AllocateAndAssign(int count, T item1, T item2)
+        {
+            T[] result = new T[count];
+            result[--count] = item2;
+            result[--count] = item1;
+            return result;
+        }
+
+        protected static T[] AllocateAndAssign(int count, T item1, T item2, T item3)
+        {
+            T[] result = new T[count];
+            result[--count] = item3;
+            result[--count] = item2;
+            result[--count] = item1;
+            return result;
+        }
+    }
+
+    internal class ToArrayEnumerable<T> : ToArrayBase<T>
+    {
+        public static readonly ToArrayEnumerable<T> Instance = new ToArrayEnumerable<T>();
+
+        private ToArrayEnumerable() { }
+
+        public T[] ToArray(IEnumerable<T> source)
+        {
+            Debug.Assert(source != null);
+
+            if (source is ICollection<T> collection)
+            {
+                int count = collection.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var result = new T[count];
+                collection.CopyTo(result, arrayIndex: 0);
+                return result;
+            }
+
+            using IEnumerator<T> e = source.GetEnumerator();
+            return InitiallyTryWithNoAllocations(e, null, 0);
+        }
+
+        public T[] ToArray(IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            Debug.Assert(source != null);
+            using IEnumerator<T> e = source.GetEnumerator();
+            return InitiallyTryWithNoAllocations(e, predicate, 0);
+        }
+
+        protected T[] InitiallyTryWithNoAllocations(IEnumerator<T> e, Func<T, bool>? predicate, int count)
+        {
+            T[] result;
+            T item1, item2, item3, item4;
+
+            do
+            {
+                if (!e.MoveNext())
+                {
+                    return Allocate(count);
+                }
+                item1 = e.Current;
+            }
+            while (predicate != null && !predicate(item1));
+
+            ++count;
+
+            do
+            {
+                if (!e.MoveNext())
+                {
+                    return AllocateAndAssign(count, item1);
+                }
+                item2 = e.Current;
+            } while (predicate != null && !predicate(item2));
+
+            ++count;
+
+            do
+            {
+                if (!e.MoveNext())
+                {
+                    return AllocateAndAssign(count, item1, item2);
+                }
+                item3 = e.Current;
+            }
+            while (predicate != null && !predicate(item3));
+
+            ++count;
+
+            do
+            {
+                if (!e.MoveNext())
+                {
+                    return AllocateAndAssign(count, item1, item2, item3);
+                }
+                item4 = e.Current;
+            }
+            while (predicate != null && !predicate(item4));
+
+            ++count;
+
+            if (count >= maxSizeForNoAllocations)
+            {
+                if (e.MoveNext())
+                    result = FinishViaAllocations(e, ref count, predicate, count);
+                else
+                    result = Allocate(count);
+            }
+            else
+            {
+                result = InitiallyTryWithNoAllocations(e, predicate, count);
+            }
+
+            result[--count] = item4;
+            result[--count] = item3;
+            result[--count] = item2;
+            result[--count] = item1;
+
+            return result;
+        }
+
+        protected override (int, bool) PopulateBuffer(T[] buffer, object source, ref int sourceIdx, Func<T, bool>? predicate)
+        {
+            var enumerator = (IEnumerator<T>)source;
+            return predicate == null ? PopulateBuffer(buffer, enumerator) : PopulateBuffer(buffer, enumerator, predicate);
+        }
+
+        private static (int, bool) PopulateBuffer(T[] buffer, IEnumerator<T> e)
+        {
+            bool moveNext;
+            int index;
+
+            for (moveNext = true, index = 0; moveNext && index < buffer.Length; ++index)
+            {
+                buffer[index] = e.Current;
+                moveNext = e.MoveNext();
+            }
+
+            return (index, moveNext);
+        }
+
+        private static (int, bool) PopulateBuffer(T[] buffer, IEnumerator<T> e, Func<T, bool> predicate)
+        {
+            bool moveNext;
+            int index;
+
+            for (moveNext = true, index = 0; moveNext;)
+            {
+                var item = e.Current;
+                if (predicate(item))
+                {
+                    buffer[index++] = e.Current;
+                    if (index >= buffer.Length)
+                    {
+                        moveNext = e.MoveNext();
+                        break;
+                    }
+                }
+                moveNext = e.MoveNext();
+            }
+
+            return (index, moveNext);
+        }
+    }
+
+    internal class ToArrayArray<T> : ToArrayBase<T>
+    {
+        public static readonly ToArrayArray<T> Instance = new ToArrayArray<T>();
+
+        private ToArrayArray() { }
+
+        public T[] ToArray(T[] source, Func<T, bool> predicate)
+        {
+            Debug.Assert(source != null);
+
+            return InitiallyTryWithNoAllocations(source, 0, predicate, 0);
+        }
+
+        protected T[] InitiallyTryWithNoAllocations(T[] array, int arrayIdx, Func<T, bool> predicate, int count)
+        {
+            T[] result;
+            T item1, item2, item3, item4;
+
+            do
+            {
+                if (arrayIdx >= array.Length)
+                {
+                    return Allocate(count);
+                }
+
+                item1 = array[arrayIdx++];
+            } while (!predicate(item1));
+
+            ++count;
+
+            do
+            {
+                if (arrayIdx >= array.Length)
+                {
+                    return AllocateAndAssign(count, item1);
+                }
+                item2 = array[arrayIdx++];
+            }
+            while (!predicate(item2));
+
+            ++count;
+
+            do
+            {
+                if (arrayIdx >= array.Length)
+                {
+                    return AllocateAndAssign(count, item1, item2);
+                }
+                item3 = array[arrayIdx++];
+            }
+            while (!predicate(item3));
+
+            ++count;
+
+            do
+            {
+                if (arrayIdx >= array.Length)
+                {
+                    return AllocateAndAssign(count, item1, item2, item3);
+                }
+                item4 = array[arrayIdx++];
+            }
+            while (!predicate(item4));
+
+            ++count;
+
+            if (count >= maxSizeForNoAllocations)
+            {
+                if (arrayIdx < array.Length)
+                {
+                    result = FinishViaAllocations(array, ref arrayIdx, predicate, count);
+                }
+                else
+                {
+                    result = Allocate(count);
+                }
+            }
+            else
+            {
+                result = InitiallyTryWithNoAllocations(array, arrayIdx, predicate, count);
+            }
+
+            result[--count] = item4;
+            result[--count] = item3;
+            result[--count] = item2;
+            result[--count] = item1;
+
+            return result;
+        }
+
+        protected override (int, bool) PopulateBuffer(T[] buffer, object source, ref int sourceIdx, Func<T, bool>? predicate)
+        {
+            Debug.Assert(predicate != null);
+
+            T[] array = (T[])source;
+
+            var bufferIdx = PopulateBuffer(buffer, array, ref sourceIdx, predicate);
+
+            return (bufferIdx, sourceIdx < array.Length);
+        }
+
+        private int PopulateBuffer(T[] buffer, T[] source, ref int sourceIdx, Func<T, bool> predicate)
+        {
+            int bufferIdx;
+            int arrayIdx;
+
+            for (arrayIdx = sourceIdx, bufferIdx = 0; arrayIdx < source.Length; ++arrayIdx)
+            {
+                if (predicate(source[arrayIdx]))
+                {
+                    buffer[bufferIdx++] = source[arrayIdx];
+
+                    if (bufferIdx >= buffer.Length)
+                    {
+                        ++arrayIdx;
+                        break;
+                    }
+                }
+            }
+
+            sourceIdx = arrayIdx;
+            return bufferIdx;
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
@@ -321,12 +321,7 @@ namespace System.Collections.Generic
                 result = InitiallyTryWithNoAllocations(source, sourceIdx, predicate, count);
             }
 
-            result[--count] = items.Item4;
-            result[--count] = items.Item3;
-            result[--count] = items.Item2;
-            result[--count] = items.Item1;
-
-            return result;
+            return Assign(result, ref items, count);
         }
 
         protected override (int, bool) PopulateBuffer(T[] buffer, object source, ref int sourceIdx, Func<T, bool>? predicate)
@@ -340,7 +335,7 @@ namespace System.Collections.Generic
             return (bufferIdx, sourceIdx < array.Length);
         }
 
-        private int PopulateBuffer(T[] buffer, T[] source, ref int sourceIdx, Func<T, bool> predicate)
+        private static int PopulateBuffer(T[] buffer, T[] source, ref int sourceIdx, Func<T, bool> predicate)
         {
             int bufferIdx;
             int arrayIdx;
@@ -442,12 +437,7 @@ namespace System.Collections.Generic
                 result = InitiallyTryWithNoAllocations(source, sourceIdx, predicate, count);
             }
 
-            result[--count] = items.Item4;
-            result[--count] = items.Item3;
-            result[--count] = items.Item2;
-            result[--count] = items.Item1;
-
-            return result;
+            return Assign(result, ref items, count);
         }
 
         protected override (int, bool) PopulateBuffer(T[] buffer, object source, ref int sourceIdx, Func<T, bool>? predicate)
@@ -461,7 +451,7 @@ namespace System.Collections.Generic
             return (bufferIdx, sourceIdx < array.Count);
         }
 
-        private int PopulateBuffer(T[] buffer, List<T> source, ref int sourceIdx, Func<T, bool> predicate)
+        private static int PopulateBuffer(T[] buffer, List<T> source, ref int sourceIdx, Func<T, bool> predicate)
         {
             int bufferIdx;
             int arrayIdx;

--- a/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
@@ -208,19 +208,14 @@ namespace System.Collections.Generic
             bool moveNext;
             int index;
 
-            for (moveNext = true, index = 0; moveNext;)
+            for (moveNext = true, index = 0; moveNext && index < buffer.Length; moveNext = e.MoveNext())
             {
                 var item = e.Current;
-                if (predicate(item))
-                {
-                    buffer[index++] = e.Current;
-                    if (index >= buffer.Length)
-                    {
-                        moveNext = e.MoveNext();
-                        break;
-                    }
-                }
-                moveNext = e.MoveNext();
+
+                if (!predicate(item))
+                    continue;
+
+                buffer[index++] = e.Current;
             }
 
             return (index, moveNext);

--- a/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ToArray.SpeedOpt.cs
@@ -36,7 +36,7 @@ namespace System.Collections.Generic
                     ? maxOtherElementsArraySize
                     : maxByteElementsArraySize;
 
-            return (int)Math.Min((uint)maxSize, (uint)count * 2) - count; ;
+            return (int)Math.Min((uint)maxSize, (uint)count * 2) - count;
         }
 
         protected T[] FinishViaAllocations(object source, int sourceSize, ref int sourceIdx, Func<T, bool>? predicate, int count)

--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -32,6 +32,12 @@
     <Compile Include="$(CommonPath)System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs">
       <Link>System\Collections\Generic\LargeArrayBuilder.SpeedOpt.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)System\Collections\Generic\EnumerableHelpers.Linq.SpeedOpt.cs">
+      <Link>System\Collections\Generic\EnumerableHelpers.Linq.SpeedOpt.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Collections\Generic\ToArray.SpeedOpt.cs">
+      <Link>System\Collections\Generic\ToArray.SpeedOpt.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -21,17 +21,7 @@ namespace System.Linq
 
         private sealed partial class SelectEnumerableIterator<TSource, TResult> : IIListProvider<TResult>
         {
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
-
-                foreach (TSource item in _source)
-                {
-                    builder.Add(_selector(item));
-                }
-
-                return builder.ToArray();
-            }
+            public TResult[] ToArray() => ToArrayEnumerableWithSelect<TSource, TResult>.Instance.ToArray(_source, _selector);
 
             public List<TResult> ToList()
             {
@@ -597,12 +587,7 @@ namespace System.Linq
             {
                 Debug.Assert(_source.GetCount(onlyIfCheap: true) == -1);
 
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
-                foreach (TSource input in _source)
-                {
-                    builder.Add(_selector(input));
-                }
-                return builder.ToArray();
+                return ToArrayEnumerableWithSelect<TSource, TResult>.Instance.ToArray(_source, _selector);
             }
 
             private TResult[] PreallocatingToArray(int count)

--- a/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
@@ -76,7 +76,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TSource[] ToArray() => ToArrayArray<TSource>.Instance.ToArray(_source, _predicate);
+            public TSource[] ToArray() => ToArrayArrayWhere<TSource>.Instance.ToArray(_source, _predicate);
 
             public List<TSource> ToList()
             {
@@ -120,7 +120,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TSource[] ToArray() => ToArrayList<TSource>.Instance.ToArray(_source, _predicate);
+            public TSource[] ToArray() => ToArrayListWhere<TSource>.Instance.ToArray(_source, _predicate);
 
             public List<TSource> ToList()
             {
@@ -168,20 +168,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(_source.Length);
-
-                foreach (TSource item in _source)
-                {
-                    if (_predicate(item))
-                    {
-                        builder.Add(_selector(item));
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TResult[] ToArray() => ToArrayArrayWhereSelect<TSource, TResult>.Instance.ToArray(_source, _predicate, _selector);
 
             public List<TResult> ToList()
             {
@@ -229,21 +216,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(_source.Count);
-
-                for (int i = 0; i < _source.Count; i++)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(_selector(item));
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TResult[] ToArray() => ToArrayListWhereSelect<TSource, TResult>.Instance.ToArray(_source, _predicate, _selector);
 
             public List<TResult> ToList()
             {
@@ -291,20 +264,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(initialize: true);
-
-                foreach (TSource item in _source)
-                {
-                    if (_predicate(item))
-                    {
-                        builder.Add(_selector(item));
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TResult[] ToArray() => ToArrayEnumerableWithSelect<TSource, TResult>.Instance.ToArray(_source, _predicate, _selector);
 
             public List<TResult> ToList()
             {

--- a/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
@@ -33,20 +33,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TSource[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TSource>(initialize: true);
-
-                foreach (TSource item in _source)
-                {
-                    if (_predicate(item))
-                    {
-                        builder.Add(item);
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TSource[] ToArray() => ToArrayEnumerable<TSource>.Instance.ToArray(_source, _predicate);
 
             public List<TSource> ToList()
             {
@@ -89,20 +76,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TSource[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TSource>(_source.Length);
-
-                foreach (TSource item in _source)
-                {
-                    if (_predicate(item))
-                    {
-                        builder.Add(item);
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TSource[] ToArray() => ToArrayArray<TSource>.Instance.ToArray(_source, _predicate);
 
             public List<TSource> ToList()
             {

--- a/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.SpeedOpt.cs
@@ -120,21 +120,7 @@ namespace System.Linq
                 return count;
             }
 
-            public TSource[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TSource>(_source.Count);
-
-                for (int i = 0; i < _source.Count; i++)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(item);
-                    }
-                }
-
-                return builder.ToArray();
-            }
+            public TSource[] ToArray() => ToArrayList<TSource>.Instance.ToArray(_source, _predicate);
 
             public List<TSource> ToList()
             {


### PR DESCRIPTION
3rd of n optimizations lifted from my exploration of an alternative `System.Linq` implementation [`Cistern.Linq`](https://github.com/manofstick/Cistern.Linq). There are lots more goodies there, but only so many that will survive the transfer to `System.Linq`!

([_Previous corefx optimization_](https://github.com/dotnet/runtime/pull/336))

This is a bit more controversial, which although I think it is reasonable, may get kicked to the curb depending on you POV. So why do I think this is is controversial? Well it uses a [Clayton's](https://en.wikipedia.org/wiki/Claytons) `stackalloc` (i.e. recursion) to store the first 64 elements (sounded like a reasonable number, but obviously up for discussion) to avoid temporary allocation buffers (can't use a "real" `stackalloc` due to not meeting the generic type constraints).

It then finishes off the process using recursion too. What this means is that you have got some deeper stack accesses than previously, but _I feel_ that they are not unreasonable. So how much stack are we using?

So the maximum function depth is 16 + 25 = 41

max array size ~ 2^31

approx stack usage = 16*(4*sizeof(T)+sizeof(T[])+sizeof(IEnumerable<>)+sizeof(int)+sizeof(Func<>)+sizeof(int)+sizeof(this)+function overhead) +  (log2(2^31/64))*(sizeof(object)+sizeof(ref int)+sizeof(Func<>)+sizeof(count)+function overhead).

which, for a sizeof(T) = 8 is ~ 2K

Anyway, so if that is unreasonable, then you can stop here and kill this PR. Otherwise, read on...

So I added some ToArray performance tests, but haven't pushed them to the Performance repository (as they are a bit excessive for what they are doing there), but you can [view them here](https://github.com/manofstick/performance/blob/9e568cc245d13416a044995013640ed4d393db9a/src/benchmarks/micro/corefx/System.Linq/Perf.ToArray.cs).

The tests are modifying 3 axes... Length, the type of predicate used in `Where` and the source type (i.e. a generator function, an array or a list). What you are not seeing here is the smaller amount of allocation that are occuring due to avoiding temporary buffers for small arrays.

Anyway, I'll add some more details - some memory usage, etc. (and I realised that I haven't actually included the case of the Generator without a `Where`) if this is actually going to be considered to be pulled into `master`

(oh, and the plan would also be to extend this to WhereSelect as well, but TBD...)

 Slower                                                                        | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ----------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: FirstHalf, Enum: Array)     |      1.15 |            15.34 |            17.64 | several?|
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: FirstHalf, Enum: Array) |      1.08 |         32662.74 |         35416.31 |         |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: Interleaved, Enum: Array)   |      1.05 |            16.57 |            17.32 |         |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: False, Enum: Array)       |      1.04 |          1376.24 |          1429.36 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality  |
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| ---------- |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: True, Enum: Array)            |      2.33 |           182.54 |            78.49 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: True, Enum: List)             |      2.29 |           182.99 |            79.78 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: True, Enum: List)             |      2.29 |           282.44 |           123.43 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: FirstHalf, Enum: List)         |      2.27 |           101.11 |            44.63 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: FirstHalf, Enum: Array)       |      2.18 |           158.58 |            72.82 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: Interleaved, Enum: List)       |      2.18 |           103.74 |            47.68 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: FirstHalf, Enum: List)         |      2.16 |           104.79 |            48.56 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: True, Enum: Array)            |      2.15 |           265.49 |           123.35 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: FirstHalf, Enum: Array)        |      2.14 |            98.21 |            45.87 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: Interleaved, Enum: List)       |      2.12 |           106.41 |            50.29 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: FirstHalf, Enum: List)        |      2.08 |           154.72 |            74.26 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: True, Enum: Array)             |      2.06 |           114.62 |            55.68 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: Interleaved, Enum: Array)      |      2.04 |           112.34 |            55.01 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: FirstHalf, Enum: Array)        |      2.02 |           103.16 |            51.06 | several?  |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: Interleaved, Enum: List)      |      2.02 |           161.18 |            79.86 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: FirstHalf, Enum: List)         |      2.02 |           115.88 |            57.49 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: Interleaved, Enum: Array)      |      2.01 |           101.01 |            50.32 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: True, Enum: List)              |      1.99 |           118.19 |            59.34 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: Interleaved, Enum: List)       |      1.96 |           114.94 |            58.51 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: Interleaved, Enum: Array)      |      1.96 |           104.32 |            53.35 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: FirstHalf, Enum: Array)        |      1.95 |           112.09 |            57.41 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: True, Enum: Array)             |      1.94 |            79.82 |            41.24 | several?  |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: Interleaved, Enum: Generator)  |      1.91 |           130.29 |            68.07 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: True, Enum: List)             |      1.90 |           425.07 |           224.20 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: True, Enum: Generator)         |      1.84 |           121.67 |            66.02 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: True, Enum: Array)             |      1.83 |            76.45 |            41.66 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: Interleaved, Enum: List)      |      1.82 |           238.43 |           131.28 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: Interleaved, Enum: Array)     |      1.81 |           149.81 |            82.90 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: FirstHalf, Enum: List)        |      1.80 |           370.30 |           205.91 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: Interleaved, Enum: Generator)  |      1.79 |           145.91 |            81.32 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: True, Enum: List)              |      1.79 |            76.82 |            42.82 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: FirstHalf, Enum: Array)       |      1.79 |           225.20 |           125.55 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: Interleaved, Enum: List)       |      1.79 |            77.34 |            43.17 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: True, Enum: List)              |      1.79 |            81.51 |            45.59 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: True, Enum: Array)             |      1.78 |            83.51 |            46.84 | several?  |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: FirstHalf, Enum: Array)       |      1.78 |           344.55 |           193.87 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: True, Enum: Generator)         |      1.77 |           188.60 |           106.76 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: True, Enum: List)              |      1.76 |            85.55 |            48.71 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: Interleaved, Enum: Array)     |      1.75 |           217.37 |           124.39 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: True, Enum: Generator)         |      1.75 |           133.35 |            76.33 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: Interleaved, Enum: Generator)  |      1.75 |           128.81 |            73.80 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: FirstHalf, Enum: List)        |      1.74 |           221.55 |           127.22 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: Interleaved, Enum: List)      |      1.72 |           393.70 |           228.39 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: Interleaved, Enum: Array)      |      1.72 |            75.78 |            44.16 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: FirstHalf, Enum: Generator)    |      1.70 |           143.33 |            84.53 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: True, Enum: Array)            |      1.69 |           367.21 |           217.87 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: True, Enum: Generator)        |      1.68 |           462.87 |           275.08 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: True, Enum: Generator)         |      1.68 |           139.65 |            83.00 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: Interleaved, Enum: Array)     |      1.66 |           355.92 |           214.32 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: Interleaved, Enum: List)     |      1.64 |           643.61 |           393.09 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: FirstHalf, Enum: Generator)    |      1.62 |           130.37 |            80.43 | bimodal   |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: FirstHalf, Enum: Array)      |      1.59 |           549.81 |           346.58 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: FirstHalf, Enum: Generator)    |      1.58 |           164.40 |           104.17 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: True, Enum: List)            |      1.57 |           694.40 |           442.13 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: Interleaved, Enum: Generator) |      1.56 |           246.04 |           157.64 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: False, Enum: Array)            |      1.55 |            57.20 |            36.89 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: False, Enum: Array)            |      1.54 |            59.82 |            38.74 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: Interleaved, Enum: Generator) |      1.54 |           734.28 |           477.95 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: Interleaved, Enum: Generator)  |      1.53 |           166.31 |           108.52 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: Interleaved, Enum: Generator) |      1.53 |           405.54 |           264.73 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: FirstHalf, Enum: List)       |      1.53 |           576.73 |           376.60 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: Interleaved, Enum: Array)    |      1.53 |           567.35 |           371.47 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: True, Enum: Generator)        |      1.52 |           757.28 |           496.94 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: True, Enum: Generator)        |      1.52 |           265.65 |           175.29 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: True, Enum: List)              |      1.51 |            51.22 |            33.88 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: False, Enum: List)             |      1.51 |            51.06 |            33.87 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: Interleaved, Enum: List)       |      1.50 |            51.32 |            34.11 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: True, Enum: Array)           |      1.49 |           622.51 |           417.38 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: False, Enum: List)             |      1.49 |            65.20 |            43.74 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: FirstHalf, Enum: Generator)   |      1.49 |           235.21 |           157.86 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: False, Enum: Generator)        |      1.49 |            80.73 |            54.25 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: FirstHalf, Enum: Generator)    |      1.48 |            77.13 |            52.17 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: FirstHalf, Enum: Array)        |      1.48 |            58.28 |            39.46 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: FirstHalf, Enum: List)         |      1.47 |            51.81 |            35.15 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: False, Enum: List)             |      1.45 |            58.91 |            40.73 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: FirstHalf, Enum: Generator)   |      1.40 |           668.98 |           477.35 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: Interleaved, Enum: Generator |      1.39 |          1249.75 |           897.68 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: True, Enum: Generator)         |      1.38 |            73.75 |            53.36 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: FirstHalf, Enum: Generator)    |      1.38 |            80.73 |            58.46 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: False, Enum: List)             |      1.38 |            52.82 |            38.32 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: FirstHalf, Enum: List)         |      1.36 |            54.37 |            40.03 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: True, Enum: List)            |      1.36 |          2421.67 |          1783.85 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: Interleaved, Enum: List)   |      1.36 |         45226.34 |         33325.68 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: False, Enum: Array)            |      1.35 |            66.03 |            48.81 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: FirstHalf, Enum: Generator)   |      1.35 |           372.16 |           275.16 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: False, Enum: List)             |      1.35 |            71.74 |            53.25 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: Interleaved, Enum: List)     |      1.34 |          2370.59 |          1765.25 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1, Pred: False, Enum: Generator)        |      1.33 |            80.45 |            60.29 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: True, Enum: Generator)       |      1.33 |          1271.30 |           955.42 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: True, Enum: List)           |      1.32 |          4562.01 |          3455.84 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: False, Enum: List)            |      1.30 |            92.53 |            71.24 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: Interleaved, Enum: Generator)  |      1.30 |            77.81 |            60.04 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 2, Pred: False, Enum: Generator)        |      1.27 |            87.50 |            68.98 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: False, Enum: Generator)        |      1.25 |            95.61 |            76.75 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: False, Enum: List)            |      1.24 |           148.23 |           119.17 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 3, Pred: False, Enum: Array)            |      1.24 |            58.82 |            47.30 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: Interleaved, Enum: List)    |      1.24 |          4533.83 |          3666.57 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: True, Enum: Generator)       |      1.23 |          5217.96 |          4236.11 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: FirstHalf, Enum: List)       |      1.23 |          1965.41 |          1597.56 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: FirstHalf, Enum: Generator)  |      1.23 |          1090.96 |           890.22 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: FirstHalf, Enum: List)      |      1.23 |          3761.06 |          3069.51 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: True, Enum: List)          |      1.22 |         41794.84 |         34157.86 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: False, Enum: List)           |      1.21 |           416.73 |           344.04 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: False, Enum: List)            |      1.21 |           241.05 |           199.08 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: True, Enum: Generator)      |      1.20 |         10135.89 |          8451.64 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 6, Pred: False, Enum: Generator)        |      1.20 |           120.48 |           100.47 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: True, Enum: Array)           |      1.20 |          1956.78 |          1636.89 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: FirstHalf, Enum: List)     |      1.18 |         35312.14 |         29887.81 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: True, Enum: Generator)     |      1.18 |         97575.66 |         83007.15 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: False, Enum: Generator)       |      1.18 |           179.29 |           152.55 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: True, Enum: Array)             |      1.17 |            16.59 |            14.13 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 12, Pred: False, Enum: Array)           |      1.17 |            80.09 |            68.46 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: Interleaved, Enum: Generator |      1.17 |          5185.25 |          4449.25 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: False, Enum: List)          |      1.16 |          3619.78 |          3123.49 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: False, Enum: List)           |      1.16 |          1833.52 |          1585.03 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 0, Pred: False, Enum: Array)            |      1.15 |            19.89 |            17.23 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: False, Enum: Generator)       |      1.14 |           286.57 |           251.01 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: True, Enum: Array)          |      1.13 |          3616.96 |          3209.43 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 25, Pred: False, Enum: Array)           |      1.12 |           127.86 |           113.83 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: False, Enum: List)         |      1.11 |         34534.83 |         30994.17 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 51, Pred: False, Enum: Generator)       |      1.11 |           504.09 |           452.85 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: Interleaved, Enum: Array)  |      1.09 |         37439.77 |         34274.85 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 100, Pred: False, Enum: Generator)      |      1.09 |           902.58 |           828.94 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: Interleaved, Enum: Generato |      1.08 |         10062.68 |          9281.56 | multimodal|
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: Interleaved, Enum: Generat |      1.08 |         93561.71 |         86407.35 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: FirstHalf, Enum: Array)      |      1.07 |          1831.45 |          1707.05 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: False, Enum: Generator)      |      1.07 |          4190.69 |          3919.56 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 10000, Pred: False, Enum: Generator)    |      1.07 |         81893.55 |         76627.60 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: False, Enum: Generator)     |      1.06 |          8239.05 |          7752.35 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 1000, Pred: Interleaved, Enum: Array)   |      1.05 |          3654.49 |          3472.22 |           |
| System.Linq.Tests.Perf_ToArray.Linq(Len: 500, Pred: FirstHalf, Enum: Generator)  |      1.03 |          4318.80 |          4174.29 |           |