### PR TITLE
Nullability annotations for main System.Data.Common types

### DIFF
--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -186,6 +186,7 @@ namespace System.Data
         public DataException(string s) { }
         public DataException(string s, System.Exception innerException) { }
     }
+#nullable enable
     public static partial class DataReaderExtensions
     {
         public static bool GetBoolean(this System.Data.Common.DbDataReader reader, string name) { throw null; }
@@ -218,6 +219,7 @@ namespace System.Data
         public static bool IsDBNull(this System.Data.Common.DbDataReader reader, string name) { throw null; }
         public static System.Threading.Tasks.Task<bool> IsDBNullAsync(this System.Data.Common.DbDataReader reader, string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+#nullable disable
     [System.ComponentModel.DefaultPropertyAttribute("RelationName")]
     public partial class DataRelation
     {
@@ -1162,15 +1164,18 @@ namespace System.Data
         System.Data.IDataParameter[] GetFillParameters();
         int Update(System.Data.DataSet dataSet);
     }
+#nullable enable
     public partial interface IDataParameter
     {
         System.Data.DbType DbType { get; set; }
         System.Data.ParameterDirection Direction { get; set; }
         bool IsNullable { get; }
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         string ParameterName { get; set; }
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         string SourceColumn { get; set; }
         System.Data.DataRowVersion SourceVersion { get; set; }
-        object Value { get; set; }
+        object? Value { get; set; }
     }
     public partial interface IDataParameterCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
     {
@@ -1219,23 +1224,25 @@ namespace System.Data
     }
     public partial interface IDbCommand : System.IDisposable
     {
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         string CommandText { get; set; }
         int CommandTimeout { get; set; }
         System.Data.CommandType CommandType { get; set; }
-        System.Data.IDbConnection Connection { get; set; }
+        System.Data.IDbConnection? Connection { get; set; }
         System.Data.IDataParameterCollection Parameters { get; }
-        System.Data.IDbTransaction Transaction { get; set; }
+        System.Data.IDbTransaction? Transaction { get; set; }
         System.Data.UpdateRowSource UpdatedRowSource { get; set; }
         void Cancel();
         System.Data.IDbDataParameter CreateParameter();
         int ExecuteNonQuery();
         System.Data.IDataReader ExecuteReader();
         System.Data.IDataReader ExecuteReader(System.Data.CommandBehavior behavior);
-        object ExecuteScalar();
+        object? ExecuteScalar();
         void Prepare();
     }
     public partial interface IDbConnection : System.IDisposable
     {
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         string ConnectionString { get; set; }
         int ConnectionTimeout { get; }
         string Database { get; }
@@ -1247,6 +1254,7 @@ namespace System.Data
         System.Data.IDbCommand CreateCommand();
         void Open();
     }
+#nullable disable
     public partial interface IDbDataAdapter : System.Data.IDataAdapter
     {
         System.Data.IDbCommand DeleteCommand { get; set; }
@@ -1254,6 +1262,7 @@ namespace System.Data
         System.Data.IDbCommand SelectCommand { get; set; }
         System.Data.IDbCommand UpdateCommand { get; set; }
     }
+#nullable enable
     public partial interface IDbDataParameter : System.Data.IDataParameter
     {
         byte Precision { get; set; }
@@ -1262,11 +1271,12 @@ namespace System.Data
     }
     public partial interface IDbTransaction : System.IDisposable
     {
-        System.Data.IDbConnection Connection { get; }
+        System.Data.IDbConnection? Connection { get; }
         System.Data.IsolationLevel IsolationLevel { get; }
         void Commit();
         void Rollback();
     }
+#nullable disable
     public partial class InRowChangingEventException : System.Data.DataException
     {
         public InRowChangingEventException() { }
@@ -1467,6 +1477,7 @@ namespace System.Data
         DateTime2 = 33,
         DateTimeOffset = 34,
     }
+#nullable enable
     public sealed partial class StateChangeEventArgs : System.EventArgs
     {
         public StateChangeEventArgs(System.Data.ConnectionState originalState, System.Data.ConnectionState currentState) { }
@@ -1474,6 +1485,7 @@ namespace System.Data
         public System.Data.ConnectionState OriginalState { get { throw null; } }
     }
     public delegate void StateChangeEventHandler(object sender, System.Data.StateChangeEventArgs e);
+#nullable disable
     public sealed partial class StatementCompletedEventArgs : System.EventArgs
     {
         public StatementCompletedEventArgs(int recordCount) { }
@@ -1758,20 +1770,21 @@ namespace System.Data.Common
         System.Data.ITableMapping System.Data.ITableMappingCollection.Add(string sourceTableName, string dataSetTableName) { throw null; }
         System.Data.ITableMapping System.Data.ITableMappingCollection.GetByDataSetTable(string dataSetTableName) { throw null; }
     }
+#nullable enable
     public abstract partial class DbColumn
     {
         protected DbColumn() { }
         public bool? AllowDBNull { get { throw null; } protected set { } }
-        public string BaseCatalogName { get { throw null; } protected set { } }
-        public string BaseColumnName { get { throw null; } protected set { } }
-        public string BaseSchemaName { get { throw null; } protected set { } }
-        public string BaseServerName { get { throw null; } protected set { } }
-        public string BaseTableName { get { throw null; } protected set { } }
+        public string? BaseCatalogName { get { throw null; } protected set { } }
+        public string? BaseColumnName { get { throw null; } protected set { } }
+        public string? BaseSchemaName { get { throw null; } protected set { } }
+        public string? BaseServerName { get { throw null; } protected set { } }
+        public string? BaseTableName { get { throw null; } protected set { } }
         public string ColumnName { get { throw null; } protected set { } }
         public int? ColumnOrdinal { get { throw null; } protected set { } }
         public int? ColumnSize { get { throw null; } protected set { } }
-        public System.Type DataType { get { throw null; } protected set { } }
-        public string DataTypeName { get { throw null; } protected set { } }
+        public System.Type? DataType { get { throw null; } protected set { } }
+        public string? DataTypeName { get { throw null; } protected set { } }
         public bool? IsAliased { get { throw null; } protected set { } }
         public bool? IsAutoIncrement { get { throw null; } protected set { } }
         public bool? IsExpression { get { throw null; } protected set { } }
@@ -1781,16 +1794,17 @@ namespace System.Data.Common
         public bool? IsLong { get { throw null; } protected set { } }
         public bool? IsReadOnly { get { throw null; } protected set { } }
         public bool? IsUnique { get { throw null; } protected set { } }
-        public virtual object this[string property] { get { throw null; } }
+        public virtual object? this[string property] { get { throw null; } }
         public int? NumericPrecision { get { throw null; } protected set { } }
         public int? NumericScale { get { throw null; } protected set { } }
-        public string UdtAssemblyQualifiedName { get { throw null; } protected set { } }
+        public string? UdtAssemblyQualifiedName { get { throw null; } protected set { } }
     }
     public abstract partial class DbCommand : System.ComponentModel.Component, System.Data.IDbCommand, System.IDisposable, System.IAsyncDisposable
     {
         protected DbCommand() { }
         [System.ComponentModel.DefaultValueAttribute("")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public abstract string CommandText { get; set; }
         public abstract int CommandTimeout { get; set; }
         [System.ComponentModel.DefaultValueAttribute(System.Data.CommandType.Text)]
@@ -1799,10 +1813,10 @@ namespace System.Data.Common
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.DefaultValueAttribute(null)]
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-        public System.Data.Common.DbConnection Connection { get { throw null; } set { } }
-        protected abstract System.Data.Common.DbConnection DbConnection { get; set; }
+        public System.Data.Common.DbConnection? Connection { get { throw null; } set { } }
+        protected abstract System.Data.Common.DbConnection? DbConnection { get; set; }
         protected abstract System.Data.Common.DbParameterCollection DbParameterCollection { get; }
-        protected abstract System.Data.Common.DbTransaction DbTransaction { get; set; }
+        protected abstract System.Data.Common.DbTransaction? DbTransaction { get; set; }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.DefaultValueAttribute(true)]
         [System.ComponentModel.DesignOnlyAttribute(true)]
@@ -1811,13 +1825,13 @@ namespace System.Data.Common
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         public System.Data.Common.DbParameterCollection Parameters { get { throw null; } }
-        System.Data.IDbConnection System.Data.IDbCommand.Connection { get { throw null; } set { } }
+        System.Data.IDbConnection? System.Data.IDbCommand.Connection { get { throw null; } set { } }
         System.Data.IDataParameterCollection System.Data.IDbCommand.Parameters { get { throw null; } }
-        System.Data.IDbTransaction System.Data.IDbCommand.Transaction { get { throw null; } set { } }
+        System.Data.IDbTransaction? System.Data.IDbCommand.Transaction { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.DefaultValueAttribute(null)]
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
-        public System.Data.Common.DbTransaction Transaction { get { throw null; } set { } }
+        public System.Data.Common.DbTransaction? Transaction { get { throw null; } set { } }
         [System.ComponentModel.DefaultValueAttribute(System.Data.UpdateRowSource.Both)]
         public abstract System.Data.UpdateRowSource UpdatedRowSource { get; set; }
         public abstract void Cancel();
@@ -1835,15 +1849,16 @@ namespace System.Data.Common
         public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteReaderAsync(System.Data.CommandBehavior behavior) { throw null; }
         public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteReaderAsync(System.Data.CommandBehavior behavior, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public abstract object ExecuteScalar();
-        public System.Threading.Tasks.Task<object> ExecuteScalarAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public abstract object? ExecuteScalar();
+        public System.Threading.Tasks.Task<object?> ExecuteScalarAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public abstract void Prepare();
         public virtual System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         System.Data.IDbDataParameter System.Data.IDbCommand.CreateParameter() { throw null; }
         System.Data.IDataReader System.Data.IDbCommand.ExecuteReader() { throw null; }
         System.Data.IDataReader System.Data.IDbCommand.ExecuteReader(System.Data.CommandBehavior behavior) { throw null; }
     }
+#nullable disable
     public abstract partial class DbCommandBuilder : System.ComponentModel.Component
     {
         protected DbCommandBuilder() { }
@@ -1883,6 +1898,7 @@ namespace System.Data.Common
         protected abstract void SetRowUpdatingHandler(System.Data.Common.DbDataAdapter adapter);
         public virtual string UnquoteIdentifier(string quotedIdentifier) { throw null; }
     }
+#nullable enable
     public abstract partial class DbConnection : System.ComponentModel.Component, System.Data.IDbConnection, System.IDisposable, System.IAsyncDisposable
     {
         protected DbConnection() { }
@@ -1890,16 +1906,17 @@ namespace System.Data.Common
         [System.ComponentModel.RecommendedAsConfigurableAttribute(true)]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
         [System.ComponentModel.SettingsBindableAttribute(true)]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public abstract string ConnectionString { get; set; }
         public virtual int ConnectionTimeout { get { throw null; } }
         public abstract string Database { get; }
         public abstract string DataSource { get; }
-        protected virtual System.Data.Common.DbProviderFactory DbProviderFactory { get { throw null; } }
+        protected virtual System.Data.Common.DbProviderFactory? DbProviderFactory { get { throw null; } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public abstract string ServerVersion { get; }
         [System.ComponentModel.BrowsableAttribute(false)]
         public abstract System.Data.ConnectionState State { get; }
-        public virtual event System.Data.StateChangeEventHandler StateChange { add { } remove { } }
+        public virtual event System.Data.StateChangeEventHandler? StateChange { add { } remove { } }
         protected abstract System.Data.Common.DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel);
         protected virtual System.Threading.Tasks.ValueTask<System.Data.Common.DbTransaction> BeginDbTransactionAsync(System.Data.IsolationLevel isolationLevel, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Data.Common.DbTransaction BeginTransaction() { throw null; }
@@ -1913,10 +1930,10 @@ namespace System.Data.Common
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
-        public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
+        public virtual void EnlistTransaction(System.Transactions.Transaction? transaction) { }
         public virtual System.Data.DataTable GetSchema() { throw null; }
         public virtual System.Data.DataTable GetSchema(string collectionName) { throw null; }
-        public virtual System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) { throw null; }
+        public virtual System.Data.DataTable GetSchema(string collectionName, string?[] restrictionValues) { throw null; }
         protected virtual void OnStateChange(System.Data.StateChangeEventArgs stateChange) { }
         public abstract void Open();
         public System.Threading.Tasks.Task OpenAsync() { throw null; }
@@ -1935,6 +1952,7 @@ namespace System.Data.Common
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool BrowsableConnectionString { get { throw null; } set { } }
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public string ConnectionString { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public virtual int Count { get { throw null; } }
@@ -1943,17 +1961,18 @@ namespace System.Data.Common
         [System.ComponentModel.BrowsableAttribute(false)]
         public bool IsReadOnly { get { throw null; } }
         [System.ComponentModel.BrowsableAttribute(false)]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public virtual object this[string keyword] { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public virtual System.Collections.ICollection Keys { get { throw null; } }
         bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
         object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        object System.Collections.IDictionary.this[object keyword] { get { throw null; } set { } }
+        object? System.Collections.IDictionary.this[object keyword] { get { throw null; } set { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         public virtual System.Collections.ICollection Values { get { throw null; } }
         public void Add(string keyword, object value) { }
-        public static void AppendKeyValuePair(System.Text.StringBuilder builder, string keyword, string value) { }
-        public static void AppendKeyValuePair(System.Text.StringBuilder builder, string keyword, string value, bool useOdbcRules) { }
+        public static void AppendKeyValuePair(System.Text.StringBuilder builder, string keyword, string? value) { }
+        public static void AppendKeyValuePair(System.Text.StringBuilder builder, string keyword, string? value, bool useOdbcRules) { }
         public virtual void Clear() { }
         protected internal void ClearPropertyDescriptors() { }
         public virtual bool ContainsKey(string keyword) { throw null; }
@@ -1962,11 +1981,12 @@ namespace System.Data.Common
         public virtual bool Remove(string keyword) { throw null; }
         public virtual bool ShouldSerialize(string keyword) { throw null; }
         void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object keyword, object value) { }
+        void System.Collections.IDictionary.Add(object keyword, object? value) { }
         bool System.Collections.IDictionary.Contains(object keyword) { throw null; }
         System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
         void System.Collections.IDictionary.Remove(object keyword) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+#nullable disable
         System.ComponentModel.AttributeCollection System.ComponentModel.ICustomTypeDescriptor.GetAttributes() { throw null; }
         string System.ComponentModel.ICustomTypeDescriptor.GetClassName() { throw null; }
         string System.ComponentModel.ICustomTypeDescriptor.GetComponentName() { throw null; }
@@ -1979,9 +1999,11 @@ namespace System.Data.Common
         System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ICustomTypeDescriptor.GetProperties() { throw null; }
         System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ICustomTypeDescriptor.GetProperties(System.Attribute[] attributes) { throw null; }
         object System.ComponentModel.ICustomTypeDescriptor.GetPropertyOwner(System.ComponentModel.PropertyDescriptor pd) { throw null; }
+#nullable enable
         public override string ToString() { throw null; }
-        public virtual bool TryGetValue(string keyword, out object value) { throw null; }
+        public virtual bool TryGetValue(string keyword, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? value) { throw null; }
     }
+#nullable disable
     public abstract partial class DbDataAdapter : System.Data.Common.DataAdapter, System.Data.IDataAdapter, System.Data.IDbDataAdapter, System.ICloneable
     {
         public const string DefaultSourceTableName = "Table";
@@ -2040,6 +2062,7 @@ namespace System.Data.Common
         public int Update(System.Data.DataSet dataSet, string srcTable) { throw null; }
         public int Update(System.Data.DataTable dataTable) { throw null; }
     }
+#nullable enable
     public abstract partial class DbDataReader : System.MarshalByRefObject, System.Collections.IEnumerable, System.Data.IDataReader, System.Data.IDataRecord, System.IDisposable, System.IAsyncDisposable
     {
         protected DbDataReader() { }
@@ -2059,9 +2082,9 @@ namespace System.Data.Common
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public abstract bool GetBoolean(int ordinal);
         public abstract byte GetByte(int ordinal);
-        public abstract long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length);
+        public abstract long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length);
         public abstract char GetChar(int ordinal);
-        public abstract long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length);
+        public abstract long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length);
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Data.Common.DbDataReader GetData(int ordinal) { throw null; }
         public abstract string GetDataTypeName(int ordinal);
@@ -2139,6 +2162,7 @@ namespace System.Data.Common
         public abstract object GetValue(int i);
         public abstract int GetValues(object[] values);
         public abstract bool IsDBNull(int i);
+#nullable disable
         System.ComponentModel.AttributeCollection System.ComponentModel.ICustomTypeDescriptor.GetAttributes() { throw null; }
         string System.ComponentModel.ICustomTypeDescriptor.GetClassName() { throw null; }
         string System.ComponentModel.ICustomTypeDescriptor.GetComponentName() { throw null; }
@@ -2151,12 +2175,14 @@ namespace System.Data.Common
         System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ICustomTypeDescriptor.GetProperties() { throw null; }
         System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ICustomTypeDescriptor.GetProperties(System.Attribute[] attributes) { throw null; }
         object System.ComponentModel.ICustomTypeDescriptor.GetPropertyOwner(System.ComponentModel.PropertyDescriptor pd) { throw null; }
+#nullable enable
     }
     public abstract partial class DbDataSourceEnumerator
     {
         protected DbDataSourceEnumerator() { }
         public abstract System.Data.DataTable GetDataSources();
     }
+#nullable disable
     public partial class DbEnumerator : System.Collections.IEnumerator
     {
         public DbEnumerator(System.Data.Common.DbDataReader reader) { }
@@ -2168,13 +2194,14 @@ namespace System.Data.Common
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void Reset() { }
     }
+#nullable enable
     public abstract partial class DbException : System.Runtime.InteropServices.ExternalException
     {
         protected DbException() { }
         protected DbException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        protected DbException(string message) { }
-        protected DbException(string message, System.Exception innerException) { }
-        protected DbException(string message, int errorCode) { }
+        protected DbException(string? message) { }
+        protected DbException(string? message, System.Exception? innerException) { }
+        protected DbException(string? message, int errorCode) { }
     }
     public static partial class DbMetaDataCollectionNames
     {
@@ -2245,11 +2272,13 @@ namespace System.Data.Common
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public abstract bool IsNullable { get; set; }
         [System.ComponentModel.DefaultValueAttribute("")]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public abstract string ParameterName { get; set; }
         public virtual byte Precision { get { throw null; } set { } }
         public virtual byte Scale { get { throw null; } set { } }
         public abstract int Size { get; set; }
         [System.ComponentModel.DefaultValueAttribute("")]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public abstract string SourceColumn { get; set; }
         [System.ComponentModel.DefaultValueAttribute(false)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
@@ -2261,7 +2290,7 @@ namespace System.Data.Common
         byte System.Data.IDbDataParameter.Scale { get { throw null; } set { } }
         [System.ComponentModel.DefaultValueAttribute(null)]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
-        public abstract object Value { get; set; }
+        public abstract object? Value { get; set; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
         public abstract void ResetDbType();
     }
@@ -2289,11 +2318,13 @@ namespace System.Data.Common
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public abstract object SyncRoot { get; }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        object? System.Collections.IList.this[int index] { get { throw null; } set { } }
         object System.Data.IDataParameterCollection.this[string parameterName] { get { throw null; } set { } }
+        int System.Collections.IList.Add(object? value) { throw null; }
         public abstract int Add(object value);
         public abstract void AddRange(System.Array values);
         public abstract void Clear();
+        bool System.Collections.IList.Contains(object? value) { throw null; }
         public abstract bool Contains(object value);
         public abstract bool Contains(string value);
         public abstract void CopyTo(System.Array array, int index);
@@ -2301,9 +2332,12 @@ namespace System.Data.Common
         public abstract System.Collections.IEnumerator GetEnumerator();
         protected abstract System.Data.Common.DbParameter GetParameter(int index);
         protected abstract System.Data.Common.DbParameter GetParameter(string parameterName);
+        int System.Collections.IList.IndexOf(object? value) { throw null; }
         public abstract int IndexOf(object value);
         public abstract int IndexOf(string parameterName);
+        void System.Collections.IList.Insert(int index, object? value) { throw null; }
         public abstract void Insert(int index, object value);
+        void System.Collections.IList.Remove(object? value) { throw null; }
         public abstract void Remove(object value);
         public abstract void RemoveAt(int index);
         public abstract void RemoveAt(string parameterName);
@@ -2312,7 +2346,7 @@ namespace System.Data.Common
     }
     public static partial class DbProviderFactories
     {
-        public static System.Data.Common.DbProviderFactory GetFactory(System.Data.Common.DbConnection connection) { throw null; }
+        public static System.Data.Common.DbProviderFactory? GetFactory(System.Data.Common.DbConnection connection) { throw null; }
         public static System.Data.Common.DbProviderFactory GetFactory(System.Data.DataRow providerRow) { throw null; }
         public static System.Data.Common.DbProviderFactory GetFactory(string providerInvariantName) { throw null; }
         public static System.Data.DataTable GetFactoryClasses() { throw null; }
@@ -2320,7 +2354,7 @@ namespace System.Data.Common
         public static void RegisterFactory(string providerInvariantName, System.Data.Common.DbProviderFactory factory) { }
         public static void RegisterFactory(string providerInvariantName, string factoryTypeAssemblyQualifiedName) { }
         public static void RegisterFactory(string providerInvariantName, System.Type providerFactoryClass) { }
-        public static bool TryGetFactory(string providerInvariantName, out System.Data.Common.DbProviderFactory factory) { throw null; }
+        public static bool TryGetFactory(string providerInvariantName, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Data.Common.DbProviderFactory? factory) { throw null; }
         public static bool UnregisterFactory(string providerInvariantName) { throw null; }
     }
     public abstract partial class DbProviderFactory
@@ -2329,13 +2363,13 @@ namespace System.Data.Common
         public virtual bool CanCreateCommandBuilder { get { throw null; } }
         public virtual bool CanCreateDataAdapter { get { throw null; } }
         public virtual bool CanCreateDataSourceEnumerator { get { throw null; } }
-        public virtual System.Data.Common.DbCommand CreateCommand() { throw null; }
-        public virtual System.Data.Common.DbCommandBuilder CreateCommandBuilder() { throw null; }
-        public virtual System.Data.Common.DbConnection CreateConnection() { throw null; }
-        public virtual System.Data.Common.DbConnectionStringBuilder CreateConnectionStringBuilder() { throw null; }
-        public virtual System.Data.Common.DbDataAdapter CreateDataAdapter() { throw null; }
-        public virtual System.Data.Common.DbDataSourceEnumerator CreateDataSourceEnumerator() { throw null; }
-        public virtual System.Data.Common.DbParameter CreateParameter() { throw null; }
+        public virtual System.Data.Common.DbCommand? CreateCommand() { throw null; }
+        public virtual System.Data.Common.DbCommandBuilder? CreateCommandBuilder() { throw null; }
+        public virtual System.Data.Common.DbConnection? CreateConnection() { throw null; }
+        public virtual System.Data.Common.DbConnectionStringBuilder? CreateConnectionStringBuilder() { throw null; }
+        public virtual System.Data.Common.DbDataAdapter? CreateDataAdapter() { throw null; }
+        public virtual System.Data.Common.DbDataSourceEnumerator? CreateDataSourceEnumerator() { throw null; }
+        public virtual System.Data.Common.DbParameter? CreateParameter() { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
     public sealed partial class DbProviderSpecificTypePropertyAttribute : System.Attribute
@@ -2346,10 +2380,10 @@ namespace System.Data.Common
     public abstract partial class DbTransaction : System.MarshalByRefObject, System.Data.IDbTransaction, System.IDisposable, System.IAsyncDisposable
     {
         protected DbTransaction() { }
-        public System.Data.Common.DbConnection Connection { get { throw null; } }
-        protected abstract System.Data.Common.DbConnection DbConnection { get; }
+        public System.Data.Common.DbConnection? Connection { get { throw null; } }
+        protected abstract System.Data.Common.DbConnection? DbConnection { get; }
         public abstract System.Data.IsolationLevel IsolationLevel { get; }
-        System.Data.IDbConnection System.Data.IDbTransaction.Connection { get { throw null; } }
+        System.Data.IDbConnection? System.Data.IDbTransaction.Connection { get { throw null; } }
         public abstract void Commit();
         public virtual System.Threading.Tasks.Task CommitAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void Dispose() { }
@@ -2376,6 +2410,7 @@ namespace System.Data.Common
         Insensitive = 1,
         Sensitive = 2,
     }
+#nullable disable
     public partial class RowUpdatedEventArgs : System.EventArgs
     {
         public RowUpdatedEventArgs(System.Data.DataRow dataRow, System.Data.IDbCommand command, System.Data.StatementType statementType, System.Data.Common.DataTableMapping tableMapping) { }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public abstract class DbColumn
     {
         public bool? AllowDBNull { get; protected set; }
-        public string BaseCatalogName { get; protected set; }
-        public string BaseColumnName { get; protected set; }
-        public string BaseSchemaName { get; protected set; }
-        public string BaseServerName { get; protected set; }
-        public string BaseTableName { get; protected set; }
-        public string ColumnName { get; protected set; }
+        public string? BaseCatalogName { get; protected set; }
+        public string? BaseColumnName { get; protected set; }
+        public string? BaseSchemaName { get; protected set; }
+        public string? BaseServerName { get; protected set; }
+        public string? BaseTableName { get; protected set; }
+        public string ColumnName { get; protected set; } = "";
         public int? ColumnOrdinal { get; protected set; }
         public int? ColumnSize { get; protected set; }
         public bool? IsAliased { get; protected set; }
@@ -26,10 +28,10 @@ namespace System.Data.Common
         public bool? IsUnique { get; protected set; }
         public int? NumericPrecision { get; protected set; }
         public int? NumericScale { get; protected set; }
-        public string UdtAssemblyQualifiedName { get; protected set; }
-        public Type DataType { get; protected set; }
-        public string DataTypeName { get; protected set; }
-        public virtual object this[string property] =>
+        public string? UdtAssemblyQualifiedName { get; protected set; }
+        public Type? DataType { get; protected set; }
+        public string? DataTypeName { get; protected set; }
+        public virtual object? this[string property] =>
             property switch
             {
                 nameof(AllowDBNull) => AllowDBNull,

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -16,6 +18,7 @@ namespace System.Data.Common
 
         [DefaultValue("")]
         [RefreshProperties(RefreshProperties.All)]
+        [AllowNull]
         public abstract string CommandText { get; set; }
 
         public abstract int CommandTimeout { get; set; }
@@ -27,23 +30,23 @@ namespace System.Data.Common
         [Browsable(false)]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public DbConnection Connection
+        public DbConnection? Connection
         {
             get { return DbConnection; }
             set { DbConnection = value; }
         }
 
-        IDbConnection IDbCommand.Connection
+        IDbConnection? IDbCommand.Connection
         {
             get { return DbConnection; }
-            set { DbConnection = (DbConnection)value; }
+            set { DbConnection = (DbConnection?)value; }
         }
 
-        protected abstract DbConnection DbConnection { get; set; }
+        protected abstract DbConnection? DbConnection { get; set; }
 
         protected abstract DbParameterCollection DbParameterCollection { get; }
 
-        protected abstract DbTransaction DbTransaction { get; set; }
+        protected abstract DbTransaction? DbTransaction { get; set; }
 
         // By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
         // to limit the number of components that clutter the design surface,
@@ -64,16 +67,16 @@ namespace System.Data.Common
         [Browsable(false)]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public DbTransaction Transaction
+        public DbTransaction? Transaction
         {
             get { return DbTransaction; }
             set { DbTransaction = value; }
         }
 
-        IDbTransaction IDbCommand.Transaction
+        IDbTransaction? IDbCommand.Transaction
         {
             get { return DbTransaction; }
-            set { DbTransaction = (DbTransaction)value; }
+            set { DbTransaction = (DbTransaction?)value; }
         }
 
         [DefaultValue(System.Data.UpdateRowSource.Both)]
@@ -128,7 +131,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
+                    registration = cancellationToken.Register(s => ((DbCommand)s!).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -169,7 +172,7 @@ namespace System.Data.Common
                 CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
+                    registration = cancellationToken.Register(s => ((DbCommand)s!).CancelIgnoreFailure(), this);
                 }
 
                 try
@@ -187,30 +190,30 @@ namespace System.Data.Common
             }
         }
 
-        public Task<object> ExecuteScalarAsync() =>
+        public Task<object?> ExecuteScalarAsync() =>
             ExecuteScalarAsync(CancellationToken.None);
 
-        public virtual Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+        public virtual Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<object>();
+                return ADP.CreatedTaskWithCancellation<object?>();
             }
             else
             {
                 CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
-                    registration = cancellationToken.Register(s => ((DbCommand)s).CancelIgnoreFailure(), this);
+                    registration = cancellationToken.Register(s => ((DbCommand)s!).CancelIgnoreFailure(), this);
                 }
 
                 try
                 {
-                    return Task.FromResult<object>(ExecuteScalar());
+                    return Task.FromResult<object?>(ExecuteScalar());
                 }
                 catch (Exception e)
                 {
-                    return Task.FromException<object>(e);
+                    return Task.FromException<object?>(e);
                 }
                 finally
                 {
@@ -219,7 +222,7 @@ namespace System.Data.Common
             }
         }
 
-        public abstract object ExecuteScalar();
+        public abstract object? ExecuteScalar();
 
         public abstract void Prepare();
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbConnection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbConnection.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+
+#nullable enable
 
 namespace System.Data.Common
 {
@@ -24,6 +27,7 @@ namespace System.Data.Common
 #pragma warning disable 618 // ignore obsolete warning about RecommendedAsConfigurable to use SettingsBindableAttribute
         [RecommendedAsConfigurable(true)]
 #pragma warning restore 618
+        [AllowNull]
         public abstract string ConnectionString { get; set; }
 
         public virtual int ConnectionTimeout => ADP.DefaultConnectionTimeout;
@@ -35,9 +39,9 @@ namespace System.Data.Common
         /// <summary>
         /// The associated provider factory for derived class.
         /// </summary>
-        protected virtual DbProviderFactory DbProviderFactory => null;
+        protected virtual DbProviderFactory? DbProviderFactory => null;
 
-        internal DbProviderFactory ProviderFactory => DbProviderFactory;
+        internal DbProviderFactory? ProviderFactory => DbProviderFactory;
 
         [Browsable(false)]
         public abstract string ServerVersion { get; }
@@ -45,7 +49,7 @@ namespace System.Data.Common
         [Browsable(false)]
         public abstract ConnectionState State { get; }
 
-        public virtual event StateChangeEventHandler StateChange;
+        public virtual event StateChangeEventHandler? StateChange;
 
         protected abstract DbTransaction BeginDbTransaction(IsolationLevel isolationLevel);
 
@@ -133,7 +137,7 @@ namespace System.Data.Common
 
         protected abstract DbCommand CreateDbCommand();
 
-        public virtual void EnlistTransaction(System.Transactions.Transaction transaction)
+        public virtual void EnlistTransaction(System.Transactions.Transaction? transaction)
         {
             throw ADP.NotSupported();
         }
@@ -150,7 +154,7 @@ namespace System.Data.Common
             throw ADP.NotSupported();
         }
 
-        public virtual DataTable GetSchema(string collectionName, string[] restrictionValues)
+        public virtual DataTable GetSchema(string collectionName, string?[] restrictionValues)
         {
             throw ADP.NotSupported();
         }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReader.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Collections;
 using System.ComponentModel;
 using System.IO;
@@ -82,11 +83,11 @@ namespace System.Data.Common
 
         public abstract byte GetByte(int ordinal);
 
-        public abstract long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length);
+        public abstract long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length);
 
         public abstract char GetChar(int ordinal);
 
-        public abstract long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length);
+        public abstract long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DbDataReader GetData(int ordinal) => GetDbDataReader(ordinal);

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReaderExtensions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReaderExtensions.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Data.Common
 {
@@ -24,11 +27,11 @@ namespace System.Data.Common
             private void PopulateFields()
             {
                 AllowDBNull = GetDbColumnValue<bool?>(SchemaTableColumn.AllowDBNull);
-                BaseCatalogName = GetDbColumnValue<string>(SchemaTableOptionalColumn.BaseCatalogName);
-                BaseColumnName = GetDbColumnValue<string>(SchemaTableColumn.BaseColumnName);
-                BaseSchemaName = GetDbColumnValue<string>(SchemaTableColumn.BaseSchemaName);
-                BaseServerName = GetDbColumnValue<string>(SchemaTableOptionalColumn.BaseServerName);
-                BaseTableName = GetDbColumnValue<string>(SchemaTableColumn.BaseTableName);
+                BaseCatalogName = GetDbColumnValue<string?>(SchemaTableOptionalColumn.BaseCatalogName);
+                BaseColumnName = GetDbColumnValue<string?>(SchemaTableColumn.BaseColumnName);
+                BaseSchemaName = GetDbColumnValue<string?>(SchemaTableColumn.BaseSchemaName);
+                BaseServerName = GetDbColumnValue<string?>(SchemaTableOptionalColumn.BaseServerName);
+                BaseTableName = GetDbColumnValue<string?>(SchemaTableColumn.BaseTableName);
                 ColumnName = GetDbColumnValue<string>(SchemaTableColumn.ColumnName);
                 ColumnOrdinal = GetDbColumnValue<int?>(SchemaTableColumn.ColumnOrdinal);
                 ColumnSize = GetDbColumnValue<int?>(SchemaTableColumn.ColumnSize);
@@ -43,12 +46,13 @@ namespace System.Data.Common
                 IsUnique = GetDbColumnValue<bool?>(SchemaTableColumn.IsUnique);
                 NumericPrecision = GetDbColumnValue<int?>(SchemaTableColumn.NumericPrecision);
                 NumericScale = GetDbColumnValue<int?>(SchemaTableColumn.NumericScale);
-                UdtAssemblyQualifiedName = GetDbColumnValue<string>("UdtAssemblyQualifiedName");
-                DataType = GetDbColumnValue<Type>(SchemaTableColumn.DataType);
-                DataTypeName = GetDbColumnValue<string>("DataTypeName");
+                UdtAssemblyQualifiedName = GetDbColumnValue<string?>("UdtAssemblyQualifiedName");
+                DataType = GetDbColumnValue<Type?>(SchemaTableColumn.DataType);
+                DataTypeName = GetDbColumnValue<string?>("DataTypeName");
             }
 
-            private T GetDbColumnValue<T>(string columnName) => _schemaColumns.Contains(columnName) && _schemaRow[columnName] is T value ? value : (default);
+            // The following may return null, but local methods can't be annotated for that yet ([MaybeNull])
+            private T GetDbColumnValue<T>(string columnName) => _schemaColumns.Contains(columnName) && _schemaRow[columnName] is T value ? value : default!;
         }
 
         public static ReadOnlyCollection<DbColumn> GetColumnSchema(this DbDataReader reader)
@@ -76,11 +80,10 @@ namespace System.Data.Common
             DataColumnCollection schemaTableColumns = schemaTable.Columns;
             foreach (DataRow row in schemaTable.Rows)
             {
+                Debug.Assert(row != null);
                 columnSchema.Add(new DataRowDbColumn(row, schemaTableColumns));
             }
             return new ReadOnlyCollection<DbColumn>(columnSchema);
         }
     }
-
-
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataRecord.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataRecord.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.ComponentModel;
 
 namespace System.Data.Common
@@ -69,6 +70,7 @@ namespace System.Data.Common
         // ICustomTypeDescriptor
         //
 
+#nullable disable
         AttributeCollection ICustomTypeDescriptor.GetAttributes() => new AttributeCollection(null);
 
         string ICustomTypeDescriptor.GetClassName() => null;
@@ -94,5 +96,6 @@ namespace System.Data.Common
             new PropertyDescriptorCollection(null);
 
         object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd) => this;
+#nullable enable
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSourceEnumerator.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSourceEnumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public abstract class DbDataSourceEnumerator

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     [Serializable]
@@ -10,11 +12,11 @@ namespace System.Data.Common
     {
         protected DbException() : base() { }
 
-        protected DbException(string message) : base(message) { }
+        protected DbException(string? message) : base(message) { }
 
-        protected DbException(string message, System.Exception innerException) : base(message, innerException) { }
+        protected DbException(string? message, System.Exception? innerException) : base(message, innerException) { }
 
-        protected DbException(string message, int errorCode) : base(message, errorCode) { }
+        protected DbException(string? message, int errorCode) : base(message, errorCode) { }
 
         protected DbException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbMetaDataCollectionNames.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbMetaDataCollectionNames.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public static class DbMetaDataCollectionNames

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbMetaDataColumnNames.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbMetaDataColumnNames.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public static class DbMetaDataColumnNames

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbParameter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbParameter.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Data.Common
 {
@@ -28,6 +30,7 @@ namespace System.Data.Common
         public abstract bool IsNullable { get; set; }
 
         [DefaultValue("")]
+        [AllowNull]
         public abstract string ParameterName { get; set; }
 
         byte IDbDataParameter.Precision
@@ -57,6 +60,7 @@ namespace System.Data.Common
         public abstract int Size { get; set; }
 
         [DefaultValue("")]
+        [AllowNull]
         public abstract string SourceColumn { get; set; }
 
         [DefaultValue(false)]
@@ -73,6 +77,6 @@ namespace System.Data.Common
 
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
-        public abstract object Value { get; set; }
+        public abstract object? Value { get; set; }
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbParameterCollection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbParameterCollection.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.ComponentModel;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Data.Common
 {
@@ -35,16 +37,16 @@ namespace System.Data.Common
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public abstract object SyncRoot { get; }
 
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get { return GetParameter(index); }
-            set { SetParameter(index, (DbParameter)value); }
+            set { SetParameter(index, (DbParameter)value!); }
         }
 
         object IDataParameterCollection.this[string parameterName]
         {
             get { return GetParameter(parameterName); }
-            set { SetParameter(parameterName, (DbParameter)value); }
+            set { SetParameter(parameterName, (DbParameter)value!); }
         }
 
         public DbParameter this[int index]
@@ -59,9 +61,33 @@ namespace System.Data.Common
             set { SetParameter(parameterName, value); }
         }
 
+        /// <summary>
+        /// For a description of this member, see <see cref="IList.Add" />.
+        /// </summary>
+        /// <param name="value">For a description of this member, see <see cref="IList.Add" />.</param>
+        /// <returns>For a description of this member, see <see cref="IList.Add" />.</returns>
+        /// <remarks>
+        /// This member is an explicit interface member implementation.
+        /// It can be used only when the <see cref="DbParameterCollection" /> instance is cast to
+        /// <see cref="IList" /> interface.
+        /// </remarks>
+        int IList.Add(object? value) => Add(value!);
+
         public abstract int Add(object value);
 
         public abstract void AddRange(System.Array values);
+
+        /// <summary>
+        /// For a description of this member, see <see cref="IList.Contains" />.
+        /// </summary>
+        /// <param name="value">For a description of this member, see <see cref="IList.Contains" />.</param>
+        /// <returns>For a description of this member, see <see cref="IList.Contains" />.</returns>
+        /// <remarks>
+        /// This member is an explicit interface member implementation.
+        /// It can be used only when the <see cref="DbParameterCollection" /> instance is cast to
+        /// <see cref="IList" /> interface.
+        /// </remarks>
+        bool IList.Contains(object? value) => Contains(value!);
 
         public abstract bool Contains(object value);
 
@@ -78,11 +104,46 @@ namespace System.Data.Common
 
         protected abstract DbParameter GetParameter(string parameterName);
 
+        /// <summary>
+        /// For a description of this member, see <see cref="IList.IndexOf" />.
+        /// </summary>
+        /// <param name="value">For a description of this member, see <see cref="IList.IndexOf" />.</param>
+        /// <returns>For a description of this member, see <see cref="IList.IndexOf" />.</returns>
+        /// <remarks>
+        /// This member is an explicit interface member implementation.
+        /// It can be used only when the <see cref="DbParameterCollection" /> instance is cast to
+        /// <see cref="IList" /> interface.
+        /// </remarks>
+        int IList.IndexOf(object? value) => IndexOf(value!);
+
         public abstract int IndexOf(object value);
 
         public abstract int IndexOf(string parameterName);
 
+        /// <summary>
+        /// For a description of this member, see <see cref="IList.Insert" />.
+        /// </summary>
+        /// <param name="index">For a description of this member, see <see cref="IList.Insert" />.</param>
+        /// <param name="value">For a description of this member, see <see cref="IList.Insert" />.</param>
+        /// <remarks>
+        /// This member is an explicit interface member implementation.
+        /// It can be used only when the <see cref="DbParameterCollection" /> instance is cast to
+        /// <see cref="IList" /> interface.
+        /// </remarks>
+        void IList.Insert(int index, object? value) => Insert(index, value!);
+
         public abstract void Insert(int index, object value);
+
+        /// <summary>
+        /// For a description of this member, see <see cref="IList.Remove" />.
+        /// </summary>
+        /// <param name="value">For a description of this member, see <see cref="IList.Remove" />.</param>
+        /// <remarks>
+        /// This member is an explicit interface member implementation.
+        /// It can be used only when the <see cref="DbParameterCollection" /> instance is cast to
+        /// <see cref="IList" /> interface.
+        /// </remarks>
+        void IList.Remove(object? value) => Remove(value!);
 
         public abstract void Remove(object value);
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderFactories.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderFactories.cs
@@ -6,10 +6,13 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+
+#nullable enable
 
 namespace System.Data.Common
 {
@@ -17,18 +20,19 @@ namespace System.Data.Common
     {
         private struct ProviderRegistration
         {
-            internal ProviderRegistration(string factoryTypeAssemblyQualifiedName, DbProviderFactory factoryInstance)
+            internal ProviderRegistration(string factoryTypeAssemblyQualifiedName, DbProviderFactory? factoryInstance)
             {
                 this.FactoryTypeAssemblyQualifiedName = factoryTypeAssemblyQualifiedName;
                 this.FactoryInstance = factoryInstance;
             }
 
             internal string FactoryTypeAssemblyQualifiedName { get; }
+
             /// <summary>
-            /// The cached instance of the type in <see cref="FactoryTypeAssemblyQualifiedName"/>. If null, this registation is seen as a deferred registration
+            /// The cached instance of the type in <see cref="FactoryTypeAssemblyQualifiedName"/>. If null, this registration is seen as a deferred registration
             /// and <see cref="FactoryTypeAssemblyQualifiedName"/> is checked the first time when this registration is requested through GetFactory().
             /// </summary>
-            internal DbProviderFactory FactoryInstance { get; }
+            internal DbProviderFactory? FactoryInstance { get; }
         }
 
         private static readonly ConcurrentDictionary<string, ProviderRegistration> _registeredFactories = new ConcurrentDictionary<string, ProviderRegistration>();
@@ -39,7 +43,7 @@ namespace System.Data.Common
         private const string ProviderGroupColumnName = "DbProviderFactories";
         private const string InstanceFieldName = "Instance";
 
-        public static bool TryGetFactory(string providerInvariantName, out DbProviderFactory factory)
+        public static bool TryGetFactory(string providerInvariantName, [NotNullWhen(true)] out DbProviderFactory? factory)
         {
             factory = GetFactory(providerInvariantName, throwOnError: false);
             return factory != null;
@@ -47,7 +51,7 @@ namespace System.Data.Common
 
         public static DbProviderFactory GetFactory(string providerInvariantName)
         {
-            return GetFactory(providerInvariantName, throwOnError: true);
+            return GetFactory(providerInvariantName, throwOnError: true)!;
         }
 
         public static DbProviderFactory GetFactory(DataRow providerRow)
@@ -60,7 +64,7 @@ namespace System.Data.Common
                 throw ADP.Argument(SR.ADP_DbProviderFactories_NoAssemblyQualifiedName);
             }
 
-            string assemblyQualifiedName = providerRow[assemblyQualifiedNameColumn] as string;
+            string? assemblyQualifiedName = providerRow[assemblyQualifiedNameColumn] as string;
             if (string.IsNullOrWhiteSpace(assemblyQualifiedName))
             {
                 throw ADP.Argument(SR.ADP_DbProviderFactories_NoAssemblyQualifiedName);
@@ -70,7 +74,7 @@ namespace System.Data.Common
         }
 
 
-        public static DbProviderFactory GetFactory(DbConnection connection)
+        public static DbProviderFactory? GetFactory(DbConnection connection)
         {
             ADP.CheckArgumentNull(connection, nameof(connection));
 
@@ -123,7 +127,8 @@ namespace System.Data.Common
             ADP.CheckArgumentLength(providerInvariantName, nameof(providerInvariantName));
             ADP.CheckArgumentNull(factory, nameof(factory));
 
-            _registeredFactories[providerInvariantName] = new ProviderRegistration(factory.GetType().AssemblyQualifiedName, factory);
+            string factoryTypeAssemblyQualifiedName = factory.GetType().AssemblyQualifiedName!;
+            _registeredFactories[providerInvariantName] = new ProviderRegistration(factoryTypeAssemblyQualifiedName, factory);
         }
 
         public static bool UnregisterFactory(string providerInvariantName)
@@ -131,7 +136,7 @@ namespace System.Data.Common
             return !string.IsNullOrWhiteSpace(providerInvariantName) && _registeredFactories.TryRemove(providerInvariantName, out _);
         }
 
-        private static DbProviderFactory GetFactory(string providerInvariantName, bool throwOnError)
+        private static DbProviderFactory? GetFactory(string providerInvariantName, bool throwOnError)
         {
             if (throwOnError)
             {
@@ -147,9 +152,9 @@ namespace System.Data.Common
             bool wasRegistered = _registeredFactories.TryGetValue(providerInvariantName, out ProviderRegistration registration);
             if (!wasRegistered)
             {
-                return throwOnError ? throw ADP.Argument(SR.Format(SR.ADP_DbProviderFactories_InvariantNameNotFound, providerInvariantName)) : (DbProviderFactory)null;
+                return throwOnError ? throw ADP.Argument(SR.Format(SR.ADP_DbProviderFactories_InvariantNameNotFound, providerInvariantName)) : (DbProviderFactory?)null;
             }
-            DbProviderFactory toReturn = registration.FactoryInstance;
+            DbProviderFactory? toReturn = registration.FactoryInstance;
             if (toReturn == null)
             {
                 // Deferred registration, do checks now on the type specified and register instance in storage.
@@ -169,7 +174,7 @@ namespace System.Data.Common
                 throw ADP.Argument(SR.Format(SR.ADP_DbProviderFactories_NotAFactoryType, providerFactoryClass.FullName));
             }
 
-            FieldInfo providerInstance = providerFactoryClass.GetField(InstanceFieldName, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static);
+            FieldInfo? providerInstance = providerFactoryClass.GetField(InstanceFieldName, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Static);
             if (null == providerInstance)
             {
                 throw ADP.InvalidOperation(SR.ADP_DbProviderFactories_NoInstance);
@@ -178,7 +183,7 @@ namespace System.Data.Common
             {
                 throw ADP.InvalidOperation(SR.ADP_DbProviderFactories_NoInstance);
             }
-            object factory = providerInstance.GetValue(null);
+            object? factory = providerInstance.GetValue(null);
             if (null == factory)
             {
                 throw ADP.InvalidOperation(SR.ADP_DbProviderFactories_NoInstance);
@@ -189,7 +194,7 @@ namespace System.Data.Common
 
         private static Type GetProviderTypeFromTypeName(string assemblyQualifiedName)
         {
-            Type providerType = Type.GetType(assemblyQualifiedName);
+            Type? providerType = Type.GetType(assemblyQualifiedName);
             if (null == providerType)
             {
                 throw ADP.Argument(SR.Format(SR.ADP_DbProviderFactories_FactoryNotLoadable, assemblyQualifiedName));

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderFactory.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderFactory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public abstract partial class DbProviderFactory
@@ -19,7 +21,7 @@ namespace System.Data.Common
             {
                 if (!_canCreateDataAdapter.HasValue)
                 {
-                    using (DbDataAdapter adapter = CreateDataAdapter())
+                    using (DbDataAdapter? adapter = CreateDataAdapter())
                     {
                         _canCreateDataAdapter = adapter != null;
                     }
@@ -35,7 +37,7 @@ namespace System.Data.Common
             {
                 if (!_canCreateCommandBuilder.HasValue)
                 {
-                    using (DbCommandBuilder builder = CreateCommandBuilder())
+                    using (DbCommandBuilder? builder = CreateCommandBuilder())
                     {
                         _canCreateCommandBuilder = builder != null;
                     }
@@ -45,18 +47,18 @@ namespace System.Data.Common
             }
         }
 
-        public virtual DbCommand CreateCommand() => null;
+        public virtual DbCommand? CreateCommand() => null;
 
-        public virtual DbCommandBuilder CreateCommandBuilder() => null;
+        public virtual DbCommandBuilder? CreateCommandBuilder() => null;
 
-        public virtual DbConnection CreateConnection() => null;
+        public virtual DbConnection? CreateConnection() => null;
 
-        public virtual DbConnectionStringBuilder CreateConnectionStringBuilder() => null;
+        public virtual DbConnectionStringBuilder? CreateConnectionStringBuilder() => null;
 
-        public virtual DbDataAdapter CreateDataAdapter() => null;
+        public virtual DbDataAdapter? CreateDataAdapter() => null;
 
-        public virtual DbParameter CreateParameter() => null;
+        public virtual DbParameter? CreateParameter() => null;
 
-        public virtual DbDataSourceEnumerator CreateDataSourceEnumerator() => null;
+        public virtual DbDataSourceEnumerator? CreateDataSourceEnumerator() => null;
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderSpecificTypePropertyAttribute.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbProviderSpecificTypePropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbTransaction.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbTransaction.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,11 +12,11 @@ namespace System.Data.Common
     {
         protected DbTransaction() : base() { }
 
-        public DbConnection Connection => DbConnection;
+        public DbConnection? Connection => DbConnection;
 
-        IDbConnection IDbTransaction.Connection => DbConnection;
+        IDbConnection? IDbTransaction.Connection => DbConnection;
 
-        protected abstract DbConnection DbConnection { get; }
+        protected abstract DbConnection? DbConnection { get; }
 
         public abstract IsolationLevel IsolationLevel { get; }
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/IDbColumnSchemaGenerator.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/IDbColumnSchemaGenerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public interface IDbColumnSchemaGenerator

--- a/src/libraries/System.Data.Common/src/System/Data/Common/identifiercase.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/identifiercase.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data.Common
 {
     public enum IdentifierCase

--- a/src/libraries/System.Data.Common/src/System/Data/IDataParameter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDataParameter.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Data
 {
     public interface IDataParameter
@@ -9,9 +12,11 @@ namespace System.Data
         DbType DbType { get; set; }
         ParameterDirection Direction { get; set; }
         bool IsNullable { get; }
+        [AllowNull]
         string ParameterName { get; set; }
+        [AllowNull]
         string SourceColumn { get; set; }
         DataRowVersion SourceVersion { get; set; }
-        object Value { get; set; }
+        object? Value { get; set; }
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/IDataParameterCollection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDataParameterCollection.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Collections;
 
 namespace System.Data

--- a/src/libraries/System.Data.Common/src/System/Data/IDataReader.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDataReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public interface IDataReader : IDisposable, IDataRecord

--- a/src/libraries/System.Data.Common/src/System/Data/IDataRecord.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDataRecord.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public interface IDataRecord

--- a/src/libraries/System.Data.Common/src/System/Data/IDbCommand.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDbCommand.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Data
 {
     public interface IDbCommand : IDisposable
     {
-        IDbConnection Connection { get; set; }
-        IDbTransaction Transaction { get; set; }
+        IDbConnection? Connection { get; set; }
+        IDbTransaction? Transaction { get; set; }
+        [AllowNull]
         string CommandText { get; set; }
         int CommandTimeout { get; set; }
         CommandType CommandType { get; set; }
@@ -19,6 +23,6 @@ namespace System.Data
         int ExecuteNonQuery();
         IDataReader ExecuteReader();
         IDataReader ExecuteReader(CommandBehavior behavior);
-        object ExecuteScalar();
+        object? ExecuteScalar();
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/IDbConnection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDbConnection.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Data
 {
     public interface IDbConnection : IDisposable
     {
+        [AllowNull]
         string ConnectionString { get; set; }
         int ConnectionTimeout { get; }
         string Database { get; }

--- a/src/libraries/System.Data.Common/src/System/Data/IDbDataParameter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDbDataParameter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public interface IDbDataParameter : IDataParameter

--- a/src/libraries/System.Data.Common/src/System/Data/IDbTransaction.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/IDbTransaction.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public interface IDbTransaction : IDisposable
     {
-        IDbConnection Connection { get; }
+        IDbConnection? Connection { get; }
         IsolationLevel IsolationLevel { get; }
         void Commit();
         void Rollback();

--- a/src/libraries/System.Data.Common/src/System/Data/StateChangeEvent.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/StateChangeEvent.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public sealed class StateChangeEventArgs : EventArgs

--- a/src/libraries/System.Data.Common/src/System/Data/StateChangeEventHandler.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/StateChangeEventHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace System.Data
 {
     public delegate void StateChangeEventHandler(object sender, StateChangeEventArgs e);


### PR DESCRIPTION
# General Notes

This PR is a proposal for annotating the main types in System.Data.Common (S.D.C). It focuses on types necessary to create ADO.NET providers, and leaves out various non-essential types; this will be revisited at a later time.

Unlike the usual NRT annotation exercise, here we're annotating a provider abstraction; there is very little actual logic in S.D.C we can consult to determine what should be nullable. In addition, specifications around nulls are unfortunately rarely present in the documentation. As such, the behavior of existing major providers was used as a guidance for annotation, as a "de-facto standard". Four providers were checked: Microsoft.Data.SqlClient, Npgsql, MySQL Connector and Microsoft.Data.SQLite. [The AdoNetApiTest suite](https://github.com/mysql-net/AdoNetApiTest) was used extensively to map out behavior across providers; this exercise also resulted in many test additions to that suite as well.

The goal here is to gather feedback from ADO.NET driver developers and other people working in the .NET database space, as well as from BCL experts and people experienced in NRT annotation.

/cc @cheenamalhotra @David-Engel @saurabh500 @Wraith2 @bgrainger @ErikEJ @FransBouma @mgravell @bricelam @ajcvickers @AndriySvyryd
/cc @stephentoub @cartermp @rynowak

## Null-returning base method implementations

There are unfortunately several cases where a base S.D.C implementation returns null for a type that providers *must* provide. Examples include methods on DbProviderFactory (e.g. CreateConnection), DbConnection.DbProviderFactory, etc.; these properties really should have been made abstract, or at least throw instead of returning null.

We have three options:

1. Make these properties throw. This would be a breaking change (largely theoretical because providers really must implement these).
2. Annotate these properties as non-nullable. This would avoid the breaking change, but for people who opt into the NRE feature, and who use a badly-implemented provider, null would be exposed.
3. Annotate these properties as nullable. This is a disservice for the 99% case, where users would have to satisfy the compiler with needless checks.

~Depending on our backwards-compatibility bar, I believe we should at least do 2, possibly 1.~

I believe the breaking change is worth it (option 1).

See some previous discussion in https://github.com/dotnet/corefx/issues/35535, and specific discussion below.

## De-facto normalized string properties

There are several cases of string properties which are documented to be an empty string by default, and which providers generally normalize to empty string when null is set:

* DbConnection.ConnectionString
* DbCommand.CommandText
* DbConnectionStringBuilder.ConnectionString
* DbParameter.ParameterName, SourceColumn

[As per the BCL nullability guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/api-guidelines/nullability.md):

> DO define a parameter as nullable if the method checks the parameter for null and does something other than throw. This may include normalizing the input, e.g. treating null as string.Empty.

As the de-facto provider behavior is to allow nulls (and normalize to empty string), these properties are annotated as non-nullable with `[AllowNull]`.

Note that the same holds for the setter of `DbConnectionStringBuilder.this[]`: setting a keyword to null means removing it.

----

# Specific Type-By-Type Notes

This section details some annotation details which are noteworthy. Where annotation was straightforward no notes were made.

### DbDataReader/IDataReader/DataReaderExtensions

* GetSchemaTable/GetColumnSchema: annotated non-nullable for now, as per https://github.com/dotnet/runtime/issues/509
* GetName/GetDataTypeName/GetFieldType/Get*: these throw when resultset isn't present, and should throw in any other error case. Annotating as non-nullable.
* GetBytes/GetChars: in SqlClient and Npgsql, passing a null buffer is valid and simply returns the number of bytes/chars in the column ([docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqldatareader.getbytes)). Annotating as nullable.

### DbTransaction/IDbTransaction

DbTransaction.Connection: always non-null before commit/rollback, always null afterwards; so annotated it as nullable. It would have been better for DbTransaction to transition to a disposed state immediately after commit/rollback, in which case the Connection would have been non-nullable.

### DbProviderFactories
No specific comments

### DbProviderFactory

* All the Create* method base implementations unfortunately return null. There are two cases here:
    * Methods which providers *must* override (e.g. CreateConnection) - the provider cannot function correctly without these. I've changed these to throw NotSupportedException by default. See general note above.
    * Methods which providers *may* override (CreateCommandBuilder, CreateDataAdapter, CreateDataSourceEnumerator). These already have CanCreate* feature check properties, which provide a way for consumers to check support before calling the method. So I'm changing these to throw NotSupportedException as well. See previous discussion in https://github.com/dotnet/corefx/issues/35535.

### DbCommand

* CommandText:
    * SqlClient and Npgsql have this as empty string by default (this is actually specified [in the docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.commandtext?view=netframework-4.8#System_Data_Common_DbCommand_CommandText)). Sqlite and MySqlConnector have null here (in process of being fixed). Setting to null normalizes to empty string (Npgsql, MySQLConnector and Sqlite throws but this is being fixed).
    * Annotating as non-nullable with `[AllowNull]` as per guidelines (see note above).
    * Issues: https://github.com/mysql-net/MySqlConnector/issues/743, https://github.com/aspnet/EntityFrameworkCore/issues/19162, https://github.com/npgsql/npgsql/pull/2762
* ExecuteScalar returns null when there is no resultset or no rows ([this is documented](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.executescalar?view=netframework-4.8#System_Data_Common_DbCommand_ExecuteScalar), and all provider implement this behavior).

### DbConnection

* ConnectionString - similar to DbCommand.CommandText
    * All but Sqlite have an empty string by default, [as per the docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbconnection.connectionstring?view=netframework-4.8#System_Data_Common_DbConnection_ConnectionString).
    * All but Sqlite also normalize to empty string when setting to null.
    * Annotating as non-nullable with `[AllowNull]` as per guidelines (see note above).
* Database (on unopened connection)
    * [The docs specify an empty string as the default value](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbconnection.database?view=netframework-4.8). Also, since applications can/should know if the connection is open or not, am annotating this as non-nullable.
    * Sqlite returns "main", SqlClient & MySqlConnector return empty string, Npgsql returns null (being fixed)
* DataSource (on unopened connection)
    * Sqlite returns null, SqlClient & MySqlConnector return empty string, Npgsql returns mangled value (being fixed)
    * [The docs specify an empty string as the default value](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbconnection.datasource?view=netframework-4.8). Also, since applications can/should know if the connection is open or not, am annotating this as non-nullable.
* ServerVersion (on unopened connection)
    * All providers except Sqlite throw InvalidOperationException; this is [kinda specified in the docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbconnection.serverversion?view=netframework-4.8).
    * Annotating as non-nullable.
* DbProviderFactory
    * Internal, but the return value is exposed publicly through DbProviderFactories (so public in practice).
    * Defaults to null in DbConnection, but really expected to be non-null for any actual ADO provider.
    * All providers implement this correctly except Sqlite, which returns null.
    * Am annotating as non-nullable for now, we could even consider changing the default implementation to throw, as this must be provided.
* EnlistTransaction: There is evidence that passing a null parameter is a way to un-enlist from the current transaction, NHibernate seems to rely on this as well. https://github.com/npgsql/npgsql/issues/1580, https://stackoverflow.com/questions/12863950/what-does-dbconnection-enlisttransaction-do. Annotating as nullable.
* GetSchema
    * Default base implementations throw NotSupportedException, and no provider returns null. Annotating return value as non-nullable.
    * [The overload accepting a restrictions array](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbconnection.getschema?view=netframework-4.8#System_Data_Common_DbConnection_GetSchema_System_String_System_String___) allows nulls to request the default value for that restriction, annotating as nullable.

### DbConnectionStringBuilder

* ConnectionString
    * Defaults to empty (documented and implemented by all providers) and normalizes null to empty string.
    * Annotating as non-nullable with `[AllowNull]` as per guidelines (see note above).    
* In general, connection string values cannot be null - setting a value to null means removing it.
* Annotating the indexer as non-nullable with `[AllowNull]` as per guidelines (see note above).    
* As an exception, annotating the parameter to Add as non-nullable, although it technically does allow removing a keyword by passing null. An explicit interface implementation of IDictionary.Add still exists which accepts nullable and uses the null-forgiving operator to delegate to the non-nullable implementation.

### DbParameter

* ParameterName, SourceColumn
    * Defaults to empty string, [as documented](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbparameter.parametername?view=netframework-4.8#System_Data_Common_DbParameter_ParameterName), on all providers except Sqlite (where it is null). Normalizes null to empty string.
    * Annotating as non-nullable with `[AllowNull]` as per guidelines (see note above).    
* Value
    * Defaults to null and can be set to null on all providers. Executing with null parameter value makes sense for output (and in/out parameters) which will receive a database value, but for input parameters should always error (null is represented by DBNull.Value).
    * Annotating as nullable.

### DbParameterCollection / IDataParameterCollection

* Null parameters (or parameter names) are not supported by any provider (Sqlite has some bugs around this). The ADO.NET to send a null value is to have a non-null parameter instance with a DBNull value.
* However, IDataParameterCollection implements IList, which allows nulls and therefore has nullable annotations on parameters and return values.
* As a result, explicit interface implementations for IList methods have been added with nullable parameters/return values, which delegate to the DbParameterCollection non-nullable implementations. No runtime behavior change has been introduced: the null-forgiving parameter is used, so if a null happens to be passed in, it gets passed as before to the overridden implementation which is expected to throw.

### DbColumn

* According [to the docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcolumn?view=netframework-4.8), ColumnName seems to be the only mandatory field (null is explicitly mentioned elsewhere).
* The only question mark in my mind is DataTypeName, which seems to be rather mandatory (unless we're dealing with some unrecognized/unsupported column or something - but I'm not aware of such a case). Am annotating as nullable.
* All others values can legitimately be null (e.g. for `SELECT 1` there is no table, schema...).

----

# Edit history

| Date | Modification |
| ----- | ------------ |
| 2019-12-09 | Initial version
