### PR TITLE
Check method can compile before rooting

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -29,6 +29,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _targetMethod = targetMethod;
             _methodToken = methodToken;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableType(delegateType);
+            signatureContext.Resolver.CompilerContext.EnsureLoadableMethod(targetMethod.Method);
         }
 
         public override int ClassCode => 99885741;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -25,6 +25,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _fixupKind = fixupKind;
             _fieldDesc = fieldDesc;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableType(fieldDesc.OwningType);
         }
 
         public override int ClassCode => 271828182;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -46,6 +46,22 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _fieldArgument = fieldArgument;
             _methodContext = methodContext;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            if (typeArgument != null)
+            {
+                signatureContext.Resolver.CompilerContext.EnsureLoadableType(typeArgument);
+            }
+            if (fieldArgument != null)
+            {
+                signatureContext.Resolver.CompilerContext.EnsureLoadableType(fieldArgument.OwningType);
+            }
+            if (methodArgument != null)
+            {
+                signatureContext.Resolver.CompilerContext.EnsureLoadableMethod(methodArgument.Method);
+                if (methodArgument.ConstrainedType != null)
+                    signatureContext.Resolver.CompilerContext.EnsureLoadableType(methodArgument.ConstrainedType);
+            }
         }
 
         public override int ClassCode => 258608008;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -37,6 +37,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _signatureContext = signatureContext;
             _isUnboxingStub = isUnboxingStub;
             _isInstantiatingStub = isInstantiatingStub;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableMethod(method.Method);
+            if (method.ConstrainedType != null)
+                signatureContext.Resolver.CompilerContext.EnsureLoadableType(method.ConstrainedType);
         }
 
         public MethodDesc Method => _method.Method;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -32,14 +32,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly CompilationModuleGroup _compilationModuleGroup;
 
-        private readonly CompilerTypeSystemContext _typeSystemContext;
-
         private Func<EcmaModule, int> _moduleIndexLookup;
+
+        public CompilerTypeSystemContext CompilerContext { get; }
 
         public ModuleTokenResolver(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext)
         {
             _compilationModuleGroup = compilationModuleGroup;
-            _typeSystemContext = typeSystemContext;
+            CompilerContext = typeSystemContext;
         }
 
         public void SetModuleIndexLookup(Func<EcmaModule, int> moduleIndexLookup)
@@ -103,7 +103,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             FieldDesc canonField = field;
             if (owningCanonType != field.OwningType)
             {
-                canonField = _typeSystemContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
+                canonField = CompilerContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
             }
 
             ModuleToken token;
@@ -160,7 +160,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             FieldDesc canonField = field;
             if (owningCanonType != field.OwningType)
             {
-                canonField = _typeSystemContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
+                canonField = CompilerContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
             }
 
             _fieldToRefTokens[canonField] = token;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -18,6 +18,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             _arrayType = arrayType;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableType(arrayType);
         }
 
         public override int ClassCode => 815543321;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
@@ -18,6 +18,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             _typeDesc = typeDesc;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableType(typeDesc);
         }
 
         public override int ClassCode => 551247760;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -24,6 +24,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _fixupKind = fixupKind;
             _typeDesc = typeDesc;
             _signatureContext = signatureContext;
+
+            // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
+            signatureContext.Resolver.CompilerContext.EnsureLoadableType(typeDesc);
         }
 
         public override int ClassCode => 255607008;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -150,6 +150,9 @@ namespace ILCompiler
         /// </summary>
         public static void CheckCanGenerateMethod(MethodDesc method)
         {
+            // Ensure the method is loadable
+            ((CompilerTypeSystemContext)method.Context).EnsureLoadableMethod(method);
+
             MethodSignature signature = method.Signature;
 
             // Vararg methods are not supported in .NET Core
@@ -162,10 +165,6 @@ namespace ILCompiler
             {
                 CheckTypeCanBeUsedInSignature(signature[i]);
             }
-
-            // Ensure the containing type of the method is also resolvable
-            if (method.OwningType is DefType defType)
-                defType.ComputeTypeContainsGCPointers();
         }
 
         private static void CheckTypeCanBeUsedInSignature(TypeDesc type)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -171,31 +171,30 @@ namespace Internal.JitInterface
             throw new NotSupportedException();
         }
 
-        private bool ShouldSkipCompilation(IMethodNode methodCodeNodeNeedingCode)
+        public static bool ShouldSkipCompilation(MethodDesc methodNeedingCode)
         {
-            MethodDesc method = methodCodeNodeNeedingCode.Method;
-            if (method.IsAggressiveOptimization)
+            if (methodNeedingCode.IsAggressiveOptimization)
             {
                 return true;
             }
-            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(methodNeedingCode))
             {
                 return true;
             }
-            if (MethodBeingCompiled.IsAbstract)
+            if (methodNeedingCode.IsAbstract)
             {
                 return true;
             }
-            if (MethodBeingCompiled.OwningType.IsDelegate && (
-                MethodBeingCompiled.IsConstructor ||
-                MethodBeingCompiled.Name == "BeginInvoke" ||
-                MethodBeingCompiled.Name == "Invoke" ||
-                MethodBeingCompiled.Name == "EndInvoke"))
+            if (methodNeedingCode.OwningType.IsDelegate && (
+                methodNeedingCode.IsConstructor ||
+                methodNeedingCode.Name == "BeginInvoke" ||
+                methodNeedingCode.Name == "Invoke" ||
+                methodNeedingCode.Name == "EndInvoke"))
             {
                 // Special methods on delegate types
                 return true;
             }
-            if (method.HasCustomAttribute("System.Runtime", "BypassReadyToRunAttribute"))
+            if (methodNeedingCode.HasCustomAttribute("System.Runtime", "BypassReadyToRunAttribute"))
             {
                 // This is a quick workaround to opt specific methods out of ReadyToRun compilation to work around bugs.
                 return true;
@@ -211,7 +210,7 @@ namespace Internal.JitInterface
 
             try
             {
-                if (!ShouldSkipCompilation(methodCodeNodeNeedingCode))
+                if (!ShouldSkipCompilation(MethodBeingCompiled))
                 {
                     CompileMethodInternal(methodCodeNodeNeedingCode);
                     codeGotPublished = true;


### PR DESCRIPTION
It's better to not root methods that we won't compile, and end up publishing "empty ones".

A side effect of checking if a method should compile is potential TypeSystem exceptions that could be thrown on malformed types, so catching these before rooting problematic methods has the benefit of not adding signature nodes with problematic signatures to the dependency graph.

Going one step further, I'm hardening signature-emitting nodes to detect signatures that could potentially throw TypeSystem exceptions early. With this, instead of crashing the compiler during object emission, the TypeSystem exception will be caught at the high level, and the current method being compiled will get aborted and skipped (that' the behavior we have in crossgen1 today).

@dotnet/crossgen-contrib 