### PR TITLE
Escape vertical bar (`|`) in the echo message of `RunTests.cmd`

### DIFF
--- a/eng/testing/RunnerTemplate.Windows.txt
+++ b/eng/testing/RunnerTemplate.Windows.txt
@@ -42,7 +42,7 @@ set EXECUTION_DIR=%~dp0
 :argparser_end
 
 if not defined RUNTIME_PATH (
-  echo error: -r|--runtime-path argument is required.
+  echo error: -r^|--runtime-path argument is required.
   call :usage
   exit /b -1
 )


### PR DESCRIPTION
* When `--runtime-path` is not specified, this unescaped character causes the batch file to attempt executing `--runtime-path` (which obviously is not possible) giving out very confusing failures.

cc @ViktorHofer 