### PR TITLE
Fix two subtle bugs in CoreCLR test build

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -582,7 +582,7 @@ REM ===
 REM =========================================================================================
 
 if NOT "%__LocalCoreFXPath%"=="" (
-    echo Patch CoreFX from %__LocalCoreFXPath% (%__LocalCoreFXConfig%)
+    echo Patch CoreFX from %__LocalCoreFXPath% ^(%__LocalCoreFXConfig%^)
     set NEXTCMD=python "%__ProjectDir%\tests\scripts\patch-corefx.py" -clr_core_root "%CORE_ROOT%"^
     -fx_root "%__LocalCoreFXPath%" -arch %__BuildArch% -build_type %__LocalCoreFXConfig%
     echo !NEXTCMD!

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -8,7 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <DisabledTestDir Include="bin" />
     <DisabledTestDir Include="Common" />
+    <DisabledTestDir Include="Tests" />
+    <DisabledTestDir Include="TestWrappers" />
     <_SkipTestDir Include="@(DisabledTestDir)" />
   </ItemGroup>
 


### PR DESCRIPTION
1) As Bruce reported, my recent live-live change regressed local
CoreCLR build in the sense that it always ended with a spurious
error message from the patch-corefx script. This was due to a typo
where I forgot to escape a parenthesis in an echo message that
the batch script parser ended up understanding as closing the
conditional block.

2) I added several folders to the exclusion list representing special
folders under "artifacts/tests/coreclr/os.arch.config" that should
be skipped when building the test wrappers.

Fixes: #578

Thanks

Tomas