### PR TITLE
Sync H2 namespace updates

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackDecoder.cs
@@ -4,6 +4,9 @@
 
 using System.Buffers;
 using System.Diagnostics;
+#if KESTREL
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+#endif
 
 namespace System.Net.Http.HPack
 {

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/StatusCodes.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/StatusCodes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
@@ -9,6 +9,8 @@ namespace System.Net.Http.HPack
 {
     internal static class StatusCodes
     {
+        // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
+
         private static ReadOnlySpan<byte> BytesStatus100 => new byte[] { (byte)'1', (byte)'0', (byte)'0' };
         private static ReadOnlySpan<byte> BytesStatus101 => new byte[] { (byte)'1', (byte)'0', (byte)'1' };
         private static ReadOnlySpan<byte> BytesStatus102 => new byte[] { (byte)'1', (byte)'0', (byte)'2' };

--- a/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
@@ -2,9 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if KESTREL
+using System;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+#else
 namespace System.Net.Http
+#endif
 {
-    internal interface IHttpHeadersHandler
+#if KESTREL
+    public
+#else
+    internal
+#endif
+    interface IHttpHeadersHandler
     {
         void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
         void OnHeadersComplete(bool endStream);

--- a/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
@@ -8,6 +8,9 @@ using System.Collections.Generic;
 using System.Text;
 using System.Net.Http.HPack;
 using Xunit;
+#if KESTREL
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+#endif
 
 namespace System.Net.Http.Unit.Tests.HPack
 {


### PR DESCRIPTION
Syncing AspNetCore changes to shared source. https://github.com/aspnet/AspNetCore/pull/17573

IHttpHeadersHandler is something we moved into shared code for HPACK. It was previously a 'pubternal' (public in an `Internal` namespace) API in our code base that our benchmarks infrastructure depended on. This PR restores it as a pubternal API in its original namespace until we can come up with a cleaner solution. I used ifdefs so no changes should be required in the runtime repo.
