### PR TITLE
Add new YAML template for combined build of CoreCLR and libraries

### DIFF
--- a/eng/pipelines/common/build-coreclr-and-libraries-job.yml
+++ b/eng/pipelines/common/build-coreclr-and-libraries-job.yml
@@ -1,0 +1,51 @@
+parameters:
+  buildConfig: ''
+  archType: ''
+  osGroup: ''
+  osSubgroup: ''
+  container: ''
+  testGroup: ''
+  crossrootfsDir: ''
+  timeoutInMinutes: ''
+  signBinaries: false
+  publishToBlobFeed: false
+  stagedBuild: false
+  variables: {}
+  pool: ''
+
+jobs:
+- template: /eng/pipelines/coreclr/templates/build-job.yml
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: ${{ parameters.archType }}
+    osGroup: ${{ parameters.osGroup }}
+    osSubgroup: ${{ parameters.osSubgroup }}
+    container: ${{ parameters.container }}
+    testGroup: ${{ parameters.testGroup }}
+    crossrootfsDir: ${{ parameters.crossrootfsDir }}
+    timeoutInminutes: ${{ parameters.timeoutInMinutes }}
+    signBinaries: ${{ parameters.signBinaries }}
+    publishToBlobFeed: ${{ parameters.publishToBlobFeed }}
+    stagedBuild: ${{ parameters.stagedBuild }}
+    variables: ${{ parameters.variables }}
+    pool: ${{ parameters.pool }}
+
+- template: /eng/pipelines/libraries/build-job.yml
+  parameters:
+    ${{ if eq(parameters.buildConfig, 'debug') }}:
+      buildConfig: Debug
+    ${{ if ne(parameters.buildConfig, 'debug') }}:
+      buildConfig: Release
+    archType: ${{ parameters.archType }}
+    osGroup: ${{ parameters.osGroup }}
+    osSubgroup: ${{ parameters.osSubgroup }}
+    container: ${{ parameters.container }}
+    testGroup: ${{ parameters.testGroup }}
+    crossrootfsDir: ${{ parameters.crossrootfsDir }}
+    timeoutInminutes: ${{ parameters.timeoutInMinutes }}
+    signBinaries: ${{ parameters.signBinaries }}
+    publishToBlobFeed: ${{ parameters.publishToBlobFeed }}
+    stagedBuild: ${{ parameters.stagedBuild }}
+    variables: ${{ parameters.variables }}
+    pool: ${{ parameters.pool }}
+    liveCoreClrBuildConfig: ${{ parameters.buildConfig }}

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -18,7 +18,7 @@ jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
     - Linux_x64
@@ -36,6 +36,7 @@ jobs:
     - Windows_NT_x64
     jobParameters:
       testGroup: innerloop
+      useLiveLibrariesBuildConfig: Release
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -51,3 +52,4 @@ jobs:
       readyToRun: true
       crossgen2: true
       displayNameArgs: R2R_CG2
+      useLiveLibrariesBuildConfig: Release


### PR DESCRIPTION
As a common idiom in many live-live CoreCLR pipelines, we need
libraries to build a platform matrix equivalent to the CoreCLR
testing matrix. I have created a new template to capture that idiom.
I have initially switched over the Crossgen2 pipeline to use it.

Thanks

Tomas