### PR TITLE
Fix .cmd scripts help arguments

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,15 +1,8 @@
 @echo off
+setlocal
 
-if "%~1"=="-h" goto help
-if "%~1"=="-help" goto help
-if "%~1"=="-?" goto help
-if "%~1"=="/?" goto help
+set _args=%*
+if "%~1"=="-?" set _args=-help
 
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %*
-goto end
-
-:help
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0eng\build.ps1'; Get-Help }"
-
-:end
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %_args%
 exit /b %ERRORLEVEL%

--- a/coreclr.cmd
+++ b/coreclr.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory coreclr %*
+setlocal
+
+set _args=-subsetCategory coreclr %*
+if "%~1"=="-?" set _args=-help
+
+"%~dp0build.cmd" %_args%

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,5 +1,6 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
+  [switch][Alias('h')]$help,
   [switch][Alias('b')]$build,
   [switch][Alias('t')]$test,
   [switch]$buildtests,
@@ -54,6 +55,11 @@ function Get-Help() {
 
 # Exit if script has been dot-sourced
 if ($MyInvocation.InvocationName -eq ".") {
+  exit 0
+}
+
+if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $properties.Contains('/?')))) {
+  Get-Help
   exit 0
 }
 

--- a/installer.cmd
+++ b/installer.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory installer %*
+setlocal
+
+set _args=-subsetCategory installer %*
+if "%~1"=="-?" set _args=-help
+
+"%~dp0build.cmd" %_args%

--- a/libraries.cmd
+++ b/libraries.cmd
@@ -1,2 +1,7 @@
 @echo off
-"%~dp0build.cmd" -subsetCategory libraries %*
+setlocal
+
+set _args=-subsetCategory libraries %*
+if "%~1"=="-?" set _args=-help
+
+"%~dp0build.cmd" %_args%


### PR DESCRIPTION
New PR for: https://github.com/dotnet/runtime/pull/1043 which was reverted in: https://github.com/dotnet/runtime/pull/1110

The reason for the build break was because when setting `_args` env variable, I was escaping the args with `"` which was causing `PowerShell` to not bind the args as an array and therefore when parsing them and passing the right Global Properties to MSBuild, we were not passing them down.

I just debugged that locally and now the arguments are bound as expected, build is green and properties passed down correctly (validated via binlog).