### PR TITLE
Honor propery naming policy when (de)serializing KeyValuePair instances

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -345,6 +345,9 @@
   <data name="SerializerPropertyNameNull" xml:space="preserve">
     <value>The JSON property name for '{0}.{1}' cannot be null.</value>
   </data>
+  <data name="SerializerPropertyNamingPolicyReturnNull" xml:space="preserve">
+    <value>The property naming policy '{0}' cannot return a null property name.</value>
+  </data>
   <data name="DeserializeDuplicateKey" xml:space="preserve">
     <value>An item with the same property name '{0}' has already been added.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
@@ -10,6 +10,43 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class JsonKeyValuePairConverter : JsonConverterFactory
     {
+        private readonly byte[] _keyName;
+        private readonly byte[] _valueName;
+
+        private readonly JsonEncodedText _encodedKeyName;
+        private readonly JsonEncodedText _encodedValueName;
+
+        public JsonKeyValuePairConverter(JsonSerializerOptions options)
+        {
+            JsonNamingPolicy namingPolicy = options.PropertyNamingPolicy;
+            if (namingPolicy == null)
+            {
+                _keyName = new byte[] { (byte)'K', (byte)'e', (byte)'y' };
+                _valueName = new byte[] { (byte)'V', (byte)'a', (byte)'l', (byte)'u', (byte)'e' };
+            }
+            else
+            {
+                string propertyName = namingPolicy.ConvertName("Key");
+                if (propertyName == null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy.GetType());
+                }
+                _keyName = JsonReaderHelper.s_utf8Encoding.GetBytes(propertyName);
+
+                propertyName = options.PropertyNamingPolicy.ConvertName("Value");
+                if (propertyName == null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy.GetType());
+                }
+                _valueName = JsonReaderHelper.s_utf8Encoding.GetBytes(propertyName);
+            }
+
+            // "encoder: null" is used since the literal values of "Key" and "Value" should not normally be escaped
+            // unless a custom encoder is used that escapes these ASCII characters (rare).
+            _encodedKeyName = JsonEncodedText.Encode(_keyName, encoder: null);
+            _encodedValueName = JsonEncodedText.Encode(_valueName, encoder: null);
+        }
+
         public override bool CanConvert(Type typeToConvert)
         {
             if (!typeToConvert.IsGenericType)
@@ -19,7 +56,9 @@ namespace System.Text.Json.Serialization.Converters
             return (generic == typeof(KeyValuePair<,>));
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.Converters.JsonKeyValuePairConverter`2")]
+        [PreserveDependency(
+            ".ctor(Byte[], Byte[], System.Text.Json.JsonEncodedText, System.Text.Json.JsonEncodedText)",
+            "System.Text.Json.Serialization.Converters.JsonKeyValuePairConverter`2")]
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             Type keyType = type.GetGenericArguments()[0];
@@ -29,7 +68,7 @@ namespace System.Text.Json.Serialization.Converters
                 typeof(JsonKeyValuePairConverter<,>).MakeGenericType(new Type[] { keyType, valueType }),
                 BindingFlags.Instance | BindingFlags.Public,
                 binder: null,
-                args: null,
+                args: new object[] { _keyName, _valueName, _encodedKeyName, _encodedValueName },
                 culture: null);
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
@@ -29,14 +29,14 @@ namespace System.Text.Json.Serialization.Converters
                 string propertyName = namingPolicy.ConvertName("Key");
                 if (propertyName == null)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy.GetType());
+                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy);
                 }
                 _keyName = JsonReaderHelper.s_utf8Encoding.GetBytes(propertyName);
 
-                propertyName = options.PropertyNamingPolicy.ConvertName("Value");
+                propertyName = namingPolicy.ConvertName("Value");
                 if (propertyName == null)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy.GetType());
+                    ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(namingPolicy);
                 }
                 _valueName = JsonReaderHelper.s_utf8Encoding.GetBytes(propertyName);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
@@ -42,12 +42,12 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowJsonException();
             }
 
-            if (reader.ValueTextEquals(_valueName))
+            if (reader.ValueTextEquals(_keyName))
             {
                 k = ReadProperty<TKey>(ref reader, typeToConvert, options);
                 keySet = true;
             }
-            else if (reader.ValueTextEquals(_keyName))
+            else if (reader.ValueTextEquals(_valueName))
             {
                 v = ReadProperty<TValue>(ref reader, typeToConvert, options);
                 valueSet = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -120,7 +120,7 @@ namespace System.Text.Json
 
                 if (key == null)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializerDictionaryKeyNull(Options.DictionaryKeyPolicy.GetType());
+                    ThrowHelper.ThrowInvalidOperationException_SerializerDictionaryKeyNull(Options.DictionaryKeyPolicy);
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -161,7 +161,7 @@ namespace System.Text.Json
 
                 if (key == null)
                 {
-                    ThrowHelper.ThrowInvalidOperationException_SerializerDictionaryKeyNull(options.DictionaryKeyPolicy.GetType());
+                    ThrowHelper.ThrowInvalidOperationException_SerializerDictionaryKeyNull(options.DictionaryKeyPolicy);
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -16,14 +16,27 @@ namespace System.Text.Json
     /// </summary>
     public sealed partial class JsonSerializerOptions
     {
-        // The global list of built-in converters that override CanConvert().
-        private readonly List<JsonConverter> _defaultFactoryConverters = GetDefaultConverters();
+        private List<JsonConverter> _defaultFactoryConverters;
 
         // The global list of built-in simple converters.
         private static readonly Dictionary<Type, JsonConverter> s_defaultSimpleConverters = GetDefaultSimpleConverters();
 
         // The cached converters (custom or built-in).
         private readonly ConcurrentDictionary<Type, JsonConverter> _converters = new ConcurrentDictionary<Type, JsonConverter>();
+
+        // The global list of built-in converters that override CanConvert().
+        private List<JsonConverter> DefaultFactoryConverters
+        {
+            get
+            {
+                if (_defaultFactoryConverters == null)
+                {
+                    _defaultFactoryConverters = GetDefaultConverters();
+                }
+
+                return _defaultFactoryConverters;
+            }
+        }
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
         {
@@ -140,7 +153,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    foreach (JsonConverter item in _defaultFactoryConverters)
+                    foreach (JsonConverter item in DefaultFactoryConverters)
                     {
                         if (item.CanConvert(typeToConvert))
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -16,11 +16,11 @@ namespace System.Text.Json
     /// </summary>
     public sealed partial class JsonSerializerOptions
     {
+        // The global list of built-in converters that override CanConvert().
+        private readonly List<JsonConverter> _defaultFactoryConverters = GetDefaultConverters();
+
         // The global list of built-in simple converters.
         private static readonly Dictionary<Type, JsonConverter> s_defaultSimpleConverters = GetDefaultSimpleConverters();
-
-        // The global list of built-in converters that override CanConvert().
-        private static readonly List<JsonConverter> s_defaultFactoryConverters = GetDefaultConverters();
 
         // The cached converters (custom or built-in).
         private readonly ConcurrentDictionary<Type, JsonConverter> _converters = new ConcurrentDictionary<Type, JsonConverter>();
@@ -40,7 +40,7 @@ namespace System.Text.Json
             return converters;
         }
 
-        private static List<JsonConverter> GetDefaultConverters()
+        private List<JsonConverter> GetDefaultConverters()
         {
             const int NumberOfConverters = 2;
 
@@ -48,7 +48,7 @@ namespace System.Text.Json
 
             // Use a list for converters that implement CanConvert().
             converters.Add(new JsonConverterEnum());
-            converters.Add(new JsonKeyValuePairConverter());
+            converters.Add(new JsonKeyValuePairConverter(this));
 
             // We will likely add collection converters here in the future.
 
@@ -140,7 +140,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    foreach (JsonConverter item in s_defaultFactoryConverters)
+                    foreach (JsonConverter item in _defaultFactoryConverters)
                     {
                         if (item.CanConvert(typeToConvert))
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -125,16 +125,15 @@ namespace System.Text.Json
             throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameNull, parentType, jsonPropertyInfo.PropertyInfo.Name));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(Type policyType)
+        public static void ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(JsonNamingPolicy namingPolicy)
         {
-            throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNamingPolicyReturnNull, policyType));
+            throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNamingPolicyReturnNull, namingPolicy.GetType()));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowInvalidOperationException_SerializerDictionaryKeyNull(Type policyType)
+        public static void ThrowInvalidOperationException_SerializerDictionaryKeyNull(JsonNamingPolicy namingPolicy)
         {
-            throw new InvalidOperationException(SR.Format(SR.SerializerDictionaryKeyNull, policyType));
+            throw new InvalidOperationException(SR.Format(SR.SerializerDictionaryKeyNull, namingPolicy.GetType()));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -126,6 +126,12 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_SerializerPropertyNamingPolicyReturnNull(Type policyType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNamingPolicyReturnNull, policyType));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializerDictionaryKeyNull(Type policyType)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializerDictionaryKeyNull, policyType));

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
@@ -439,8 +439,8 @@ namespace System.Text.Json.Serialization.Tests
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 
-            const string jsonWithoutPolicy = @"{""Key"":,""Value"":""MyValue""}";
-            const string jsonWithPolicy = @"{""key"":,""value"":""MyValue""}";
+            const string jsonWithoutPolicy = @"{""Key"":""MyKey"",""Value"":""MyValue""}";
+            const string jsonWithPolicy = @"{""key"":""MyKey"",""value"":""MyValue""}";
 
             // Baseline: Without policy.
             string serialized = JsonSerializer.Serialize(new KeyValuePair<string, string>("MyKey", "MyValue"));
@@ -473,11 +473,11 @@ namespace System.Text.Json.Serialization.Tests
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 
-            const string jsonWithoutPolicy = @"[{""Key"":,""Value"":""MyValue""}]";
-            const string jsonWithPolicy = @"[{""key"":,""value"":""MyValue""}]";
+            const string jsonWithoutPolicy = @"[{""Key"":""MyKey"",""Value"":""MyValue""}]";
+            const string jsonWithPolicy = @"[{""key"":""MyKey"",""value"":""MyValue""}]";
 
             // Baseline: Without policy.
-            string serialized = JsonSerializer.Serialize(new KeyValuePair[] { new KeyValuePair<string, string>("MyKey", "MyValue") });
+            string serialized = JsonSerializer.Serialize(new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("MyKey", "MyValue") });
             Assert.Equal(jsonWithoutPolicy, serialized);
 
             KeyValuePair<string, string>[] arr = JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(serialized);
@@ -488,10 +488,10 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(jsonWithPolicy));
 
             // With policy.
-            serialized = JsonSerializer.Serialize(new KeyValuePair[] { new KeyValuePair<string, string>("MyKey", "MyValue") }, options);
+            serialized = JsonSerializer.Serialize(new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("MyKey", "MyValue") }, options);
             Assert.Equal(jsonWithPolicy, serialized);
 
-            arr = JsonSerializer.Deserialize<KeyValuePair<string, string>>(serialized, options);
+            arr = JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(serialized, options);
             Assert.Equal("MyKey", arr[0].Key);
             Assert.Equal("MyValue", arr[0].Value);
 
@@ -507,19 +507,21 @@ namespace System.Text.Json.Serialization.Tests
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 
-            const string jsonWithoutPolicy = @"{""Kvp"":{""Key"":,""Value"":""MyValue""}}";
-            const string jsonWithPolicy = @"{""kvp"":{""key"":,""value"":""MyValue""}}";
+            const string jsonWithoutPolicy = @"{""Kvp"":{""Key"":""MyKey"",""Value"":""MyValue""}}";
+            const string jsonWithPolicy = @"{""kvp"":{""key"":""MyKey"",""value"":""MyValue""}}";
 
             // Baseline: Without policy.
             string serialized = JsonSerializer.Serialize(new ClassWithKVP { Kvp = new KeyValuePair<string, string>("MyKey", "MyValue") });
             Assert.Equal(jsonWithoutPolicy, serialized);
 
-            ClassWithKVP obj = JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(serialized);
+            ClassWithKVP obj = JsonSerializer.Deserialize<ClassWithKVP>(serialized);
             Assert.Equal("MyKey", obj.Kvp.Key);
             Assert.Equal("MyValue", obj.Kvp.Value);
 
             // No property name match.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithKVP>(jsonWithPolicy));
+            obj = JsonSerializer.Deserialize<ClassWithKVP>(jsonWithPolicy);
+            Assert.Null(obj.Kvp.Key);
+            Assert.Null(obj.Kvp.Value);
 
             // With policy.
             serialized = JsonSerializer.Serialize(new ClassWithKVP { Kvp = new KeyValuePair<string, string>("MyKey", "MyValue") }, options);
@@ -531,7 +533,8 @@ namespace System.Text.Json.Serialization.Tests
 
             // No property name match.
             obj = JsonSerializer.Deserialize<ClassWithKVP>(jsonWithoutPolicy, options);
-            Assert.Null(obj.Kvp);
+            Assert.Null(obj.Kvp.Key);
+            Assert.Null(obj.Kvp.Value);
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
@@ -430,6 +430,109 @@ namespace System.Text.Json.Serialization.Tests
             string jsonRoundTripped = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonRoundTripped);
         }
+
+        [Fact]
+        public static void RootKeyValuePairSerialize()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            const string jsonWithoutPolicy = @"{""Key"":,""Value"":""MyValue""}";
+            const string jsonWithPolicy = @"{""key"":,""value"":""MyValue""}";
+
+            // Baseline: Without policy.
+            string serialized = JsonSerializer.Serialize(new KeyValuePair<string, string>("MyKey", "MyValue"));
+            Assert.Equal(jsonWithoutPolicy, serialized);
+
+            KeyValuePair<string, string> kvp = JsonSerializer.Deserialize<KeyValuePair<string, string>>(serialized);
+            Assert.Equal("MyKey", kvp.Key);
+            Assert.Equal("MyValue", kvp.Value);
+
+            // No property name match.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, string>>(jsonWithPolicy));
+
+            // With policy.
+            serialized = JsonSerializer.Serialize(new KeyValuePair<string, string>("MyKey", "MyValue"), options);
+            Assert.Equal(jsonWithPolicy, serialized);
+
+            kvp = JsonSerializer.Deserialize<KeyValuePair<string, string>>(serialized, options);
+            Assert.Equal("MyKey", kvp.Key);
+            Assert.Equal("MyValue", kvp.Value);
+
+            // No property name match.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, string>>(jsonWithoutPolicy, options));
+        }
+
+        [Fact]
+        public static void KeyValuePairAsCollectionElementSerialize()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            const string jsonWithoutPolicy = @"[{""Key"":,""Value"":""MyValue""}]";
+            const string jsonWithPolicy = @"[{""key"":,""value"":""MyValue""}]";
+
+            // Baseline: Without policy.
+            string serialized = JsonSerializer.Serialize(new KeyValuePair[] { new KeyValuePair<string, string>("MyKey", "MyValue") });
+            Assert.Equal(jsonWithoutPolicy, serialized);
+
+            KeyValuePair<string, string>[] arr = JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(serialized);
+            Assert.Equal("MyKey", arr[0].Key);
+            Assert.Equal("MyValue", arr[0].Value);
+
+            // No property name match.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(jsonWithPolicy));
+
+            // With policy.
+            serialized = JsonSerializer.Serialize(new KeyValuePair[] { new KeyValuePair<string, string>("MyKey", "MyValue") }, options);
+            Assert.Equal(jsonWithPolicy, serialized);
+
+            arr = JsonSerializer.Deserialize<KeyValuePair<string, string>>(serialized, options);
+            Assert.Equal("MyKey", arr[0].Key);
+            Assert.Equal("MyValue", arr[0].Value);
+
+            // No property name match.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(jsonWithoutPolicy, options));
+        }
+
+        [Fact]
+        public static void KeyValuePairAsClassPropertyElementSerialize()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            const string jsonWithoutPolicy = @"{""Kvp"":{""Key"":,""Value"":""MyValue""}}";
+            const string jsonWithPolicy = @"{""kvp"":{""key"":,""value"":""MyValue""}}";
+
+            // Baseline: Without policy.
+            string serialized = JsonSerializer.Serialize(new ClassWithKVP { Kvp = new KeyValuePair<string, string>("MyKey", "MyValue") });
+            Assert.Equal(jsonWithoutPolicy, serialized);
+
+            ClassWithKVP obj = JsonSerializer.Deserialize<KeyValuePair<string, string>[]>(serialized);
+            Assert.Equal("MyKey", obj.Kvp.Key);
+            Assert.Equal("MyValue", obj.Kvp.Value);
+
+            // No property name match.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithKVP>(jsonWithPolicy));
+
+            // With policy.
+            serialized = JsonSerializer.Serialize(new ClassWithKVP { Kvp = new KeyValuePair<string, string>("MyKey", "MyValue") }, options);
+            Assert.Equal(jsonWithPolicy, serialized);
+
+            obj = JsonSerializer.Deserialize<ClassWithKVP>(serialized, options);
+            Assert.Equal("MyKey", obj.Kvp.Key);
+            Assert.Equal("MyValue", obj.Kvp.Value);
+
+            // No property name match.
+            obj = JsonSerializer.Deserialize<ClassWithKVP>(jsonWithoutPolicy, options);
+            Assert.Null(obj.Kvp);
+        }
     }
 
     public class OverridePropertyNameDesignTime_TestClass
@@ -494,5 +597,10 @@ namespace System.Text.Json.Serialization.Tests
     {
         [JsonExtensionData]
         public IDictionary<string, JsonElement> MyOverflow { get; set; }
+    }
+
+    public class ClassWithKVP
+    {
+        public KeyValuePair<string, string> Kvp { get; set; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1197.