### PR TITLE
Improve atomic type detection in ConcurrentDictionary

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -81,33 +81,9 @@ namespace System.Collections.Concurrent
             // Section 12.6.6 of ECMA CLI explains which types can be read and written atomically without
             // the risk of tearing.
             //
-            // See http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf
+            // See https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
             //
-            Type valueType = typeof(TValue);
-            if (!valueType.IsValueType)
-            {
-                return true;
-            }
-
-            switch (Type.GetTypeCode(valueType))
-            {
-                case TypeCode.Boolean:
-                case TypeCode.Byte:
-                case TypeCode.Char:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                case TypeCode.SByte:
-                case TypeCode.Single:
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                    return true;
-                case TypeCode.Int64:
-                case TypeCode.Double:
-                case TypeCode.UInt64:
-                    return IntPtr.Size == 8;
-                default:
-                    return false;
-            }
+            return Unsafe.SizeOf<TValue>() <= IntPtr.Size;
         }
 
         /// <summary>

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -70,21 +70,13 @@ namespace System.Collections.Concurrent
         private const int MaxLockNumber = 1024;
 
         // Whether TValue is a type that can be written atomically (i.e., with no danger of torn reads)
-        private static readonly bool s_isValueWriteAtomic = IsValueWriteAtomic();
-
-        /// <summary>
-        /// Determines whether type TValue can be written atomically
-        /// </summary>
-        private static bool IsValueWriteAtomic()
-        {
-            //
-            // Section 12.6.6 of ECMA CLI explains which types can be read and written atomically without
-            // the risk of tearing.
-            //
-            // See https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
-            //
-            return Unsafe.SizeOf<TValue>() <= IntPtr.Size;
-        }
+        //
+        // Section 12.6.6 of ECMA CLI explains which types can be read and written atomically without
+        // the risk of tearing.
+        //
+        // See https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+        //
+        private static readonly bool s_isValueWriteAtomic = Unsafe.SizeOf<TValue>() <= IntPtr.Size;
 
         /// <summary>
         /// Initializes a new instance of the <see


### PR DESCRIPTION
This change supports checking any value type provided in TValue for direct write capability (including small Nullable<> types), avoiding allocation of a new Node.