### PR TITLE
Fix to array validation in type loadability checks

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -76,11 +76,14 @@ namespace ILCompiler
                         ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
                     }
 
-                    LayoutInt elementSize = parameterType.GetElementSize();
-                    if (!elementSize.IsIndeterminate && elementSize.AsInt >= ushort.MaxValue)
+                    if (!parameterType.IsRuntimeDeterminedSubtype)
                     {
-                        // Element size over 64k can't be encoded in the GCDesc
-                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, parameterType);
+                        LayoutInt elementSize = parameterType.GetElementSize();
+                        if (!elementSize.IsIndeterminate && elementSize.AsInt >= ushort.MaxValue)
+                        {
+                            // Element size over 64k can't be encoded in the GCDesc
+                            ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, parameterType);
+                        }
                     }
 
                     if (((ArrayType)parameterizedType).Rank > 32)


### PR DESCRIPTION
Avoid computing the layout/size for runtime determined element types in arrays

cc @dotnet/crossgen-contrib 