### PR TITLE
Change `mcs -dump` to show the full function name for each MC

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -478,6 +478,15 @@ void MethodContext::dumpToConsole(int mcNumber)
     {
         printf(" method context #%d", mcNumber);
     }
+
+    // Dump method name, etc., to output.
+    char bufferIdentityInfo[METHOD_IDENTITY_INFO_SIZE];
+    int cbLen = dumpMethodIdentityInfoToBuffer(bufferIdentityInfo, METHOD_IDENTITY_INFO_SIZE);
+    if (cbLen >= 0)
+    {
+        printf(" %s", bufferIdentityInfo);
+    }
+
     printf("\n");
 
 #define LWM(map, key, value) dumpLWM(this, map)


### PR DESCRIPTION
With this, we see for each dumped MC what function that MC represents. E.g.:
```
***************************************** method context #1 System.SpanHelpers:IndexOf(byref,char,int):int -- CallingConvention: 0, CorInfoOptions: 0, CorInfoRegionKind: 3 ILCode Hash: 5C7C2C929F525B1CE5F74A8DA309A59C
```
