### PR TITLE
more appropriate default rootfs-dir path

### DIFF
--- a/src/coreclr/build.sh
+++ b/src/coreclr/build.sh
@@ -658,7 +658,7 @@ __CrossGenCoreLibLog="$__LogsDir/CrossgenCoreLib_$__BuildOS.$__BuildArch.$__Buil
 if [ $__CrossBuild == 1 ]; then
     export CROSSCOMPILE=1
     if ! [[ -n "$ROOTFS_DIR" ]]; then
-        export ROOTFS_DIR="$__RepoRootDir/eng/common/cross/rootfs/$__BuildArch"
+        export ROOTFS_DIR="$__RepoRootDir/.tools/rootfs/$__BuildArch"
     fi
 fi
 


### PR DESCRIPTION
crossbuilding of at least armel:tizen and arm64:xenial works fine
without specifying the ROOTFS_DIR environment variable (with default
path) only if changes of this PR are applied. (building coreclr using
src/coreclr/build.sh script on linux)

If changes are not applied, build script fails.
If we pass the ROOTFS_DIR environment variable, everything works fine (but only with absolute path).

We think that defaults (without passing the ROOTFS_DIR env. variable) should also work.