### PR TITLE
WIP: Experimentally revert "Fix dependencies.props import (#833)"

### DIFF
--- a/src/coreclr/dir.common.props
+++ b/src/coreclr/dir.common.props
@@ -37,19 +37,28 @@
 
   <!-- Common properties -->
   <PropertyGroup>
-    <RootRepoDir>$(MSBuildThisFileDirectory)..\..\</RootRepoDir>
-    <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
+
+    <__ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)</__ProjectDir>
+    <ProjectDir>$(__ProjectDir)\</ProjectDir>
+    <RootRepoDir>$(ProjectDir)\..\..\</RootRepoDir>
+    <ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)</ProjectDir>
 
     <BaseIntermediateOutputPath>$(RootRepoDir)artifacts\obj\coreclr\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 
-    <SourceDir>$(ProjectDir)src\</SourceDir>
-    <RootBinDir>$(RootRepoDir)artifacts\</RootBinDir>
-    <BinDir>$(RootBinDir)bin\coreclr\$(PlatformConfigPathPart)\</BinDir>
+    <SourceDir>$(__SourceDir)\</SourceDir>
+    <SourceDir Condition="'$(__SourceDir)'==''">$(ProjectDir)src\</SourceDir>
+
+    <RootBinDir>$(__RootBinDir)\</RootBinDir>
+    <RootBinDir Condition="'$(__RootBinDir)'==''">$(RootRepoDir)artifacts\</RootBinDir>
+
+    <BinDir>$(__BinDir)\</BinDir>
+    <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)bin\coreclr\$(PlatformConfigPathPart)\</BinDir>
 
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->
-    <PackagesBinDir>$(BinDir).nuget\</PackagesBinDir>
+    <PackagesBinDir>$(__PackagesBinDir)</PackagesBinDir>
+    <PackagesBinDir Condition="'$(__PackagesBinDir)'==''">$(BinDir).nuget\</PackagesBinDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -113,5 +122,5 @@
   </PropertyGroup>
 
   <!-- Provides properties for dependency versions and configures dependency verification/auto-upgrade. -->
-  <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
+  <Import Project="$(ProjectDir)dependencies.props" />
 </Project>

--- a/src/coreclr/tests/Directory.Build.props
+++ b/src/coreclr/tests/Directory.Build.props
@@ -14,17 +14,20 @@
 
   <!-- Common repo directories -->
   <PropertyGroup>
-    <TestProjectDir>$(MSBuildThisFileDirectory)</TestProjectDir>
-    <TestSourceDir>$(MSBuildThisFileDirectory)src\</TestSourceDir>
+    <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
+    <SourceDir>$(ProjectDir)src\</SourceDir>
   </PropertyGroup>
 
   <!-- Common properties -->
   <PropertyGroup>
-    <RootBinDir>$(MSBuildThisFileDirectory)..\..\..\artifacts\</RootBinDir>
-    <BinDir>$(RootBinDir)bin\coreclr\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
+    <RootBinDir>$(__RootBinDir)\</RootBinDir>
+    <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)..\..\..\artifacts\</RootBinDir>
+
+    <BinDir>$(__BinDir)\</BinDir>
+    <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)bin\coreclr\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
     <TestWorkingDir>$(__TestWorkingDir)\</TestWorkingDir>
-    <TestWorkingDir>$(RootBinDir)tests\coreclr\$(BuildOS).$(BuildArch).$(BuildType)\</TestWorkingDir>
+    <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\coreclr\$(BuildOS).$(BuildArch).$(BuildType)\</TestWorkingDir>
 
     <AltJitArch>$(__AltJitArch)</AltJitArch>
   </PropertyGroup>

--- a/src/coreclr/tests/publishdependency.targets
+++ b/src/coreclr/tests/publishdependency.targets
@@ -17,7 +17,7 @@
     <!-- These projects are individually restored in order. Each
          subsequent restore only copies files that don't already exist
          in CORE_ROOT, so assets from the first project file win. -->
-    <CoreRootProjectFiles Include="$(TestSourceDir)Common\test_dependencies\test_dependencies.csproj" />
+    <CoreRootProjectFiles Include="$(SourceDir)Common\test_dependencies\test_dependencies.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -16,7 +16,7 @@ set "__ProjectDir=%~dp0"
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__ProjectFilesDir=%__ProjectDir%"
-set "__RootBinDir=%~dp0..\..\..\artifacts"
+set "__RootBinDir=%__ProjectDir%\..\artifacts"
 set "__LogsDir=%__RootBinDir%\log"
 set "__MsbuildDebugLogsDir=%__LogsDir%\MsbuildDebugLogs"
 set __ToolsDir=%__ProjectDir%\..\Tools
@@ -185,7 +185,8 @@ if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python "%~dp0runtest.py" %__RuntestPyArgs%
+REM __ProjectDir is poorly named, it is actually <projectDir>/tests
+set NEXTCMD=python "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
 echo !NEXTCMD!
 !NEXTCMD!
 

--- a/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/coreclr/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRunScript>false</GenerateRunScript>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <ProjectAssetsFile>$(TestSourceDir)Common\CoreCLRTestLibrary\obj\project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)Common\CoreCLRTestLibrary\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
@@ -28,6 +28,6 @@
   <!-- This project depends on properties pulled in by Directory.Build.targets in the test/src directory,
        which isn't usually imported for the tests/src/Common
        projects. -->
-  <Import Project="$(TestSourceDir)\Directory.Build.targets" />
+  <Import Project="$(SourceDir)\Directory.Build.targets" />
 
 </Project>

--- a/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
+++ b/src/coreclr/tests/src/Common/Coreclr.TestWrapper/Coreclr.TestWrapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ProjectAssetsFile>$(TestSourceDir)Common\Coreclr.TestWrapper\obj\project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)Common\Coreclr.TestWrapper\obj\project.assets.json</ProjectAssetsFile>
     <NuGetTargetMoniker>$(NetCoreAppCurrentTargetFrameworkMoniker)</NuGetTargetMoniker>
     <NuGetTargetMonikerShort>$(NetCoreAppCurrent)</NuGetTargetMonikerShort>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Common/ilasm/ilasm.ilproj
+++ b/src/coreclr/tests/src/Common/ilasm/ilasm.ilproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <ProjectAssetsFile>$(TestSourceDir)Common\ilasm\obj\project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)Common\ilasm\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -16,7 +16,7 @@
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />
 
   <PropertyGroup>
-    <ProjectAssetsFile>$(TestSourceDir)Common\test_dependencies\obj\project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)Common\test_dependencies\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)liveBuilds.targets" />

--- a/src/coreclr/tests/src/CoreMangLib/system/buffer/ASURT_99893.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/buffer/ASURT_99893.csproj
@@ -9,6 +9,6 @@
     <Compile Include="asurt_99893.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateCombine1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateCombine1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegatecombine1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateCombineImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateCombineImpl.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegatecombineimpl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateEquals1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateEquals1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegateequals1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateGetHashCode1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateGetHashCode1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegategethashcode1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateGetInvocationList1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateGetInvocationList1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegategetinvocationlist1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateRemove.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/DelegateRemove.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegateremove.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/delegateRemoveImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/delegate/delegateRemoveImpl.csproj
@@ -9,6 +9,6 @@
     <Compile Include="delegateremoveimpl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NG_Standard.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NG_Standard.csproj
@@ -10,6 +10,6 @@
     <Compile Include="ng_standard.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NegativeGenerics.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NegativeGenerics.csproj
@@ -9,6 +9,6 @@
     <Compile Include="negativegenerics.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NullableTypes.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/generics/NullableTypes.csproj
@@ -9,6 +9,6 @@
     <Compile Include="nullabletypes.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Central.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Central.csproj
@@ -9,6 +9,6 @@
     <Compile Include="central.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Co6010DelegateEqualsTwo.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Co6010DelegateEqualsTwo.csproj
@@ -9,7 +9,7 @@
     <Compile Include="co6010delegateequalstwo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <WarningLevel Include="1" />

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Co6031GetHashCode.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/miscellaneous/Co6031GetHashCode.csproj
@@ -9,7 +9,7 @@
     <Compile Include="co6031gethashcode.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <WarningLevel Include="1" />

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.csproj
@@ -9,6 +9,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/DDB113347.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/DDB113347.csproj
@@ -9,6 +9,6 @@
     <Compile Include="ddb113347.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToInt64.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToInt64.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletoint64.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToSingle.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToSingle.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletosingle.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToType.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToType.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletotype.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint16.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint16.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletouint16.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint32.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint32.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletouint32.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint64.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/enum/EnumIConvertibleToUint64.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enumiconvertibletouint64.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateCombineImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateCombineImpl.csproj
@@ -11,6 +11,6 @@
     <Compile Include="verificationagent.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateEquals.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateEquals.csproj
@@ -11,6 +11,6 @@
     <Compile Include="verificationagent.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateGetHashCode.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateGetHashCode.csproj
@@ -11,6 +11,6 @@
     <Compile Include="verificationagent.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateGetInvocationList.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/multicastdelegate/MulticastDelegateGetInvocationList.csproj
@@ -11,6 +11,6 @@
     <Compile Include="verificationagent.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf1_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf1_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="marshalsizeof1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf2_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf2_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="marshalsizeof2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleCtor_cti_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleCtor_cti_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandlector_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousAddRef_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousAddRef_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandledangerousaddref.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousGetHandle_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousGetHandle_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandledangerousgethandle.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousRelease_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousRelease_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandledangerousrelease.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDispose1_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDispose1_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandledispose1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDispose2_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDispose2_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandledispose2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleHandle_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleHandle_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandlehandle.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleIsClosed_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleIsClosed_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandleisclosed.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleIsInvalid_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleIsInvalid_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandleisinvalid.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleSetHandleAsInvalid_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleSetHandleAsInvalid_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandlesethandleasinvalid.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleSetHandle_PSC.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleSetHandle_PSC.csproj
@@ -9,6 +9,6 @@
     <Compile Include="safehandlesethandle.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedAdd1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedAdd1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedadd1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedAdd2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedAdd2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedadd2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedcompareexchange1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange5.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange5.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedcompareexchange5.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange6.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange6.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedcompareexchange6.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange7.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange7.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedcompareexchange7.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedDecrement1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedDecrement1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockeddecrement1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedDecrement2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedDecrement2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockeddecrement2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedexchange1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange5.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange5.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedexchange5.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange6.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange6.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedexchange6.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange7.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedExchange7.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedexchange7.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedIncrement1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedIncrement1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedincrement1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedIncrement2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/threading/interlocked/InterlockedIncrement2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockedincrement2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeEquals1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeEquals1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typeequals1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeEquals2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeEquals2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typeequals2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetArrayRank.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetArrayRank.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegetarrayrank.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetElementType.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetElementType.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegetelementtype.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetGenericTypeDefinition.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetGenericTypeDefinition.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegetgenerictypedefinition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetHashCode.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetHashCode.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegethashcode.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetType1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetType1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegettype1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetType2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetType2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegettype2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetTypeFromHandle.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeGetTypeFromHandle.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typegettypefromhandle.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeHasElementTypeImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeHasElementTypeImpl.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typehaselementtypeimpl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeIsByRefImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeIsByRefImpl.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typeisbyrefimpl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeIsPointerImpl.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeIsPointerImpl.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typeispointerimpl.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeArrayType1.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeArrayType1.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typemakearraytype1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeArrayType2.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeArrayType2.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typemakearraytype2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeByRefType.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakeByRefType.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typemakebyreftype.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakePointerType.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeMakePointerType.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typemakepointertype.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/CoreMangLib/system/type/TypeToString.csproj
+++ b/src/coreclr/tests/src/CoreMangLib/system/type/TypeToString.csproj
@@ -9,6 +9,6 @@
     <Compile Include="typetostring.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Directory.Build.props
+++ b/src/coreclr/tests/src/Directory.Build.props
@@ -32,7 +32,7 @@
     <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
     <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\..\coreclr\obj\$(BuildOS).$(Platform).$(Configuration)\Native\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
-    <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(TestSourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(TestSourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
+    <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
     <SkipXunitDependencyCopying>true</SkipXunitDependencyCopying>

--- a/src/coreclr/tests/src/Directory.Build.targets
+++ b/src/coreclr/tests/src/Directory.Build.targets
@@ -183,8 +183,8 @@
           Condition="'$(_CopyNativeProjectBinaries)' == 'true'"
           BeforeTargets="Build" >
      <ItemGroup Condition="'@(NativeProjectReferenceNormalized)' != ''">
-        <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(TestSourceDir),$(__NativeTestIntermediatesDir)\src\))" Condition="'$(RunningOnUnix)' == 'true'" />
-        <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(TestSourceDir),$(__NativeTestIntermediatesDir)\src\))$(Configuration)\" Condition="'$(RunningOnUnix)' != 'true'" />
+        <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__NativeTestIntermediatesDir)\src\))" Condition="'$(RunningOnUnix)' == 'true'" />
+        <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__NativeTestIntermediatesDir)\src\))$(Configuration)\" Condition="'$(RunningOnUnix)' != 'true'" />
      </ItemGroup>
 
     <Message Text= "Full native project references are :%(NativeProjectReferenceNormalized.Identity)" />
@@ -227,7 +227,7 @@
   </Target>
 
   <PropertyGroup>
-    <ProjectAssetsFile>$(TestSourceDir)Common\test_dependencies\obj\project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)Common\test_dependencies\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ReferenceSystemPrivateCoreLib)' == 'true' and '$(UsingMicrosoftNETSdk)' != 'true'">

--- a/src/coreclr/tests/src/GC/Features/HeapExpansion/Finalizer.csproj
+++ b/src/coreclr/tests/src/GC/Features/HeapExpansion/Finalizer.csproj
@@ -8,7 +8,7 @@
     <Compile Include="Finalizer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="GCUtil_HeapExpansion.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Features/HeapExpansion/Handles.csproj
+++ b/src/coreclr/tests/src/GC/Features/HeapExpansion/Handles.csproj
@@ -8,7 +8,7 @@
     <Compile Include="Handles.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="GCUtil_HeapExpansion.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/DirectedGraph.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/DirectedGraph.csproj
@@ -8,6 +8,6 @@
     <Compile Include="DirectedGraph.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAlloc.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc1.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc1.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAlloc1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc2.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc2.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAlloc2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc3.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc3.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAlloc3.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc4.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAlloc4.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAlloc4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAllocPinned.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/LargeObjectAllocPinned.csproj
@@ -8,6 +8,6 @@
     <Compile Include="LargeObjectAllocPinned.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/GC/Stress/Tests/RedBlackTree.csproj
+++ b/src/coreclr/tests/src/GC/Stress/Tests/RedBlackTree.csproj
@@ -8,6 +8,6 @@
     <Compile Include="RedBlackTree.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="MarshalBoolArrayTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="MarshalArrayByValTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/coreclr/tests/src/Interop/BestFitMapping/BestFitMapping.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -18,6 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NETServer/NETServer.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="CoreShim.X.manifest">

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -19,6 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -18,6 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -18,6 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="NetClientPrimitives.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="DefaultInterfaces/CMakeLists.txt" />
     <ProjectReference Include="../NetServer/NetServer.DefaultInterfaces.ilproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="Dispatch/CMakeLists.txt" />
     <ProjectReference Include="../NetServer/NetServer.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="Licensing/CMakeLists.txt" />
     <ProjectReference Include="../NetServer/NetServer.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="Primitives/CMakeLists.txt" />
     <ProjectReference Include="../NetServer/NetServer.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />

--- a/src/coreclr/tests/src/Interop/COM/Reflection/Reflection.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Reflection/Reflection.csproj
@@ -7,7 +7,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="..\NETServer\NETServer.csproj">
       <Project>{C04AB564-CC61-499D-9F4C-AA1A9FDE42C9}</Project>
       <Name>NETServer</Name>

--- a/src/coreclr/tests/src/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/src/coreclr/tests/src/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -21,6 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
     <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -21,6 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
     <ProjectReference Include="../ijwhostmock/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/LayoutClass/LayoutClassTest.csproj
+++ b/src/coreclr/tests/src/Interop/LayoutClass/LayoutClassTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/src/coreclr/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="IUnknownTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -10,7 +10,7 @@
     <Compile Include="TestInALC.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="IUnknownTest.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryTests.csproj
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryTests.csproj
@@ -12,7 +12,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/PInvoke/Varargs/VarargsTest.csproj
+++ b/src/coreclr/tests/src/Interop/PInvoke/Varargs/VarargsTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="PInvokeUIntPtrTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/src/coreclr/tests/src/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/RefInt/RefIntTest.csproj
+++ b/src/coreclr/tests/src/Interop/RefInt/RefIntTest.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/src/coreclr/tests/src/Interop/SimpleStruct/SimpleStruct.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/SizeConst/SizeConstTest.csproj
+++ b/src/coreclr/tests/src/Interop/SizeConst/SizeConstTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="SizeConstTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -9,7 +9,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
@@ -11,7 +11,7 @@
     <Compile Include="Helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -10,7 +10,7 @@
     <Compile Include="Helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
+++ b/src/coreclr/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeComponent/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/WinRT/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/coreclr/tests/src/Interop/WinRT/NETClients/Primitives/NETClientPrimitives.csproj
@@ -24,6 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeComponent/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/HardwareIntrinsics/Directory.Build.props
+++ b/src/coreclr/tests/src/JIT/HardwareIntrinsics/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.csproj
@@ -10,6 +10,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
+++ b/src/coreclr/tests/src/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
@@ -11,6 +11,6 @@
     <Compile Include="TestBase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Loader/AssemblyDependencyResolver/MissingHostPolicyTests/MissingHostPolicyTests.csproj
+++ b/src/coreclr/tests/src/Loader/AssemblyDependencyResolver/MissingHostPolicyTests/MissingHostPolicyTests.csproj
@@ -8,6 +8,6 @@
     <Compile Include="InvalidHostingTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Loader/ContextualReflection/ContextualReflection.csproj
+++ b/src/coreclr/tests/src/Loader/ContextualReflection/ContextualReflection.csproj
@@ -10,6 +10,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="ContextualReflectionDependency.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Loader/ContextualReflection/ContextualReflectionDependency.csproj
+++ b/src/coreclr/tests/src/Loader/ContextualReflection/ContextualReflectionDependency.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ContextualReflectionDependency.cs" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Loader/NativeLibs/FromNativePaths.csproj
+++ b/src/coreclr/tests/src/Loader/NativeLibs/FromNativePaths.csproj
@@ -9,7 +9,7 @@
     <Compile Include="FromNativePaths.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="Helpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="AssemblyToLoad.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Regressions/common/AboveStackLimit.csproj
+++ b/src/coreclr/tests/src/Regressions/common/AboveStackLimit.csproj
@@ -7,6 +7,6 @@
     <Compile Include="AboveStackLimit.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/ArrayCopy.csproj
+++ b/src/coreclr/tests/src/Regressions/common/ArrayCopy.csproj
@@ -8,6 +8,6 @@
     <Compile Include="ArrayCopy.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/CompEx.csproj
+++ b/src/coreclr/tests/src/Regressions/common/CompEx.csproj
@@ -7,6 +7,6 @@
     <Compile Include="CompEx.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/DisableTransparencyEnforcement.csproj
+++ b/src/coreclr/tests/src/Regressions/common/DisableTransparencyEnforcement.csproj
@@ -8,6 +8,6 @@
     <Compile Include="DisableTransparencyEnforcement.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/Marshal.csproj
+++ b/src/coreclr/tests/src/Regressions/common/Marshal.csproj
@@ -8,6 +8,6 @@
     <Compile Include="Marshal.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/ThreadCulture.csproj
+++ b/src/coreclr/tests/src/Regressions/common/ThreadCulture.csproj
@@ -8,6 +8,6 @@
     <Compile Include="ThreadCulture.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/ToLower.csproj
+++ b/src/coreclr/tests/src/Regressions/common/ToLower.csproj
@@ -7,6 +7,6 @@
     <Compile Include="ToLower.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/Unsafe.csproj
+++ b/src/coreclr/tests/src/Regressions/common/Unsafe.csproj
@@ -8,6 +8,6 @@
     <Compile Include="unsafe.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/avtest.csproj
+++ b/src/coreclr/tests/src/Regressions/common/avtest.csproj
@@ -7,6 +7,6 @@
     <Compile Include="avtest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/interlock.csproj
+++ b/src/coreclr/tests/src/Regressions/common/interlock.csproj
@@ -8,6 +8,6 @@
     <Compile Include="interlock.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/pow3.csproj
+++ b/src/coreclr/tests/src/Regressions/common/pow3.csproj
@@ -7,6 +7,6 @@
     <Compile Include="pow3.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/test1307.csproj
+++ b/src/coreclr/tests/src/Regressions/common/test1307.csproj
@@ -8,6 +8,6 @@
     <Compile Include="test1307.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/testClass.csproj
+++ b/src/coreclr/tests/src/Regressions/common/testClass.csproj
@@ -8,6 +8,6 @@
     <Compile Include="testClass.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/common/testInterface.csproj
+++ b/src/coreclr/tests/src/Regressions/common/testInterface.csproj
@@ -8,6 +8,6 @@
     <Compile Include="testInterface.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0075/LargeArrayTest.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0075/LargeArrayTest.csproj
@@ -9,6 +9,6 @@
     <Compile Include="largearraytest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0099/AboveStackLimit.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0099/AboveStackLimit.csproj
@@ -9,6 +9,6 @@
     <Compile Include="abovestacklimit.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0138/pow3.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0138/pow3.csproj
@@ -9,6 +9,6 @@
     <Compile Include="pow3.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0198/CompEx.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0198/CompEx.csproj
@@ -9,6 +9,6 @@
     <Compile Include="compex.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0202/ThreadCulture.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0202/ThreadCulture.csproj
@@ -9,6 +9,6 @@
     <Compile Include="threadculture.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0275/Marshal.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0275/Marshal.csproj
@@ -9,6 +9,6 @@
     <Compile Include="marshal.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0308/ToLower.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0308/ToLower.csproj
@@ -9,6 +9,6 @@
     <Compile Include="tolower.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0341/PlatformCode.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0341/PlatformCode.csproj
@@ -9,6 +9,6 @@
     <Compile Include="platformcode.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0341/UserCode.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0341/UserCode.csproj
@@ -9,6 +9,6 @@
     <Compile Include="usercode.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0342/unsafe.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0342/unsafe.csproj
@@ -9,6 +9,6 @@
     <Compile Include="unsafe.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0570/Test570.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0570/Test570.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test570.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0584/Test584.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0584/Test584.csproj
@@ -12,6 +12,6 @@
     <Compile Include="test584.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0694/CriticalCode.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0694/CriticalCode.csproj
@@ -9,6 +9,6 @@
     <Compile Include="criticalcode.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/0939/test0939.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/0939/test0939.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test0939.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/1386/Co1727ctor_OO.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/1386/Co1727ctor_OO.csproj
@@ -9,6 +9,6 @@
     <Compile Include="co1727ctor_oo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/1514/InterlockExchange.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/1514/InterlockExchange.csproj
@@ -9,6 +9,6 @@
     <Compile Include="interlockexchange.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/72162/Test72162.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/72162/Test72162.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test72162.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_11611/Test11611.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_11611/Test11611.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test11611.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
@@ -10,6 +10,6 @@
     <Compile Include="test12224.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_16833/Test16833.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_16833/Test16833.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test16833.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_17398/test17398.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_17398/test17398.csproj
@@ -12,6 +12,6 @@
     <Compile Include="test17398.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_22348/Test22348.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_22348/Test22348.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test22348.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_22888/test22888.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_22888/test22888.csproj
@@ -9,7 +9,7 @@
     <Compile Include="test22888.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="test22888resources.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_22888/test22888resources.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_22888/test22888resources.csproj
@@ -14,6 +14,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_27937/Test27937.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test27937.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_7685/Test7685.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_7685/Test7685.csproj
@@ -9,6 +9,6 @@
     <Compile Include="test7685.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/exceptions/simple/ArrayInit.csproj
+++ b/src/coreclr/tests/src/baseservices/exceptions/simple/ArrayInit.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="VT.ilproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/exceptions/simple/HardwareEh.csproj
+++ b/src/coreclr/tests/src/baseservices/exceptions/simple/HardwareEh.csproj
@@ -9,7 +9,7 @@
     <Compile Include="HardwareEh.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="ILHelper.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/exceptions/simple/finally.csproj
+++ b/src/coreclr/tests/src/baseservices/exceptions/simple/finally.csproj
@@ -9,6 +9,6 @@
     <Compile Include="finally.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/multidimmarray/enum.csproj
+++ b/src/coreclr/tests/src/baseservices/multidimmarray/enum.csproj
@@ -9,6 +9,6 @@
     <Compile Include="enum.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange1_cti.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange1_cti.csproj
@@ -7,6 +7,6 @@
     <Compile Include="compareexchange1_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange2.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange2.csproj
@@ -7,6 +7,6 @@
     <Compile Include="compareexchange2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange3.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange3.csproj
@@ -7,6 +7,6 @@
     <Compile Include="compareexchange3.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange4.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange4.csproj
@@ -7,6 +7,6 @@
     <Compile Include="compareexchange4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange5_cti.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/compareexchange/compareexchange5_cti.csproj
@@ -7,6 +7,6 @@
     <Compile Include="compareexchange5_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange1_cti.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange1_cti.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange1_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange2.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange2.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange3.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange3.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange3.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange4.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange4.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange4_cti.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange4_cti.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange4_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange5_cti.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/interlocked/exchange/exchange5_cti.csproj
@@ -7,6 +7,6 @@
     <Compile Include="exchange5_cti.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/mutex/misc/mutexctor1.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/mutex/misc/mutexctor1.csproj
@@ -7,6 +7,6 @@
     <Compile Include="mutexctor1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/mutex/misc/mutexctor2.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/mutex/misc/mutexctor2.csproj
@@ -7,6 +7,6 @@
     <Compile Include="mutexctor2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/mutex/misc/waitone1.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/mutex/misc/waitone1.csproj
@@ -7,6 +7,6 @@
     <Compile Include="waitone1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/mutex/misc/waitone2.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/mutex/misc/waitone2.csproj
@@ -8,6 +8,6 @@
     <Compile Include="waitone2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/waithandle/misc/waithandledispose2.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/waithandle/misc/waithandledispose2.csproj
@@ -7,6 +7,6 @@
     <Compile Include="waithandledispose2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/threading/waithandle/misc/waithandlewaitone1.csproj
+++ b/src/coreclr/tests/src/baseservices/threading/waithandle/misc/waithandlewaitone1.csproj
@@ -8,6 +8,6 @@
     <Compile Include="waithandlewaitone1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/baseservices/typeequivalence/simple/Simple.csproj
+++ b/src/coreclr/tests/src/baseservices/typeequivalence/simple/Simple.csproj
@@ -12,7 +12,7 @@
       <EmbedTypes>true</EmbedTypes>
     </ProjectReference>
     <ProjectReference Include="../impl/TypeImpl.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('TypeEquivalence.targets', '$(MSBuildThisFileDirectory)../'))" />
 </Project>

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -93,7 +93,7 @@ $(_XunitEpilog)
         <![CDATA[
 <Project>
 
-  <Import Project="$(TestProjectDir)dir.sdkbuild.props" />
+  <Import Project="$(ProjectDir)dir.sdkbuild.props" />
 
   <PropertyGroup>
     <OutputPath>$(XUnitTestBinBase)\$(CategoryWithSlash)</OutputPath>
@@ -107,7 +107,7 @@ $(_XunitEpilog)
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common\Coreclr.TestWrapper\Coreclr.TestWrapper.csproj" />
+    <ProjectReference Include="$(SourceDir)Common\Coreclr.TestWrapper\Coreclr.TestWrapper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/coreclr/tests/src/sizeondisk/Directory.Build.props
+++ b/src/coreclr/tests/src/sizeondisk/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <ProjectAssetsFile>$(TestSourceDir)performance/obj/project.assets.json</ProjectAssetsFile>
+    <ProjectAssetsFile>$(SourceDir)performance/obj/project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This reverts commit bd27324b31954c66f7fd5f5e00d5b42307ea500f.
This is one of the four commits in the time range between the last
passing runtime-coreclr run and the first run after which all runs
have been failing on Windows ARM / ARM64.

Thanks

Tomas