### PR TITLE
HttpListener.Stop closes the request queue handle with CloseIoEx method

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -451,9 +451,10 @@ namespace System.Net
                 if (NetEventSource.IsEnabled) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
                 _requestQueueBoundHandle?.Dispose();
                 _requestQueueHandle.Dispose();
-                // CancelIoEx is called after Dispose to prevent a race condition when GetContext and consequently
-                // HttpReceiveHttpRequest is called after CancelIoEx, but before Dispose what would block the synchronous
-                // GetContext call until the next request arrives
+
+                // CancelIoEx is called after Dispose to prevent a race condition involving parallel GetContext and
+                // HttpReceiveHttpRequest calls. Otherwise, calling CancelIoEx before Dispose might block the synchronous
+                // GetContext call until the next request arrives.
                 try
                 {
                     Interop.Kernel32.CancelIoEx(_requestQueueHandle, null); // This cancels the synchronous call to HttpReceiveHttpRequest

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -449,9 +449,16 @@ namespace System.Net
             if ((_requestQueueHandle != null) && (!_requestQueueHandle.IsInvalid))
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
-                Interop.Kernel32.CancelIoEx(_requestQueueHandle, null);
                 _requestQueueBoundHandle?.Dispose();
                 _requestQueueHandle.Dispose();
+                try
+                {
+                    Interop.Kernel32.CancelIoEx(_requestQueueHandle, null); // this cancells the synchronous call to HttpReceiveHttpRequest
+                }
+                catch (ObjectDisposedException)
+                {
+                    // ignore the exception since it only means that the queue handle has been successfully disposed
+                }
             }
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -449,6 +449,7 @@ namespace System.Net
             if ((_requestQueueHandle != null) && (!_requestQueueHandle.IsInvalid))
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
+                Interop.Kernel32.CancelIoEx(_requestQueueHandle, null);
                 _requestQueueBoundHandle?.Dispose();
                 _requestQueueHandle.Dispose();
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -453,7 +453,7 @@ namespace System.Net
                 _requestQueueHandle.Dispose();
                 try
                 {
-                    Interop.Kernel32.CancelIoEx(_requestQueueHandle, null); // this cancells the synchronous call to HttpReceiveHttpRequest
+                    Interop.Kernel32.CancelIoEx(_requestQueueHandle, null); // this cancels the synchronous call to HttpReceiveHttpRequest
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -176,7 +176,7 @@ namespace System.Net.Tests
                 }
             });
 
-            Task.Delay(1000).Wait(); // let listenerTask to call GetContext
+            Task.Delay(1000).Wait(1100); // let listenerTask to call GetContext
             listener.Stop();
             listener.Close();
             listenerTask.Wait();

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -158,7 +158,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        //[OuterLoop]
+        [OuterLoop]
         public void GetContext_StopIsCalled_GetContextUnblocked()
         {
             using var listenerFactory = new HttpListenerFactory();

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -159,27 +159,16 @@ namespace System.Net.Tests
 
         [Fact]
         [OuterLoop]
-        public void GetContext_StopIsCalled_GetContextUnblocked()
+        public async Task GetContext_StopIsCalled_GetContextUnblocked()
         {
             using var listenerFactory = new HttpListenerFactory();
             var listener = listenerFactory.GetListener();
             listener.Start();
-
-            var listenerTask = Task.Run(() =>
-            {
-                try
-                {
-                    var context = listener.GetContext();
-                }
-                catch (Exception)
-                {
-                }
-            });
-
-            Task.Delay(1000).Wait(1100); // let listenerTask to call GetContext
+            var listenerTask = Task.Run(() => Assert.Throws<HttpListenerException>(() => listener.GetContext()));
+            await Task.Delay(1000).TimeoutAfter(1100); // let listenerTask to call GetContext
             listener.Stop();
             listener.Close();
-            listenerTask.Wait();
+            await listenerTask.TimeoutAfter(10000);
         }
     }
 }

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -165,7 +165,7 @@ namespace System.Net.Tests
             var listener = listenerFactory.GetListener();
             listener.Start();
             var listenerTask = Task.Run(() => Assert.Throws<HttpListenerException>(() => listener.GetContext()));
-            await Task.Delay(1000).TimeoutAfter(1100); // let listenerTask to call GetContext
+            await Task.Delay(1000).TimeoutAfter(1100); // Wait for listenerTask to call GetContext.
             listener.Stop();
             listener.Close();
             await listenerTask.TimeoutAfter(10000);

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -165,7 +165,7 @@ namespace System.Net.Tests
             var listener = listenerFactory.GetListener();
             listener.Start();
             var listenerTask = Task.Run(() => Assert.Throws<HttpListenerException>(() => listener.GetContext()));
-            await Task.Delay(1000).TimeoutAfter(1100); // Wait for listenerTask to call GetContext.
+            await Task.Delay(1000).TimeoutAfter(10000); // Wait for listenerTask to call GetContext.
             listener.Stop();
             listener.Close();
             await listenerTask.TimeoutAfter(10000);


### PR DESCRIPTION
Currently, if HttpListener.Stop is called while the other thread is blocked inside a synchronous GetContext cal, it has no effect because Stop cannot dispose the request queue handle. This is caused by a reference counting mechanism implemented in SafeHandle which prevents disposal of the native handle due to the following reason.

GetContext method invokes the native HttpReceiveHttpRequest to start listening for incoming requests. HttpReceiveHttpRequest is called through P/Invoke and accepts SafeHandle as a request queue handle. In such case, runtime injects a special call to SafeHandle.DangerousAddRef incrementing the ref counter to prevent an accidental disposal from the managed side. In general, it's a good safety measure, but in the given scenario it prevents SafeHandle.Dispose from actually closing the underlying OS handle thus GetContext gets blocked until a next request arrives.

To overcome this limitation, PR adds call to CloseIoEx before invoking Dispose to close the request queue and unblock GetContext.