### PR TITLE
Fix tests running from VS

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -76,7 +76,7 @@ if ($vs) {
   $archTestHost = if ($arch) { $arch } else { "x64" }
 
   # This tells .NET Core to use the same dotnet.exe that build scripts use
-  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp-Windows_NT-$configuration-$archTestHost";
+  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-$configuration-$archTestHost";
 
   # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
   $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=InitializeDotNetCli -install:$false

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -74,9 +74,19 @@ if ($vs) {
   }
 
   $archTestHost = if ($arch) { $arch } else { "x64" }
+  if ((!$framework) -or ($framework.ToLowerInvariant() -eq 'netcoreapp')) {
+    $targetFramework = "netcoreapp5.0"
+  } else {
+    if ($framework.ToLowerInvariant() -eq 'netfx') {
+      $targetFramework = "net472"
+    } else {
+      $targetFramework = $framework.ToLowerInvariant()
+    }
+  }
+  Write-Host "TargetFramework: $targetFramework"
 
   # This tells .NET Core to use the same dotnet.exe that build scripts use
-  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-$configuration-$archTestHost";
+  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\$targetFramework-Windows_NT-$configuration-$archTestHost";
 
   # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
   $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=InitializeDotNetCli -install:$false

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -83,7 +83,6 @@ if ($vs) {
       $targetFramework = $framework.ToLowerInvariant()
     }
   }
-  Write-Host "TargetFramework: $targetFramework"
 
   # This tells .NET Core to use the same dotnet.exe that build scripts use
   $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\$targetFramework-Windows_NT-$configuration-$archTestHost";


### PR DESCRIPTION
Artifacts path changed to use `netcoreapp5.0`, so change the `DOTNET_ROOT` set for VS `testhost`

With this change, when I open VS via `libraries.cmd -vs System.Net.Http` it works assuming that you set:
> Test -> Processor Architecture for AnyCPU Projects -> x64

With all that the tests run from VS. Don't know how to set the processor architecture in code just yet.