### PR TITLE
[WIP] Loading assembly references in parallel

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -145,11 +145,14 @@ namespace ILCompiler
 
         private EcmaModule GetOrAddModuleFromPath(string filePath, bool useForBinding)
         {
-            // This method is not expected to be called frequently. Linear search is acceptable.
-            foreach (var entry in ModuleHashtable.Enumerator.Get(_moduleHashtable))
+            lock (this)
             {
-                if (entry.FilePath == filePath)
-                    return entry.Module;
+                // This method is not expected to be called frequently. Linear search is acceptable.
+                foreach (var entry in ModuleHashtable.Enumerator.Get(_moduleHashtable))
+                {
+                    if (entry.FilePath == filePath)
+                        return entry.Module;
+                }
             }
 
             return AddModule(filePath, null, useForBinding);


### PR DESCRIPTION
While debugging multiple issues with crossgen2, i started noticing that the loading of references was slightly slow, especially that we reference *.dll from core_root and the test directory now.

On a cold run of crossgen2 to compile some random test and run it, it took 7292ms for just loading the references.

With the proposed changes, it takes only 900ms, so it's shaving off a good ~88% of the loading time on 8 cores. Multiply that by the number of P0/P1 tests, I believe this small win could be quite beneficial.

Thoughts?

@dotnet/crossgen-contrib 