### PR TITLE
Send QUIT on SmtpClient.Dispose()

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -1093,16 +1093,8 @@ namespace System.Net.Mail
                     Abort();
                 }
 
-                if (_transport != null)
-                {
-                    _transport.ReleaseConnection();
-                }
-
-                if (_timer != null)
-                {
-                    _timer.Dispose();
-                }
-
+                _transport?.ReleaseConnection();
+                _timer?.Dispose();
                 _disposed = true;
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -1092,8 +1092,10 @@ namespace System.Net.Mail
                     _cancelled = true;
                     Abort();
                 }
-
-                _transport?.ReleaseConnection();
+                else
+                {
+                    _transport?.ReleaseConnection();
+                }
                 _timer?.Dispose();
                 _disposed = true;
             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -543,7 +543,6 @@ namespace System.Net.Mail
                     _message = message;
                     message.Send(writer, DeliveryMethod != SmtpDeliveryMethod.Network, allowUnicode);
                     writer.Close();
-                    _transport.ReleaseConnection();
 
                     //throw if we couldn't send to any of the recipients
                     if (DeliveryMethod == SmtpDeliveryMethod.Network && recipientException != null)
@@ -690,7 +689,6 @@ namespace System.Net.Mail
                                 if (_writer != null)
                                     _writer.Close();
 
-                                _transport.ReleaseConnection();
                                 AsyncCompletedEventArgs eventArgs = new AsyncCompletedEventArgs(null, false, _asyncOp.UserSuppliedState);
                                 InCall = false;
                                 _asyncOp.PostOperationCompleted(_onSendCompletedDelegate, eventArgs);
@@ -937,7 +935,6 @@ namespace System.Net.Mail
                             exception = se;
                         }
                     }
-                    _transport.ReleaseConnection();
                 }
             }
             finally
@@ -1096,7 +1093,7 @@ namespace System.Net.Mail
                     Abort();
                 }
 
-                if ((_transport != null))
+                if (_transport != null)
                 {
                     _transport.ReleaseConnection();
                 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -132,17 +132,22 @@ namespace System.Net.Mail
                 {
                     if (!_isClosed && _tcpClient != null)
                     {
-                        // Gracefully close the transmission channel
-                        QuitCommand.Send(this);
-
-                        //free cbt buffer
-                        if (_channelBindingToken != null)
+                        try
                         {
-                            _channelBindingToken.Close();
+                            // Gracefully close the transmission channel
+                            QuitCommand.Send(this);
                         }
+                        finally
+                        {
+                            //free cbt buffer
+                            if (_channelBindingToken != null)
+                            {
+                                _channelBindingToken.Close();
+                            }
 
-                        _networkStream?.Close();
-                        _tcpClient.Dispose();
+                            _networkStream?.Close();
+                            _tcpClient.Dispose();
+                        }
                     }
 
                     _isClosed = true;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -132,6 +132,9 @@ namespace System.Net.Mail
                 {
                     if (!_isClosed && _tcpClient != null)
                     {
+                        // Gracefully close the transmission channel
+                        QuitCommand.Send(this);
+
                         //free cbt buffer
                         if (_channelBindingToken != null)
                         {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -140,11 +140,7 @@ namespace System.Net.Mail
                         finally
                         {
                             //free cbt buffer
-                            if (_channelBindingToken != null)
-                            {
-                                _channelBindingToken.Close();
-                            }
-
+                            _channelBindingToken?.Close();
                             _networkStream?.Close();
                             _tcpClient.Dispose();
                         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -135,6 +135,7 @@ namespace System.Net.Mail
                         try
                         {
                             // Gracefully close the transmission channel
+                            _tcpClient.Client.Blocking = false;
                             QuitCommand.Send(this);
                         }
                         finally

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -195,10 +195,7 @@ namespace System.Net.Mail
 
         internal void ReleaseConnection()
         {
-            if (_connection != null)
-            {
-                _connection.ReleaseConnection();
-            }
+            _connection?.ReleaseConnection();
         }
 
         internal void Abort()

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -488,5 +488,33 @@ namespace System.Net.Mail.Tests
         }
 
         private static string GetClientDomain() => IPGlobalProperties.GetIPGlobalProperties().HostName.Trim().ToLower();
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SendMail_SendQUITOnDispose(bool asyncSend)
+        {
+            bool quitMessageReceived = false;
+
+            using var server = new LoopbackSmtpServer();
+            server.OnQuitReceived += _ => quitMessageReceived = true;
+
+            using (SmtpClient client = server.CreateClient())
+            {
+                client.Credentials = new NetworkCredential("Foo", "Bar");
+                MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "hello", "howdydoo");
+                if (asyncSend)
+                {
+                    await client.SendMailAsync(msg).TimeoutAfter((int)TimeSpan.FromSeconds(30).TotalMilliseconds);
+                }
+                else
+                {
+                    client.Send(msg);
+                }
+                Assert.False(quitMessageReceived, "QUIT received");
+            }
+
+            Assert.True(quitMessageReceived, "QUIT message not received");
+        }
     }
 }

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -495,9 +495,13 @@ namespace System.Net.Mail.Tests
         public async Task SendMail_SendQUITOnDispose(bool asyncSend)
         {
             bool quitMessageReceived = false;
-
+            using ManualResetEventSlim quitReceived = new ManualResetEventSlim();
             using var server = new LoopbackSmtpServer();
-            server.OnQuitReceived += _ => quitMessageReceived = true;
+            server.OnQuitReceived += _ =>
+            {
+                quitMessageReceived = true;
+                quitReceived.Set();
+            };
 
             using (SmtpClient client = server.CreateClient())
             {
@@ -514,6 +518,8 @@ namespace System.Net.Mail.Tests
                 Assert.False(quitMessageReceived, "QUIT received");
             }
 
+            // There is a latency between send/receive.
+            quitReceived.Wait(TimeSpan.FromSeconds(30));
             Assert.True(quitMessageReceived, "QUIT message not received");
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34868

When code was ported `SmtpConnection` pooling present on old code base was removed but seem that semantic wasn't correctly updated.
On netfx code base the call to `ReleaseConnection()` ends to place where the connection is [cached](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/mail/smtpconnection.cs#L197) for [future use](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/mail/smtpconnection.cs#L326)([creation callback](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/mail/smtpconnection.cs#L20))
When we call `SmtpClient.Dispose()` we end calling pool manager [cleanup](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/mail/SmtpTransport.cs#L354) that calls real dispose on [pooled stream](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/connectionpool.cs#L441)  with the result of send QUIT message on all opened [network stream](https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System/net/System/Net/mail/SmtpTransport.cs#L44)

On core this mechanism is not present, so until today every `ReleaseConnection()` called after send messages closes socket/stream violating RFC https://tools.ietf.org/html/rfc5321#section-4.1.1.10
```
The sender MUST NOT intentionally close the transmission
channel until it sends a QUIT command, and it SHOULD wait until it
receives the reply (even if there was an error response to a previous
command).
```

If users forget to dispose network stream will be closed in a "bad" way(like today) by [finalizer](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs#L464)
I didn't found any finalizer on pool on netfx code base, btw it's a bit hard navigate without "Go to" vs feature(it doesn't work), so I could have missed some place where `PooledStream` are released thank's to some finalizer.

However the guide is clear `Sends a QUIT message to the SMTP server, gracefully ends the TCP connection, and releases all resources used by the current instance of the SmtpClient class.` so we should always call Dispose()(missing in the main example https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient?view=netframework-4.8#examples).

cc: @davidsh @wfurt 

Bonus: during test I found that if we call 2 time one after another async send, test hang, I don't know if it's related to `LoopbackSmtpServer`, this issue it's not related to this PR the behaviour is already present.