### PR TITLE
Fix coreclr test build and execution

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -75,8 +75,12 @@
     </ItemGroup>
 
     <MSBuild Projects="@(RepoTaskProjects)"
-             Properties="Configuration=Debug;Platform=AnyCPU"
-             Targets="Restore;Build"/>
+             Properties="Configuration=Debug;Platform=AnyCPU;__BuildPhase=Restore"
+             Targets="Restore"/>
+
+    <MSBuild Projects="@(RepoTaskProjects)"
+             Properties="Configuration=Debug;Platform=AnyCPU;__BuildPhase=Build"
+             Targets="Build"/>
 
     <WriteLinesToFile File="$(RepoTasksOutputFile)"
                       Lines="$(RepoTasksOutputFile)"

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -33,6 +33,9 @@ set "__ProjectDir=%~dp0"
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__RepoRootDir=%__ProjectDir%\..\.."
 
+:: normalize the path
+for %%i in ("%__RepoRootDir%") do SET "__RepoRootDir=%%~fi"
+
 set "__TestDir=%__ProjectDir%\tests"
 set "__ProjectFilesDir=%__TestDir%"
 set "__SourceDir=%__ProjectDir%\src"

--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -38,6 +38,7 @@
   <!-- Common properties -->
   <PropertyGroup>
     <RootRepoDir>$(MSBuildThisFileDirectory)..\..\</RootRepoDir>
+    <RootRepoDir>$([MSBuild]::NormalizePath('$(RootRepoDir)'))</RootRepoDir>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
 
     <BaseIntermediateOutputPath>$(RootRepoDir)artifacts\obj\coreclr\$(MSBuildProjectName)\</BaseIntermediateOutputPath>

--- a/src/coreclr/tests/Directory.Build.props
+++ b/src/coreclr/tests/Directory.Build.props
@@ -21,6 +21,7 @@
   <!-- Common properties -->
   <PropertyGroup>
     <RootBinDir>$(MSBuildThisFileDirectory)..\..\..\artifacts\</RootBinDir>
+    <RootBinDir>$([MSBuild]::NormalizePath('$(RootBinDir)'))</RootBinDir>
     <BinDir>$(RootBinDir)bin\coreclr\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
     <TestWorkingDir>$(__TestWorkingDir)\</TestWorkingDir>

--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -5,7 +5,7 @@ setlocal EnableDelayedExpansion EnableExtensions
 :: it easier to see where these are coming from. Note that there is a trailing space here.
 set "__MsgPrefix=RUNTEST: "
 
-set __ThisScriptDir="%~dp0"
+set "__ThisScriptDir=%~dp0"
 
 :: Set the default arguments
 set __BuildArch=x64
@@ -185,7 +185,7 @@ if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python "%~dp0runtest.py" %__RuntestPyArgs%
+set NEXTCMD=python "%__ThisScriptDir%runtest.py" %__RuntestPyArgs%
 echo !NEXTCMD!
 !NEXTCMD!
 

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -139,7 +139,19 @@ $(_XunitEpilog)
   </Target>
 
   <Target Name="BuildXunitWrapper">
-    <MSBuild Projects="$(XunitWrapperSrcDir)\$(XunitWrapper).csproj" Targets="Restore;Build" />
+    <!--
+      Restore and Build tasks shouldn't run in the same msbuild invocation as that could cause
+      issues with nuget auto-generated props/targets.
+    -->
+    <ItemGroup>
+      <XUnitWrapperProjectFile Include="$(XunitWrapperSrcDir)\$(XunitWrapper).csproj" />
+    </ItemGroup>
+    <MSBuild Projects="@(XUnitWrapperProjectFile)"
+             Targets="Restore"
+             Properties="__BuildPhase=Restore" />
+    <MSBuild Projects="@(XUnitWrapperProjectFile)"
+             Targets="Build"
+             Properties="__BuildPhase=Build" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)../testgrouping.proj" />


### PR DESCRIPTION
The local coreclr test build and execution has been broken for some time,
basically ever since we've switched to the runtime repo. The test build
was failing with the following error:

> The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded
 from the assembly
 C:\Users\xxxxx\.nuget\packages\microsoft.net.compilers.toolset\3.3.1-beta3-final\build\..\tasks\netcoreapp2.1\Microsoft.Build.Tasks.CodeAnalysis.dll.
 Assembly with same name is already loaded Confirm that the <UsingTask>
 declaration is correct, that the assembly and all its dependencies are
 available, and that the task contains a public class that implements
 Microsoft.Build.Framework.ITask.

The already loaded assembly was coming from
`F:\git\runtime\.dotnet\sdk\5.0.100-alpha1-015772\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll`

The main issue happens due to the fact that we ended up passing
non-normalized path to the msbuild `exists` function and it was
returning false even though the file existed. The path looked like this:
`F:\git\runtime\src\coreclr\\\..\..\\artifacts\tests\coreclr\obj\Windows_NT.x64.Debug\Managed\`
There was also a problem with ordering of the Restore and Build tasks
for the test wrappers.