### PR TITLE
Make sure we tell the same lie to the JIT for default interface methods

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -20652,7 +20652,7 @@ void Compiler::addGuardedDevirtualizationCandidate(GenTreeCall*          call,
         return;
     }
 
-    // CT_INDRECT calls may use the cookie, bail if so...
+    // CT_INDIRECT calls may use the cookie, bail if so...
     //
     // If transforming these provides a benefit, we could save this off in the same way
     // we save the stub address below.

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
@@ -984,7 +984,7 @@ namespace Internal.JitInterface
     // thisTransform and constraint calls
     // ----------------------------------
     //
-    // For evertyhing besides "constrained." calls "thisTransform" is set to
+    // For everything besides "constrained." calls "thisTransform" is set to
     // CORINFO_NO_THIS_TRANSFORM.
     //
     // For "constrained." calls the EE attempts to resolve the call at compile

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1220,7 +1220,8 @@ namespace Internal.JitInterface
             }
             else
             {
-                // At this point, we knew it is a virtual call to targetMethod method, if it is a default interface method call, it should go through instantiating stub
+                // At this point, we knew it is a virtual call to targetMethod, 
+                // If it is also a default interface method call, it should go through instantiating stub.
                 useInstantiatingStub = useInstantiatingStub || (targetMethod.OwningType.IsInterface && !originalMethod.IsAbstract);
                 // Insert explicit null checks for cross-version bubble non-interface calls.
                 // It is required to handle null checks properly for non-virtual <-> virtual change between versions

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1220,6 +1220,8 @@ namespace Internal.JitInterface
             }
             else
             {
+                // At this point, we knew it is a virtual call to targetMethod method, if it is a default interface method call, it should go through instantiating stub
+                useInstantiatingStub = useInstantiatingStub || (targetMethod.OwningType.IsInterface && !originalMethod.IsAbstract);
                 // Insert explicit null checks for cross-version bubble non-interface calls.
                 // It is required to handle null checks properly for non-virtual <-> virtual change between versions
                 pResult->nullInstanceCheck = callVirtCrossingVersionBubble && !targetMethod.OwningType.IsInterface;


### PR DESCRIPTION
This pull request is intended to fix the crossgen2 compilation crash of [constrained2.ilproj](https://github.com/dotnet/runtime/blob/master/src/coreclr/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.ilproj).

The compilation failure was found by @janvorli by running all the CoreCLR Pri 1 test on Linux under crossgen2 using SuperIlc.

Luckily, the failure reproduces itself on Windows when building a non-optimized build. The compilation crashed with an assertion here:

https://github.com/dotnet/runtime/blob/f1890a75f5afc6fbd8e4e0ef966523578a8d2813/src/coreclr/src/jit/importer.cpp#L8106

My first attempt was to comment out the assertion and see what happened, the test case passed. That mislead me to think the assertion could be wrong. Indeed, when I read the code around that function, I have no idea why the JIT can assert that fact, it looks like it should be handling whatever input that the `getCallInfo()` produces.

Turn out, that was wrong. The assert was meant for detecting wrong data from `getCallInfo()`. The first few comments below were reacting to my wrong attempt to remove the assertion, and they are obsolete by now.

A comparative study with `crossgen` revealed that the real root cause for the assert is that the VM was lying to the JIT in `crossgen` but `crossgen2` wasn't lying the same way. In particular, we have this gem:

https://github.com/dotnet/runtime/blob/f1890a75f5afc6fbd8e4e0ef966523578a8d2813/src/coreclr/src/vm/jitinterface.cpp#L8793-L8796

Because of the above, the `CORINFO_CALLCONV_PARAMTYPE` was not specified when `crossgen` compile the same test case, no wonder the assert is not a problem from `crossgen`.

It would be nice if we can come up with a little comment in the JIT about the handling of default interface method, the lie is just far from obvious.

@dotnet/jit-contrib 
@dotnet/crossgen-contrib 