### PR TITLE
Disable generating a map file by default.

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -21,6 +21,7 @@ namespace ReadyToRun.SuperIlc
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
         public bool NoCleanup { get; set; }
+        public bool GenerateMapFile { get; set; }
         public FileInfo PackageList { get; set; }
         public int DegreeOfParallelism { get; set; }
         public bool Sequential { get; set; }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -38,6 +38,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        GenerateMapFile(),
                         DegreeOfParallelism(),
                         Sequential(),
                         Framework(),
@@ -70,6 +71,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        GenerateMapFile(),
                         DegreeOfParallelism(),
                         Sequential(),
                         Framework(),
@@ -178,6 +180,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoCleanup() =>
                 new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());
+
+            Option GenerateMapFile() =>
+                new Option(new[] { "--generate-map-file" }, "Generate a map file (Crossgen2)", new Argument<bool>());
 
             Option DegreeOfParallelism() =>
                 new Option(new[] { "--degree-of-parallelism", "-dop" }, "Override default compilation / execution DOP (default = logical processor count)", new Argument<int>());

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -182,7 +182,7 @@ namespace ReadyToRun.SuperIlc
                 new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());
 
             Option GenerateMapFile() =>
-                new Option(new[] { "--generate-map-file" }, "Generate a map file (Crossgen2)", new Argument<bool>());
+                new Option(new[] { "--map" }, "Generate a map file (Crossgen2)", new Argument<bool>());
 
             Option DegreeOfParallelism() =>
                 new Option(new[] { "--degree-of-parallelism", "-dop" }, "Override default compilation / execution DOP (default = logical processor count)", new Argument<int>());

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -51,7 +51,7 @@ namespace ReadyToRun.SuperIlc
 
             if (_options.GenerateMapFile)
             {
-                yield return "--generate-map-file";
+                yield return "--map";
             }
 
             if (_options.Release)

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -49,6 +49,11 @@ namespace ReadyToRun.SuperIlc
             // Todo: Allow control of some of these
             yield return "--targetarch=x64";
 
+            if (_options.GenerateMapFile)
+            {
+                yield return "--generate-map-file";
+            }
+
             if (_options.Release)
             {
                 yield return "-O";

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -205,6 +205,8 @@ namespace ILCompiler
 
         private int _parallelism;
 
+        private bool _generateMapFile;
+
         public new ReadyToRunCodegenNodeFactory NodeFactory { get; }
 
         public ReadyToRunSymbolNodeFactory SymbolNodeFactory { get; }
@@ -220,11 +222,13 @@ namespace ILCompiler
             string inputFilePath,
             IEnumerable<ModuleDesc> modulesBeingInstrumented,
             bool resilient,
+            bool generateMapFile,
             int parallelism)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, devirtualizationManager, modulesBeingInstrumented, logger)
         {
             _resilient = resilient;
             _parallelism = parallelism;
+            _generateMapFile = generateMapFile;
             NodeFactory = nodeFactory;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);
             _jitConfigProvider = configProvider;
@@ -247,7 +251,7 @@ namespace ILCompiler
                 using (PerfEventSource.StartStopEvents.EmittingEvents())
                 {
                     NodeFactory.SetMarkingComplete();
-                    ReadyToRunObjectWriter.EmitObject(inputPeReader, outputFile, nodes, NodeFactory);
+                    ReadyToRunObjectWriter.EmitObject(inputPeReader, outputFile, nodes, NodeFactory, _generateMapFile);
                 }
             }
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -22,6 +22,7 @@ namespace ILCompiler
         private readonly EcmaModule _inputModule;
         private bool _ibcTuning;
         private bool _resilient;
+        private bool _generateMapFile;
         private int _parallelism;
         private string _jitPath;
 
@@ -91,6 +92,12 @@ namespace ILCompiler
         public ReadyToRunCodegenCompilationBuilder UseResilience(bool resilient)
         {
             _resilient = resilient;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder UseMapFile(bool generateMapFile)
+        {
+            _generateMapFile = generateMapFile;
             return this;
         }
 
@@ -185,6 +192,7 @@ namespace ILCompiler
                 _inputFilePath,
                 new ModuleDesc[] { _inputModule },
                 _resilient,
+                _generateMapFile,
                 _parallelism);
         }
     }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -31,6 +31,7 @@ namespace ILCompiler
         public bool Tuning { get; set; }
         public bool Partial { get; set; }
         public bool Resilient { get; set; }
+        public bool GenerateMapFile { get; set; }
         public int Parallelism { get; set; }
 
 
@@ -145,6 +146,10 @@ namespace ILCompiler
                 new Option(new[] { "--parallelism" }, "Maximum number of threads to use during compilation")
                 { 
                     Argument = new Argument<int>(() => Environment.ProcessorCount)
+                },
+                new Option(new[] { "--generate-map-file" }, "Generate the map file")
+                {
+                    Argument = new Argument<bool>()
                 },
             };
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -147,7 +147,7 @@ namespace ILCompiler
                 { 
                     Argument = new Argument<int>(() => Environment.ProcessorCount)
                 },
-                new Option(new[] { "--generate-map-file" }, "Generate the map file")
+                new Option(new[] { "--map" }, "Generate the map file")
                 {
                     Argument = new Argument<bool>()
                 },

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -323,6 +323,7 @@ namespace ILCompiler
                     builder
                         .UseIbcTuning(_commandLineOptions.Tuning)
                         .UseResilience(_commandLineOptions.Resilient)
+                        .UseMapFile(_commandLineOptions.GenerateMapFile)
                         .UseParallelism(_commandLineOptions.Parallelism)
                         .UseILProvider(ilProvider)
                         .UseJitPath(_commandLineOptions.JitPath)


### PR DESCRIPTION
Generating a map file is slow and not necessary most of the time, so don't do it by default. This reduces emission time when compiling CoreLib with Crossgen2 by about 1.4s (4596.18 ms to 3114.38 ms).
- Add a flag to enable generating a map file in Crossgen2
- Add a flag to enable generating a map file when using Crossgen2 from SuperIlc