### PR TITLE
Use default setting for UseSharedCompilation

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -5,10 +5,6 @@
   <Import Project="..\..\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- We use the compiler toolset that comes from NuGet Packages rather than the SDK built-in.
-    This one sets UseSharedCompilation to false by default. -->
-    <UseSharedCompilation>true</UseSharedCompilation>
-
     <ToolSetCommonDirectory>$(RepoRoot)artifacts\toolset\Common\</ToolSetCommonDirectory>
     <IsSourceProject>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))</IsSourceProject>
   </PropertyGroup>


### PR DESCRIPTION
UseSharedCompilation now defaults to true in the Microsoft.Net.Compilers.Toolset package. Previously we used the deprecated Microsoft.Net.Compilers package in which the property defaults to false.