### PR TITLE
Remove early exit logic in GetSortKey-related code paths

### DIFF
--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -627,6 +627,18 @@ namespace System.Globalization.Tests
             Assert.Equal(version, new CultureInfo(cultureName).CompareInfo.Version);
         }
 
+        [Fact]
+        public void TestSortKey_ZeroWeightCodePoints()
+        {
+            // In the invariant globalization mode, there's no such thing as a zero-weight code point,
+            // so the U+200C ZERO WIDTH NON-JOINER code point contributes to the final sort key value.
+
+            CompareInfo compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+            SortKey sortKeyForEmptyString = compareInfo.GetSortKey("");
+            SortKey sortKeyForZeroWidthJoiner = compareInfo.GetSortKey("\u200c");
+            Assert.NotEqual(0, SortKey.Compare(sortKeyForEmptyString, sortKeyForZeroWidthJoiner));
+        }
+
 
         private static StringComparison GetStringComparison(CompareOptions options)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1062.

When generating sort keys, certain code points such as `U+200C` and `U+FFFD` (depending on OS) are given zero weight and are ignored during the sort key calculation. This means, e.g., that the strings `"ab"` and `"a\u200cb"` can compare as equal using some culture-aware comparers.

One consequence of this is that the _empty_ string can compare as equal to some _non-empty_ strings if they contain only zero-weight code points. For instance, `""` and `"\u200c"` should compare as equal under the invariant culture-aware comparer, which means that they should also have the same sort key. However, this conflicts with the optimization we have at the entry point to most of our sort key generation routines, where the early-exit code optimistically assumes that the sort key of the empty string will be distinct from all possible sort keys of non-empty strings.

The fix is to remove the early-exit code and to always call into ICU / NLS for sort key generation.