### PR TITLE
Flow archType to build script in global live build

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ue
+
 source="${BASH_SOURCE[0]}"
 
 # resolve $source until the file is no longer a symlink

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -33,7 +33,5 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: |
-        $(setScriptToEchoAndFailOnNonZero)
-        $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -arch ${{ parameters.archType }}
       displayName: Build product


### PR DESCRIPTION
I noticed that we are not flowing archType in the global live build, so even though our intention was that the Windows leg is built for x86, it is building for x64. 

cc: @dotnet/runtime-infrastructure 