### PR TITLE
Initialize Delimiter from Attributes

### DIFF
--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Console" />
     <Reference Include="System.Collections.NonGeneric" />
+    <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.Diagnostics.TraceSource" />
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -14,6 +14,7 @@ namespace System.Diagnostics
     {
         private string _delimiter = ";";
         private string _secondaryDelim = ",";
+        private bool _initializedDelim = false;
 
         public DelimitedListTraceListener(Stream stream) : base(stream)
         {
@@ -43,6 +44,17 @@ namespace System.Diagnostics
         {
             get
             {
+                lock (this)
+                {
+                    if (!_initializedDelim)
+                    {
+                        if (Attributes.ContainsKey("delimiter"))
+                        {
+                            _delimiter = Attributes["delimiter"];
+                        }
+                        _initializedDelim = true;
+                    }
+                }
                 return _delimiter;
             }
             set
@@ -56,6 +68,7 @@ namespace System.Diagnostics
                 lock (this)
                 {
                     _delimiter = value;
+                    _initializedDelim = true;
                 }
 
                 if (_delimiter == ",")

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics
     {
         private string _delimiter = ";";
         private string _secondaryDelim = ",";
-        private bool _initializedDelim = false;
+        private bool _initializedDelim;
 
         public DelimitedListTraceListener(Stream stream) : base(stream)
         {

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 {
     internal static class CommonUtilities
     {
-        private const string DefaultDelimiter = ";";
+        internal const string DefaultDelimiter = ";";
 
         internal static void DeleteFile(string fileName)
         {

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
@@ -186,7 +186,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         [MemberData(nameof(TraceDataObjectArrayInvariants))]
         public void AttributeDelimiter_ChangesDelimiter_Test(string delimiter, TraceFilter filter, TraceEventCache eventCache, string source, TraceEventType eventType, int id, object[] data)
         {
-            var newDelimiter = "||";
+            string newDelimiter = "||";
             using (var target = GetListener())
             {
                 target.Filter = filter;
@@ -207,7 +207,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         [MemberData(nameof(TraceDataObjectArrayInvariants))]
         public void AttributeDelimiter_IgnoredAfterDelimiterSet_Test(string delimiter, TraceFilter filter, TraceEventCache eventCache, string source, TraceEventType eventType, int id, object[] data)
         {
-            var newDelimiter = "||";
+            string newDelimiter = "||";
             using (var target = GetListener())
             {
                 target.Filter = filter;
@@ -230,7 +230,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         [MemberData(nameof(TraceDataObjectArrayInvariants))]
         public void AttributeDelimiter_IgnoredAfterDelimiterRead_Test(string delimiter, TraceFilter filter, TraceEventCache eventCache, string source, TraceEventType eventType, int id, object[] data)
         {
-            var newDelimiter = "||";
+            string newDelimiter = "||";
             using (var target = GetListener())
             {
                 target.Filter = filter;


### PR DESCRIPTION
If a DelimitedListTraceListener has a Delimiter attribute, use it
to initialize the Delimiter unless (and until) a delimiter is set
explicitly.

Also add unit tests for these scenarios.

Fix https://github.com/dotnet/runtime/issues/30211