### PR TITLE
[WIP] Put EventPipeThread destructor on Thread's destructor

### DIFF
--- a/src/coreclr/src/vm/eventpipethread.cpp
+++ b/src/coreclr/src/vm/eventpipethread.cpp
@@ -109,6 +109,13 @@ thread_local
 #endif // !__GNUC__
 EventPipeThreadHolder EventPipeThread::gCurrentEventPipeThreadHolder;
 
+#ifndef __GNUC__
+__declspec(thread)
+#else // !__GNUC__
+thread_local
+#endif // !__GNUC__
+EventPipeThreadDestroyer destroyer;
+
 EventPipeThread::EventPipeThread()
 {
     CONTRACTL
@@ -180,12 +187,12 @@ void EventPipeThread::AddRef()
 void EventPipeThread::Release()
 {
     LIMITED_METHOD_CONTRACT;
-    if (FastInterlockDecrement(&m_refCount) == 0)
-    {
-        // https://isocpp.org/wiki/faq/freestore-mgmt#delete-this
-        // As long as you're careful, it's okay (not evil) for an object to commit suicide (delete this).
-        delete this;
-    }
+    // if (FastInterlockDecrement(&m_refCount) == 0)
+    // {
+    //     // https://isocpp.org/wiki/faq/freestore-mgmt#delete-this
+    //     // As long as you're careful, it's okay (not evil) for an object to commit suicide (delete this).
+    //     delete this;
+    // }
 }
 
 EventPipeThreadSessionState *EventPipeThread::GetOrCreateSessionState(EventPipeSession *pSession)

--- a/src/coreclr/src/vm/eventpipethread.h
+++ b/src/coreclr/src/vm/eventpipethread.h
@@ -90,6 +90,7 @@ public:
 
 class EventPipeThread
 {
+    friend struct EventPipeThreadDestroyer;
     static EVENTPIPE_THREAD_LOCAL EventPipeThreadHolder gCurrentEventPipeThreadHolder;
 
     ~EventPipeThread();
@@ -169,6 +170,18 @@ public:
         return m_writingEventInProgress.Load();
     }
 };
+
+struct EventPipeThreadDestroyer
+{
+    ~EventPipeThreadDestroyer()
+    {
+        if (EventPipeThread::Get() != nullptr)
+        {
+            delete EventPipeThread::gCurrentEventPipeThreadHolder;
+        }
+    }
+};
+
 
 #endif // FEATURE_PERFTRACING
 

--- a/src/coreclr/src/vm/eventpipethread.h
+++ b/src/coreclr/src/vm/eventpipethread.h
@@ -19,7 +19,8 @@ class EventPipeThread;
 
 void ReleaseEventPipeThreadRef(EventPipeThread* pThread);
 void AcquireEventPipeThreadRef(EventPipeThread* pThread);
-typedef Wrapper<EventPipeThread*, AcquireEventPipeThreadRef, ReleaseEventPipeThreadRef> EventPipeThreadHolder;
+// typedef Wrapper<EventPipeThread*, AcquireEventPipeThreadRef, ReleaseEventPipeThreadRef> EventPipeThreadHolder;
+typedef EventPipeThread* EventPipeThreadHolder;
 
 class EventPipeThreadSessionState
 {

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -2627,13 +2627,6 @@ Thread::~Thread()
     }
 #endif // FEATURE_EVENT_TRACE
 
-#ifdef FEATURE_PERFTRACING
-    if (EventPipeThread::Get() != nullptr)
-    {
-        EventPipeThread::Get()->Release();
-    }
-#endif // FEATURE_PERFTRACING
-
     // Wait for another thread to leave its loop in DeadlockAwareLock::TryBeginEnterLock
     CrstHolder lock(&g_DeadlockAwareCrst);
 }

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -2627,6 +2627,13 @@ Thread::~Thread()
     }
 #endif // FEATURE_EVENT_TRACE
 
+#ifdef FEATURE_PERFTRACING
+    if (EventPipeThread::Get() != nullptr)
+    {
+        EventPipeThread::Get()->Release();
+    }
+#endif // FEATURE_PERFTRACING
+
     // Wait for another thread to leave its loop in DeadlockAwareLock::TryBeginEnterLock
     CrstHolder lock(&g_DeadlockAwareCrst);
 }


### PR DESCRIPTION
fixes #168 

To work around #168, I'm moving the destructor for `EventPIpeThread` on to the `Thread` object.  This also moves the desctructor from being fired at process exit which can cause issues.

WIP for now to test on CI