### PR TITLE
Start generating LCL_FLDs in LocalAddressVisitor

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -7959,6 +7959,7 @@ private:
 
     void setLclRelatedToSIMDIntrinsic(GenTree* tree);
     bool areFieldsContiguous(GenTree* op1, GenTree* op2);
+    bool areLocalFieldsContiguous(GenTreeLclFld* first, GenTreeLclFld* second);
     bool areArrayElementsContiguous(GenTree* op1, GenTree* op2);
     bool areArgumentsContiguous(GenTree* op1, GenTree* op2);
     GenTree* createAddressNodeForSIMDInit(GenTree* tree, unsigned simdSize);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -18009,7 +18009,7 @@ bool FieldSeqNode::IsConstantIndexFieldSeq()
     return m_fieldHnd == FieldSeqStore::ConstantIndexPseudoField;
 }
 
-bool FieldSeqNode::IsPseudoField()
+bool FieldSeqNode::IsPseudoField() const
 {
     return m_fieldHnd == FieldSeqStore::FirstElemPseudoField || m_fieldHnd == FieldSeqStore::ConstantIndexPseudoField;
 }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -247,7 +247,9 @@ struct FieldSeqNode
     {
         FieldSeqNode* tail = this;
         while (tail->m_next != nullptr)
+        {
             tail = tail->m_next;
+        }
         return tail;
     }
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -235,7 +235,21 @@ struct FieldSeqNode
     bool IsConstantIndexFieldSeq();
 
     // returns true when this is the the pseudo #FirstElem field sequence or the pseudo #ConstantIndex field sequence
-    bool IsPseudoField();
+    bool IsPseudoField() const;
+
+    CORINFO_FIELD_HANDLE GetFieldHandle() const
+    {
+        assert(!IsPseudoField() && (m_fieldHnd != nullptr));
+        return m_fieldHnd;
+    }
+
+    FieldSeqNode* GetTail()
+    {
+        FieldSeqNode* tail = this;
+        while (tail->m_next != nullptr)
+            tail = tail->m_next;
+        return tail;
+    }
 
     // Make sure this provides methods that allow it to be used as a KeyFuncs type in SimplerHash.
     static int GetHashCode(FieldSeqNode fsn)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3244,6 +3244,13 @@ struct GenTreeField : public GenTree
         gtFieldLookup.addr = nullptr;
 #endif
     }
+
+    // True if this field is a volatile memory operation.
+    bool IsVolatile() const
+    {
+        return (gtFlags & GTF_FLD_VOLATILE) != 0;
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeField() : GenTree()
     {
@@ -5038,6 +5045,18 @@ struct GenTreeIndir : public GenTreeOp
     {
     }
 
+    // True if this indirection is a volatile memory operation.
+    bool IsVolatile() const
+    {
+        return (gtFlags & GTF_IND_VOLATILE) != 0;
+    }
+
+    // True if this indirection is an unaligned memory operation.
+    bool IsUnaligned() const
+    {
+        return (gtFlags & GTF_IND_UNALIGNED) != 0;
+    }
+
 #if DEBUGGABLE_GENTREE
 protected:
     friend GenTree;
@@ -5087,18 +5106,6 @@ public:
     {
         assert((m_layout != nullptr) || OperIs(GT_DYN_BLK, GT_STORE_DYN_BLK));
         return (m_layout != nullptr) ? m_layout->GetSize() : 0;
-    }
-
-    // True if this BlkOpNode is a volatile memory operation.
-    bool IsVolatile() const
-    {
-        return (gtFlags & GTF_BLK_VOLATILE) != 0;
-    }
-
-    // True if this BlkOpNode is an unaligned memory operation.
-    bool IsUnaligned() const
-    {
-        return (gtFlags & GTF_BLK_UNALIGNED) != 0;
     }
 
     // Instruction selection: during codegen time, what code sequence we will be using

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -18446,7 +18446,7 @@ private:
         {
             // If we have an IND node and a field sequence then they should have the same type.
             // Otherwise it's best to forget the field sequence since the resulting LCL_FLD
-            // doesn't match a real struct field. Value numbering to protect itself from such
+            // doesn't match a real struct field. Value numbering protects itself from such
             // mismatches but there doesn't seem to be any good reason to generate a LCL_FLD
             // with a mismatched field sequence only to have to ignore it later.
 
@@ -18477,6 +18477,8 @@ private:
 
         indir->gtFlags = flags;
 
+        // Promoted struct vars aren't currently handled here so the created LCL_FLD can't be
+        // later transformed into a LCL_VAR and the variable cannot be enregistered.
         m_compiler->lvaSetVarDoNotEnregister(val.LclNum() DEBUGARG(Compiler::DNER_LocalField));
 
         INDEBUG(m_stmtModified = true;)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5759,7 +5759,7 @@ GenTree* Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varType,
         // Create a node representing the local pointing to the base of the args
         GenTree* ptrArg =
             gtNewOperNode(GT_SUB, TYP_I_IMPL, gtNewLclvNode(lvaVarargsBaseOfStkArgs, TYP_I_IMPL),
-                          gtNewIconNode(varDsc->lvStkOffs - codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES +
+                          gtNewIconNode(varDsc->lvStkOffs - codeGen->intRegState.rsCalleeRegArgCount * REGSIZE_BYTES -
                                         lclOffs));
 
         // Access the argument through the local

--- a/src/coreclr/src/jit/simd.cpp
+++ b/src/coreclr/src/jit/simd.cpp
@@ -2112,6 +2112,26 @@ bool Compiler::areFieldsContiguous(GenTree* first, GenTree* second)
     return false;
 }
 
+//----------------------------------------------------------------------
+// areLocalFieldsContiguous: Check whether two local field are contiguous
+//
+// Arguments:
+//    first - the first local field
+//    second - the second local field
+//
+// Return Value:
+//    If the first field is located before second field, and they are located contiguously,
+//    then return true. Otherwise, return false.
+//
+bool Compiler::areLocalFieldsContiguous(GenTreeLclFld* first, GenTreeLclFld* second)
+{
+    assert(first->TypeIs(TYP_FLOAT));
+    assert(second->TypeIs(TYP_FLOAT));
+
+    return (first->TypeGet() == second->TypeGet()) &&
+           (first->GetLclOffs() + genTypeSize(first->TypeGet()) == second->GetLclOffs());
+}
+
 //-------------------------------------------------------------------------------
 // Check whether two array element nodes are located contiguously or not.
 // Arguments:
@@ -2176,6 +2196,10 @@ bool Compiler::areArgumentsContiguous(GenTree* op1, GenTree* op2)
     else if (op1->OperGet() == GT_FIELD && op2->OperGet() == GT_FIELD)
     {
         return areFieldsContiguous(op1, op2);
+    }
+    else if (op1->OperIs(GT_LCL_FLD) && op2->OperIs(GT_LCL_FLD))
+    {
+        return areLocalFieldsContiguous(op1->AsLclFld(), op2->AsLclFld());
     }
     return false;
 }


### PR DESCRIPTION
Continuing from #305 - this starts generating `LCL_FLD` nodes in `LocalAddressVisitor`, before global morph. For now this only handles the most simple case - `TYP_STRUCT` variable field access. Later I'll expand it to also handle SIMD and primitive type variables (I actually have the primitive case mostly done but decided to leave it out for simplicity) and eventually I'll also use this to generate struct typed `LCL_FLD`s that are useful for both `ADDR` and `ASG` removal.

Despite trying to limit this to `TYP_STRUCT` variables, it still affects a bit SIMD variables due to contiguous field assignment that now has to recognize `LCL_FLD` in addition to `FIELD` and `INDEX`. And since it recognizes `LCL_FLD`s it also produces a `LCL_FLD` when combining assignments which results in a small CQ improvement in some Matrix methods.