### PR TITLE
Ignore full method name when doing `mcs -removeDup`

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
@@ -26,7 +26,7 @@ bool unique(MethodContext* mc)
     mc->repCompileMethod(&newInfo, &newFlags);
 
     char* md5Buff = new char[MD5_HASH_BUFFER_SIZE];
-    mc->dumpMethodMD5HashToBuffer(md5Buff, MD5_HASH_BUFFER_SIZE);
+    mc->dumpMethodMD5HashToBuffer(md5Buff, MD5_HASH_BUFFER_SIZE, /* ignoreMethodName */ true);
 
     if (inFile->GetIndex(newInfo.ILCodeSize) == -1)
         inFile->Add(newInfo.ILCodeSize, new DenseLightWeightMap<char*>());

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/callutils.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/callutils.cpp
@@ -258,12 +258,14 @@ const char* CallUtils::GetMethodName(MethodContext* mc, CORINFO_METHOD_HANDLE me
 }
 
 // Originally from src/jit/eeinterface.cpp
-const char* CallUtils::GetMethodFullName(MethodContext* mc, CORINFO_METHOD_HANDLE hnd, CORINFO_SIG_INFO sig)
+// If `ignoreMethodName` is `true`, we construct the function signature with a dummy method name that will be the
+// same for all methods.
+const char* CallUtils::GetMethodFullName(MethodContext* mc, CORINFO_METHOD_HANDLE hnd, CORINFO_SIG_INFO sig, bool ignoreMethodName /* = false */)
 {
     const char* returnType = NULL;
 
-    const char* className;
-    const char* methodName = GetMethodName(mc, hnd, &className);
+    const char* className = ignoreMethodName ? "CLASS" : nullptr;
+    const char* methodName = ignoreMethodName ? "METHOD" : GetMethodName(mc, hnd, &className);
     if ((GetHelperNum(hnd) != CORINFO_HELP_UNDEF) || IsNativeMethod(hnd))
     {
         return methodName;

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/callutils.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/callutils.h
@@ -34,7 +34,7 @@ public:
     static bool IsNativeMethod(CORINFO_METHOD_HANDLE method);
     static CORINFO_METHOD_HANDLE GetMethodHandleForNative(CORINFO_METHOD_HANDLE method);
     static const char* GetMethodName(MethodContext* mc, CORINFO_METHOD_HANDLE method, const char** classNamePtr);
-    static const char* GetMethodFullName(MethodContext* mc, CORINFO_METHOD_HANDLE hnd, CORINFO_SIG_INFO sig);
+    static const char* GetMethodFullName(MethodContext* mc, CORINFO_METHOD_HANDLE hnd, CORINFO_SIG_INFO sig, bool ignoreMethodName = false);
 };
 
 #endif

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -6346,7 +6346,7 @@ const WCHAR* MethodContext::repGetStringConfigValue(const WCHAR* name)
     return value;
 }
 
-int MethodContext::dumpMethodIdentityInfoToBuffer(char* buff, int len)
+int MethodContext::dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName /* = false */)
 {
     char* obuff = buff;
 
@@ -6360,7 +6360,7 @@ int MethodContext::dumpMethodIdentityInfoToBuffer(char* buff, int len)
     repCompileMethod(&info, &flags);
 
     // Add the Method Signature
-    int t = sprintf_s(buff, len, "%s -- ", CallUtils::GetMethodFullName(this, info.ftn, info.args));
+    int t = sprintf_s(buff, len, "%s -- ", CallUtils::GetMethodFullName(this, info.ftn, info.args, ignoreMethodName));
     buff += t;
     len -= t;
 
@@ -6379,11 +6379,11 @@ int MethodContext::dumpMethodIdentityInfoToBuffer(char* buff, int len)
 
     return (int)(buff - obuff);
 }
-int MethodContext::dumpMethodMD5HashToBuffer(char* buff, int len)
+int MethodContext::dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName /* = false */)
 {
     char bufferIdentityInfo[METHOD_IDENTITY_INFO_SIZE];
 
-    int cbLen = dumpMethodIdentityInfoToBuffer(bufferIdentityInfo, METHOD_IDENTITY_INFO_SIZE);
+    int cbLen = dumpMethodIdentityInfoToBuffer(bufferIdentityInfo, METHOD_IDENTITY_INFO_SIZE, ignoreMethodName);
 
     if (cbLen < 0)
         return cbLen;

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -584,8 +584,8 @@ public:
     static int dumpStatTitleToBuffer(char* buff, int len);
     int methodSize;
 
-    int dumpMethodIdentityInfoToBuffer(char* buff, int len);
-    int dumpMethodMD5HashToBuffer(char* buff, int len);
+    int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false);
+    int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false);
 
     void recGlobalContext(const MethodContext& other);
 


### PR DESCRIPTION
Thus, methods with different names but otherwise identical will
match and only one will be retained.