### PR TITLE
Fix coredistools lookup for users with spaces in usernames

### DIFF
--- a/src/coreclr/tests/setup-stress-dependencies.cmd
+++ b/src/coreclr/tests/setup-stress-dependencies.cmd
@@ -90,7 +90,7 @@ set /p __PkgDir=<"%CoreDisToolsPackagePathOutputFile%"
 
 REM Get downloaded dll path
 echo Locating coredistools.dll
-FOR /F "delims=" %%i IN ('dir %__PkgDir%\coredistools.dll /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
+FOR /F "delims=" %%i IN ('dir "%__PkgDir%\coredistools.dll" /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
 echo CoreDisTools library path: %__LibPath%
 if not exist "%__LibPath%" (
     echo Failed to locate the downloaded library: %__LibPath%


### PR DESCRIPTION
Locating the downloaded coredistools.dll fails for users that have
spaces in their names (their home directory has spaces in the path).

This change fixes the problem by adding quotes to the locating command.