### PR TITLE
Fix race condition in live-live CoreCLR PR

### DIFF
--- a/eng/pipelines/coreclr/templates/run-test-job.yml
+++ b/eng/pipelines/coreclr/templates/run-test-job.yml
@@ -56,6 +56,8 @@ jobs:
         - 'coreclr_test_build_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
     - ${{ if ne(parameters.stagedBuild, true) }}:
       - ${{ format('coreclr_product_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
+        - ${{ format('libraries_build_{0}_{1}{2}_{3}_{4}', 'netcoreapp', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
 
     # Compute job name from template parameters
     ${{ if eq(parameters.testGroup, 'innerloop') }}:


### PR DESCRIPTION
I was going over the various artifacts while writing a
response to Chad Nedzlek trying to explain to him that his
assessment of the bug is incorrect and I found out he is
actually right. As the managed test components corresponding
to the "test_build_..." can be redirected to a different OS,
we need to create an explicit dependency edge as otherwise
there's no guarantee that the run job will depend on the
library build job for the corresponding platform.

Thanks

Tomas