### PR TITLE
Remove unused CMake define.

### DIFF
--- a/src/coreclr/src/pal/tools/gen-buildsys.cmd
+++ b/src/coreclr/src/pal/tools/gen-buildsys.cmd
@@ -40,7 +40,7 @@ shift
 goto loop
 :end_loop
 
-"%CMakePath%" -DCMAKE_USER_MAKE_RULES_OVERRIDE= "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLR_CMAKE_HOST_ARCH=%__Arch%" %__ExtraCmakeParams% -G "%__CmakeGenerator%" -S %__SourceDir% -B %__IntermediatesDir%
+"%CMakePath%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLR_CMAKE_HOST_ARCH=%__Arch%" %__ExtraCmakeParams% -G "%__CmakeGenerator%" -S %__SourceDir% -B %__IntermediatesDir%
 endlocal
 exit /B !errorlevel!
 

--- a/src/coreclr/src/pal/tools/gen-buildsys.sh
+++ b/src/coreclr/src/pal/tools/gen-buildsys.sh
@@ -23,7 +23,7 @@ then
   echo "Specify the path to the top level CMake file."
   echo "Specify the path that the build system files are generated in."
   echo "Specify the target architecture."
-  echo "Optionally specify the build configuration (flavor.) Defaults to DEBUG." 
+  echo "Optionally specify the build configuration (flavor.) Defaults to DEBUG."
   echo "Optionally specify 'scan-build' to enable build with clang static analyzer."
   echo "Use the Ninja generator instead of the Unix Makefiles generator."
   echo "Pass additional arguments to CMake call."
@@ -84,7 +84,6 @@ $cmake_command \
   -G "$generator" \
   "-DCMAKE_BUILD_TYPE=$buildtype" \
   "-DCMAKE_INSTALL_PREFIX=$__CMakeBinDir" \
-  "-DCMAKE_USER_MAKE_RULES_OVERRIDE=" \
   $cmake_extra_defines \
   $__UnprocessedCMakeArgs \
   -S "$1" \


### PR DESCRIPTION
Remove unused CMAKE_USER_MAKE_RULES_OVERRIDE define. We used to use this define before 3.0 in coreclr. When we stopped using it, we had to define the variable in this command on each invocation to update it in the CMake cache, otherwise the old value might still be there and cause an error. As a result, I added in these "set to empty" lines to avoid issues checking out old branches that still used these files.

Now that we're in the dotnet/runtime repo and don't have any old servicing branches, we can remove this CMake define.