### PR TITLE
Fix crossgenning of framework libraries on Windows

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -634,13 +634,10 @@ REM subsequent compilations from picking it up as a reference
 set __CrossgenOutputFile="%CORE_ROOT%\temp.ni._dll"
 set __CrossgenCmd=
 
-if defined __Crossgen (
+if defined __DoCrossgen (
     set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile! >nul 2>nul
 ) else (
     set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\*.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath! >nul 2>nul
-    echo !__CrossgenCmd!
-    !__CrossgenCmd!
-    set /a __exitCode = !errorlevel!
 )
 
 echo %__CrossgenCmd%

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -612,12 +612,6 @@ REM Compile the managed assemblies in Core_ROOT before running the tests
 set AssemblyPath=%1
 set AssemblyName=%2
 
-REM Skip mscorlib since it is already precompiled.
-if /I "%AssemblyName%" == "mscorlib.dll" exit /b 0
-if /I "%AssemblyName%" == "mscorlib.ni.dll" exit /b 0
-REM don't precompile anything from CoreCLR
-if /I exist %CORE_ROOT_STAGE%\%AssemblyName% exit /b 0
-
 REM Don't precompile xunit.* files
 echo "%AssemblyName%" | findstr /b "xunit." >nul && (
   exit /b 0

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -508,6 +508,21 @@ echo { "build_os": "%__BuildOS%", "build_arch": "%__BuildArch%", "build_type": "
 
 REM =========================================================================================
 REM ===
+REM === Copy CoreFX assemblies if needed.
+REM ===
+REM =========================================================================================
+
+if NOT "%__LocalCoreFXPath%"=="" (
+    echo Patch CoreFX from %__LocalCoreFXPath% ^(%__LocalCoreFXConfig%^)
+    set NEXTCMD=python "%__ProjectDir%\tests\scripts\patch-corefx.py" -clr_core_root "%CORE_ROOT%"^
+    -fx_root "%__LocalCoreFXPath%" -arch %__BuildArch% -build_type %__LocalCoreFXConfig%
+    echo !NEXTCMD!
+    !NEXTCMD!
+)
+
+
+REM =========================================================================================
+REM ===
 REM === Crossgen assemblies if needed.
 REM ===
 REM =========================================================================================
@@ -635,9 +650,9 @@ set __CrossgenOutputFile="%CORE_ROOT%\temp.ni._dll"
 set __CrossgenCmd=
 
 if defined __DoCrossgen (
-    set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile! >nul 2>nul
+    set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile!
 ) else (
-    set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\*.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath! >nul 2>nul
+    set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\mscorlib.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath!
 )
 
 echo %__CrossgenCmd%

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -516,7 +516,7 @@ set __CrossgenArg = ""
 if defined __DoCrossgen (
     set __CrossgenArg="/p:Crossgen=true"
     if "%__TargetsWindows%" == "1" (
-        echo %__MsgPrefix%Running crossgen on framework assemblies
+        echo %__MsgPrefix%Running crossgen on framework assemblies in CORE_ROOT: %CORE_ROOT%
         call :PrecompileFX
     ) else (
         echo "%__MsgPrefix%Crossgen only supported on Windows, for now"
@@ -526,7 +526,7 @@ if defined __DoCrossgen (
 if defined __DoCrossgen2 (
     set __CrossgenArg="/p:Crossgen2=true"
     if "%__BuildArch%" == "x64" (
-        echo %__MsgPrefix%Running crossgen2 on framework assemblies
+        echo %__MsgPrefix%Running crossgen2 on framework assemblies in CORE_ROOT: %CORE_ROOT%
         call :PrecompileFX
     ) else (
         echo "%__MsgPrefix%Crossgen2 only supported on x64, for now"
@@ -609,51 +609,65 @@ exit /b 0
 REM Compile the managed assemblies in Core_ROOT before running the tests
 :PrecompileAssembly
 
+set AssemblyPath=%1
+set AssemblyName=%2
+
 REM Skip mscorlib since it is already precompiled.
-if /I "%2" == "mscorlib.dll" exit /b 0
-if /I "%2" == "mscorlib.ni.dll" exit /b 0
+if /I "%AssemblyName%" == "mscorlib.dll" exit /b 0
+if /I "%AssemblyName%" == "mscorlib.ni.dll" exit /b 0
 REM don't precompile anything from CoreCLR
-if /I exist %CORE_ROOT_STAGE%\%2 exit /b 0
+if /I exist %CORE_ROOT_STAGE%\%AssemblyName% exit /b 0
 
 REM Don't precompile xunit.* files
-echo "%2" | findstr /b "xunit." >nul && (
+echo "%AssemblyName%" | findstr /b "xunit." >nul && (
   exit /b 0
 )
 
-set __CrossgenExe="%CORE_ROOT_STAGE%\crossgen.exe"
-if /i "%__BuildArch%" == "arm" ( set __CrossgenExe="%CORE_ROOT_STAGE%\x86\crossgen.exe" )
-if /i "%__BuildArch%" == "arm64" ( set __CrossgenExe="%CORE_ROOT_STAGE%\x64\crossgen.exe" )
+REM Skip the Win32 API dll's
+if /i "%AssemblyName:~0,4%"=="api-" exit /b 0
+
+set __CrossgenExe="%CORE_ROOT%\crossgen.exe"
+if /i "%__BuildArch%" == "arm" ( set __CrossgenExe="%CORE_ROOT%\x86\crossgen.exe" )
+if /i "%__BuildArch%" == "arm64" ( set __CrossgenExe="%CORE_ROOT%\x64\crossgen.exe" )
 set __CrossgenExe=%__CrossgenExe%
 
 if defined __DoCrossgen2 (
-    set __CrossgenExe="%CORE_ROOT_STAGE%\crossgen2\crossgen2.exe"
+    set __CrossgenExe="%CORE_ROOT%\crossgen2\crossgen2.exe"
 )
 
-set __CrossgenOutputFile="%CORE_ROOT%\temp.ni.dll"
+REM Intentionally avoid using the .dll extension to prevent
+REM subsequent compilations from picking it up as a reference
+set __CrossgenOutputFile="%CORE_ROOT%\temp.ni._dll"
+set __CrossgenCmd=
 
 if defined __Crossgen (
-    "!__CrossgenExe!" /Platform_Assemblies_Paths "!CORE_ROOT!" /in "%1" /out "!__CrossgenOutputFile" >nul 2>nul
-    set /a __exitCode = !errorlevel!
+    set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile! >nul 2>nul
 ) else (
-    "!CORE_ROOT_STAGE!\crossgen2\crossgen2 -r:"!CORE_ROOT!\*.dll" -O --inputbubble -out:"__CrossgenOutputFile" "%1" >nul 2>nul
+    set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\*.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath! >nul 2>nul
+    echo !__CrossgenCmd!
+    !__CrossgenCmd!
     set /a __exitCode = !errorlevel!
 )
 
+echo %__CrossgenCmd%
+%__CrossgenCmd%
+set /a __exitCode = !errorlevel!
+
 if "%__exitCode%" == "-2146230517" (
-    echo %2 is not a managed assembly.
+    echo %AssemblyPath% is not a managed assembly.
     exit /b 0
 )
 
 if %__exitCode% neq 0 (
-    echo Unable to precompile %2, Exit Code is %__exitCode%
+    echo Unable to precompile %AssemblyPath%, Exit Code is %__exitCode%
     exit /b 0
 )
 
 REM Delete original .dll & replace it with the Crossgened .dll
-del %1
-ren "%__CrossgenOutputFile%" %2
+del %AssemblyPath%
+ren "%__CrossgenOutputFile%" %AssemblyName%
 
-echo Successfully precompiled %2
+echo Successfully precompiled %AssemblyPath%
 exit /b 0
 
 :Exit_Failure

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -344,6 +344,10 @@ build_Tests()
     fi
 
     if [ $__SkipGenerateLayout != 1 ]; then
+        if [ ! -z "$__LocalCoreFXPath" ]; then
+            patch_corefx_libraries
+        fi
+
         generate_layout
     fi
 }

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -71,7 +71,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen2/crossgen2" -r:$CORE_ROOT/*.dll -r:$PWD/*.dll --targetarch=x64 -O --inputbubble -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
+          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen2/crossgen2" -r:$CORE_ROOT/System.*.dll -r:$CORE_ROOT/Microsoft.*.dll -r:$CORE_ROOT/mscorlib.dll -r:$PWD/*.dll --targetarch=x64 -O --inputbubble -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
           echo $__Command
           $__Command
           __cg2ExitCode=$?
@@ -132,7 +132,7 @@ if defined RunCrossGen2 (
             mkdir IL
             copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
             ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble -r:!CORE_ROOT!\*.dll -r:%25cd%25\*.dll
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\mscorlib.dll" -r:%25cd%25\*.dll
             echo "!__Command!"
             call !__Command!
             set CrossGen2Status=!ERRORLEVEL!


### PR DESCRIPTION
I tried to slightly improve the data flow by creating explicit
environment variables for the two arguments. There were a bunch
of errors regarding % vs !, duplicate double-quoting and the like.
It seems to be working now.

Thanks

Tomas