### PR TITLE
Improve performance of iterating with ForEach over ImmutableArray

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
@@ -283,6 +284,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <returns>An enumerator.</returns>
         [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator()
         {
             var self = this;
@@ -407,6 +409,7 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Throws a null reference exception if the array field is null.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ThrowNullRefIfNotInitialized()
         {
             // Force NullReferenceException if array is null by touching its Length.

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -409,7 +409,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Throws a null reference exception if the array field is null.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void ThrowNullRefIfNotInitialized()
         {
             // Force NullReferenceException if array is null by touching its Length.


### PR DESCRIPTION
Fixes: #780. 

Use `AggressiveInline` on `ImmutableArray<T>.GetEnumerator` so the JIT can optimize the `foreach` loops to be closer to the code when using an simple `T[]`.

The benchmark for `String` doesn't show the same improvement because it is coded as a generic class, and the JIT can't apply the same optimization on a shared generic method called inside another shared generic class. But it's possible to see the same performance gain than the `Int32` case in a non-generic benchmark.

Based on the reported assembly from the benchmark, the code size doesn't increase even when inlining the method call, because the JIT is able to optimize the loop further and make it smaller (see the discussion on the issue for more details).

Benchmark results, including a non-generic version for comparison.

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4075.0), X64 RyuJIT
  Job-RUPWLA : .NET Core 5.0.0 (CoreCLR 5.0.19.61901, CoreFX 5.0.19.61901), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                   Type |         Method | Size |       Mean |    Error |   StdDev |     Median |        Min |        Max | Gen 0 | Gen 1 | Gen 2 | Allocated | BranchInstructions/Op | BranchMispredictions/Op | CacheMisses/Op |
|----------------------- |--------------- |----- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|------:|------:|------:|----------:|----------------------:|------------------------:|---------------:|
|  IterateForEach&lt;Int32&gt; |          Array |  512 |   369.9 ns | 15.74 ns | 16.84 ns |   364.3 ns |   351.5 ns |   404.8 ns |     - |     - |     - |         - |                   519 |                       1 |              0 |
| IterateForEach&lt;String&gt; |          Array |  512 |   305.1 ns | 10.97 ns | 12.63 ns |   304.9 ns |   288.7 ns |   334.0 ns |     - |     - |     - |         - |                   518 |                       1 |              0 |
|   IterateForEach_Int32 |          Array |  512 |   288.5 ns | 25.03 ns | 28.83 ns |   272.9 ns |   254.4 ns |   331.7 ns |     - |     - |     - |         - |                   517 |                       1 |              0 |
|  IterateForEach_String |          Array |  512 |   317.7 ns | 25.76 ns | 29.67 ns |   321.8 ns |   251.4 ns |   371.4 ns |     - |     - |     - |         - |                   517 |                       1 |              0 |
|  IterateForEach&lt;Int32&gt; | ImmutableArray |  512 |   396.7 ns |  9.58 ns | 10.25 ns |   395.1 ns |   378.2 ns |   419.2 ns |     - |     - |     - |         - |                 1,031 |                       1 |              0 |
| IterateForEach&lt;String&gt; | ImmutableArray |  512 | 1,531.5 ns | 91.32 ns | 93.78 ns | 1,514.5 ns | 1,439.6 ns | 1,823.3 ns |     - |     - |     - |         - |                 1,059 |                       2 |              1 |
|   IterateForEach_Int32 | ImmutableArray |  512 |   314.8 ns | 28.15 ns | 32.42 ns |   303.5 ns |   270.7 ns |   359.0 ns |     - |     - |     - |         - |                 1,030 |                       1 |              0 |
|  IterateForEach_String | ImmutableArray |  512 |   421.9 ns |  8.41 ns |  9.35 ns |   423.7 ns |   408.8 ns |   437.3 ns |     - |     - |     - |         - |                 1,031 |                       1 |              0 |

cc @adamsitnik, @danmosemsft, @AndyAyersMS