### PR TITLE
FileSystemAclExtensions missing `this` nullchecks

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -13,11 +13,21 @@ namespace System.IO
     {
         public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo)
         {
+            if (directoryInfo == null)
+            {
+                throw new ArgumentNullException(nameof(directoryInfo));
+            }
+
             return new DirectorySecurity(directoryInfo.FullName, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
         public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo, AccessControlSections includeSections)
         {
+            if (directoryInfo == null)
+            {
+                throw new ArgumentNullException(nameof(directoryInfo));
+            }
+
             return new DirectorySecurity(directoryInfo.FullName, includeSections);
         }
 
@@ -34,20 +44,36 @@ namespace System.IO
 
         public static FileSecurity GetAccessControl(this FileInfo fileInfo)
         {
+            if (fileInfo == null)
+            {
+                throw new ArgumentNullException(nameof(fileInfo));
+            }
+
             return GetAccessControl(fileInfo, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
         public static FileSecurity GetAccessControl(this FileInfo fileInfo, AccessControlSections includeSections)
         {
+            if (fileInfo == null)
+            {
+                throw new ArgumentNullException(nameof(fileInfo));
+            }
+
             return new FileSecurity(fileInfo.FullName, includeSections);
         }
 
         public static void SetAccessControl(this FileInfo fileInfo, FileSecurity fileSecurity)
         {
+            if (fileInfo == null)
+            {
+                throw new ArgumentNullException(nameof(fileInfo));
+            }
+
             if (fileSecurity == null)
             {
                 throw new ArgumentNullException(nameof(fileSecurity));
             }
+
             string fullPath = Path.GetFullPath(fileInfo.FullName);
             // Appropriate security check should be done for us by FileSecurity.
             fileSecurity.Persist(fullPath);

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
@@ -32,40 +32,62 @@ namespace System.IO
 
         public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo)
         {
+            if (directoryInfo == null)
+                throw new ArgumentNullException(nameof(directoryInfo));
+
             return directoryInfo.GetAccessControl();
         }
 
         public static DirectorySecurity GetAccessControl(this DirectoryInfo directoryInfo, AccessControlSections includeSections)
         {
+            if (directoryInfo == null)
+                throw new ArgumentNullException(nameof(directoryInfo));
+
             return directoryInfo.GetAccessControl(includeSections);
         }
 
         public static void SetAccessControl(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
+            if (directoryInfo == null)
+                throw new ArgumentNullException(nameof(directoryInfo));
+
+            if (directorySecurity == null)
+                throw new ArgumentNullException(nameof(directorySecurity));
+
             directoryInfo.SetAccessControl(directorySecurity);
         }
 
         public static FileSecurity GetAccessControl(this FileInfo fileInfo)
         {
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
+
             return fileInfo.GetAccessControl();
         }
 
         public static FileSecurity GetAccessControl(this FileInfo fileInfo, AccessControlSections includeSections)
         {
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
+
             return fileInfo.GetAccessControl(includeSections);
         }
 
         public static void SetAccessControl(this FileInfo fileInfo, FileSecurity fileSecurity)
         {
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
+
+            if (fileSecurity == null)
+                throw new ArgumentNullException(nameof(fileSecurity));
+
             fileInfo.SetAccessControl(fileSecurity);
         }
 
         public static FileSecurity GetAccessControl(this FileStream fileStream)
         {
             if (fileStream == null)
-            {
                 throw new ArgumentNullException(nameof(fileStream));
-            }
 
             return fileStream.GetAccessControl();
         }
@@ -73,14 +95,10 @@ namespace System.IO
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)
         {
             if (fileStream == null)
-            {
                 throw new ArgumentNullException(nameof(fileStream));
-            }
 
             if (fileSecurity == null)
-            {
                 throw new ArgumentNullException(nameof(fileSecurity));
-            }
 
             fileStream.SetAccessControl(fileSecurity);
         }

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -22,85 +22,69 @@ namespace System.IO
         [Fact]
         public void GetAccessControl_DirectoryInfo_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null));
         }
 
         [Fact]
         public void GetAccessControl_DirectoryInfo_ReturnsValidObject()
         {
-            using (var directory = new TempDirectory())
-            {
-                DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
-
-                DirectorySecurity directorySecurity = directoryInfo.GetAccessControl();
-
-                Assert.NotNull(directorySecurity);
-                Assert.Equal(typeof(FileSystemRights), directorySecurity.AccessRightType);
-            }
+            using var directory = new TempDirectory();
+            DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
+            DirectorySecurity directorySecurity = directoryInfo.GetAccessControl();
+            Assert.NotNull(directorySecurity);
+            Assert.Equal(typeof(FileSystemRights), directorySecurity.AccessRightType);
         }
 
         [Fact]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null, new AccessControlSections()));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null, new AccessControlSections()));
         }
 
         [Fact]
         public void GetAccessControl_DirectoryInfo_AccessControlSections_ReturnsValidObject()
         {
-            using (var directory = new TempDirectory())
-            {
-                DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
-                AccessControlSections accessControlSections = new AccessControlSections();
-
-                DirectorySecurity directorySecurity = directoryInfo.GetAccessControl(accessControlSections);
-
-                Assert.NotNull(directorySecurity);
-                Assert.Equal(typeof(FileSystemRights), directorySecurity.AccessRightType);
-            }
+            using var directory = new TempDirectory();
+            DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
+            AccessControlSections accessControlSections = new AccessControlSections();
+            DirectorySecurity directorySecurity = directoryInfo.GetAccessControl(accessControlSections);
+            Assert.NotNull(directorySecurity);
+            Assert.Equal(typeof(FileSystemRights), directorySecurity.AccessRightType);
         }
 
         [Fact]
         public void GetAccessControl_FileInfo_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null));
         }
 
         [Fact]
         public void GetAccessControl_FileInfo_ReturnsValidObject()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            {
-                FileInfo fileInfo = new FileInfo(file.Path);
-
-                FileSecurity fileSecurity = fileInfo.GetAccessControl();
-
-                Assert.NotNull(fileSecurity);
-                Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            FileInfo fileInfo = new FileInfo(file.Path);
+            FileSecurity fileSecurity = fileInfo.GetAccessControl();
+            Assert.NotNull(fileSecurity);
+            Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
         }
 
         [Fact]
         public void GetAccessControl_FileInfo_AccessControlSections_InvalidArguments()
         {
-            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null, new AccessControlSections()));
+            Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.GetAccessControl((FileInfo)null, new AccessControlSections()));
         }
 
         [Fact]
         public void GetAccessControl_FileInfo_AccessControlSections_ReturnsValidObject()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            {
-                FileInfo fileInfo = new FileInfo(file.Path);
-                AccessControlSections accessControlSections = new AccessControlSections();
-
-                FileSecurity fileSecurity = fileInfo.GetAccessControl(accessControlSections);
-
-                Assert.NotNull(fileSecurity);
-                Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            FileInfo fileInfo = new FileInfo(file.Path);
+            AccessControlSections accessControlSections = new AccessControlSections();
+            FileSecurity fileSecurity = fileInfo.GetAccessControl(accessControlSections);
+            Assert.NotNull(fileSecurity);
+            Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
         }
 
         [Fact]
@@ -112,14 +96,12 @@ namespace System.IO
         [Fact]
         public void GetAccessControl_Filestream_ReturnValidObject()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            using (FileStream fileStream = File.Open(file.Path, System.IO.FileMode.Append, System.IO.FileAccess.Write, System.IO.FileShare.None))
-            {
-                FileSecurity fileSecurity = FileSystemAclExtensions.GetAccessControl(fileStream);
-                Assert.NotNull(fileSecurity);
-                Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.None);
+            FileSecurity fileSecurity = FileSystemAclExtensions.GetAccessControl(fileStream);
+            Assert.NotNull(fileSecurity);
+            Assert.Equal(typeof(FileSystemRights), fileSecurity.AccessRightType);
         }
 
         #endregion
@@ -129,76 +111,62 @@ namespace System.IO
         [Fact]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_InvalidArguments()
         {
-            using (var directory = new TempDirectory())
-            {
-                DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
-                AssertExtensions.Throws<ArgumentNullException>("directorySecurity", () => directoryInfo.SetAccessControl((DirectorySecurity)null));
-            }
+            using var directory = new TempDirectory();
+            DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
+            AssertExtensions.Throws<ArgumentNullException>("directorySecurity", () => directoryInfo.SetAccessControl(directorySecurity: null));
         }
 
         [Fact]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_Success()
         {
-            using (var directory = new TempDirectory())
-            {
-                DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
-                DirectorySecurity directorySecurity = new DirectorySecurity();
-
-                directoryInfo.SetAccessControl(directorySecurity);
-            }
+            using var directory = new TempDirectory();
+            DirectoryInfo directoryInfo = new DirectoryInfo(directory.Path);
+            DirectorySecurity directorySecurity = new DirectorySecurity();
+            directoryInfo.SetAccessControl(directorySecurity);
         }
 
         [Fact]
         public void SetAccessControl_FileInfo_FileSecurity_InvalidArguments()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            {
-                FileInfo fileInfo = new FileInfo(file.Path);
-                AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => fileInfo.SetAccessControl((FileSecurity)null));
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            FileInfo fileInfo = new FileInfo(file.Path);
+            AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => fileInfo.SetAccessControl(fileSecurity: null));
         }
 
         [Fact]
         public void SetAccessControl_FileInfo_FileSecurity_Success()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            {
-                FileInfo fileInfo = new FileInfo(file.Path);
-                FileSecurity fileSecurity = new FileSecurity();
-
-                fileInfo.SetAccessControl(fileSecurity);
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            FileInfo fileInfo = new FileInfo(file.Path);
+            FileSecurity fileSecurity = new FileSecurity();
+            fileInfo.SetAccessControl(fileSecurity);
         }
 
         [Fact]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, (FileSecurity)null));
+            Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, fileSecurity: null));
         }
 
         [Fact]
         public void SetAccessControl_FileStream_FileSecurity_InvalidFileSecurityObject()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            using (FileStream fileStream = File.Open(file.Path, System.IO.FileMode.Append, System.IO.FileAccess.Write, System.IO.FileShare.None))
-            {
-                AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, (FileSecurity)null));
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.None);
+            AssertExtensions.Throws<ArgumentNullException>("fileSecurity", () => FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity: null));
         }
 
         [Fact]
         public void SetAccessControl_FileStream_FileSecurity_Success()
         {
-            using (var directory = new TempDirectory())
-            using (var file = new TempFile(Path.Combine(directory.Path, "file.txt")))
-            using (FileStream fileStream = File.Open(file.Path, System.IO.FileMode.Append, System.IO.FileAccess.Write, System.IO.FileShare.None))
-            {
-                FileSecurity fileSecurity = new FileSecurity();
-                FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity);
-            }
+            using var directory = new TempDirectory();
+            using var file = new TempFile(Path.Combine(directory.Path, "file.txt"));
+            using FileStream fileStream = File.Open(file.Path, FileMode.Append, FileAccess.Write, FileShare.None);
+            FileSecurity fileSecurity = new FileSecurity();
+            FileSystemAclExtensions.SetAccessControl(fileStream, fileSecurity);
         }
 
         #endregion


### PR DESCRIPTION
Some of the extension methods in this class were not nullchecking their `this` argument.
Made sure to modify the related unit tests so instead of checking for `NullReferenceException`, we check for `ArgumentNullException`.
Did some cleaning in the unit tests as well.