### PR TITLE
Use goto to exit in build.cmd so that error code propagates out of cmd

### DIFF
--- a/src/coreclr/build.cmd
+++ b/src/coreclr/build.cmd
@@ -11,7 +11,7 @@ set __ThisScriptFull="%~f0"
 set __ThisScriptDir="%~dp0"
 
 call "%__ThisScriptDir%"\setup_vs_tools.cmd
-if NOT '%ERRORLEVEL%' == '0' exit /b 1
+if NOT '%ERRORLEVEL%' == '0' goto ExitWithError
 
 if defined VS160COMNTOOLS (
     set "__VSToolsRoot=%VS160COMNTOOLS%"
@@ -376,7 +376,8 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng
     %__CommonMSBuildArgs% %__UnprocessedBuildArgs%
 if not !errorlevel! == 0 (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to generate version headers.
-    exit /b !errorlevel!
+    set __exitCode=!errorlevel!
+    goto ExitWithCode
 )
 
 REM =========================================================================================
@@ -393,7 +394,8 @@ if %__RestoreOptData% EQU 1 (
         %__CommonMSBuildArgs% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to restore the optimization data package.
-        exit /b !errorlevel!
+        set __exitCode=!errorlevel!
+        goto ExitWithCode
     )
 )
 
@@ -406,11 +408,12 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng
 
  if not !errorlevel! == 0 (
     echo %__ErrMsgPrefix%Failed to get PGO data package path.
-    exit /b !errorlevel!
+    set __exitCode=!errorlevel!
+    goto ExitWithCode
 )
 if not exist "!PgoDataPackagePathOutputFile!" (
     echo %__ErrMsgPrefix%Failed to get PGO data package path.
-    exit /b 1
+    goto ExitWithError
 )
 
 set /p __PgoOptDataPath=<"!PgoDataPackagePathOutputFile!"
@@ -420,12 +423,13 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng
 
  if not !errorlevel! == 0 (
     echo %__ErrMsgPrefix%Failed to get IBC data package path.
-    exit /b !errorlevel!
+    set __exitCode=!errorlevel!
+    goto ExitWithCode
 )
 
 if not exist "!IbcDataPackagePathOutputFile!" (
     echo %__ErrMsgPrefix%Failed to get IBC data package path.
-    exit /b 1
+    goto ExitWithError
 )
 
 set /p __IbcOptDataPath=<"!IbcDataPackagePathOutputFile!"
@@ -447,12 +451,12 @@ set /p PYTHON=<%TEMP%\pythonlocation.txt
 
 if NOT DEFINED PYTHON (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Could not find a python installation
-    exit /b 1
+    goto ExitWithError
 )
 
 if %__BuildCoreLib% EQU 1 (
     echo %__MsgPrefix%Laying out dynamically generated EventSource classes
-    "!PYTHON!" -B -Wall %__SourceDir%\scripts\genRuntimeEventSources.py --man %__SourceDir%\vm\ClrEtwAll.man --intermediate %__IntermediatesEventingDir% || exit /b 1
+    "!PYTHON!" -B -Wall %__SourceDir%\scripts\genRuntimeEventSources.py --man %__SourceDir%\vm\ClrEtwAll.man --intermediate %__IntermediatesEventingDir% || goto ExitWithError
 )
 
 REM =========================================================================================
@@ -485,14 +489,14 @@ if %__BuildCrossArchNative% EQU 1 (
     
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate native component build project!
-        exit /b 1
+        goto ExitWithError
     )
     @if defined _echo @echo on
 
 :SkipConfigureCrossBuild
     if not exist "%__CrossCompIntermediatesDir%\CMakeCache.txt" (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: unable to find generated native component build project!
-        exit /b 1
+        goto ExitWithError
     )
 
     if defined __ConfigureOnly goto SkipCrossCompBuild
@@ -511,7 +515,8 @@ if %__BuildCrossArchNative% EQU 1 (
 
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: cross-arch components build failed.
-        exit /b !errorlevel!
+        set __exitCode=!errorlevel!
+        goto ExitWithCode
     )
 
 :SkipCrossCompBuild
@@ -554,7 +559,7 @@ if %__BuildNative% EQU 1 (
 
     if not defined VSINSTALLDIR (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: VSINSTALLDIR variable not defined.
-        exit /b 1
+        goto ExitWithError
     )
     if not exist "!VSINSTALLDIR!DIA SDK" goto NoDIA
 
@@ -566,7 +571,7 @@ if %__BuildNative% EQU 1 (
     call "%__SourceDir%\pal\tools\gen-buildsys.cmd" "%__ProjectDir%" "%__IntermediatesDir%" %__VSVersion% %__BuildArch% !__ExtraCmakeArgs!
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: failed to generate native component build project!
-        exit /b 1
+        goto ExitWithError
     )
     
     @if defined _echo @echo on
@@ -574,7 +579,7 @@ if %__BuildNative% EQU 1 (
 :SkipConfigure
     if not exist "%__IntermediatesDir%\CMakeCache.txt" (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: unable to find generated native component build project!
-        exit /b 1
+        goto ExitWithError
     )
 
     if defined __ConfigureOnly goto SkipNativeBuild
@@ -593,7 +598,8 @@ if %__BuildNative% EQU 1 (
 
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: native component build failed.
-        exit /b !errorlevel!
+        set __exitCode=!errorlevel!
+        goto ExitWithCode
     )
 
 :SkipNativeBuild
@@ -640,7 +646,8 @@ if %__BuildCoreLib% EQU 1 (
             echo     !__BuildLog!
             echo     !__BuildWrn!
             echo     !__BuildErr!
-            exit /b !errorlevel!
+            set __exitCode=!errorlevel!
+            goto ExitWithCode
         )
 
         powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__RepoRootDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
@@ -651,7 +658,8 @@ if %__BuildCoreLib% EQU 1 (
             echo     !__BuildLog!
             echo     !__BuildWrn!
             echo     !__BuildErr!
-            exit /b !errorlevel!
+            set __exitCode=!errorlevel!
+            goto ExitWithCode
         )
 
         if "%__BuildManagedTools%" == "1" (
@@ -663,7 +671,8 @@ if %__BuildCoreLib% EQU 1 (
                 echo     !__BuildLog!
                 echo     !__BuildWrn!
                 echo     !__BuildErr!
-                exit /b !errorlevel!
+                set __exitCode=!errorlevel!
+                goto ExitWithCode
             )
 
             copy /Y "%__BinDir%\clrjit.dll" "%__BinDir%\crossgen2\clrjitilc.dll"
@@ -679,11 +688,12 @@ if %__BuildCoreLib% EQU 1 (
 
         if not !errorlevel! == 0 (
             echo %__ErrMsgPrefix%Failed to determine IBC Merge path.
-            exit /b !errorlevel!
+            set __exitCode=!errorlevel!
+            goto ExitWithCode
         )
         if not exist "!IbcMergePackagePathOutputFile!" (
             echo %__ErrMsgPrefix%Failed to determine IBC Merge path.
-            exit /b 1
+            goto ExitWithError
         )
 
         set /p __IbcMergePath=<"!IbcMergePackagePathOutputFile!"
@@ -716,7 +726,7 @@ if %__BuildCoreLib% EQU 1 (
                     echo %__ErrMsgPrefix%%__MsgPrefix%Error: IbcMerge of System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
                     REM Put it in the same log, helpful for Jenkins
                     type %__CrossGenCoreLibLog%
-                    goto CrossgenFailure
+                    goto ExitWithError
                 )
 
                 REM Verify that the optimization data has been merged
@@ -727,7 +737,7 @@ if %__BuildCoreLib% EQU 1 (
                     echo %__ErrMsgPrefix%%__MsgPrefix%Error: IbcMerge of System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
                     REM Put it in the same log, helpful for Jenkins
                     type %__CrossGenCoreLibLog%
-                    goto CrossgenFailure
+                    goto ExitWithError
                 )
 
                 REM Save the module as *.pgo to match the convention expected
@@ -746,7 +756,7 @@ if %__BuildCoreLib% EQU 1 (
                     echo %__ErrMsgPrefix%%__MsgPrefix%Error: IbcMerge of System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
                     REM Put it in the same log, helpful for Jenkins
                     type %__CrossGenCoreLibLog%
-                    goto CrossgenFailure
+                    goto ExitWithError
                 )
 
                 REM Verify that the optimization data has been applied
@@ -757,18 +767,18 @@ if %__BuildCoreLib% EQU 1 (
                     echo %__ErrMsgPrefix%%__MsgPrefix%Error: IbcMerge of System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
                     REM Put it in the same log, helpful for Jenkins
                     type %__CrossGenCoreLibLog%
-                    goto CrossgenFailure
+                    goto ExitWithError
                 )
             ) else (
                 echo %__MsgPrefix%!TargetOptimizationDataFile! does not exist >> %__CrossGenCoreLibLog%
                 echo %__ErrMsgPrefix%%__MsgPrefix%Error: IbcMerge of System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
                 REM Put it in the same log, helpful for Jenkins
                 type %__CrossGenCoreLibLog%
-                goto CrossgenFailure
+                goto ExitWithError
             )
         ) else (
           echo Could not find IBCMerge at !IbcMergePath!. Have you restored src/.nuget/optdata/ibcmerge.csproj?
-          goto CrossgenFailure
+          goto ExitWithError
         )
     )
 
@@ -801,7 +811,7 @@ if %__BuildNativeCoreLib% EQU 1 (
         @if defined _echo @echo on
         if NOT !errorlevel! == 0 (
             echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to load native tools environment for !__VCExecArch!
-            goto CrossgenFailure
+            goto ExitWithError
         )
 
         REM HACK: Workaround for [dotnet/coreclr#13970](https://github.com/dotnet/coreclr/issues/13970)
@@ -812,7 +822,7 @@ if %__BuildNativeCoreLib% EQU 1 (
         echo %__MsgPrefix%Copying "!__PgoRtPath!" into "%__BinDir%"
         copy /y "!__PgoRtPath!" "%__BinDir%" || (
             echo %__ErrMsgPrefix%%__MsgPrefix%Error: copy failed
-            goto CrossgenFailure
+            goto ExitWithError
         )
         REM End HACK
     )
@@ -838,7 +848,7 @@ if %__BuildNativeCoreLib% EQU 1 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: CrossGen System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
         REM Put it in the same log, helpful for Jenkins
         type %__CrossGenCoreLibLog%
-        goto CrossgenFailure
+        goto ExitWithError
     )
 
     set NEXTCMD="%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /CreatePdb "%__BinDir%\PDB" "%__BinDir%\System.Private.CoreLib.dll"
@@ -849,7 +859,7 @@ if %__BuildNativeCoreLib% EQU 1 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: CrossGen /CreatePdb System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
         REM Put it in the same log, helpful for Jenkins
         type %__CrossGenCoreLibLog%
-        goto CrossgenFailure
+        goto ExitWithError
     )
 )
 
@@ -880,7 +890,8 @@ if %__BuildPackages% EQU 1 (
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: Nuget package generation failed. Refer to the build log file for details.
         echo     !__BuildLog!
-        exit /b !errorlevel!
+        set __exitCode=!errorlevel!
+        goto ExitWithCode
     )
 
     REM } Scope environment changes end
@@ -906,7 +917,7 @@ if %__BuildTests% EQU 1 (
 
     if not !errorlevel! == 0 (
         REM buildtest.cmd has already emitted an error message and mentioned the build log file to examine.
-        exit /b 1
+        goto ExitWithError
     )
 ) else if %__GenerateLayout% EQU 1 (
     echo %__MsgPrefix%Generating layout for %__BuildOS%.%__BuildArch%.%__BuildType%
@@ -917,7 +928,7 @@ if %__BuildTests% EQU 1 (
 
     if not !errorlevel! == 0 (
         REM runtest.cmd has already emitted an error message and mentioned the build log file to examine.
-        exit /b 1
+        goto ExitWithError
     )
 )
 
@@ -986,7 +997,7 @@ if %__AllBuildSuccess%==true (
     echo %__MsgPrefix%Builds failed:
     type %__BuildResultFile%
     del /f /q %__BuildResultFile%
-    exit /b 1
+    goto ExitWithError
 )
 
 REM This code is unreachable, but leaving it nonetheless, just in case things change.
@@ -1010,8 +1021,11 @@ REM === Helper routines
 REM ===
 REM =========================================================================================
 
-:CrossgenFailure
+:ExitWithError
 exit /b 1
+
+:ExitWithCode
+exit /b !__exitCode!
 
 :Usage
 echo.

--- a/src/coreclr/build.cmd
+++ b/src/coreclr/build.cmd
@@ -1021,6 +1021,12 @@ REM === Helper routines
 REM ===
 REM =========================================================================================
 
+
+REM =========================================================================================
+REM === These two routines are intended for the exit code to propagate to the parent process
+REM === Like MSBuild or Powershell. If we directly exit /b 1 from within a if statement in
+REM === any of the routines, the exit code is not propagated.
+REM =========================================================================================
 :ExitWithError
 exit /b 1
 

--- a/src/coreclr/configurecompiler.cmake
+++ b/src/coreclr/configurecompiler.cmake
@@ -11,6 +11,7 @@ cmake_policy(SET CMP0083 NEW)
 include(CheckPIESupported)
 include(CheckCXXCompilerFlag)
 
+
 # All code we build should be compiled as position independent
 check_pie_supported(OUTPUT_VARIABLE PIE_SUPPORT_OUTPUT LANGUAGES CXX)
 if(NOT MSVC AND NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
@@ -641,3 +642,7 @@ if(CLR_CMAKE_ENABLE_CODE_COVERAGE)
   endif(CLR_CMAKE_PLATFORM_UNIX)
 
 endif(CLR_CMAKE_ENABLE_CODE_COVERAGE)
+
+if (CMAKE_BUILD_TOOL STREQUAL nmake)
+  set(CMAKE_RC_CREATE_SHARED_LIBRARY "${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
+endif(CMAKE_BUILD_TOOL STREQUAL nmake)


### PR DESCRIPTION
If there is a failure in some nested steps of coreclr/build.cmd the exit code was not being propagated due to nested calls and if blocks, instead, go to the end of the script and exit. Because the exit code wasn't propagated, when running `build.cmd` from the root, `coreclr.proj` is called and that shells out via `Exec` into `coreclr/build.cmd`, and MSBuild was getting a 0 exit code, so the build wouldn't fail if there was a failure. I.e: the `sdk.txt` failure which was manifesting latter on the build up when the installer tried to crossgen libraries assemblies.

cc: @dotnet/runtime-infrastructure  