### PR TITLE
host: Allow comments in JSON files

### DIFF
--- a/src/installer/corehost/cli/json_parser.cpp
+++ b/src/installer/corehost/cli/json_parser.cpp
@@ -84,9 +84,11 @@ bool json_parser_t::parse_json(const pal::string_t& context)
     // UTF-8 and the host expects wide strings.  m_document will store
     // data in UTF-16 (with pal::char_t as the character type), but it
     // has to know that data is encoded in UTF-8 to convert during parsing.
-    m_document.Parse<rapidjson::ParseFlag::kParseStopWhenDoneFlag, rapidjson::UTF8<>>(m_json.data());
+    constexpr auto flags = rapidjson::ParseFlag::kParseStopWhenDoneFlag
+                         | rapidjson::ParseFlag::kParseCommentsFlag;
+    m_document.Parse<flags, rapidjson::UTF8<>>(m_json.data());
 #else
-    m_document.ParseInsitu(m_json.data());
+    m_document.ParseInsitu<rapidjson::ParseFlag::kParseCommentsFlag>(m_json.data());
 #endif
 
     if (m_document.HasParseError())

--- a/src/installer/test/Assets/TestUtils/SDKLookup/dotnet.runtimeconfig.json
+++ b/src/installer/test/Assets/TestUtils/SDKLookup/dotnet.runtimeconfig.json
@@ -1,8 +1,10 @@
 {
   "runtimeOptions": {
+    /* This is a multiline comment to test that the JSON parser is correctly
+     * set up to ignore them. */
     "framework": {
-      "name": "Microsoft.NETCore.App",
-      "version": "9999.0.0"
+      "name": "Microsoft.NETCore.App", // And this is a single-line comment
+      "version": "9999.0.0"            // that should be ignored by the parser
     }
   }
 }


### PR DESCRIPTION
Although JSON doesn't support comments, a common extension is to enable
JavaScript-style comments.  By default, RapidJSON will error out if
comments are found in the input data, but it can be configured to
ignore them.

This is useful especially when testing out changes in
runtimeconfig.json files.

Fixes dotnet/core-setup#5661