### PR TITLE
Fix memory leaked caused by Marshal.GetFunctionPointerForDelegate

### DIFF
--- a/src/coreclr/src/vm/comdelegate.cpp
+++ b/src/coreclr/src/vm/comdelegate.cpp
@@ -1307,7 +1307,9 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
             umHolder.Assign(pUMEntryThunk);
 
             // multicast. go thru Invoke
-            OBJECTHANDLE objhnd = GetAppDomain()->CreateLongWeakHandle(pDelegate);
+            OBJECTHANDLE objhnd = pUMEntryThunk->GetObjectHandle();
+            if (objhnd == NULL)
+                objhnd = GetAppDomain()->CreateLongWeakHandle(pDelegate);
             _ASSERTE(objhnd != NULL);
 
             // This target should not ever be used. We are storing it in the thunk for better diagnostics of "call on collected delegate" crashes.

--- a/src/coreclr/src/vm/comdelegate.cpp
+++ b/src/coreclr/src/vm/comdelegate.cpp
@@ -1307,9 +1307,7 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
             umHolder.Assign(pUMEntryThunk);
 
             // multicast. go thru Invoke
-            OBJECTHANDLE objhnd = pUMEntryThunk->GetObjectHandle();
-            if (objhnd == NULL)
-                objhnd = GetAppDomain()->CreateLongWeakHandle(pDelegate);
+            OBJECTHANDLE objhnd = GetAppDomain()->CreateLongWeakHandle(pDelegate);
             _ASSERTE(objhnd != NULL);
 
             // This target should not ever be used. We are storing it in the thunk for better diagnostics of "call on collected delegate" crashes.

--- a/src/coreclr/src/vm/dllimportcallback.cpp
+++ b/src/coreclr/src/vm/dllimportcallback.cpp
@@ -961,12 +961,18 @@ void UMEntryThunk::Terminate()
     CONTRACTL
     {
         NOTHROW;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
     m_code.Poison();
 
     s_thunkFreeList.AddToList(this);
+
+    if (GetObjectHandle())
+    {
+        DestroyLongWeakHandle(GetObjectHandle());
+    }
 }
 
 VOID UMEntryThunk::FreeUMEntryThunk(UMEntryThunk* p)

--- a/src/coreclr/src/vm/dllimportcallback.cpp
+++ b/src/coreclr/src/vm/dllimportcallback.cpp
@@ -965,14 +965,15 @@ void UMEntryThunk::Terminate()
     }
     CONTRACTL_END;
 
-    m_code.Poison();
-
-    s_thunkFreeList.AddToList(this);
-
     if (GetObjectHandle())
     {
         DestroyLongWeakHandle(GetObjectHandle());
+        this->m_pObjectHandle = 0;
     }
+
+    m_code.Poison();
+
+    s_thunkFreeList.AddToList(this);
 }
 
 VOID UMEntryThunk::FreeUMEntryThunk(UMEntryThunk* p)

--- a/src/coreclr/src/vm/dllimportcallback.cpp
+++ b/src/coreclr/src/vm/dllimportcallback.cpp
@@ -965,13 +965,13 @@ void UMEntryThunk::Terminate()
     }
     CONTRACTL_END;
 
+    m_code.Poison();
+
     if (GetObjectHandle())
     {
         DestroyLongWeakHandle(GetObjectHandle());
-        this->m_pObjectHandle = 0;
+        m_pObjectHandle = 0;
     }
-
-    m_code.Poison();
 
     s_thunkFreeList.AddToList(this);
 }

--- a/src/coreclr/src/vm/dllimportcallback.h
+++ b/src/coreclr/src/vm/dllimportcallback.h
@@ -310,22 +310,6 @@ public:
 #endif
     }
 
-    ~UMEntryThunk()
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-            MODE_ANY;
-        }
-        CONTRACTL_END;
-
-        if (GetObjectHandle())
-        {
-            DestroyLongWeakHandle(GetObjectHandle());
-        }
-    }
-
     void Terminate();
 
     VOID RunTimeInit()


### PR DESCRIPTION
We now delete the long weak handle of a `UMEntryThunk` whenever we terminate it.

Fixes #353.