### PR TITLE
W3C Trace-Context: Allow hex chars in version and don't crash on non-hex chars in traceFlags

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -714,8 +714,8 @@ namespace System.Diagnostics
             //  = 55 chars (see https://w3c.github.io/trace-context)
             // The version (00-fe) is used to indicate that this is a WC3 ID.
             return id.Length == 55 &&
-                   (('0' <= id[0] && id[0] <= '9') || ('a' <= id[0] && id[0] <= 'f') &&
-                    ('0' <= id[1] && id[1] <= '9') || ('a' <= id[1] && id[1] <= 'e'));
+                   ('0' <= id[0] && id[0] <= '9' || 'a' <= id[0] && id[0] <= 'f') &&
+                   ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'e');
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -730,11 +730,7 @@ namespace System.Diagnostics.Tests
             activity.SetParentId("0.-0123456789abcdef0123456789abcdef-0123456789abcdef-00");
             activity.Start();
 
-            Assert.Equal(ActivityIdFormat.W3C, activity.IdFormat);
-            Assert.True(IdIsW3CFormat(activity.Id));
-
-            Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
-            Assert.Equal("0123456789abcdef", activity.ParentSpanId.ToHexString());
+            Assert.Equal(ActivityIdFormat.Hierarchical, activity.IdFormat);
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -734,6 +734,20 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void Version_W3CNonHexCharsNotSupportedAndDoesNotThrow_ForceW3C()
+        {
+            Activity activity = new Activity("activity");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.SetParentId("0.-0123456789abcdef0123456789abcdef-0123456789abcdef-00");
+            activity.Start();
+
+            Assert.Equal(ActivityIdFormat.W3C, activity.IdFormat);
+            Assert.NotEqual("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
+            Assert.Equal(default, activity.ParentSpanId);
+            Assert.True(IdIsW3CFormat(activity.Id));
+        }
+
+        [Fact]
         public void Options_W3CNonHexCharsNotSupportedAndDoesNotThrow()
         {
             Activity activity = new Activity("activity");


### PR DESCRIPTION
[W3C Trace-Context](https://www.w3.org/TR/trace-context-1/) allows version [00, fe]. `Activity` only allowed two digits.

Also, `Start()` threw on invalid (non-hex) chars in traceFlags:

```
        System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values. (Parameter 'idData')
        Stack Trace:
          C:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs(1157,0): at System.Diagnostics.ActivityTraceId.HexDigitToBinary(Char c)
          C:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs(1148,0): at System.Diagnostics.ActivityTraceId.HexByteFromChars(Char char1, Char char2)
          C:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs(904,0): at System.Diagnostics.Activity.TrySetTraceFlagsFromParent()
          C:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs(740,0): at System.Diagnostics.Activity.GenerateW3CId()
          C:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\src\System\Diagnostics\Activity.cs(490,0): at System.Diagnostics.Activity.Start()
          c:\repo\runtime\src\libraries\System.Diagnostics.DiagnosticSource\tests\ActivityTests.cs(745,0): at System.Diagnostics.Tests.ActivityTests.Options_W3CNonHexCharsNotSupportedAndDoesNotThrow()
```