### PR TITLE
Fix NameValueHeaderValue.CheckValueFormat

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -361,7 +361,7 @@ namespace System.Net.Http.Headers
             }
 
             // Trailing/leading space are not allowed
-            if (value[0] == ' ' || value[^1] == ' ')
+            if (value[0] == ' ' || value[0] == '\t' || value[^1] == ' ' || value[^1] == '\t')
             {
                 throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -354,10 +354,26 @@ namespace System.Net.Http.Headers
 
         private static void CheckValueFormat(string value)
         {
-            // Either value is null/empty or a valid token/quoted string
-            if (!(string.IsNullOrEmpty(value) || (GetValueLength(value, 0) == value.Length)))
+            // Either value is null/empty or a valid token/quoted string https://tools.ietf.org/html/rfc7230#section-3.2.6
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            // Trailing/leading space are not allowed
+            if (value[0] == ' ' || value[^1] == ' ')
             {
                 throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
+            }
+
+            // If it's not a token we check if it's a valid quoted string
+            if (HttpRuleParser.GetTokenLength(value, 0) == 0)
+            {
+                HttpParseResult parseResult = HttpRuleParser.GetQuotedStringLength(value, 0, out int valueLength);
+                if ((parseResult == HttpParseResult.Parsed && valueLength != value.Length) || parseResult != HttpParseResult.Parsed)
+                {
+                    throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
+                }
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
@@ -27,16 +27,21 @@ namespace System.Net.Http.Tests
             AssertExtensions.Throws<ArgumentException>("name", () => { NameValueHeaderValue nameValue = new NameValueHeaderValue(string.Empty); });
         }
 
-        [Fact]
-        public void Ctor_NameInvalidFormat_ThrowFormatException()
+        [Theory]
+        [InlineData(" text ")]
+        [InlineData("text ")]
+        [InlineData(" text")]
+        [InlineData("\ttext\t")]
+        [InlineData("text\t")]
+        [InlineData("\ttext")]
+        [InlineData("te xt")]
+        // The ctor takes a name which must not contain '='.
+        [InlineData("te=xt")]
+        [InlineData("te\u00E4xt")]
+        public void Ctor_NameInvalidFormat_ThrowFormatException(string value)
         {
             // When adding values using strongly typed objects, no leading/trailing LWS (whitespace) are allowed.
-            AssertFormatException(" text ", null);
-            AssertFormatException("text ", null);
-            AssertFormatException(" text", null);
-            AssertFormatException("te xt", null);
-            AssertFormatException("te=xt", null); // The ctor takes a name which must not contain '='.
-            AssertFormatException("te\u00E4xt", null);
+            AssertFormatException(value, null);
         }
 
         [Theory]
@@ -55,6 +60,9 @@ namespace System.Net.Http.Tests
         [InlineData(" token ")]
         [InlineData("token ")]
         [InlineData(" token")]
+        [InlineData("\ttoken")]
+        [InlineData("\ttoken\t")]
+        [InlineData("token\t")]
         [InlineData("\"quoted string with \" quotes\"")]
         [InlineData("\"quoted string with \"two\" quotes\"")]
         [InlineData("\"")]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
@@ -39,23 +39,28 @@ namespace System.Net.Http.Tests
             AssertFormatException("te\u00E4xt", null);
         }
 
-        [Fact]
-        public void Ctor_NameValidFormat_SuccessfullyCreated()
+        [Theory]
+        [InlineData("text", null)]
+        [InlineData("host", "server.example.com:80")]
+        [InlineData("quoted", "\"value\"")]
+        public void Ctor_NameValidFormat_SuccessfullyCreated(string name, string value)
         {
-            NameValueHeaderValue nameValue = new NameValueHeaderValue("text", null);
-            Assert.Equal("text", nameValue.Name);
+            NameValueHeaderValue nameValue = new NameValueHeaderValue(name, value);
+            Assert.Equal(name, nameValue.Name);
+            Assert.Equal(value, nameValue.Value);
         }
 
-        [Fact]
-        public void Ctor_ValueInvalidFormat_ThrowFormatException()
+        [Theory]
+        [InlineData(" token ")]
+        [InlineData("token ")]
+        [InlineData(" token")]
+        [InlineData("\"quoted string with \" quotes\"")]
+        [InlineData("\"quoted string with \"two\" quotes\"")]
+        [InlineData("\"")]
+        public void Ctor_ValueInvalidFormat_ThrowFormatException(string value)
         {
             // When adding values using strongly typed objects, no leading/trailing LWS (whitespace) are allowed.
-            AssertFormatException("text", " token ");
-            AssertFormatException("text", "token ");
-            AssertFormatException("text", " token");
-            AssertFormatException("text", "token string");
-            AssertFormatException("text", "\"quoted string with \" quotes\"");
-            AssertFormatException("text", "\"quoted string with \"two\" quotes\"");
+            AssertFormatException("text", value);
         }
 
         [Fact]
@@ -73,7 +78,6 @@ namespace System.Net.Http.Tests
         {
             // Just verify that the setter calls the same validation the ctor invokes.
             Assert.Throws<FormatException>(() => { var x = new NameValueHeaderValue("name"); x.Value = " x "; });
-            Assert.Throws<FormatException>(() => { var x = new NameValueHeaderValue("name"); x.Value = "x y"; });
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/NameValueHeaderValueTest.cs
@@ -43,6 +43,7 @@ namespace System.Net.Http.Tests
         [InlineData("text", null)]
         [InlineData("host", "server.example.com:80")]
         [InlineData("quoted", "\"value\"")]
+        [InlineData("empty", "")]
         public void Ctor_NameValidFormat_SuccessfullyCreated(string name, string value)
         {
             NameValueHeaderValue nameValue = new NameValueHeaderValue(name, value);
@@ -57,6 +58,7 @@ namespace System.Net.Http.Tests
         [InlineData("\"quoted string with \" quotes\"")]
         [InlineData("\"quoted string with \"two\" quotes\"")]
         [InlineData("\"")]
+        [InlineData(" ")]
         public void Ctor_ValueInvalidFormat_ThrowFormatException(string value)
         {
             // When adding values using strongly typed objects, no leading/trailing LWS (whitespace) are allowed.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/30653 https://github.com/dotnet/runtime/issues/1504

RFC 7230 https://tools.ietf.org/html/rfc7230#section-3.2.6 states
```
Most HTTP header field values are defined using common syntax
components (token, quoted-string, and comment) separated by
whitespace or specific delimiting characters.  Delimiters are chosen
from the set of US-ASCII visual characters not allowed in a token
(DQUOTE and "(),/:;<=>?@[\]{}").
...
```

Current code try to do check searching for "token" length inside input, if the length returned is equal to 0 means that the start char of input is a not allowed token delimiter, in turn it tries to check if input is a valid quoted string. To do this check uses `GetValueLength` that returns a "value length" and if it's different from input length means that input is a "token" or an invalid quoted string.

This PR try to fix issue allowing "token", but I cannot reuse `GetValueLength` because simple "value length" is not enough to understand if it's valid or not. For instance a `GetValueLength` < inpunt.Length it's ok for a "token" value.

I added also new check for trailing/leading not allowed spaces, was "gratis" before.
Updated also a test becasue "x y" it's valid per RFC `separated by whitespace or specific delimiting characters`.

Some note: RFC talks also about "comments" that aren't covered by check.

cc: @scalablecory @davidsh 

