### PR TITLE
Improving performance of R2RDump

### DIFF
--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -93,7 +93,7 @@ namespace R2RDump
     public abstract class Dumper
     {
         protected readonly R2RReader _r2r;
-        protected readonly TextWriter _writer;
+        protected TextWriter _writer;
         protected readonly Disassembler _disassembler;
         protected readonly DumpOptions _options;
 

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -120,7 +120,11 @@ namespace R2RDump
             SkipLine();
             foreach (R2RMethod method in NormalizedMethods())
             {
+                TextWriter temp = _writer;
+                _writer = new StringWriter();
                 DumpMethod(method);
+                temp.Write(_writer.ToString());
+                _writer = temp;
             }
         }
 


### PR DESCRIPTION
By avoiding hitting the real `TextWriter` (either going to a file or to the `Console`) too often, the change reduced the latency of `R2RDump` of `System.Private.CoreLib` with disassembly on by 45%. 

On average it takes around 11 seconds to dump `System.Private.CoreLib`, with the change, it takes on average 6 seconds. (Windows/x64/Release)