### PR TITLE
Remove *_i.h blacklist from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ dlldata.c
 
 *_i.c
 *_p.c
-*_i.h
 *.ilk
 *.meta
 *.obj


### PR DESCRIPTION
According to @jkotas [the .gitignore `*_i.h` blacklist was removed from coreclr .gitignore](https://github.com/dotnet/coreclr/pull/17094/files#diff-a084b794bc0759e7a6b77810e01874f2) but that change didn't make it post-consolidation. This PR addresses the issue.