### PR TITLE
Add Job for Release testing

### DIFF
--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -1,0 +1,79 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 6 * * *"
+  displayName: Daily at 10:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+#
+# Release builds
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    buildConfig: release
+    platformGroup: all
+    jobParameters:
+      timeoutInMinutes: 120
+
+#
+# Release test builds
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    buildConfig: release
+    platformGroup: all
+    testGroup: outerloop
+
+#
+# Release test runs
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/run-test-job.yml
+    buildConfig: release
+    platformGroup: all
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+
+#
+# Release R2R test runs
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/run-test-job.yml
+    buildConfig: release
+    platformGroup: all
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      readyToRun: true
+      displayNameArgs: R2R
+
+
+#
+# Crossgen-comparison jobs
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_arm
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml


### PR DESCRIPTION
This change adds a job description for testing release bits.
It runs outer loop tests on all platforms (with and without R2R) every night at 10pm. 

A test run is scheduled here:
https://dev.azure.com/dnceng/public/_build/results?buildId=463542&view=logs&j=6c5bbe10-d41c-5008-b9b3-09c7d6d8c0b3