### PR TITLE
Revert changes to EncoderNLS/DecoderNLS.Convert

### DIFF
--- a/src/libraries/System.Memory/tests/EncodingExtensions/EncodingExtensionsTests.cs
+++ b/src/libraries/System.Memory/tests/EncodingExtensions/EncodingExtensionsTests.cs
@@ -85,7 +85,7 @@ namespace System.Text.Tests
             inputData = Encoding.UTF8.GetBytes(new string('x', 20_000_000)).Concat(new byte[] { 0xE0, 0xA0 }).ToArray();
             EncodingExtensions.Convert(decoder, inputData, writer, flush: false, out charsUsed, out completed);
             Assert.Equal(20_000_000, charsUsed);
-            Assert.False(completed);
+            Assert.True(completed);
 
             // Then, a large input with flushing and leftover data (should be replaced).
 
@@ -133,7 +133,7 @@ namespace System.Text.Tests
                 new byte[] { 0xF4, 0x80 }); // U+100000 (continues on next line)
             EncodingExtensions.Convert(decoder, inputData, writer, flush: false, out charsUsed, out completed);
             Assert.Equal(0, charsUsed);
-            Assert.False(completed);
+            Assert.True(completed);
 
             // Then, input with flushing and leftover data (should be replaced).
 
@@ -177,7 +177,7 @@ namespace System.Text.Tests
             inputData = new string('x', 20_000_000) + '\ud800';
             EncodingExtensions.Convert(encoder, inputData, writer, flush: false, out bytesUsed, out completed);
             Assert.Equal(20_000_000, bytesUsed);
-            Assert.False(completed);
+            Assert.True(completed);
 
             // Then, a large input with flushing and leftover data (should be replaced).
 
@@ -224,7 +224,7 @@ namespace System.Text.Tests
                 new char[] { '\udbc0' }); // U+100000 (continues on next line)
             EncodingExtensions.Convert(encoder, inputData, writer, flush: false, out bytesUsed, out completed);
             Assert.Equal(0, bytesUsed);
-            Assert.False(completed);
+            Assert.True(completed);
 
             // Then, input with flushing and leftover data (should be replaced).
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
@@ -207,12 +207,10 @@ namespace System.Text
             charsUsed = _encoding.GetChars(bytes, byteCount, chars, charCount, this);
             bytesUsed = _bytesUsed;
 
-            // Per MSDN, "The completed output parameter indicates whether all the data in the input
-            // buffer was converted and stored in the output buffer." That means we've successfully
-            // consumed all the input _and_ there's no pending state or fallback data remaining to be output.
+            // See comment in EncoderNLS.Convert for the details of the logic below.
 
             completed = (bytesUsed == byteCount)
-                && !this.HasState
+                && (!flush || !this.HasState)
                 && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
         }
 

--- a/src/libraries/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
+++ b/src/libraries/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
@@ -165,7 +165,7 @@ namespace System.Text.Tests
             }
 
             Decoder decoder = Encoding.Unicode.GetDecoder();
-            VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, false, bytes.Length, chars.Length / 2, false, "006.1");
+            VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, false, bytes.Length, chars.Length / 2, true, "006.1");
             decoder.Reset();
             // There will be 1 byte left unconverted after previous statement, and set flush = false should left this 1 byte in the buffer.
             VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, true, bytes.Length, chars.Length / 2 + 1, true, "006.2");
@@ -288,8 +288,8 @@ namespace System.Text.Tests
             char[] chars = new char[32];
             Decoder decoder = Encoding.UTF8.GetDecoder();
 
-            VerificationHelper(decoder, bytes, 0, 1, chars, 0, 10, false, 1, 0, false, "011.1"); // incomplete since still state in Decoder
-            VerificationHelper(decoder, bytes, 1, 2, chars, 0, 10, false, 2, 1, false, "011.2"); // incomplete since still state in Decoder
+            VerificationHelper(decoder, bytes, 0, 1, chars, 0, 10, false, 1, 0, true, "011.1"); // complete since all source bytes consumed and no pending data for destination
+            VerificationHelper(decoder, bytes, 1, 2, chars, 0, 10, false, 2, 1, true, "011.2"); // complete since all source bytes consumed and no pending data for destination
             VerificationHelper(decoder, bytes, 3, 6, chars, 1, 1, false, 2, 1, false, "011.3"); // incomplete since not all bytes consumed
             VerificationHelper(decoder, bytes, 5, 4, chars, 2, 10, false, 4, 2, true, "011.4"); // complete since all bytes consumed and no leftover state
             VerificationHelper(decoder, bytes, 9, 1, chars, 4, 10, true, 1, 1, true, "011.5"); // complete since all bytes consumed and no leftover state

--- a/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -224,7 +224,7 @@ namespace System.Text.Tests
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 3, false, 1, 3, expectedCompleted: false);
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, expectedCompleted: true);
 
-            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 0, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 0, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 4, expectedCompleted: true);
         }
 
@@ -259,7 +259,7 @@ namespace System.Text.Tests
             Encoder encoder = Encoding.UTF8.GetEncoder();
 
             VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, expectedCompleted: true);
-            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 2, 1, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 2, 1, expectedCompleted: true);
             VerificationHelper(encoder, chars, 2, 1, bytes, 0, 5, false, 1, 4, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 2, bytes, 0, 7, false, 2, 4, expectedCompleted: true);
             VerificationHelper(encoder, chars, 0, 5, bytes, 0, 7, false, 5, 7, expectedCompleted: true);
@@ -268,7 +268,7 @@ namespace System.Text.Tests
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, false, 3, 5, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, expectedCompleted: true);
 
-            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 1, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 1, expectedCompleted: true);
             VerificationHelper(encoder, chars, 2, 2, bytes, 0, bytes.Length, false, 2, 5, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 3, expectedCompleted: true);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/594.

This restores the original _completed_ output parameter behavior that was present in Full Framework and .NET Core 2.x, reverting the changes that were introduced in the .NET Core 3.0 / 3.1 timeframe. I've also added a code comment explaining the contract of the _completed_ parameter for the `Convert` routines. That comment can serve as the basis for updated API documentation text.

This PR is for .NET 5.0 specifically. After approval there will be separate PRs for .NET Core 3.1.1 (downlevel).