### PR TITLE
Clean workspace in global-build-job.yml

### DIFF
--- a/eng/pipelines/common/clone-checkout-bundle-step.yml
+++ b/eng/pipelines/common/clone-checkout-bundle-step.yml
@@ -1,6 +1,5 @@
 steps:
 - checkout: none
-  clean: true
 
 - download: current
   artifact: Checkout_bundle

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -18,6 +18,8 @@ jobs:
     container: ${{ parameters.container }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables: ${{ parameters.variables }}
+    workspace:
+      clean: all
 
     steps:
     - ${{ if eq(parameters.osGroup, 'OSX') }}:


### PR DESCRIPTION
I observed https://github.com/dotnet/runtime/issues/1114 failures only during *runtime-live-build* pipeline runs. 

I believe the reason why it affects only that pipeline is because `workspace` is not set to `clean: all` in global-build-job.yml leaving an agent machine in the state from previous run.

Fixes #1114