### PR TITLE
Add List<T>.CopyTo Span<T> APIs

### DIFF
--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -326,8 +326,8 @@ namespace System.Collections.Generic
         public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
         public void CopyTo(T[] array) { }
         public void CopyTo(T[] array, int arrayIndex) { }
-        public void CopyTo(int sourceIndex, int count, Span<T> span) { }
-        public void CopyTo(Span<T> span) { }
+        public void CopyTo(int sourceIndex, int count, Span<T> destination) { }
+        public void CopyTo(Span<T> destination) { }
         public bool Exists(System.Predicate<T> match) { throw null; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNullAttribute]
         public T Find(System.Predicate<T> match) { throw null; }

--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -326,6 +326,8 @@ namespace System.Collections.Generic
         public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
         public void CopyTo(T[] array) { }
         public void CopyTo(T[] array, int arrayIndex) { }
+        public void CopyTo(int sourceIndex, int count, Span<T> span) { }
+        public void CopyTo(Span<T> span) { }
         public bool Exists(System.Predicate<T> match) { throw null; }
         [return: System.Diagnostics.CodeAnalysis.MaybeNullAttribute]
         public T Find(System.Predicate<T> match) { throw null; }

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
@@ -198,7 +198,7 @@ namespace System.Collections.Tests
                 nonDefaultValue = CreateT(1);
             }
             while (EqualityComparer<T>.Default.Equals(nonDefaultValue, default));
-            
+
             span[count] = nonDefaultValue;
 
             list.CopyTo(span);

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
@@ -181,6 +181,30 @@ namespace System.Collections.Tests
                 Assert.True(Enumerable.SequenceEqual(list.Skip(1).Take(count - 2), span.Slice(0, count - 2).ToArray()));
             }
         }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void CopyToSpan_EnsureDoesntCopyMoreThanListCount(int count)
+        {
+            List<T> list = GenericListFactory(count);
+            list.Capacity = count + 1;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count + 1]; list.CopyTo(0, count + 1, span); });
+
+            Span<T> span = new T[count + 1];
+            T nonDefaultValue;
+            do
+            {
+                nonDefaultValue = CreateT(1);
+            }
+            while (EqualityComparer<T>.Default.Equals(nonDefaultValue, default));
+            
+            span[count] = nonDefaultValue;
+
+            list.CopyTo(span);
+            Assert.Equal(span[count], nonDefaultValue);
+
+        }
         #endregion
 
         [Theory]

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.cs
@@ -62,8 +62,8 @@ namespace System.Collections.Tests
         {
             List<T> list = GenericListFactory(count);
 
-            Assert.Throws<ArgumentOutOfRangeException>("sourceIndex", () => { Span<T> span = new T[count]; list.CopyTo(-1, count, span); });
-            Assert.Throws<ArgumentOutOfRangeException>("sourceIndex", () => { Span<T> span = new T[count]; list.CopyTo(int.MinValue, count, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(-1, count, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(int.MinValue, count, span); });
         }
 
         [Theory]
@@ -72,35 +72,35 @@ namespace System.Collections.Tests
         {
             List<T> list = GenericListFactory(count);
 
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => { Span<T> span = new T[count]; list.CopyTo(0, -1, span); });
-            Assert.Throws<ArgumentOutOfRangeException>("count", () => { Span<T> span = new T[count]; list.CopyTo(0, int.MinValue, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(0, -1, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(0, int.MinValue, span); });
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void CopyToSpan_SourceIndexLargerThanListCount_ThrowsAnyArgumentException(int count)
+        public void CopyToSpan_SourceIndexLargerThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             List<T> list = GenericListFactory(count);
 
-            Assert.Throws<ArgumentException>(() => { Span<T> span = new T[count]; list.CopyTo(count + 1, 0, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(count + 1, 0, span); });
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void CopyToSpan_CountLargerThanListCount_ThrowsAnyArgumentException(int count)
+        public void CopyToSpan_CountLargerThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             List<T> list = GenericListFactory(count);
 
-            Assert.Throws<ArgumentException>(() => { Span<T> span = new T[count]; list.CopyTo(0, count + 1, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(0, count + 1, span); });
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
-        public void CopyToSpan_SourceIndexPlusCountLargerThanListCount_ThrowsAnyArgumentException(int count)
+        public void CopyToSpan_SourceIndexPlusCountLargerThanListCount_ThrowsArgumentOutOfRangeException(int count)
         {
             List<T> list = GenericListFactory(count);
 
-            Assert.Throws<ArgumentException>(() => { Span<T> span = new T[count]; list.CopyTo(1, count, span); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Span<T> span = new T[count]; list.CopyTo(1, count, span); });
         }
 
         [Theory]

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -393,6 +393,13 @@ namespace System.Collections.Generic
             Array.Copy(_items, 0, array, arrayIndex, _size);
         }
 
+        /// <summary>
+        /// Copies the contents of this List, beginning at 'sourceIndex', into destination span.
+        /// </summary>
+        /// <param name="sourceIndex">The index in this List at which copying begins.</param>
+        /// <param name="count">The number of items to copy</param>
+        /// <param name="destination">The span to copy items into.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the specified <paramref name="sourceIndex"/> or <paramref name="count"/> is not in range.</exception>
         public void CopyTo(int sourceIndex, int count, Span<T> destination)
         {
             if (sourceIndex < 0)
@@ -413,6 +420,10 @@ namespace System.Collections.Generic
             _items.AsSpan(sourceIndex, count).CopyTo(destination);
         }
 
+        /// <summary>
+        /// Copies the contents of this List into destination span.
+        /// </summary>
+        /// <param name="destination">The span to copy items into.</param>
         public void CopyTo(Span<T> destination)
         {
             _items.AsSpan(0, _size).CopyTo(destination);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -395,12 +395,27 @@ namespace System.Collections.Generic
 
         public void CopyTo(int sourceIndex, int count, Span<T> destination)
         {
+            if (sourceIndex < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceIndex, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_size - sourceIndex < count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+            }
+
             _items.AsSpan(sourceIndex, count).CopyTo(destination);
         }
 
-       public void CopyTo(Span<T> destination)
+        public void CopyTo(Span<T> destination)
         {
-            _items.AsSpan().CopyTo(destination);
+            _items.AsSpan(0, _size).CopyTo(destination);
         }
 
         // Ensures that the capacity of this list is at least the given minimum

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -7,15 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
-using nint = System.Int64;
-using nuint = System.UInt64;
-#else
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-
 namespace System.Collections.Generic
 {
     // Implements a variable-size List that uses an array of objects to store the
@@ -404,35 +395,12 @@ namespace System.Collections.Generic
 
         public void CopyTo(int sourceIndex, int count, Span<T> destination)
         {
-            if (sourceIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
-            }
-
-            if (count < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            }
-
-            if (_size - sourceIndex < count)
-            {
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-            }
-
-            if (count > destination.Length)
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            if (_size > 0 && count > 0)
-            {
-                Buffer.Memmove(ref destination[0], ref _items[sourceIndex], (nuint)count);
-            }
+            _items.AsSpan(sourceIndex, count).CopyTo(destination);
         }
 
        public void CopyTo(Span<T> destination)
         {
-            CopyTo(0, _size, destination);
+            _items.AsSpan().CopyTo(destination);
         }
 
         // Ensures that the capacity of this list is at least the given minimum


### PR DESCRIPTION
Add List<T>.CopyTo(Span<T> destination) and List<T>.CopyTo(int sourceIndex, int count, Span<T> destination)

Fix https://github.com/dotnet/corefx/issues/33006

-----
I watched the Design Review video but I still have some questions (this is my first non-trivial contribution).

1. CopyTo(Span<T> destination) should throw if Span.Length is smaller than List.Count?
2. CopyTo(int sourceIndex, int count, Span<T> destination) should throw if count is greater than destination Span?
3. Do I need to use the ThrowHelper.ThrowXXX methods? Or can I just use throw new XException?
4. Is expected to use Buffer.Memmove? I'm not familiar with this class.

Thanks

@safern @sywhang 