### PR TITLE
Unset RunCrossgen2 variable when CrossGenTest is set to false

### DIFF
--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -27,6 +27,8 @@ WARNING:   When setting properties based on their current state (for example:
     <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'true'" Include = "set RunCrossGen=1"/>
     <CLRTestBashEnvironmentVariable  Condition="'$(CrossGenTest)' == 'false'" Include = "unset RunCrossGen"/>
     <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'false'" Include = "set RunCrossGen="/>
+    <CLRTestBashEnvironmentVariable  Condition="'$(CrossGenTest)' == 'false'" Include = "unset RunCrossGen2"/>
+    <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'false'" Include = "set RunCrossGen2="/>
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Fixes mainv1 and mainv2 readytorun test failures in the crossgen2 azure run

@dotnet/crossgen-contrib 