### PR TITLE
Add RuntimeProperties Trace Event

### DIFF
--- a/src/coreclr/src/inc/eventtracebase.h
+++ b/src/coreclr/src/inc/eventtracebase.h
@@ -1130,8 +1130,10 @@ namespace ETW
 
 #ifdef FEATURE_EVENT_TRACE
         static VOID RuntimeInformation(INT32 type);
+        static VOID RuntimeInputProperties(int nProperties, LPCWSTR* propertyNames, LPCWSTR* propertyValues);
 #else
         static VOID RuntimeInformation(INT32 type) {};
+        static VOID RuntimeInputProperties() {};
 #endif // FEATURE_EVENT_TRACE
     };
 

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -710,6 +710,43 @@
                         </UserData>
                     </template>
 
+                    <template tid="RuntimeProperties">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="TrustedPlatformAssemblies" inType="win:UnicodeString"/>
+                        <data name="NativeDllSearchDirectories" inType="win:UnicodeString"/>
+                        <data name="PlatformResourceRoots" inType="win:UnicodeString"/>
+                        <data name="AppContextBaseDirectory" inType="win:UnicodeString"/>
+                        <data name="AppContextDepsFiles" inType="win:UnicodeString"/>
+                        <data name="ProbingDirectories" inType="win:UnicodeString"/>
+                        <data name="FxProductVersion" inType="win:UnicodeString"/>
+                        <data name="JitPath" inType="win:UnicodeString"/>
+                        <data name="FxDepsFile" inType="win:UnicodeString"/>
+                        <data name="AppPaths" inType="win:UnicodeString"/>
+                        <data name="AppNIPaths" inType="win:UnicodeString"/>
+                        <data name="StartUpHooks" inType="win:UnicodeString"/>
+                        <data name="ResolvedFrameworks" inType="win:UnicodeString"/>
+                        <data name="Others" inType="win:UnicodeString"/>
+                        <UserData>
+                            <Type xmlns="myNs">
+                                <ClrInstanceID> %1  </ClrInstanceID>
+                                <TrustedPlatformAssemblies> %2 </TrustedPlatformAssemblies>
+                                <NativeDllSearchDirectories> %3 </NativeDllSearchDirectories>
+                                <PlatformResourceRoots> %4 </PlatformResourceRoots>
+                                <AppContextBaseDirectory> %5 </AppContextBaseDirectory>
+                                <AppContextDepsFiles> %6 </AppContextDepsFiles>
+                                <ProbingDirectories> %7 </ProbingDirectories>
+                                <FxProductVersion> %8 </FxProductVersion>
+                                <JitPath> %9 </JitPath>
+                                <FxDepsFile> %10 </FxDepsFile>
+                                <AppPaths> %11 </AppPaths>
+                                <AppNIPaths> %12 </AppNIPaths>
+                                <StartUpHooks> %13 </StartUpHooks>
+                                <ResolvedFrameworks> %14 </ResolvedFrameworks>
+                                <Others> %15 </Others>
+                            </Type>
+                        </UserData>
+                    </template>
+
                     <template tid="GCStart">
                         <data name="Count" inType="win:UInt32" outType="xs:unsignedInt"/>
                         <data name="Reason" inType="win:UInt32" map="GCReasonMap" />
@@ -3470,7 +3507,12 @@
                            opcode="win:Start"
                            task="CLRRuntimeInformation"
                            symbol="RuntimeInformationStart" message="$(string.RuntimePublisher.RuntimeInformationEventMessage)"/>
-
+                    
+                    <event value="296" version="0" level="win:Informational"  template="RuntimeProperties"
+                           opcode="win:Start"
+                           task="CLRRuntimeInformation"
+                           symbol="RuntimeProperties" message="$(string.RuntimePublisher.RuntimePropertiesEventMessage)"/>
+                    
                     <!-- Additional GC events 200-239 -->
                     <event value="200" version="0" level="win:Verbose" template="IncreaseMemoryPressure"
                            keywords="GCKeyword" opcode="IncreaseMemoryPressure"
@@ -6791,6 +6833,7 @@
                 <string id="RuntimePublisher.AuthenticodeVerificationEnd_V1EventMessage" value="VerificationFlags=%1;%nErrorCode=%2;%nModulePath=%3;%nClrInstanceID=%4"/>
                 <string id="RuntimePublisher.EEStartupStartEventMessage" value="VerificationFlags=%1;%nErrorCode=%2;%nModulePath=%3;%nClrInstanceID=%4"/>
                 <string id="RuntimePublisher.RuntimeInformationEventMessage" value="ClrInstanceID=%1;%nSKU=%2;%nBclMajorVersion=%3;%nBclMinorVersion=%4;%nBclBuildNumber=%5;%nBclQfeNumber=%6;%nVMMajorVersion=%7;%nVMMinorVersion=%8;%nVMBuildNumber=%9;%nVMQfeNumber=%10;%nStartupFlags=%11;%nStartupMode=%12;%nCommandLine=%13;%nComObjectGUID=%14;%nRuntimeDllPath=%15"/>
+                <string id="RuntimePublisher.RuntimePropertiesEventMessage" value="ClrInstanceID=%1;%nTrustedPlatformAssemblies=%2;%nNativeDllSearchDirectories=%3;%nPlatformResourceRoots=%4;%nAppContextBaseDirectory=%5;%nAppContextDepsFiles=%6;%nProbingDirectories=%7;%nFxProductVersion=%8;%nJitPath=%9;%nFxDepsFile=%10;%nAppPaths=%11;%nAppNIPaths=%12;%nStartUpHooks=%13;%nResolvedFrameworks=%14;%nOthers=%15" />
                 <string id="RuntimePublisher.MethodJitInliningFailedEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nInlinerNamespace=%4;%nInlinerName=%5;%nInlinerNameSignature=%6;%nInlineeNamespace=%7;%nInlineeName=%8;%nInlineeNameSignature=%9;%nFailAlways=%10;%nFailReason=%11;%nClrInstanceID=%12" />
                 <string id="RuntimePublisher.MethodJitInliningSucceededEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nInlinerNamespace=%4;%nInlinerName=%5;%nInlinerNameSignature=%6;%nInlineeNamespace=%7;%nInlineeName=%8;%nInlineeNameSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodJitTailCallFailedEventMessage" value="MethodBeingCompiledNamespace=%1;%nMethodBeingCompiledName=%2;%nMethodBeingCompiledNameSignature=%3;%nCallerNamespace=%4;%nCallerName=%5;%nCallerNameSignature=%6;%nCalleeNamespace=%7;%nCalleeName=%8;%nCalleeNameSignature=%9;%nTailPrefix=%10;%nFailReason=%11;%nClrInstanceID=%12" />

--- a/src/coreclr/src/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/src/vm/ClrEtwAllMeta.lst
@@ -298,6 +298,7 @@ nomac:CLRAuthenticodeVerification:::AuthenticodeVerificationStop_V1
 # RuntimeInfo events
 ####################
 nostack:CLRRuntimeInformation:::RuntimeInformationStart
+nostack:CLRRuntimeInformation:::RuntimeProperties
 
 ###########################
 # Tiered compilation events

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -681,6 +681,7 @@ HRESULT CorHost2::_CreateAppDomain(
     pDomain->SetFriendlyName(wszFriendlyName);
 
     ETW::LoaderLog::DomainLoad(pDomain, (LPWSTR)wszFriendlyName);
+    ETW::InfoLog::RuntimeInputProperties(nProperties, pPropertyNames, pPropertyValues);
 
     if (dwFlags & APPDOMAIN_IGNORE_UNHANDLED_EXCEPTIONS)
         pDomain->SetIgnoreUnhandledExceptions();

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -5035,6 +5035,108 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
 }
 
+/****************************************************************************/
+/* This is called by the runtime during startup to log the
+   properties passed on from the host. */
+/****************************************************************************/
+
+VOID ETW::InfoLog::RuntimeInputProperties(int nProperties, LPCWSTR* propertyNames, LPCWSTR* propertyValues)
+{
+    CONTRACTL{
+        NOTHROW;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
+
+    EX_TRY{
+        if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, RuntimeProperties))
+        {
+            unsigned short ClrInstanceID = GetClrInstanceId();
+            LPCWSTR trustedPlatformAssemblies = nullptr;
+            LPCWSTR nativeDllSearchDirectories = nullptr;
+            LPCWSTR platformResourceRoots = nullptr;
+            LPCWSTR appContextBaseDirectory = nullptr;
+            LPCWSTR appContextDepsFiles = nullptr;
+            LPCWSTR probingDirectories = nullptr;
+            LPCWSTR fxProductVersion = nullptr;
+            LPCWSTR jitPath = nullptr;
+            LPCWSTR fxDepsFile = nullptr;
+            LPCWSTR appPaths = nullptr;
+            LPCWSTR appNIPaths = nullptr;
+            LPCWSTR startUpHooks = nullptr;
+            LPCWSTR resolvedFrameworks = nullptr;
+            SString others;
+
+            for (int i = 0; i < nProperties; i++)
+            {
+                if (wcscmp(propertyNames[i], W("TRUSTED_PLATFORM_ASSEMBLIES")) == 0)
+                {
+                    trustedPlatformAssemblies = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("NATIVE_DLL_SEARCH_DIRECTORIES")) == 0)
+                {
+                    nativeDllSearchDirectories = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("PLATFORM_RESOURCE_ROOTS")) == 0)
+                {
+                    platformResourceRoots = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("APP_CONTEXT_BASE_DIRECTORY")) == 0)
+                {
+                    appContextBaseDirectory = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("APP_CONTEXT_DEPS_FILES")) == 0)
+                {
+                    appContextDepsFiles = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("PROBING_DIRECTORIES")) == 0)
+                {
+                    probingDirectories = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("FX_PRODUCT_VERSION")) == 0)
+                {
+                    fxProductVersion = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("JIT_PATH")) == 0)
+                {
+                    jitPath = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("FX_DEPS_FILE")) == 0)
+                {
+                    fxDepsFile = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("APP_PATHS")) == 0)
+                {
+                    appPaths = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("APP_NI_PATHS")) == 0)
+                {
+                    appNIPaths = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("STARTUP_HOOKS")) == 0)
+                {
+                    startUpHooks = propertyValues[i];
+                }
+                else if (wcscmp(propertyNames[i], W("RESOLVED_FRAMEWORKS")) == 0)
+                {
+                    resolvedFrameworks = propertyValues[i];
+                }
+                else
+                {
+                    others.Append(propertyNames[i]);
+                    others.Append(W("="));
+                    others.Append(propertyValues[i]);
+                    others.Append(W("\n"));
+                }
+            }
+
+            FireEtwRuntimeProperties(ClrInstanceID, trustedPlatformAssemblies, nativeDllSearchDirectories,
+                platformResourceRoots, appContextBaseDirectory, appContextDepsFiles,
+                probingDirectories, fxProductVersion, jitPath, fxDepsFile,
+                appPaths, appNIPaths, startUpHooks, resolvedFrameworks, others);
+        }
+    } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+}
+
 /* Fires ETW events every time a pdb is dynamically loaded.
 *
 * The ETW events correspond to sending parts of the pdb in roughly


### PR DESCRIPTION
As part of dotnet/core-setup#4112, this change adds the RuntimeProperties event.
This event during fired on startup, and publishes all properties passed by the host to the runtime.

Known properties are explicitly called out by the event template.
Other properties are accumulated into the "Others" string.

Currently, due to EventPipe’s attach only nature, a test using event-pipe may miss the event.
So, this change doesn't include an automated test.

The recommended method for testing the event was using ETW.
I'll send out a PR to the PerfView repo to add this event to TraceEvent.