### PR TITLE
Fix sqlstatistics and clientconnectionid

### DIFF
--- a/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -360,7 +360,9 @@ namespace System.Data.SqlClient
                 else
                 {
                     Task reconnectTask = _currentReconnectionTask;
-                    if (reconnectTask != null && !reconnectTask.IsCompleted)
+                    // Connection closed but previously open should return the correct ClientConnectionId
+                    DbConnectionClosedPreviouslyOpened innerConnectionClosed = (InnerConnection as DbConnectionClosedPreviouslyOpened);
+                    if ((reconnectTask != null && !reconnectTask.IsCompleted) || null != innerConnectionClosed)
                     {
                         return _originalConnectionId;
                     }
@@ -633,6 +635,7 @@ namespace System.Data.SqlClient
             // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and
             // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
             // outside of the scope of Whidbey RTM.  See (SqlCommand::Cancel) for other lock.
+            _originalConnectionId = ClientConnectionId;
             InnerConnection.CloseConnection(this, ConnectionFactory);
         }
 

--- a/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
+++ b/src/libraries/System.Data.SqlClient/src/System/Data/SqlClient/SqlStatistics.cs
@@ -212,9 +212,9 @@ namespace System.Data.SqlClient
         internal void UpdateStatistics()
         {
             // update connection time
-            if (_closeTimestamp >= _openTimestamp)
+            if (_closeTimestamp >= _openTimestamp && long.MaxValue > _closeTimestamp - _openTimestamp)
             {
-                SafeAdd(ref _connectionTime, _closeTimestamp - _openTimestamp);
+                _connectionTime = _closeTimestamp - _openTimestamp;
             }
             else
             {


### PR DESCRIPTION
Port fixes from [Microsoft.Data.SqlClient PR#341](https://github.com/dotnet/SqlClient/pull/341).

> Before the change, the ConnectionTime is reported as MaxValue/1000 because the _closeTimestamp was not set properly. Further, calling RetrieveStatistics multiple times causes the ConnectionTime to increase exponentially because the total connection time was SafeAdded to the previously saves _connectionTime. The _connectionTime should be overwritten instead.
> 
> When the connection is closed, the ClientConnectionId is set to empty and it's unavailable to the user. The new change allows the user to access the ClientConnectionId even after the connection is closed.