### PR TITLE
[doc] Add requirements for cross building

### DIFF
--- a/docs/workflow/building/coreclr/cross-building.md
+++ b/docs/workflow/building/coreclr/cross-building.md
@@ -36,6 +36,10 @@ and conversely for arm64:
 
     ~/runtime/ $ sudo apt-get install binutils-aarch64-linux-gnu
 
+and for armel (ARM softfp):
+
+    ~/runtime/ $ sudo apt-get install binutils-arm-linux-gnueabi
+
 
 Requirements for targetting ARM or ARM64 Alpine Linux
 -----------------------------------------------------


### PR DESCRIPTION
Checked for clang building under Ubuntu 18.04 x64.





@alpencolt 