### PR TITLE
Fix crossgen2 gc layout handling for TypedReference

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1394,7 +1394,7 @@ namespace Internal.JitInterface
         {
             int result = 0;
 
-            if (type.IsByReferenceOfT)
+            if (type.IsByReferenceOfT || type.IsWellKnownType(WellKnownType.TypedReference))
             {
                 *gcPtrs = (byte)CorInfoGCType.TYPE_GC_BYREF;
                 return 1;

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -41,8 +41,6 @@ namespace ReadyToRun.SuperIlc
             new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef", crossgen2Only: true),
             new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef", crossgen2Only: true),
-            
-            new FrameworkExclusion("System.Runtime.Serialization.Formatters", "Assert in JIT on Linux", crossgen2Only: true)
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;


### PR DESCRIPTION
The getClassGCLayout jit interface method was not handling TypedReference
explicitly like its runtime counterpart. That was causing the layout to
be incorrect for TypedReference and resulted in 100 failures (asserts)
in the coreclr pri1 tests build and one framework assembly build with
crossgen2.
The assert in JIT was in Linux specific code path, so we weren't hitting
it on Windows.
With this fix, the build and test run results match the Windows ones.