### PR TITLE
Live-live CoreCLR CI.yml

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -76,6 +76,18 @@ jobs:
       testGroup: outerloop
 
 #
+# Release library builds
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    buildConfig: Release
+    platformGroup: all
+    jobParameters:
+      isOfficialBuild: false
+      liveCoreClrBuildConfig: checked
+
+#
 # Checked test builds
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -91,6 +103,8 @@ jobs:
     - Windows_NT_x64
     - Windows_NT_x86
     testGroup: outerloop
+    jobParameters:
+      liveLibrariesBuildConfig: Release
 
 #
 # Checked JIT test runs
@@ -104,6 +118,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
       testGroup: outerloop
+      liveLibrariesBuildConfig: Release
 
 #
 # Checked R2R test runs
@@ -128,6 +143,7 @@ jobs:
       testGroup: outerloop
       readyToRun: true
       displayNameArgs: R2R
+      liveLibrariesBuildConfig: Release
 
 #
 # Crossgen-comparison jobs


### PR DESCRIPTION
This change modifies the ci.yml pipeline under <code>eng/pipelines/coreclr</code>
to build live-live libraries and consume them during test build / execution.
I haven't yet addressed switching over the crossgen comparison job but
I think I already know how to do that, I'll send that out as a separate follow-up PR.

Thanks

Tomas