### PR TITLE
FileSecurity/DirectorySecurity should support long paths

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", SetLastError = true, ExactSpelling = true)]
         internal static extern /*DWORD*/ uint GetSecurityInfoByHandle(SafeHandle handle, /*DWORD*/ uint objectType, /*DWORD*/ uint securityInformation,
             out IntPtr sidOwner, out IntPtr sidGroup, out IntPtr dacl, out IntPtr sacl, out IntPtr securityDescriptor);
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
@@ -9,8 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         internal static extern /*DWORD*/ uint GetSecurityInfoByHandle(SafeHandle handle, /*DWORD*/ uint objectType, /*DWORD*/ uint securityInformation,
             out IntPtr sidOwner, out IntPtr sidGroup, out IntPtr dacl, out IntPtr sacl, out IntPtr securityDescriptor);
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
@@ -9,8 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         internal static extern /*DWORD*/ uint GetSecurityInfoByName(string name, /*DWORD*/ uint objectType, /*DWORD*/ uint securityInformation,
             out IntPtr sidOwner, out IntPtr sidGroup, out IntPtr dacl, out IntPtr sacl, out IntPtr securityDescriptor);
     }

--- a/src/libraries/Common/tests/System/IO/TempDirectory.cs
+++ b/src/libraries/Common/tests/System/IO/TempDirectory.cs
@@ -56,19 +56,7 @@ namespace System.IO
         public static string GetMaxLengthRandomName()
         {
             string guid = Guid.NewGuid().ToString("N");
-            StringBuilder sb = new StringBuilder(MaxNameLength, MaxNameLength);
-            while (sb.Length < MaxNameLength)
-            {
-                try
-                {
-                    sb.Append(guid);
-                }
-                catch
-                {
-                    sb.Append(guid.Substring(0, MaxNameLength - sb.Length));
-                }
-            }
-            return sb.ToString();
+            return guid + new string('x', 255 - guid.Length);
         }
     }
 }

--- a/src/libraries/Common/tests/System/IO/TempDirectory.cs
+++ b/src/libraries/Common/tests/System/IO/TempDirectory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text;
+
 namespace System.IO
 {
     /// <summary>
@@ -10,6 +12,8 @@ namespace System.IO
     /// </summary>
     public sealed class TempDirectory : IDisposable
     {
+        public const int MaxNameLength = 255;
+
         /// <summary>Gets the created directory's path.</summary>
         public string Path { get; private set; }
 
@@ -41,6 +45,30 @@ namespace System.IO
         {
             try { Directory.Delete(Path, recursive: true); }
             catch { /* Ignore exceptions on disposal paths */ }
+        }
+
+        /// <summary>
+        /// Generates a string with 255 random valid filename characters.
+        /// 255 is the max file/folder name length in NTFS and FAT32:
+        // https://docs.microsoft.com/en-us/windows/win32/fileio/filesystem-functionality-comparison?redirectedfrom=MSDN#limits
+        /// </summary>
+        /// <returns>A 255 length string with random valid filename characters.</returns>
+        public static string GetMaxLengthRandomName()
+        {
+            string guid = Guid.NewGuid().ToString("N");
+            StringBuilder sb = new StringBuilder(MaxNameLength, MaxNameLength);
+            while (sb.Length < MaxNameLength)
+            {
+                try
+                {
+                    sb.Append(guid);
+                }
+                catch
+                {
+                    sb.Append(guid.Substring(0, MaxNameLength - sb.Length));
+                }
+            }
+            return sb.ToString();
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -21,27 +21,27 @@
     <Compile Include="System\Security\AccessControl\FileSystemAuditRule.cs" />
     <Compile Include="System\Security\AccessControl\FileSystemRights.cs" />
     <Compile Include="System\Security\AccessControl\FileSystemSecurity.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs" Link="Interop\Windows\Interop.BOOL.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Interop\Windows\Interop.CreateFile.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FILE_TIME.cs" Link="Interop\Windows\Interop.FILE_TIME.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Interop.BOOL.cs" Link="Common\Interop\Windows\Interop.BOOL.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\Interop\Windows\Interop.CreateFile.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FILE_TIME.cs" Link="Common\Interop\Windows\Interop.FILE_TIME.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileAttributes.cs" Link="Common\Interop\Windows\Interop.FileAttributes.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FileTypes.cs" Link="Common\Interop\Windows\Interop.FileTypes.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FindClose.cs" Link="Interop\Windows\Interop.FindClose.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs" Link="Interop\Windows\Interop.FindFirstFileEx.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FindClose.cs" Link="Common\Interop\Windows\Interop.FindClose.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs" Link="Common\Interop\Windows\Interop.FindFirstFileEx.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.FormatMessage.cs" Link="Common\Interop\Windows\Interop.FormatMessage.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Interop\Windows\Interop.GenericOperations.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GET_FILEEX_INFO_LEVELS.cs" Link="Interop\Windows\Interop.GET_FILEEX_INFO_LEVELS.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GET_FILEEX_INFO_LEVELS.cs" Link="Common\Interop\Windows\Interop.GET_FILEEX_INFO_LEVELS.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileAttributesEx.cs" Link="Common\Interop\Windows\Interop.GetFileAttributesEx.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs" Link="Common\Interop\Windows\Interop.GetFileType_SafeHandle.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetFullPathNameW.cs" Link="Common\Interop\Windows\Interop.GetFullPathNameW.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetLongPathNameW.cs" Link="Common\Interop\Windows\Interop.GetLongPathNameW.cs" />
     <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.GetLogicalDrives.cs" Link="Common\Interop\Windows\Interop.GetLogicalDrives.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs" Link="Interop\Windows\Interop.MAX_PATH.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs" Link="Interop\Windows\Interop.SecurityOptions.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" Link="Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs" Link="Interop\Windows\Interop.SetThreadErrorMode.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" Link="Interop\Windows\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" />
-    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WIN32_FIND_DATA.cs" Link="Interop\Windows\Interop.WIN32_FIND_DATA.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.MAX_PATH.cs" Link="Common\Interop\Windows\Interop.MAX_PATH.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SecurityOptions.cs" Link="Common\Interop\Windows\Interop.SecurityOptions.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" Link="Common\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs" Link="Common\Interop\Windows\Interop.SetThreadErrorMode.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" Link="Common\Interop\Windows\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" />
+    <Compile Include="$(CoreLibSharedDir)Interop\Windows\Kernel32\Interop.WIN32_FIND_DATA.cs" Link="Common\Interop\Windows\Interop.WIN32_FIND_DATA.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\DisableMediaInsertionPrompt.cs" Link="Common\System\IO\DisableMediaInsertionPrompt.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PathHelper.Windows.cs" Link="System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PathInternal.cs" Link="System\IO\PathInternal.cs" />

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/DirectorySecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/DirectorySecurity.cs
@@ -16,7 +16,6 @@ namespace System.Security.AccessControl
         public DirectorySecurity(string name, AccessControlSections includeSections)
             : base(true, name, includeSections, true)
         {
-            Path.GetFullPath(name);
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
@@ -17,8 +17,6 @@ namespace System.Security.AccessControl
         public FileSecurity(string fileName, AccessControlSections includeSections)
             : base(false, fileName, includeSections, false)
         {
-            // This will validate the passed path
-            Path.GetFullPath(fileName);
         }
 
         internal FileSecurity(SafeFileHandle handle, AccessControlSections includeSections)

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
@@ -19,7 +19,7 @@ namespace System.Security.AccessControl
         }
 
         internal FileSystemSecurity(bool isContainer, string name, AccessControlSections includeSections, bool isDirectory)
-            : base(isContainer, s_ResourceType, name, includeSections, _HandleErrorCode, isDirectory)
+            : base(isContainer, s_ResourceType, PathInternal.EnsureExtendedPrefixIfNeeded(Path.GetFullPath(name)), includeSections, _HandleErrorCode, isDirectory)
         {
         }
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -418,7 +418,11 @@ namespace System.IO
         {
             using TempDirectory tempDirectory = new TempDirectory();
             string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
-            Assert.Throws<DirectoryNotFoundException>(() =>
+
+            // A non-existent directory path is considered:
+            // - In NetFX: an invalid name because paths that are too long are not correctly handled
+            // - NetCore: a valid name because long paths are correctly handled, and non-existent, as expected
+            AssertExtensions.Throws<DirectoryNotFoundException, ArgumentException>(() =>
             {
                 var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
             });
@@ -431,12 +435,18 @@ namespace System.IO
             using TempDirectory tempDirectory = new TempDirectory();
             string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
             string filePath = Path.Combine(longDir, "file.txt");
-            Assert.Throws<FileNotFoundException>(() =>
+
+            // A non-existent file path is considered:
+            // - In NetFX: an invalid name because paths that are too long are not correctly handled
+            // - NetCore: a valid name because long paths are correctly handled, and non-existent, as expected
+            AssertExtensions.Throws<FileNotFoundException, ArgumentException>(() =>
             {
                 var security = new FileSecurity(filePath, AccessControlSections.Owner);
             });
         }
 
+        // Attempting to create a directory with a very long path in NetFX fails with DirectoryNotFoundException
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [Fact]
         public void MaxLengthPath_DirectorySecurity()
         {
@@ -446,6 +456,8 @@ namespace System.IO
             Assert.NotNull(security);
         }
 
+        // Attempting to create a directory with a very long path in NetFX fails with DirectoryNotFoundException
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [Fact]
         public void MaxLengthPath_FileSecurity()
         {

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -421,50 +421,43 @@ namespace System.IO
         public void DirNotFound_DirectorySecurity()
         {
             using TempDirectory tempDirectory = new TempDirectory();
+            string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
+            Assert.Throws<DirectoryNotFoundException>(() =>
             {
-                string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
-                Assert.Throws<DirectoryNotFoundException>(() =>
-                {
-                    var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
-                });
-            }
+                var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
+            });
+            
         }
 
         [Fact]
         public void FileNotFound_FileSecurity()
         {
             using TempDirectory tempDirectory = new TempDirectory();
+            string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
+            string filePath = Path.Combine(longDir, "file.txt");
+            Assert.Throws<FileNotFoundException>(() =>
             {
-                string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
-                string filePath = Path.Combine(longDir, "file.txt");
-                Assert.Throws<FileNotFoundException>(() =>
-                {
-                    var security = new FileSecurity(filePath, AccessControlSections.Owner);
-                });
-            }
+                var security = new FileSecurity(filePath, AccessControlSections.Owner);
+            });
         }
 
         [Fact]
         public void MaxLengthPath_DirectorySecurity()
         {
             using TempDirectory tempDirectory = new TempDirectory();
-            {
-                string longDir = CreateLongDirectory(tempDirectory.Path);
-                var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
-                Assert.NotNull(security);
-            }
+            string longDir = CreateLongDirectory(tempDirectory.Path);
+            var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
+            Assert.NotNull(security);
         }
 
         [Fact]
         public void MaxLengthPath_FileSecurity()
         {
-            using (TempDirectory tempDirectory = new TempDirectory())
-            {
-                string longDir = CreateLongDirectory(tempDirectory.Path);
-                using TempFile tempFile = new TempFile(Path.Combine(longDir, "file.txt"));
-                var security = new FileSecurity(tempFile.Path, AccessControlSections.Owner);
-                Assert.NotNull(security);
-            }
+            using TempDirectory tempDirectory = new TempDirectory();
+            string longDir = CreateLongDirectory(tempDirectory.Path);
+            using TempFile tempFile = new TempFile(Path.Combine(longDir, "file.txt"));
+            var security = new FileSecurity(tempFile.Path, AccessControlSections.Owner);
+            Assert.NotNull(security);
         }
 
         private string CreateLongDirectory(string basePath, bool create = true)

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -18,10 +18,6 @@ namespace System.IO
 {
     public class FileSystemSecurityTests
     {
-        // Max file name length in NTFS and FAT32 is 255
-        // https://docs.microsoft.com/en-us/windows/win32/fileio/filesystem-functionality-comparison?redirectedfrom=MSDN#limits
-        private const int MaxFileNameLength = 255;
-
         [Fact]
         public void AddAccessRule_InvalidFileSystemAccessRule()
         {
@@ -462,7 +458,9 @@ namespace System.IO
 
         private string CreateLongDirectory(string basePath, bool create = true)
         {
-            string fullPath = Path.Combine(basePath, GetRandomName(), GetRandomName(), GetRandomName(), GetRandomName(), GetRandomName());
+            string name = TempDirectory.GetMaxLengthRandomName();
+
+            string fullPath = Path.Combine(basePath, name, name, name, name, name);
 
             if (create)
             {
@@ -470,24 +468,6 @@ namespace System.IO
             }
 
             return fullPath;
-        }
-
-        private string GetRandomName()
-        {
-            string guid = Guid.NewGuid().ToString("N");
-            StringBuilder sb = new StringBuilder(MaxFileNameLength, MaxFileNameLength);
-            while (sb.Length < MaxFileNameLength)
-            {
-                try
-                {
-                    sb.Append(guid);
-                }
-                catch
-                {
-                    sb.Append(guid.Substring(0, MaxFileNameLength - sb.Length));
-                }
-            }
-            return sb.ToString();
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -4,10 +4,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,6 +18,10 @@ namespace System.IO
 {
     public class FileSystemSecurityTests
     {
+        // Max file name length in NTFS and FAT32 is 255
+        // https://docs.microsoft.com/en-us/windows/win32/fileio/filesystem-functionality-comparison?redirectedfrom=MSDN#limits
+        private const int MaxFileNameLength = 255;
+
         [Fact]
         public void AddAccessRule_InvalidFileSystemAccessRule()
         {
@@ -408,6 +415,86 @@ namespace System.IO
             var fileSecurity = new FileSecurity();
             Type type = fileSecurity.AuditRuleType;
             Assert.Equal(typeof(FileSystemAuditRule), type);
+        }
+
+        [Fact]
+        public void DirNotFound_DirectorySecurity()
+        {
+            using TempDirectory tempDirectory = new TempDirectory();
+            {
+                string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
+                Assert.Throws<DirectoryNotFoundException>(() =>
+                {
+                    var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
+                });
+            }
+        }
+
+        [Fact]
+        public void FileNotFound_FileSecurity()
+        {
+            using TempDirectory tempDirectory = new TempDirectory();
+            {
+                string longDir = CreateLongDirectory(tempDirectory.Path, create: false);
+                string filePath = Path.Combine(longDir, "file.txt");
+                Assert.Throws<FileNotFoundException>(() =>
+                {
+                    var security = new FileSecurity(filePath, AccessControlSections.Owner);
+                });
+            }
+        }
+
+        [Fact]
+        public void MaxLengthPath_DirectorySecurity()
+        {
+            using TempDirectory tempDirectory = new TempDirectory();
+            {
+                string longDir = CreateLongDirectory(tempDirectory.Path);
+                var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
+                Assert.NotNull(security);
+            }
+        }
+
+        [Fact]
+        public void MaxLengthPath_FileSecurity()
+        {
+            using (TempDirectory tempDirectory = new TempDirectory())
+            {
+                string longDir = CreateLongDirectory(tempDirectory.Path);
+                using TempFile tempFile = new TempFile(Path.Combine(longDir, "file.txt"));
+                var security = new FileSecurity(tempFile.Path, AccessControlSections.Owner);
+                Assert.NotNull(security);
+            }
+        }
+
+        private string CreateLongDirectory(string basePath, bool create = true)
+        {
+            string fullPath = Path.Combine(basePath, GetRandomName(), GetRandomName(), GetRandomName(), GetRandomName(), GetRandomName());
+
+            if (create)
+            {
+                Directory.CreateDirectory(fullPath);
+            }
+
+            return fullPath;
+        }
+
+        private string GetRandomName()
+        {
+            string guid = Guid.NewGuid().ToString("N");
+            StringBuilder sb = new StringBuilder(MaxFileNameLength, MaxFileNameLength);
+            while (sb.Length < MaxFileNameLength)
+            {
+                try
+                {
+                    sb.Append(guid);
+                }
+                catch
+                {
+                    sb.Append(guid.Substring(0, MaxFileNameLength - sb.Length));
+                }
+            }
+            return sb.ToString();
         }
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -144,14 +144,14 @@ namespace System.Security.AccessControl
                     }
                     else if (error == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     {
-                        exception = (name == null ? new FileNotFoundException() : new FileNotFoundException(name));
+                        exception = new FileNotFoundException(name);
                     }
                     else if (error == Interop.Errors.ERROR_PATH_NOT_FOUND)
                     {
                         exception = isContainer switch
                         {
-                            false => (name == null ? new FileNotFoundException()      : new FileNotFoundException(name)),
-                            true  => (name == null ? new DirectoryNotFoundException() : new DirectoryNotFoundException(name))
+                            false => new FileNotFoundException(name),
+                            true  => new DirectoryNotFoundException(name)
                         };
                     }
                     else if (error == Interop.Errors.ERROR_NO_SECURITY_ON_OBJECT)

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Principal;
@@ -144,6 +145,14 @@ namespace System.Security.AccessControl
                     else if (error == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     {
                         exception = (name == null ? new FileNotFoundException() : new FileNotFoundException(name));
+                    }
+                    else if (error == Interop.Errors.ERROR_PATH_NOT_FOUND)
+                    {
+                        exception = isContainer switch
+                        {
+                            false => (name == null ? new FileNotFoundException()      : new FileNotFoundException(name)),
+                            true  => (name == null ? new DirectoryNotFoundException() : new DirectoryNotFoundException(name))
+                        };
                     }
                     else if (error == Interop.Errors.ERROR_NO_SECURITY_ON_OBJECT)
                     {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/29275

When creating a `FileSecurity` or `DirectorySecurity` object passing a very long path, we throw an exception because we fail to read permissions from a file/directory that has a path length exceeding 259 characters.

Windows 10 allows handling very long paths as long as we prefix the path string with `\\?\`.

This fix addressed the problem by ensuring that this prefix is added.

Note: File and folder names are still restricted to 255 characters.

I also moved the `Path.GetFullPath` calls in the constructors of `FileSecurity` and `DirectorySecurity` to be called by their shared ancestor's constructor when passing the path argument to its `base` constructor in `NativeObjectSecurity`, to ensure we throw it early, way before we attempt to read security using the P/Invoke and fail because the file/folder does not exist.

I also found there is a missing case among the Windows errors detected in `NativeObjectSecurity`. I added it, ensuring it throws the appropriate exception depending on if the file system element is a container or not.