### PR TITLE
Change bIsFree check in DacValidateMethodTable

### DIFF
--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -129,15 +129,8 @@ BOOL DacValidateMethodTable(MethodTable *pMT, BOOL &bIsFree)
     EX_TRY
     {
         bIsFree = FALSE;
-        EEClass *pEEClass = pMT->GetClass();
-        if (pEEClass==NULL)
+        if (HOST_CDADDR(pMT) == HOST_CDADDR(g_pFreeObjectMethodTable))
         {
-            // Okay to have a NULL EEClass if this is a free methodtable
-            CLRDATA_ADDRESS MethTableAddr = HOST_CDADDR(pMT);
-            CLRDATA_ADDRESS FreeObjMethTableAddr = HOST_CDADDR(g_pFreeObjectMethodTable);
-            if (MethTableAddr != FreeObjMethTableAddr)
-                goto BadMethodTable;
-
             bIsFree = TRUE;
         }
         else


### PR DESCRIPTION
Some commands of SOS validate a method table in DacValidateMethodTable.
In the function, it checks whether a method table is FreeObjectMethodTable or not with GetClass() value.
However, GetClass() should not be NULL. (There is an assert in GetClass())
In this patch, it compares pMT address with g_pFreeObjectMethodTable address only.