### PR TITLE
Set azure pipelines variables based on changed paths

### DIFF
--- a/eng/pipelines/common/checkout-job.yml
+++ b/eng/pipelines/common/checkout-job.yml
@@ -50,15 +50,15 @@ jobs:
     artifact: Checkout_bundle
     displayName: Upload Checkout.bundle
 
-  - ${{ if and(ne(parameters.paths[0], ''), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(ne(parameters.paths[0], ''), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - ${{ each path in parameters.paths }}:
       - template: evaluate-changed-paths.yml
         parameters:
           subsetName: ${{ path.subset }} 
           arguments:
-          - -difftarget origin/$(System.PullRequest.TargetBranch)
-          - -subset ${{ path.subset }}
+          - --difftarget origin/$(System.PullRequest.TargetBranch)
+          - --subset ${{ path.subset }}
           - ${{ if ne(path.include[0], '') }}:
-            - -includepaths '${{ join('+', path.include) }}'
+            - --includepaths '${{ join('+', path.include) }}'
           - ${{ if ne(path.exclude[0], '') }}:
-            - -excludepaths '${{ join('+', path.exclude) }}'
+            - --excludepaths '${{ join('+', path.exclude) }}'

--- a/eng/pipelines/common/checkout-job.yml
+++ b/eng/pipelines/common/checkout-job.yml
@@ -1,5 +1,32 @@
 ### Check out job creating a git bundle and publishing it
 ### into an Azure artifact for reuse by the subsequent build and test execution phases.
+### If paths is specified, we will create a job using evaluate-changed-paths.yml template
+### for each path specified.
+
+parameters:
+  # Object containing subset include and exclude paths in an array form.
+  # Scenarios:
+  #  1. exclude paths are specified
+  #     Will include all paths except the ones in the exclude list.
+  #  2. include paths are specified
+  #     Will only include paths specified in the list.
+  #  3. exclude + include:
+  #     1st we evaluate changes for all paths except ones in excluded list. If we can't find
+  #     any applicable changes like that, then we evaluate changes for incldued paths
+  #     if any of these two finds changes, then a variable will be set to true.
+  #  In order to consume this variable you need to reference it via: $[ dependencies.checkout.outputs['SetPathVars_<subset>.containschange'] ]
+  #
+  #  Array form example
+  #  paths:
+  #  - subset: coreclr
+  #    include:
+  #    - src/libraries/System.Private.CoreLib/*
+  #    exclude:
+  #    - src/libraries/*
+  #
+  #  This example will include ALL path changes except the ones under src/libraries/*!System.Private.CoreLib/*
+  paths: []
+
 jobs:
 - job: checkout
   displayName: Checkout
@@ -10,7 +37,7 @@ jobs:
 
     ${{ if ne(variables['System.TeamProject'], 'public') }}:
       name: Hosted Mac Internal
-  
+
   steps:
   - checkout: self
     clean: true
@@ -22,3 +49,16 @@ jobs:
   - publish: $(Build.StagingDirectory)/Checkout.bundle
     artifact: Checkout_bundle
     displayName: Upload Checkout.bundle
+
+  - ${{ if and(ne(parameters.paths[0], ''), in(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ each path in parameters.paths }}:
+      - template: evaluate-changed-paths.yml
+        parameters:
+          subsetName: ${{ path.subset }} 
+          arguments:
+          - -difftarget origin/$(System.PullRequest.TargetBranch)
+          - -subset ${{ path.subset }}
+          - ${{ if ne(path.include[0], '') }}:
+            - -includepaths '${{ join('+', path.include) }}'
+          - ${{ if ne(path.exclude[0], '') }}:
+            - -excludepaths '${{ join('+', path.exclude) }}'

--- a/eng/pipelines/common/evaluate-changed-paths.yml
+++ b/eng/pipelines/common/evaluate-changed-paths.yml
@@ -1,0 +1,11 @@
+parameters:
+  subsetName: ''
+  arguments: ''
+
+steps:
+  - ${{ if ne(parameters.arguments[0], '') }}:
+    - script: eng/pipelines/evaluate-changed-paths.sh
+              -azurevariable containschange
+              ${{ join(' ', parameters.arguments) }}
+      displayName: Evaluate paths for ${{ parameters.subsetName }}
+      name: ${{ format('SetPathVars_{0}', parameters.subsetName) }} # need a name to access output variable

--- a/eng/pipelines/common/evaluate-changed-paths.yml
+++ b/eng/pipelines/common/evaluate-changed-paths.yml
@@ -1,11 +1,23 @@
+# This file is intended to evaluate git changes using git based on a include/exclude path filter.
+# For more information on how the path evaluation works look at evaluate-changed-paths.sh docs
+# at the beginning of that file.
+#
+# paramters
+# subsetName:
+#   Name for the subset that we're evaluating changes for.
+#   It is required to name the step correctly and so the variable created can be consumable.
+# arguments:
+#   Array containing the arguments that are to be passed down to evaluate-changed-paths.sh
+#   Note that --azurevariable is always set to containschange, no need to pass it down.
+
 parameters:
   subsetName: ''
-  arguments: ''
+  arguments: []
 
 steps:
   - ${{ if ne(parameters.arguments[0], '') }}:
     - script: eng/pipelines/evaluate-changed-paths.sh
-              -azurevariable containschange
+              --azurevariable containschange
               ${{ join(' ', parameters.arguments) }}
       displayName: Evaluate paths for ${{ parameters.subsetName }}
       name: ${{ format('SetPathVars_{0}', parameters.subsetName) }} # need a name to access output variable

--- a/eng/pipelines/common/evaluate-changed-paths.yml
+++ b/eng/pipelines/common/evaluate-changed-paths.yml
@@ -1,23 +1,19 @@
-# This file is intended to evaluate git changes using git based on a include/exclude path filter.
+# This step template evaluates git changes using git based on a include/exclude path filter.
 # For more information on how the path evaluation works look at evaluate-changed-paths.sh docs
 # at the beginning of that file.
-#
-# paramters
-# subsetName:
-#   Name for the subset that we're evaluating changes for.
-#   It is required to name the step correctly and so the variable created can be consumable.
-# arguments:
-#   Array containing the arguments that are to be passed down to evaluate-changed-paths.sh
-#   Note that --azurevariable is always set to containschange, no need to pass it down.
 
 parameters:
+  # Name for the subset that we're evaluating changes for.
+  # It is required to name the step correctly and so the variable created can be consumable.
   subsetName: ''
+  # Array containing the arguments that are to be passed down to evaluate-changed-paths.sh
+  # Note that --azurevariable is always set to containschange, no need to pass it down.
   arguments: []
 
 steps:
   - ${{ if ne(parameters.arguments[0], '') }}:
     - script: eng/pipelines/evaluate-changed-paths.sh
-              --azurevariable containschange
+              --azurevariable containsChange
               ${{ join(' ', parameters.arguments) }}
       displayName: Evaluate paths for ${{ parameters.subsetName }}
       name: ${{ format('SetPathVars_{0}', parameters.subsetName) }} # need a name to access output variable

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -12,6 +12,13 @@ jobs:
 - template: ${{ coalesce(parameters.helixQueuesTemplate, parameters.jobTemplate) }}
   parameters:
     variables:
+      - name: _containsCoreClrChange
+        value: $[ dependencies.checkout.outputs['SetPathVars_coreclr.containschange'] ]
+      - name: _containsLibrariesChange
+        value: $[ dependencies.checkout.outputs['SetPathVars_libraries.containschange'] ]
+      - name: _containsInstallerChange
+        value: $[ dependencies.checkout.outputs['SetPathVars_Installer.containschange'] ]
+
       - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
         - name: archiveExtension
           value: '.zip'

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -17,7 +17,7 @@ jobs:
       - name: _containsLibrariesChange
         value: $[ dependencies.checkout.outputs['SetPathVars_libraries.containschange'] ]
       - name: _containsInstallerChange
-        value: $[ dependencies.checkout.outputs['SetPathVars_Installer.containschange'] ]
+        value: $[ dependencies.checkout.outputs['SetPathVars_installer.containschange'] ]
 
       - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
         - name: archiveExtension

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -13,11 +13,11 @@ jobs:
   parameters:
     variables:
       - name: _containsCoreClrChange
-        value: $[ dependencies.checkout.outputs['SetPathVars_coreclr.containschange'] ]
+        value: $[ dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'] ]
       - name: _containsLibrariesChange
-        value: $[ dependencies.checkout.outputs['SetPathVars_libraries.containschange'] ]
+        value: $[ dependencies.checkout.outputs['SetPathVars_libraries.containsChange'] ]
       - name: _containsInstallerChange
-        value: $[ dependencies.checkout.outputs['SetPathVars_installer.containschange'] ]
+        value: $[ dependencies.checkout.outputs['SetPathVars_installer.containsChange'] ]
 
       - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
         - name: archiveExtension

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -24,6 +24,30 @@ jobs:
 # Checkout repository
 #
 - template: /eng/pipelines/common/checkout-job.yml
+  parameters:
+    paths:
+    - subset: coreclr
+      include:
+      - src/libraries/System.Private.CoreLib/*
+      exclude:
+      - src/installer/*
+      - src/libraries/*
+      - eng/pipelines/installer/*
+      - eng/pipelines/libraries/*
+    - subset: libraries
+      exclude:
+      - src/installer/*
+      - src/coreclr/*
+      - eng/pipelines/coreclr/*
+      - eng/pipelines/installer/*
+    - subset: installer
+      include:
+      - docs/manpages/*
+      exclude:
+      - src/coreclr/*
+      - src/libraries/*
+      - eng/pipelines/coreclr/*
+      - eng/pipelines/libraries/*
 
 #
 # Build CoreCLR


### PR DESCRIPTION
This will allow us to condition test runs and build jobs based on changed paths so that we can have a single pipeline and stop duplicating build and test jobs with our current multi pipeline approach.

Contributes to: https://github.com/dotnet/runtime/issues/98

Currently the paths are defined on the yml to avoid parsing a file or what not. However we could always change this approach in the future by having a convention of directories under src/ and for each subdirectory run the command and exclude other directories so that we don't need to have a hard coded list.  However currently we can't do that because coreclr covers `src/libraries/System.Private.CoreLib/*` and installer includes `docs/manpages/*`

The reason why I like having it in the yml file is because it brings consistency with Azure DevOps feature, it makes it clear when reading the runtime.yml file and is simple to find. However, it adds a little complexity on the `checkout` template to iterate on the paths and calculate the script arguments.

This evaluation is now part of the checkout job and you can see it running only on the `runtime` pipeline as it is conditioned based on if the array passed down is empty or not. Also, this is currently scoped to PRs as based on: https://github.com/dotnet/runtime/issues/98#issuecomment-561796227 we should batch commits and run the full matrix on rolling builds: 

> Rolling builds (CI runs) which run per commit in master. To keep the volume low, we should batch these together. We run/test on/against the full platform matrix.

### Images

![image](https://user-images.githubusercontent.com/22899328/70582156-61d62c80-1b6e-11ea-8483-a3d9521ef776.png)

![image](https://user-images.githubusercontent.com/22899328/70582182-71ee0c00-1b6e-11ea-9447-a791be7e50e3.png)

cc: @dotnet/runtime-infrastructure 