### PR TITLE
Preserve HResult for bad password in managed PKCS12 PAL

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/Windows/CryptoThrowHelper.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/Windows/CryptoThrowHelper.cs
@@ -13,6 +13,10 @@ namespace Internal.Cryptography
         public static CryptographicException ToCryptographicException(this int hr)
         {
             string message = Interop.Kernel32.GetMessage(hr);
+
+            if ((hr & 0x80000000) != 0x80000000)
+                hr = (hr & 0x0000FFFF) | unchecked((int)0x80070000);
+
             return new WindowsCryptographicException(hr, message);
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/UnixPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/UnixPkcs12Reader.cs
@@ -19,6 +19,7 @@ namespace Internal.Cryptography.Pal
     internal abstract class UnixPkcs12Reader : IDisposable
     {
         private const string DecryptedSentinel = nameof(UnixPkcs12Reader);
+        private const int ErrorInvalidPasswordHResult = unchecked((int)0x80070056);
 
         private PfxAsn _pfxAsn;
         private ContentInfoAsn[] _safeContentsValues;
@@ -190,7 +191,10 @@ namespace Internal.Cryptography.Pal
             }
             catch (Exception e)
             {
-                throw new CryptographicException(SR.Cryptography_Pfx_BadPassword, e);
+                throw new CryptographicException(SR.Cryptography_Pfx_BadPassword, e)
+                {
+                    HResult = ErrorInvalidPasswordHResult
+                };
             }
             finally
             {
@@ -225,7 +229,10 @@ namespace Internal.Cryptography.Pal
                 return;
             }
 
-            throw new CryptographicException(SR.Cryptography_Pfx_BadPassword);
+            throw new CryptographicException(SR.Cryptography_Pfx_BadPassword)
+            {
+                HResult = ErrorInvalidPasswordHResult
+            };
         }
 
         private void Decrypt(ReadOnlySpan<char> password, ReadOnlyMemory<byte> authSafeContents)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // Use a MAC count of 1 because we're not persisting things, and the password
         // is with the test... just save some CPU cycles.
         private const int MacCount = 1;
+        protected const int ErrorInvalidPasswordHResult = unchecked((int)0x80070056);
 
         // Use SHA-1 for Windows 7-8.1 support.
         private static readonly HashAlgorithmName s_digestAlgorithm = HashAlgorithmName.SHA1;
@@ -764,7 +765,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 cert2.Attributes.Add(id2);
                 key1.Attributes.Add(id3);
                 key2.Attributes.Add(id4);
-                
+
                 AddContents(keyContents, builder, pw, encrypt: false);
                 AddContents(certContents, builder, pw, encrypt: true);
                 builder.SealWithMac(pw, s_digestAlgorithm, MacCount);
@@ -815,7 +816,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     -2146893819);
             }
         }
-        
+
         [Theory]
         [InlineData(false, false)]
         [InlineData(false, true)]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
@@ -84,6 +84,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 () => coll.Import(pfxBytes, wrongPassword, s_importFlags));
 
             AssertMessageContains("password", ex);
+            Assert.Equal(ErrorInvalidPasswordHResult, ex.HResult);
         }
 
         protected override void ReadUnreadablePfx(

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
@@ -58,6 +58,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 () => new X509Certificate2(pfxBytes, wrongPassword, s_importFlags));
 
             AssertMessageContains("password", ex);
+            Assert.Equal(ErrorInvalidPasswordHResult, ex.HResult);
         }
 
         protected override void ReadUnreadablePfx(


### PR DESCRIPTION
Fixes #735.

/cc @bartonjs 