### PR TITLE
Fix crossgen2 issue with generic delegates

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     enforceOwningType: false,
                     innerContext,
                     isUnboxingStub: false,
-                    isInstantiatingStub: false);
+                    isInstantiatingStub: _targetMethod.Method.HasInstantiation);
 
                 builder.EmitTypeSignature(_delegateType, innerContext);
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -102,7 +102,7 @@ namespace ILCompiler.DependencyAnalysis
                 IMethodNode targetMethodNode = _codegenNodeFactory.MethodEntrypoint(
                     ctorKey.Method,
                     isUnboxingStub: false,
-                    isInstantiatingStub: false,
+                    isInstantiatingStub: ctorKey.Method.Method.HasInstantiation,
                     isPrecodeImportRequired: false,
                     signatureContext: signatureContext);
 


### PR DESCRIPTION
The coreclr pri1 test is failing with the following error:
Expected typeof generic method Type Parameter for parameter, 'aaaa', to
be 'System.String', but found 'System.__Canon'

The issue was caused by the fact that we were not setting the
isInstantiatingStub for calls to generic delegates. The old crossgen
was doing that correctly.