### PR TITLE
Add back CODEOWNERS for Http2 shared code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+/src/libraries/Common/src/System/Net/Http/Http2/                    @dotnet/http2
+/src/libraries/Common/tests/Tests/System/Net/Http2/                 @dotnet/http2


### PR DESCRIPTION
We were using CODEOWNERS in the CoreFx repo but it wasn't included in the migration to Runtime. It's used to automatically notify the http2 working group about changes to shared code.

@terrajobst @karelz This will require giving the @dotnet/http2 write access to this repo, which only a repo admin can do.