### PR TITLE
Fix .cmd scripts help arguments

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,8 @@
 @echo off
+setlocal
 
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %*
-goto end
+set _args="%*"
+if "%~1"=="-?" set _args="-help"
 
-:end
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %_args%
 exit /b %ERRORLEVEL%

--- a/build.cmd
+++ b/build.cmd
@@ -1,15 +1,7 @@
 @echo off
 
-if "%~1"=="-h" goto help
-if "%~1"=="-help" goto help
-if "%~1"=="-?" goto help
-if "%~1"=="/?" goto help
-
 powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %*
 goto end
-
-:help
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0eng\build.ps1'; Get-Help }"
 
 :end
 exit /b %ERRORLEVEL%

--- a/coreclr.cmd
+++ b/coreclr.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory coreclr %*
+setlocal
+
+set _args="-subsetCategory coreclr %*"
+if "%~1"=="-?" set _args="-help"
+
+"%~dp0build.cmd" %_args%

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [switch][Alias('h', '?')]$help,
+  [switch][Alias('h')]$help,
   [switch][Alias('b')]$build,
   [switch][Alias('t')]$test,
   [switch]$buildtests,

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,5 +1,6 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
+  [switch][Alias('h', '?')]$help,
   [switch][Alias('b')]$build,
   [switch][Alias('t')]$test,
   [switch]$buildtests,
@@ -54,6 +55,11 @@ function Get-Help() {
 
 # Exit if script has been dot-sourced
 if ($MyInvocation.InvocationName -eq ".") {
+  exit 0
+}
+
+if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $properties.Contains('/?')))) {
+  Get-Help
   exit 0
 }
 

--- a/installer.cmd
+++ b/installer.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory installer %*
+setlocal
+
+set _args="-subsetCategory installer %*"
+if "%~1"=="-?" set _args="-help"
+
+"%~dp0build.cmd" %_args%

--- a/libraries.cmd
+++ b/libraries.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory libraries %*
+setlocal
+
+set _args="-subsetCategory libraries %*"
+if "%~1"=="-?" set _args="-help"
+
+"%~dp0build.cmd" %_args%


### PR DESCRIPTION
In windows if we call any of the subset helper scripts, `coreclr.cmd`, `libraries.cmd` or `installer.cmd` with `-h, -help or -?` we get arcade's help which is miss leading in some arguments like, -arch is shown as -platform. The reason for that is because subset scripts pass `-subsetCategory <subset>` as the first argument when calling `build.cmd` and in `build.cmd`, in order to print help, we check for `%~1`.

Also without this change, it doesn't match Unix behavior, as if we call `coreclr.sh-h` then we get the expected output of our `eng\build` usage output.