### PR TITLE
Make the CastCache table rooted by a managed static field.

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -243,6 +243,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\CrossLoaderAllocatorHashHelpers.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\DependentHandle.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\GCHeapHash.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\CastCache.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\ICastableHelpers.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\QCallHandles.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\RuntimeFeature.CoreCLR.cs" />

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    // Provides managed root for the CastCache table.
+    internal static class CastCache
+    {
+#pragma warning disable CA1823, 169 // this field is not used by managed code, yet.
+        private static int[]? s_table;
+#pragma warning restore CA1823, 169
+    }
+}

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -2005,7 +2005,6 @@ void SystemDomain::LoadBaseSystemClasses()
 
     // further loading of nonprimitive types may need casting support.
     // initialize cast cache here.
-    MscorlibBinder::GetClass(CLASS__CASTCACHE);
     CastCache::Initialize();
 
     // unfortunately, the following cannot be delay loaded since the jit

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -32,6 +32,7 @@
 #include "comdelegate.h"
 #include "siginfo.hpp"
 #include "typekey.h"
+#include "castcache.h"
 
 #include "caparser.h"
 #include "ecall.h"
@@ -2001,6 +2002,11 @@ void SystemDomain::LoadBaseSystemClasses()
 
     MscorlibBinder::LoadPrimitiveType(ELEMENT_TYPE_I);
     MscorlibBinder::LoadPrimitiveType(ELEMENT_TYPE_U);
+
+    // further loading of nonprimitive types may need casting support.
+    // initialize cast cache here.
+    MscorlibBinder::GetClass(CLASS__CASTCACHE);
+    CastCache::Initialize();
 
     // unfortunately, the following cannot be delay loaded since the jit
     // uses it to compute method attributes within a function that cannot

--- a/src/coreclr/src/vm/castcache.cpp
+++ b/src/coreclr/src/vm/castcache.cpp
@@ -142,7 +142,7 @@ TypeHandle::CastResult CastCache::TryGet(TADDR source, TADDR target)
     BASEARRAYREF table = *s_pTableRef;
 
     // we use NULL as a sentinel for a rare case when a table could not be allocated
-    // because we avoid OOMs in conversions
+    // because we avoid OOMs.
     // we could use 0-element table instead, but then we would have to check the size here.
     if (!table)
     {

--- a/src/coreclr/src/vm/castcache.cpp
+++ b/src/coreclr/src/vm/castcache.cpp
@@ -10,8 +10,8 @@
 
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 
-OBJECTHANDLE CastCache::s_cache = NULL;
-DWORD CastCache::s_lastFlushSize = INITIAL_CACHE_SIZE;
+BASEARRAYREF* CastCache::s_pTableRef = NULL;
+DWORD CastCache::s_lastFlushSize     = INITIAL_CACHE_SIZE;
 
 BASEARRAYREF CastCache::CreateCastCache(DWORD size)
 {
@@ -93,7 +93,7 @@ BOOL CastCache::MaybeReplaceCacheWithLarger(DWORD size)
         return FALSE;
     }
 
-    StoreObjectInHandle(s_cache, newTable);
+    SetObjectReference((OBJECTREF *)s_pTableRef, newTable);
     return TRUE;
 }
 
@@ -107,10 +107,10 @@ void CastCache::FlushCurrentCache()
     }
     CONTRACTL_END;
 
-    BASEARRAYREF currentTableRef = (BASEARRAYREF)ObjectFromHandle(s_cache);
+    BASEARRAYREF currentTableRef = *s_pTableRef;
     s_lastFlushSize = !currentTableRef ? INITIAL_CACHE_SIZE : CacheElementCount(currentTableRef);
 
-    StoreObjectInHandle(s_cache, NULL);
+    *s_pTableRef = NULL;
 }
 
 void CastCache::Initialize()
@@ -123,7 +123,10 @@ void CastCache::Initialize()
     }
     CONTRACTL_END;
 
-    s_cache = CreateGlobalHandle(NULL);
+    FieldDesc* pTableField = MscorlibBinder::GetField(FIELD__CASTCACHE__TABLE);
+
+    GCX_COOP();
+    s_pTableRef = (BASEARRAYREF*)pTableField->GetCurrentStaticAddress();
 }
 
 TypeHandle::CastResult CastCache::TryGet(TADDR source, TADDR target)
@@ -136,7 +139,7 @@ TypeHandle::CastResult CastCache::TryGet(TADDR source, TADDR target)
     }
     CONTRACTL_END;
 
-    BASEARRAYREF table = (BASEARRAYREF)ObjectFromHandle(s_cache);
+    BASEARRAYREF table = *s_pTableRef;
 
     // we use NULL as a sentinel for a rare case when a table could not be allocated
     // because we avoid OOMs in conversions
@@ -207,7 +210,7 @@ void CastCache::TrySet(TADDR source, TADDR target, BOOL result)
 
     do
     {
-        table = (BASEARRAYREF)ObjectFromHandle(s_cache);
+        table = *s_pTableRef;
         if (!table)
         {
             // we did not allocate a table or flushed it, try replacing, but do not continue looping.
@@ -263,7 +266,7 @@ void CastCache::TrySet(TADDR source, TADDR target, BOOL result)
     } while (TryGrow(table));
 
     // reread table after TryGrow.
-    table = (BASEARRAYREF)ObjectFromHandle(s_cache);
+    table = *s_pTableRef;
     if (!table)
     {
         // we did not allocate a table.

--- a/src/coreclr/src/vm/castcache.h
+++ b/src/coreclr/src/vm/castcache.h
@@ -199,7 +199,7 @@ private:
 // We pick 8 as the probe limit (hoping for 4 probes on average), but the number can be refined further.
     static const DWORD BUCKET_SIZE = 8;
 
-    static OBJECTHANDLE   s_cache;
+    static BASEARRAYREF*  s_pTableRef;
     static DWORD          s_lastFlushSize;
 
     FORCEINLINE static TypeHandle::CastResult TryGetFromCache(TADDR source, TADDR target)

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -166,7 +166,6 @@
 #include "threadsuspend.h"
 #include "disassembler.h"
 #include "jithost.h"
-#include "castcache.h"
 
 #ifndef FEATURE_PAL
 #include "dwreport.h"
@@ -960,9 +959,6 @@ void EEStartupHelper(COINITIEE fFlags)
 
         // Now we really have fully initialized the garbage collector
         SetGarbageCollectorFullyInitialized();
-
-        // This will allocate a handle, so do this after GC is initialized.
-        CastCache::Initialize();
 
 #ifdef DEBUGGING_SUPPORTED
         // Make a call to publish the DefaultDomain for the debugger

--- a/src/coreclr/src/vm/mscorlib.h
+++ b/src/coreclr/src/vm/mscorlib.h
@@ -1450,6 +1450,9 @@ DEFINE_FIELD_U(_deletedCount,              GCHeapHashObject,                _del
 
 DEFINE_CLASS(GCHEAPHASH, CompilerServices, GCHeapHash)
 
+DEFINE_CLASS(CASTCACHE, CompilerServices, CastCache)
+DEFINE_FIELD(CASTCACHE, TABLE, s_table)
+
 DEFINE_CLASS_U(CompilerServices,           LAHashDependentHashTracker,      LAHashDependentHashTrackerObject)
 DEFINE_FIELD_U(_dependentHandle,           LAHashDependentHashTrackerObject,_dependentHandle)
 DEFINE_FIELD_U(_loaderAllocator,           LAHashDependentHashTrackerObject,_loaderAllocator)


### PR DESCRIPTION

This makes managing the cast table a bit simpler (no handles).

Also a prerequisite to accessing the cast cache directly from managed code (re: https://github.com/dotnet/coreclr/issues/27931)