### PR TITLE
Fix Thread.GetCurrentProcessorId   for  > 64 CPUs on Windows.

### DIFF
--- a/src/coreclr/src/vm/comsynchronizable.cpp
+++ b/src/coreclr/src/vm/comsynchronizable.cpp
@@ -1450,6 +1450,12 @@ FCIMPL0(INT32, ThreadNative::GetCurrentProcessorNumber)
 {
     FCALL_CONTRACT;
 
+#ifndef FEATURE_PAL
+    PROCESSOR_NUMBER proc_no_cpu_group;
+    GetCurrentProcessorNumberEx(&proc_no_cpu_group);
+    return (proc_no_cpu_group.Group << 6) | proc_no_cpu_group.Number;
+#else
     return ::GetCurrentProcessorNumber();
+#endif //!FEATURE_PAL
 }
 FCIMPLEND;


### PR DESCRIPTION
`GetCurrentProcessorNumber` is capped to 64 on Windows and that results in unexpected sharing when having 64+ cores. In particular if the processor groups are in different NUMA nodes.
We need to use `GetCurrentProcessorNumberEx`.

`GCToOSInterface::GetCurrentProcessorNumber` has another implementation, which looks correct.  This is basically a short version of that.