### PR TITLE
Revert target framework version change to netcoreapp3.0 when building from VS

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -3,6 +3,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>ILCompiler.ReadyToRun</AssemblyName>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTargets Condition="'$(BuildArch)' != ''">$(BuildArch)</PlatformTargets>


### PR DESCRIPTION
Broken by https://github.com/dotnet/runtime/pull/445 (cc @ViktorHofer)

Using 3.0 for now enables us to build from VS, which is an important scenario for our team currently

@dotnet/crossgen-contrib 