### PR TITLE
Exclude test from crossgenning

### DIFF
--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract02.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract02.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract02.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract03.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract03.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract03.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract04.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract04.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract04.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract05.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract05.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract05.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract06.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract06.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract06.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract07.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract07.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract07.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract08.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract08.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract08.il" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract10.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract10.ilproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="abstract10.il" />

--- a/src/coreclr/tests/src/Regressions/coreclr/16354/notimplemented.ilproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/16354/notimplemented.ilproj
@@ -3,6 +3,11 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+
+    <!-- Not useful for crossgen testing, especially with crossgen2, given how the TypeSystem doesn't have all the type checks that
+         exist in the runtime's type system. -->
+    <CrossGenTest>false</CrossGenTest>
+    
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="notimplemented.il" />

--- a/src/coreclr/tests/src/Regressions/coreclr/16354/notimplemented.ilproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/16354/notimplemented.ilproj
@@ -4,8 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
 
-    <!-- Not useful for crossgen testing, especially with crossgen2, given how the TypeSystem doesn't have all the type checks that
-         exist in the runtime's type system. -->
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
     <CrossGenTest>false</CrossGenTest>
     
   </PropertyGroup>


### PR DESCRIPTION
This test has a method that calls the ctor of a type that doesn't implement all interface methods, and expects an exception.

The runtime's TypeSystem used by crossgen1 will throw. At runtime, the exception is also thrown when we jit the code, and the test catches it and passes.

With the TypeSystem in crossgen2, we're not validating the type and emit codegen for the method. The problem is that the infrastructure currently compiles with optimizations, causing the code that should throw to be optimized away. No exception => test fails.

There's really no benefit we're getting when crossgenning this particular test, so i'm disabling crossgenning for it (we could alternatively fix the test in a way that would still throw, but it's not worth it).

@dotnet/crossgen-contrib 