### PR TITLE
Added OS and Bit Specific tags to accordingly .csproj files.

### DIFF
--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
@@ -10,4 +10,7 @@
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -16,5 +16,8 @@
     <ProjectReference Include="../NetServer/NetServer.DefaultInterfaces.ilproj" />
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
@@ -16,5 +16,8 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
@@ -16,5 +16,8 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -16,5 +16,8 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -20,4 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
@@ -8,4 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
+++ b/src/coreclr/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
@@ -10,4 +10,7 @@
     <Compile Include="ICustomMarshaler.cs" />
     <Compile Include="..\..\common\XunitBase.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/NativeLibraryResolveCallback/CallbackStressTest.csproj
+++ b/src/coreclr/tests/src/Interop/NativeLibraryResolveCallback/CallbackStressTest.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Directed/arglist/vararg.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/arglist/vararg.csproj
@@ -17,4 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -23,4 +23,7 @@ export COMPlus_GcStressOnDirectCalls=1
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
@@ -13,4 +13,7 @@
     <Compile Include="VectorConvert.cs" />
     <Compile Include="VectorUtil.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
@@ -13,4 +13,7 @@
     <Compile Include="VectorConvert.cs" />
     <Compile Include="VectorUtil.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
+++ b/src/coreclr/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
As part of the test build infrastructure changes, tags determining OS-specific, Bitness-Specific, and other behaviors will be added to the necessary project files. This will be used in the future by an include/exclude mechanism for builds. By looking into preprocessor directives in the test files, this PR adds the first two tags mentioned before.