### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -36,7 +36,7 @@ If you are attempting to cross build the CoreCLR runtime for arm/arm64 then use 
 docker run --rm -v /home/dotnet-bot/runtime/src/coreclr:/coreclr -w /coreclr -e ROOTFS_DIR=/crossrootfs/arm64 mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921 ./build.sh arm64 cross
 ```
 
-Note that instructions on building the crossrootfs location can be found at https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/cross-building.md. These instructions are suggested only if there are plans to change the rootfs, or the Docker images for arm/arm64 are insufficient for your build.
+Note that instructions on building the crossrootfs location can be found at https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/cross-building.md. These instructions are suggested only if there are plans to change the rootfs, or the Docker images for arm/arm64 are insufficient for your build.
 
 Docker Images
 =============

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -319,7 +319,7 @@ if defined __SkipManaged goto SkipManagedBuild
 echo %__MsgPrefix%Starting the Managed Tests Build
 
 if not defined VSINSTALLDIR (
-    echo %__ErrMsgPrefix%%__MsgPrefix%Error: build-test.cmd should be run from a Visual Studio Command Prompt.  Please see https://github.com/dotnet/runtime/blob/master/docs/coreclr/project-docs/developer-guide.md for build instructions.
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: build-test.cmd should be run from a Visual Studio Command Prompt.  Please see https://github.com/dotnet/runtime/tree/master/docs/workflow for build instructions.
     exit /b 1
 )
 set __AppendToLog=false

--- a/src/coreclr/setup_vs_tools.cmd
+++ b/src/coreclr/setup_vs_tools.cmd
@@ -31,7 +31,7 @@ echo Visual Studio 2017 or later not found
 :call_vs
 if not exist "%_VSCOMNTOOLS%" (
     echo %__MsgPrefix%Error: Visual Studio 2017 or 2019 required.
-    echo        Please see https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/windows-instructions.md for build instructions.
+    echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/windows-instructions.md for build instructions.
     exit /b 1
 )
 echo %__MsgPrefix%"%_VSCOMNTOOLS%\VsDevCmd.bat"

--- a/src/coreclr/setup_vs_tools.cmd
+++ b/src/coreclr/setup_vs_tools.cmd
@@ -31,7 +31,7 @@ echo Visual Studio 2017 or later not found
 :call_vs
 if not exist "%_VSCOMNTOOLS%" (
     echo %__MsgPrefix%Error: Visual Studio 2017 or 2019 required.
-    echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/windows-instructions.md for build instructions.
+    echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/windows-requirements.md for build instructions.
     exit /b 1
 )
 echo %__MsgPrefix%"%_VSCOMNTOOLS%\VsDevCmd.bat"

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4119,7 +4119,7 @@ void Compiler::compFunctionTraceEnd(void* methodCodePtr, ULONG methodCodeSize, b
 // code:CILJit::compileMethod function.
 //
 // For an overview of the structure of the JIT, see:
-//   https://github.com/dotnet/runtime/blob/master/docs/coreclr/botr/ryujit-overview.md
+//   https://github.com/dotnet/runtime/blob/master/docs/design/coreclr/botr/ryujit-overview.md
 //
 void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags* compileFlags)
 {

--- a/src/coreclr/src/jit/conventions.txt
+++ b/src/coreclr/src/jit/conventions.txt
@@ -3,7 +3,7 @@ Coding Conventions" document, that can be used as a template when writing new
 comments in the JIT source code. The definitive coding conventions document is
 located here:
 
-https://github.com/dotnet/runtime/blob/master/docs/coreclr/coding-guidelines/clr-jit-coding-conventions.md
+https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/clr-jit-coding-conventions.md
 
 
 ********** Section 7.1.5 TODO comments

--- a/src/coreclr/src/vm/eetoprofinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/eetoprofinterfaceimpl.cpp
@@ -16,7 +16,7 @@
 // PLEASE READ!
 //
 // There are strict rules for how to implement ICorProfilerCallback* wrappers.  Please read
-// https://github.com/dotnet/runtime/blob/master/docs/coreclr/botr/profilability.md
+// https://github.com/dotnet/runtime/blob/master/docs/design/coreclr/botr/profilability.md
 // to understand the rules and why they exist.
 //
 // As a reminder, here is a short summary of your responsibilities.  Every PUBLIC

--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -17,7 +17,7 @@
 // PLEASE READ!
 //
 // There are strict rules for how to implement ICorProfilerInfo* methods.  Please read
-// https://github.com/dotnet/runtime/blob/master/docs/coreclr/botr/profilability.md
+// https://github.com/dotnet/runtime/blob/master/docs/design/coreclr/botr/profilability.md
 // to understand the rules and why they exist.
 //
 // As a reminder, here is a short summary of your responsibilities.  Every PUBLIC

--- a/src/coreclr/tests/src/JIT/superpmi/runtests.sh
+++ b/src/coreclr/tests/src/JIT/superpmi/runtests.sh
@@ -2,7 +2,7 @@
 
 # Run CoreCLR OSS tests on Linux or Mac
 # Use the instructions here:
-#    https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/unix-test-instructions.md
+#    https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/unix-test-instructions.md
 #
 # Summary:
 # 1. On Linux/Mac, in coreclr, ./build.sh

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/installer/pkg/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
+++ b/src/installer/pkg/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
@@ -15,7 +15,7 @@
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
         There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/osx-instructions.md#openssl">on this page</a>.
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/libraries/Common/src/System/Net/Http/Http2/ReadMe.SharedCode.md
+++ b/src/libraries/Common/src/System/Net/Http/Http2/ReadMe.SharedCode.md
@@ -13,8 +13,7 @@ aspnet/AspNetCore code paths:
 - To copy code from aspnet/AspNetCore to dotnet/runtime, set RUNTIME_REPO to the runtime repo root and then run CopyToRuntime.cmd.
 
 ## Building dotnet/runtime code:
-- https://github.com/dotnet/runtime/blob/master/docs/libraries/building/windows-instructions.md
-- https://github.com/dotnet/runtime/blob/master/docs/libraries/project-docs/developer-guide.md
+- https://github.com/dotnet/runtime/tree/master/docs/workflow
 - Run libraries.cmd from the root once: `PS D:\github\runtime> .\libraries.cmd`
 - Build the individual projects:
 - `PS D:\github\dotnet\src\libraries\Common\tests> dotnet msbuild /t:rebuild`

--- a/src/libraries/Common/tests/System/Net/Prerequisites/README.md
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/README.md
@@ -12,7 +12,7 @@ Note: the `config.ps1` file has been added to .gitignore to prevent it being upd
 
 ### Build the server applications 
 
-Prepare the $COREFX_NET_CLIENT_Machine as any Dev station following the instructions at https://github.com/dotnet/runtime/blob/master/docs/libraries/building/windows-instructions.md. Ensure that you can build and test CoreFX on this machine.
+Prepare the $COREFX_NET_CLIENT_Machine as any Dev station following the instructions at https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/windows-instructions.md. Ensure that you can build and test CoreFX on this machine.
 In addition, you will also need to install the _Azure development_ workload for Visual Studio 2017.
 
 From a Visual Studio command prompt:

--- a/src/libraries/Common/tests/System/Net/Prerequisites/README.md
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/README.md
@@ -12,7 +12,7 @@ Note: the `config.ps1` file has been added to .gitignore to prevent it being upd
 
 ### Build the server applications 
 
-Prepare the $COREFX_NET_CLIENT_Machine as any Dev station following the instructions at https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/windows-instructions.md. Ensure that you can build and test CoreFX on this machine.
+Prepare the $COREFX_NET_CLIENT_Machine as any Dev station following the instructions at https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/windows-requirements.md. Ensure that you can build and test CoreFX on this machine.
 In addition, you will also need to install the _Azure development_ workload for Visual Studio 2017.
 
 From a Visual Studio command prompt:

--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -70,7 +70,7 @@ if "%VisualStudioVersion%"=="16.0" (
 :MissingVersion
 :: Can't find VS 2017, 2019
 echo Error: Visual Studio 2017 or 2019 required
-echo        Please see https://github.com/dotnet/runtime/tree/master/docs/libraries/building for build instructions.
+echo        Please see https://github.com/dotnet/runtime/tree/master/docs/workflow/building/libraries for build instructions.
 exit /b 1
 
 :VS2019

--- a/src/libraries/System.Data.SqlClient/tests/ManualTests/README.md
+++ b/src/libraries/System.Data.SqlClient/tests/ManualTests/README.md
@@ -4,7 +4,7 @@ These tests require dedicated test servers, so they're designed to be run manual
 
 ## Prerequisites
 
-- CoreFX building. you need to be able to do a successful build and run the standard tests, [Unix](https://github.com/dotnet/runtime/blob/master/docs/libraries/building/cross-platform-testing.md) or [Windows](https://github.com/dotnet/runtime/blob/master/docs/libraries/building/windows-instructions.md) Use build.cmd for windows and build.sh for Linux to build CoreFX.
+- CoreFX building. you need to be able to do a successful build and run the standard tests, [Unix](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/cross-platform-testing.md) or [Windows](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/windows-instructions.md) Use build.cmd for windows and build.sh for Linux to build CoreFX.
 
   **N.B.** if you want to run the EFCore tests later you will need to build -allconfigurations to generate the NuGet packages, build -allconfigurations works only on windows.
 

--- a/src/libraries/System.Data.SqlClient/tests/ManualTests/README.md
+++ b/src/libraries/System.Data.SqlClient/tests/ManualTests/README.md
@@ -4,7 +4,7 @@ These tests require dedicated test servers, so they're designed to be run manual
 
 ## Prerequisites
 
-- CoreFX building. you need to be able to do a successful build and run the standard tests, [Unix](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/cross-platform-testing.md) or [Windows](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/libraries/windows-instructions.md) Use build.cmd for windows and build.sh for Linux to build CoreFX.
+- Libraries building. You need to be able to do a successful [build](https://github.com/dotnet/runtime/tree/master/docs/workflow/building/libraries) and [run the standard tests](https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/libraries/testing.md).
 
   **N.B.** if you want to run the EFCore tests later you will need to build -allconfigurations to generate the NuGet packages, build -allconfigurations works only on windows.
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Readme.md
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Readme.md
@@ -20,7 +20,7 @@ $ dotnet run -- -help
 
 Note that the stress suite will test the sdk available in the environment,
 that is to say it will not necessarily test the implementation of the local runtime repo.
-To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/testing-with-corefx.md).
+To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/testing-with-corefx.md).
 
 ### Running using docker-compose
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Readme.md
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Readme.md
@@ -20,7 +20,7 @@ $ dotnet run -- -help
 
 Note that the stress suite will test the sdk available in the environment,
 that is to say it will not necessarily test the implementation of the local runtime repo.
-To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/testing-with-corefx.md).
+To achieve this, we will first need to build a new sdk from source. This can be done [using docker](https://github.com/dotnet/runtime/blob/master/eng/docker/Readme.md).
 
 ### Running using docker-compose
 

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Readme.md
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Readme.md
@@ -20,7 +20,7 @@ $ dotnet run -- -help
 
 Note that the stress suite will test the sdk available in the environment,
 that is to say it will not necessarily test the implementation of the local runtime repo.
-To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/coreclr/building/testing-with-corefx.md).
+To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/testing-with-corefx.md).
 
 ### Running using docker-compose
 

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Readme.md
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Readme.md
@@ -20,7 +20,7 @@ $ dotnet run -- -help
 
 Note that the stress suite will test the sdk available in the environment,
 that is to say it will not necessarily test the implementation of the local runtime repo.
-To achieve this, you will need to point your environment to the [`testhost` build](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/testing-with-corefx.md).
+To achieve this, we will first need to build a new sdk from source. This can be done [using docker](https://github.com/dotnet/runtime/blob/master/eng/docker/Readme.md).
 
 ### Running using docker-compose
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SuppressGCTransitionAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SuppressGCTransitionAttribute.cs
@@ -33,7 +33,7 @@ namespace System.Runtime.InteropServices
     /// of the unmanaged function. However, avoiding this transition removes some of the guarantees the runtime
     /// provides through a normal P/Invoke. When exiting the managed runtime to enter an unmanaged function the
     /// GC must transition from Cooperative mode into Preemptive mode. Full details on these modes can be found at
-    /// https://github.com/dotnet/runtime/blob/master/docs/coreclr/coding-guidelines/clr-code-guide.md#2.1.8.
+    /// https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/clr-code-guide.md#2.1.8.
     /// Suppressing the GC transition is an advanced scenario and should not be done without fully understanding
     /// potential consequences.
     ///

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -466,7 +466,7 @@ namespace System.Runtime.Loader
         ///
         /// The property is stored in an AsyncLocal&lt;AssemblyLoadContext&gt;. This means the setting can be unique for every async or thread in the process.
         ///
-        /// For more details see https://github.com/dotnet/runtime/blob/master/docs/coreclr/design-docs/AssemblyLoadContext.ContextualReflection.md
+        /// For more details see https://github.com/dotnet/runtime/blob/master/docs/design/features/AssemblyLoadContext.ContextualReflection.md
         /// </remarks>
         public static AssemblyLoadContext? CurrentContextualReflectionContext => s_asyncLocalCurrent?.Value;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -135,7 +135,7 @@ namespace System.Threading
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
             // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/runtime/blob/master/docs/coreclr/design-docs/eh-writethru.md
+            //       https://github.com/dotnet/runtime/blob/master/docs/design/features/eh-writethru.md
 
             // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
@@ -205,7 +205,7 @@ namespace System.Threading
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
             // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/runtime/blob/master/docs/coreclr/design-docs/eh-writethru.md
+            //       https://github.com/dotnet/runtime/blob/master/docs/design/features/eh-writethru.md
 
             // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts

--- a/src/libraries/System.Text.Encodings.Web/tools/updating-encodings.md
+++ b/src/libraries/System.Text.Encodings.Web/tools/updating-encodings.md
@@ -26,7 +26,7 @@ dotnet run -- "path_to_UnicodeData.txt" ../../src/System/Text/Unicode/UnicodeHel
 dotnet run -- "path_to_Blocks.txt" ../../src/System/Text/Unicode/UnicodeRanges.generated.cs ../../tests/UnicodeRangesTests.generated.cs
 ```
 
-4. Update the __ref__ APIs to reflect any new `UnicodeRanges` static properties which were added in the previous step, otherwise the unit test project will not be able to reference them. See https://github.com/dotnet/runtime/blob/master/docs/libraries/coding-guidelines/updating-ref-source.md for instructions on how to update the reference assemblies.
+4. Update the __ref__ APIs to reflect any new `UnicodeRanges` static properties which were added in the previous step, otherwise the unit test project will not be able to reference them. See https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/updating-ref-source.md for instructions on how to update the reference assemblies.
 
 5. Update the __src/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj__ file to reference the new file that you dropped into the __src/Common/tests/data__ folder in the first step above. Open the .csproj file in a text editor, and replace both the `<EmbeddedResource>` and the `<LogicalName>` elements at the end of the document to reference the new file name.
 


### PR DESCRIPTION
Presumably after the [dotnet/announcements#119 "Consolidating .NET GitHub repos"](https://github.com/dotnet/announcements/issues/119) changes, there are some broken docs links scattered through the repo.  I discovered this while doing a fresh dev machine setup and attempting to build for the first time -- some of the build error messages had broken links.

There was a pattern to the docs links that were broken:
- `/docs/coreclr/building/` became `/docs/workflow/building/coreclr/`
- `/docs/libraries/building/` became `/docs/workflow/building/libraries/`

By searching for links matching `/docs/coreclr/` and `/docs/libraries/`, I was able to find some more broken links too.

The broken docs links were found in a handful of different categories of files, each covered in a separate commit:
1. Within the workflow docs
1. Within build commands' output
1. Within `txt`/`md` files under `src`
1. Within some HTML resource files
1. Within a few source files