### PR TITLE
Use wildcard to resolve S.P.CoreLib from CoreCLRArtifacts

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -32,7 +32,7 @@
       <CoreCLRFiles>
         <IsNative>true</IsNative>
       </CoreCLRFiles>
-      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)**/System.Private.CoreLib.dll" />
       <CoreCLRFiles
         Include="
           $(CoreCLRSharedFrameworkDir)PDB/*.pdb;

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -32,7 +32,11 @@
       <CoreCLRFiles>
         <IsNative>true</IsNative>
       </CoreCLRFiles>
-      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)**/System.Private.CoreLib.dll" />
+      <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll"
+                             Condition="Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')" />
+      <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll"
+                             Condition="Exists('$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll') and '@(_systemPrivateCoreLib)' == ''" />
+      <CoreCLRFiles Include="@(_systemPrivateCoreLib)" />
       <CoreCLRFiles
         Include="
           $(CoreCLRSharedFrameworkDir)PDB/*.pdb;


### PR DESCRIPTION
When building with `build.cmd` the build fails to resolve System.Private.CoreLib when trying to generate facades on libraries because the item includes a hardcoded path, which doesn't exist, since System.Private.CoreLib is under the `IL` directory. Change to use a wildcard so that the ItemGroup resolves the real path and avoid this error:

```
E:\repos\dotnet\sdk\3.0.100\Microsoft.Common.CurrentVersion.targets(2106,5): warning MSB3106: Assembly strong name "E:\repos\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug\System.Private.CoreLib.dll" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\). [E:\repos\runtime\src\libraries\System.Globalization.Calendars\src\System.Globalization.Calendars.csproj]
```

FYI: @danmosemsft @jaredpar 