### PR TITLE
Publish CoreCLR packages

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -3,6 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
+  platform: ''
   container: ''
   testGroup: ''
   crossrootfsDir: ''
@@ -12,12 +13,14 @@ parameters:
   stagedBuild: false
   variables: {}
   pool: ''
+  isOfficialBuild: false
 
 ### Product build
 jobs:
 - template: xplat-pipeline-job.yml
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
+    _BuildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
@@ -186,8 +189,14 @@ jobs:
           SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Build packages
-    - script: $(coreClrRepoRootDir)build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) -ci
+    - script: $(coreClrRepoRootDir)build-packages$(scriptExt) -BuildArch=$(archType) -BuildType=$(_BuildConfig) $(crossPackagesArg) $(officialBuildIdArg) -ci --configuration $(_BuildConfig)
       displayName: Build packages
+
+    # Save packages using the prepare-signed-artifacts format.
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - template: /eng/pipelines/common/upload-unsigned-artifacts-step.yml
+        parameters:
+          name: ${{ parameters.platform }}
 
     # Publish official build
     - ${{ if eq(parameters.publishToBlobFeed, 'true') }}:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -57,6 +57,8 @@ stages:
       - Windows_NT_x64
       - Windows_NT_arm
       - Windows_NT_arm64
+      jobParameters:
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
 
   #
   # Build libraries using live CoreLib from CoreCLR

--- a/src/coreclr/build-packages.sh
+++ b/src/coreclr/build-packages.sh
@@ -127,7 +127,7 @@ if [ "${__DistroRid}" = "linux-musl-arm64" ]; then
     export OutputRID=${__DistroRid}
 fi
 
-logFile=$__ProjectRoot/artifacts/log/build-packages.binlog
+logFile=$__RepoRootDir/artifacts/log/build-packages.binlog
 $__RepoRootDir/eng/common/build.sh -r -b -projects $__ProjectRoot/src/.nuget/packages.builds \
                                    -verbosity minimal -bl:$logFile \
                                    /p:__BuildOS=$__BuildOS \

--- a/src/coreclr/src/.nuget/Directory.Build.targets
+++ b/src/coreclr/src/.nuget/Directory.Build.targets
@@ -3,12 +3,6 @@
 
   <Import Project="../Directory.Build.targets" />
 
-  <PropertyGroup>
-    <!-- Reset PackageOutputPath. The ProjectDefaults targets from Arcade set it to be in the artifacts directory,
-         but our publishing step currently looks under PackagesBinDir -->
-    <PackageOutputPath>$(PackagesBinDir)/pkg/</PackageOutputPath>
-  </PropertyGroup>
-
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />
 
   <!--

--- a/src/coreclr/src/.nuget/packaging.props
+++ b/src/coreclr/src/.nuget/packaging.props
@@ -21,9 +21,6 @@
     <HasCrossTargetComponents Condition="'$(TargetsWindows)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm')">true</HasCrossTargetComponents>
     <HasCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm') and '$(__DoCrossArchBuild)' == '1'">true</HasCrossTargetComponents>
 
-    <!-- Created package output locations must be kept in sync with eng/build-job.yml -->
-    <PackageOutputPath>$(PackagesBinDir)/pkg/</PackageOutputPath>
-    <SymbolPackageOutputPath>$(PackagesBinDir)/symbolpkg/</SymbolPackageOutputPath>
     <PackageIndexFile>$(MSBuildThisFileDirectory)/packageIndex.json</PackageIndexFile>
 
     <!-- coreclr doesn't currently use the index so don't force it to be in sync -->


### PR DESCRIPTION
* Add missing _BuildConfig. Pass configuration with Arcade style, at the end for win arg parsing.
* Fix build-packages.sh binlog location.
* Remove CoreCLR nupkg output redirection.

Publish the CoreCLR packages so that downstream repos can update to a complete set of packages. A test build with these changes prepared `Microsoft.NET.Sdk.IL` for publish, for example.

Trial build: https://dev.azure.com/dnceng/internal/_build/results?buildId=462514&view=results

For https://github.com/dotnet/runtime/issues/98#issuecomment-567566284.