### PR TITLE
Fix bug with type loadability validation

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -107,8 +107,8 @@ namespace ILCompiler
                 // Validate classes, structs, enums, interfaces, and delegates
                 Debug.Assert(type.IsDefType);
 
-                // Don't validate generic definitons or RuntimeDeterminiedTypes
-                if (type.IsGenericDefinition || type.IsRuntimeDeterminedType)
+                // Don't validate generic definitons or runtime determined subtypes
+                if (type.IsGenericDefinition || type.IsRuntimeDeterminedSubtype)
                 {
                     return type;
                 }


### PR DESCRIPTION
The check had a small typo: .IsRuntimeDeterminiedType instead of .IsRuntimeDeterminedSubtype

@dotnet/crossgen-contrib 