### PR TITLE
Fix token encoding crash when compiling without version bubble

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysis.ReadyToRun;
 
 namespace ILCompiler
 {
@@ -36,6 +37,36 @@ namespace ILCompiler
         /// <returns>True if the given module versions with the current compilation module group</returns>
         public abstract bool VersionsWithModule(ModuleDesc module);
 
+        /// <summary>
+        /// Checks if the given PInvoke method can produce a PInvoke stub in the current compilation, depending on the method's
+        /// signature and the compilation policy.
+        /// </summary>
+        /// <param name="method">PInvoke method to check</param>
+        /// <returns>Returns true if the given PInvoke method can produce a PInvoke stub in the current compilation</returns>
         public abstract bool GeneratesPInvoke(MethodDesc method);
+
+        /// <summary>
+        /// Retrieve the module-based token for a type that is not part of the version bubble of the current compilation.
+        /// </summary>
+        /// <param name="type">Type to get a module token for</param>
+        /// <param name="token">Module-based token for the type</param>
+        /// <returns>Returns true the type was referenced by any of the input modules in the current compliation</returns>
+        public abstract bool TryGetModuleTokenForExternalType(TypeDesc type, out ModuleToken token);
+
+        /// <summary>
+        /// Retrieve the module-based token for a method that is not part of the version bubble of the current compilation.
+        /// </summary>
+        /// <param name="method">Method to get a module token for</param>
+        /// <param name="token">Module-based memberref token for the method</param>
+        /// <returns>Returns true the method was referenced by any of the input modules in the current compliation</returns>
+        public abstract bool TryGetModuleTokenForExternalMethod(MethodDesc method, out ModuleToken token);
+
+        /// <summary>
+        /// Retrieve the module-based token for a field that is not part of the version bubble of the current compilation.
+        /// </summary>
+        /// <param name="field">Field to get a module token for</param>
+        /// <param name="token">Module-based memberref token for the field</param>
+        /// <returns>Returns true the field was referenced by any of the input modules in the current compliation</returns>
+        public abstract bool TryGetModuleTokenForExternalField(FieldDesc field, out ModuleToken token);
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -52,21 +52,5 @@ namespace ILCompiler
         /// <param name="token">Module-based token for the type</param>
         /// <returns>Returns true the type was referenced by any of the input modules in the current compliation</returns>
         public abstract bool TryGetModuleTokenForExternalType(TypeDesc type, out ModuleToken token);
-
-        /// <summary>
-        /// Retrieve the module-based token for a method that is not part of the version bubble of the current compilation.
-        /// </summary>
-        /// <param name="method">Method to get a module token for</param>
-        /// <param name="token">Module-based memberref token for the method</param>
-        /// <returns>Returns true the method was referenced by any of the input modules in the current compliation</returns>
-        public abstract bool TryGetModuleTokenForExternalMethod(MethodDesc method, out ModuleToken token);
-
-        /// <summary>
-        /// Retrieve the module-based token for a field that is not part of the version bubble of the current compilation.
-        /// </summary>
-        /// <param name="field">Field to get a module token for</param>
-        /// <param name="token">Module-based memberref token for the field</param>
-        /// <returns>Returns true the field was referenced by any of the input modules in the current compliation</returns>
-        public abstract bool TryGetModuleTokenForExternalField(FieldDesc field, out ModuleToken token);
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -81,18 +81,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             method = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
-            ModuleToken token;
-
-            if (method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
+            if (_compilationModuleGroup.VersionsWithMethodBody(method) &&
+                method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
             {
-                if (_compilationModuleGroup.VersionsWithMethodBody(method))
-                {
-                    return new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle);
-                }
-                else if (_compilationModuleGroup.TryGetModuleTokenForExternalMethod(ecmaMethod, out token))
-                {
-                    return token;
-                }
+                return new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle);
             }
 
             // Reverse lookup failed
@@ -108,18 +100,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public ModuleToken GetModuleTokenForField(FieldDesc field, bool throwIfNotFound = true)
         {
-            ModuleToken token;
-
-            if (field is EcmaField ecmaField)
+            if (_compilationModuleGroup.VersionsWithType(field.OwningType) && field is EcmaField ecmaField)
             {
-                if (_compilationModuleGroup.VersionsWithType(field.OwningType))
-                {
-                    return new ModuleToken(ecmaField.Module, ecmaField.Handle);
-                }
-                else if (_compilationModuleGroup.TryGetModuleTokenForExternalField(field, out token))
-                {
-                    return token;
-                }
+                return new ModuleToken(ecmaField.Module, ecmaField.Handle);
             }
 
             TypeDesc owningCanonType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
@@ -129,12 +112,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 canonField = CompilerContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
             }
 
+            ModuleToken token;
             if (_fieldToRefTokens.TryGetValue(canonField, out token))
             {
                 return token;
             }
 
-            // Reverse lookup failed
             if (throwIfNotFound)
             {
                 throw new NotImplementedException(field.ToString());

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -225,11 +225,15 @@ namespace ILCompiler
                     EcmaModule ecmaModule = (EcmaModule)module;
                     foreach (var typeRefHandle in ecmaModule.MetadataReader.TypeReferences)
                     {
-                        TypeDesc typeFromTypeRef = ecmaModule.GetType(typeRefHandle);
-                        if (!_typeRefsInCompilationModuleSet.ContainsKey(typeFromTypeRef))
+                        try
                         {
-                            _typeRefsInCompilationModuleSet.Add(typeFromTypeRef, new ModuleToken(ecmaModule, typeRefHandle));
+                            TypeDesc typeFromTypeRef = ecmaModule.GetType(typeRefHandle);
+                            if (!_typeRefsInCompilationModuleSet.ContainsKey(typeFromTypeRef))
+                            {
+                                _typeRefsInCompilationModuleSet.Add(typeFromTypeRef, new ModuleToken(ecmaModule, typeRefHandle));
+                            }
                         }
+                        catch (TypeSystemException) { }
                     }
                 }
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -56,8 +56,12 @@ namespace ILCompiler
                 EcmaModule ecmaModule = ((EcmaMethod)_method.GetTypicalMethodDefinition()).Module;
                 foreach (var typeRefHandle in ecmaModule.MetadataReader.TypeReferences)
                 {
-                    TypeDesc typeFromTypeRef = ecmaModule.GetType(typeRefHandle);
-                    _typeRefsInCompilationModuleSet[typeFromTypeRef] = new ModuleToken(ecmaModule, typeRefHandle);
+                    try
+                    {
+                        TypeDesc typeFromTypeRef = ecmaModule.GetType(typeRefHandle);
+                        _typeRefsInCompilationModuleSet[typeFromTypeRef] = new ModuleToken(ecmaModule, typeRefHandle);
+                    }
+                    catch (TypeSystemException) { }
                 }
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using ILCompiler.DependencyAnalysis.ReadyToRun;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
-using System.Reflection.Metadata.Ecma335;
 
 namespace ILCompiler
 {
@@ -39,6 +40,24 @@ namespace ILCompiler
         public override bool GeneratesPInvoke(MethodDesc method)
         {
             return true;
+        }
+
+        public override bool TryGetModuleTokenForExternalType(TypeDesc type, out ModuleToken token)
+        {
+            // TODO: implement if needed (needed if not compiling with large version bubble)
+            throw new NotImplementedException();
+        }
+
+        public override bool TryGetModuleTokenForExternalMethod(MethodDesc method, out ModuleToken token)
+        {
+            // TODO: implement if needed (needed if not compiling with large version bubble)
+            throw new NotImplementedException();
+        }
+
+        public override bool TryGetModuleTokenForExternalField(FieldDesc field, out ModuleToken token)
+        {
+            // TODO: implement if needed (needed if not compiling with large version bubble)
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using ILCompiler.DependencyAnalysis.ReadyToRun;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
+using ILCompiler.DependencyAnalysis.ReadyToRun;
 
 namespace ILCompiler
 {
@@ -45,19 +44,7 @@ namespace ILCompiler
         public override bool TryGetModuleTokenForExternalType(TypeDesc type, out ModuleToken token)
         {
             // TODO: implement if needed (needed if not compiling with large version bubble)
-            throw new NotImplementedException();
-        }
-
-        public override bool TryGetModuleTokenForExternalMethod(MethodDesc method, out ModuleToken token)
-        {
-            // TODO: implement if needed (needed if not compiling with large version bubble)
-            throw new NotImplementedException();
-        }
-
-        public override bool TryGetModuleTokenForExternalField(FieldDesc field, out ModuleToken token)
-        {
-            // TODO: implement if needed (needed if not compiling with large version bubble)
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Implement the ability to get token values for typeRefs and memberRefs that are not part of the version bubble. This fixes the ability to compile the CoreFX set without the --large-bubble switch