### PR TITLE
Prevent method from being inlined to get correctly handled in try-catch blocks

### DIFF
--- a/src/coreclr/tests/src/Loader/classloader/MethodImpl/override_override1.il
+++ b/src/coreclr/tests/src/Loader/classloader/MethodImpl/override_override1.il
@@ -87,7 +87,7 @@
        extends [mscorlib]System.Object
 {
 
-  .method public static int32 Go(){
+  .method public static int32 Go() noinlining {
     .maxstack 8
     .locals init (class MyFoo V_1)
     newobj     instance void MyBar::.ctor()


### PR DESCRIPTION
Crossgen1 will fail to compile the problematic methods due to typeloader exceptions, which we don't have in the crossgen2's TypeSystem

cc @dotnet/crossgen-contrib 