### PR TITLE
Don't change current directory in dotnet.cmd wrapper script

### DIFF
--- a/src/coreclr/dotnet.cmd
+++ b/src/coreclr/dotnet.cmd
@@ -27,10 +27,8 @@ if NOT [%ERRORLEVEL%] == [0] (
 
 set "dotnetPath=%__dotnetDir%\dotnet.exe"
 
-pushd %~dp0
 echo Running: "%dotnetPath%" %*
 call "%dotnetPath%" %*
-popd
 if NOT [%ERRORLEVEL%]==[0] (
   exit /b 1
 )


### PR DESCRIPTION
The current behavior causes failures when invoking dotnet.cmd
from an individual test subdirectory, e.g.,
```
F:\gh\runtime\src\coreclr\tests\src\JIT\superpmi>f:\gh\runtime\src\coreclr\dotnet.cmd msbuild /p:__BuildOS=Windows_NT /p:__BuildArch=x64 /p:__BuildType=Checked superpmicollect.csproj
```