### PR TITLE
Update environ.cpp

### DIFF
--- a/src/coreclr/src/pal/src/misc/environ.cpp
+++ b/src/coreclr/src/pal/src/misc/environ.cpp
@@ -914,7 +914,7 @@ Return Value
 --*/
 char* FindEnvVarValue(const char* name)
 {
-    if(*name == '\0')
+    if (*name == '\0')
         return nullptr;
     
     for (int i = 0; palEnvironment[i] != nullptr; ++i)
@@ -927,7 +927,7 @@ char* FindEnvVarValue(const char* name)
             if (*pch == '\0') 
             {
                 if (*p == '=')
-                    return p+1;
+                    return p + 1;
                     
                 if (*p == '\0') // no = sign -> empty value
                     return p;
@@ -935,7 +935,7 @@ char* FindEnvVarValue(const char* name)
                 break;
             }
         }
-        while(*pch++ == *p++);
+        while (*pch++ == *p++);
     }
     
     return nullptr;

--- a/src/coreclr/src/pal/src/misc/environ.cpp
+++ b/src/coreclr/src/pal/src/misc/environ.cpp
@@ -927,12 +927,14 @@ static char* match_prefix(const char* name, char** list)
         const char* pch = name;
         char* p = list[i];
 
-        for (;;) {
-            if (*pch == '\0') {
-                if(*p == '=')
+        for (;;) 
+        {
+            if (*pch == '\0') 
+            {
+                if (*p == '=')
                     return p+1;
                     
-                if(*p == '\0') // no = sign -> empty value
+                if (*p == '\0') // no = sign -> empty value
                     return p;
                 
                 break;

--- a/src/coreclr/src/pal/src/misc/environ.cpp
+++ b/src/coreclr/src/pal/src/misc/environ.cpp
@@ -919,46 +919,46 @@ Return Value
 --*/
 static char* match_prefix(const char* name, char** list)
 {
-	if(*name == '\0')
-		return nullptr;
-	
-	for (int i = 0; list[i] != nullptr; ++i)
-	{
-		const char* pch = name;
-		char* p = list[i];
+    if(*name == '\0')
+        return nullptr;
+    
+    for (int i = 0; list[i] != nullptr; ++i)
+    {
+        const char* pch = name;
+        char* p = list[i];
 
-		for (;;) {
-			if (*pch == '\0') {
-				if(*p == '=')
-					return p+1;
-					
-				if(*p == '\0') // no = sign -> empty value
-					return p;
-				
-				break;
-			}
-			
-			if (*pch++ != *p++) break;
-		}
-	}
-	
-	return nullptr;
+        for (;;) {
+            if (*pch == '\0') {
+                if(*p == '=')
+                    return p+1;
+                    
+                if(*p == '\0') // no = sign -> empty value
+                    return p;
+                
+                break;
+            }
+            
+            if (*pch++ != *p++) break;
+        }
+    }
+    
+    return nullptr;
 }
-	
+    
 char* EnvironGetenv(const char* name, BOOL copyValue)
 {
-	CPalThread * pthrCurrent = InternalGetCurrentThread();
-	InternalEnterCriticalSection(pthrCurrent, &gcsEnvironment);
-	
-	char* retValue = match_prefix(name, palEnvironment);
-	
-	if ((retValue != nullptr) && copyValue)
-	{
-		retValue = strdup(retValue);
-	}
+    CPalThread * pthrCurrent = InternalGetCurrentThread();
+    InternalEnterCriticalSection(pthrCurrent, &gcsEnvironment);
+    
+    char* retValue = match_prefix(name, palEnvironment);
+    
+    if ((retValue != nullptr) && copyValue)
+    {
+        retValue = strdup(retValue);
+    }
 
-	InternalLeaveCriticalSection(pthrCurrent, &gcsEnvironment);
-	return retValue;
+    InternalLeaveCriticalSection(pthrCurrent, &gcsEnvironment);
+    return retValue;
 }
 
 


### PR DESCRIPTION
The search for a prefix has been inlined to squeeze some extra performance by directly comparing bytes.

The prefix search functionality has been put in a separate static function to have all the state given as input and use multiple returns as control flow.

Ref: https://github.com/dotnet/corefx/issues/42216