### PR TITLE
Add more path exclusions to subsets

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -30,12 +30,22 @@ jobs:
       include:
       - src/libraries/System.Private.CoreLib/*
       exclude:
+      - '*.md'
+      - LICENSE.TXT
+      - PATENTS.TXT
+      - THIRD-PARTY-NOTICES.TXT
+      - docs/*
       - src/installer/*
       - src/libraries/*
       - eng/pipelines/installer/*
       - eng/pipelines/libraries/*
     - subset: libraries
       exclude:
+      - '*.md'
+      - LICENSE.TXT
+      - PATENTS.TXT
+      - THIRD-PARTY-NOTICES.TXT
+      - docs/*
       - src/installer/*
       - src/coreclr/*
       - eng/pipelines/coreclr/*
@@ -44,6 +54,11 @@ jobs:
       include:
       - docs/manpages/*
       exclude:
+      - '*.md'
+      - LICENSE.TXT
+      - PATENTS.TXT
+      - THIRD-PARTY-NOTICES.TXT
+      - docs/*
       - src/coreclr/*
       - src/libraries/*
       - eng/pipelines/coreclr/*


### PR DESCRIPTION
By looking at some PRs I noticed that these need to be specified as well as part of the path exclusions using git. The reason for that is, if a .md file is changed for example, and the PR contains more changes under `src/libraries`, because of the .md file, we would emit a variable for all partitions rather than for `libraries` only.

cc: @dotnet/runtime-infrastructure 