### PR TITLE
Fix the gc layout algorithm to not double count byref

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1389,24 +1389,29 @@ namespace Internal.JitInterface
             return (uint)type.InstanceFieldAlignment.AsInt;
         }
 
+        private int MarkGcField(byte* gcPtrs, CorInfoGCType gcType)
+        {
+            // Ensure that if we have multiple fields with the same offset,
+            // that we don't double count the data in the gc layout.
+            if (*gcPtrs == (byte)CorInfoGCType.TYPE_GC_NONE)
+            {
+                *gcPtrs = (byte)gcType;
+                return 1;
+            }
+            else
+            {
+                Debug.Assert(*gcPtrs == (byte)gcType);
+                return 0;
+            }
+        }
+
         private int GatherClassGCLayout(TypeDesc type, byte* gcPtrs)
         {
             int result = 0;
 
             if (type.IsByReferenceOfT || type.IsWellKnownType(WellKnownType.TypedReference))
             {
-                // Ensure that if we have multiple fields with the same offset, 
-                // that we don't double count the data in the gc layout.
-                if (*gcPtrs == (byte)CorInfoGCType.TYPE_GC_NONE)
-                {
-                    *gcPtrs = (byte)CorInfoGCType.TYPE_GC_BYREF;
-                    result++;
-                }
-                else
-                {
-                    Debug.Assert(*gcPtrs == (byte)CorInfoGCType.TYPE_GC_BYREF);
-                }
-                return result;
+                return MarkGcField(gcPtrs, CorInfoGCType.TYPE_GC_BYREF);
             }
 
             foreach (var field in type.GetFields())
@@ -1447,17 +1452,7 @@ namespace Internal.JitInterface
                 }
                 else
                 {
-                    // Ensure that if we have multiple fields with the same offset, 
-                    // that we don't double count the data in the gc layout.
-                    if (*fieldGcPtrs == (byte)CorInfoGCType.TYPE_GC_NONE)
-                    {
-                        *fieldGcPtrs = (byte)gcType;
-                        result++;
-                    }
-                    else
-                    {
-                        Debug.Assert(*fieldGcPtrs == (byte)gcType);
-                    }
+                    result += MarkGcField(fieldGcPtrs, gcType);
                 }
             }
             return result;

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1395,8 +1395,18 @@ namespace Internal.JitInterface
 
             if (type.IsByReferenceOfT || type.IsWellKnownType(WellKnownType.TypedReference))
             {
-                *gcPtrs = (byte)CorInfoGCType.TYPE_GC_BYREF;
-                return 1;
+                // Ensure that if we have multiple fields with the same offset, 
+                // that we don't double count the data in the gc layout.
+                if (*gcPtrs == (byte)CorInfoGCType.TYPE_GC_NONE)
+                {
+                    *gcPtrs = (byte)CorInfoGCType.TYPE_GC_BYREF;
+                    result++;
+                }
+                else
+                {
+                    Debug.Assert(*gcPtrs == (byte)CorInfoGCType.TYPE_GC_BYREF);
+                }
+                return result;
             }
 
             foreach (var field in type.GetFields())
@@ -1450,7 +1460,6 @@ namespace Internal.JitInterface
                     }
                 }
             }
-
             return result;
         }
 


### PR DESCRIPTION
This pull request is intended to fix the crossgen2 compilation crash of [SlowTailCallArgs.csproj](https://github.com/dotnet/runtime/blob/master/src/coreclr/tests/src/CoreMangLib/system/span/SlowTailCallArgs.csproj).

The compilation failure was found by @janvorli by running all the CoreCLR Pri 1 test on Linux under crossgen2 using SuperIlc.

This bug repro consistently on both debug and release compilation using `crossgen2` on Linux only.

The symptom is that when we generate code that put an instance of [TestByRefStruct](https://github.com/dotnet/runtime/blob/d8f744dbd3ee9f3189a46e1886b63dc1a9fd5efc/src/coreclr/tests/src/CoreMangLib/system/span/SlowTailCallArgs.cs#L124) on the stack, we hit an assertion in the code generator here:

https://github.com/dotnet/runtime/blob/d8f744dbd3ee9f3189a46e1886b63dc1a9fd5efc/src/coreclr/src/jit/codegenxarch.cpp#L8312

With some digging, I figured there is a bug in the GC layout algorithm. If a struct happens to contain two instances of `ByReferenceOfT` or `TypedReference` placed in the same location using ExplicitLayout, the existing code would have double-counted it.

The obvious fix is to avoid double-counting, and that is what the code change does.

@dotnet/crossgen-contrib 