### PR TITLE
JIT: detect address of field as an invariant inlining arg

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -18571,7 +18571,9 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     inlCurArgInfo->argNode = curArgVal;
 
     GenTree* lclVarTree;
-    if (impIsAddressInLocal(curArgVal, &lclVarTree) && varTypeIsStruct(lclVarTree))
+
+    const bool isAddressInLocal = impIsAddressInLocal(curArgVal, &lclVarTree);
+    if (isAddressInLocal && varTypeIsStruct(lclVarTree))
     {
         inlCurArgInfo->argIsByRefToStructLocal = true;
 #ifdef FEATURE_SIMD
@@ -18596,8 +18598,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
         INDEBUG(curArgVal->AsLclVar()->gtLclILoffs = argNum;)
     }
 
-    if ((curArgVal->OperKind() & GTK_CONST) ||
-        ((curArgVal->gtOper == GT_ADDR) && (curArgVal->AsOp()->gtOp1->gtOper == GT_LCL_VAR)))
+    if ((curArgVal->OperKind() & GTK_CONST) || isAddressInLocal)
     {
         inlCurArgInfo->argIsInvariant = true;
         if (inlCurArgInfo->argIsThis && (curArgVal->gtOper == GT_CNS_INT) && (curArgVal->AsIntCon()->gtIconVal == 0))


### PR DESCRIPTION
Update the check for arg invariance to include addresses of fields in local
structs. This allows the inliner to directly substitute more arguments into
the body of the inlinee.

Resolves dotnet/coreclr#27630.