### PR TITLE
Fix incorrect merge of my framework crossgenning fix with Jeremy's local live-live change

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -508,21 +508,6 @@ echo { "build_os": "%__BuildOS%", "build_arch": "%__BuildArch%", "build_type": "
 
 REM =========================================================================================
 REM ===
-REM === Copy CoreFX assemblies if needed.
-REM ===
-REM =========================================================================================
-
-if NOT "%__LocalCoreFXPath%"=="" (
-    echo Patch CoreFX from %__LocalCoreFXPath% ^(%__LocalCoreFXConfig%^)
-    set NEXTCMD=python "%__ProjectDir%\tests\scripts\patch-corefx.py" -clr_core_root "%CORE_ROOT%"^
-    -fx_root "%__LocalCoreFXPath%" -arch %__BuildArch% -build_type %__LocalCoreFXConfig%
-    echo !NEXTCMD!
-    !NEXTCMD!
-)
-
-
-REM =========================================================================================
-REM ===
 REM === Crossgen assemblies if needed.
 REM ===
 REM =========================================================================================

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -126,6 +126,11 @@ generate_layout()
         fi
     fi
 
+    # Patch framework assemblies from a local source if requested
+    if [ ! -z "$__LocalCoreFXPath" ]; then
+        patch_corefx_libraries
+    fi
+
     # Precompile framework assemblies with crossgen if required
     if [[ $__DoCrossgen != 0 || $__DoCrossgen2 != 0 ]]; then
         precompile_coreroot_fx
@@ -344,10 +349,6 @@ build_Tests()
     fi
 
     if [ $__SkipGenerateLayout != 1 ]; then
-        if [ ! -z "$__LocalCoreFXPath" ]; then
-            patch_corefx_libraries
-        fi
-
         generate_layout
     fi
 }

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -126,11 +126,6 @@ generate_layout()
         fi
     fi
 
-    # Patch framework assemblies from a local source if requested
-    if [ ! -z "$__LocalCoreFXPath" ]; then
-        patch_corefx_libraries
-    fi
-
     # Precompile framework assemblies with crossgen if required
     if [[ $__DoCrossgen != 0 || $__DoCrossgen2 != 0 ]]; then
         precompile_coreroot_fx


### PR DESCRIPTION
I found out that my fix for crossgenning framework assemblies
merged incorrectly in two places with Jeremy's change and inadvertently
resurrected two bits of scripts related to patching CORE_ROOT with an
explicit CoreFX build that Jeremy previously deleted. The leftovers
should be benign as the variables in question are newly never defined
but it's cleaner to delete them nonetheless.

Thanks

Tomas