### PR TITLE
Optimize AdjustMaxWorkersActive

### DIFF
--- a/src/coreclr/src/vm/win32threadpool.cpp
+++ b/src/coreclr/src/vm/win32threadpool.cpp
@@ -919,10 +919,6 @@ void ThreadpoolMgr::AdjustMaxWorkersActive()
 
     _ASSERTE(ThreadAdjustmentLock.IsHeld());
 
-    DWORD currentTicks = GetTickCount();
-    LONG totalNumCompletions = (LONG)Thread::GetTotalWorkerThreadPoolCompletionCount();
-    LONG numCompletions = totalNumCompletions - VolatileLoad(&PriorCompletedWorkRequests);
-
     LARGE_INTEGER startTime = CurrentSampleStartTime;
     LARGE_INTEGER endTime;
     QueryPerformanceCounter(&endTime);
@@ -941,6 +937,9 @@ void ThreadpoolMgr::AdjustMaxWorkersActive()
     //
     if (elapsed*1000.0 >= (ThreadAdjustmentInterval/2))
     {
+        DWORD currentTicks = GetTickCount();
+        LONG totalNumCompletions = (LONG)Thread::GetTotalWorkerThreadPoolCompletionCount();
+        LONG numCompletions = totalNumCompletions - VolatileLoad(&PriorCompletedWorkRequests);
         ThreadCounter::Counts currentCounts = WorkerCounter.GetCleanCounts();
 
         int newMax = HillClimbingInstance.Update(


### PR DESCRIPTION
@ninedan reported this function as expensive in one of the server scenarios
he monitors. The actual time is spent in `ThreadStore::GetAllThreadList`.
Moving the call to `GetTotalWorkerThreadPoolCompletionCount` should reduce this
cost.

(This trace is from .NET Framework, but the code is similar and still calls `ThreadStore::GetAllThreadList` in .NET Core)
![image](https://user-images.githubusercontent.com/4523120/71301160-c6ed0780-2350-11ea-928d-b3ffa323bd16.png)


Fixes #1079 