### PR TITLE
More R2RDump refactoring to make it easier for ILSpy to consume the APIs

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection.Metadata;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
     public interface IAssemblyResolver
     {
-        string FindAssembly(string name, string filename);
+        MetadataReader FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile);
         // TODO (refactoring) - signature formatting options should be independent of assembly resolver
         bool Naked { get; }
         bool SignatureBinary { get; }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/R2RReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/R2RReader.cs
@@ -77,22 +77,34 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
     }
 
-    public class EcmaMetadataReader
+    public sealed class R2RReader
     {
-        protected IAssemblyResolver _assemblyResolver;
-        protected Dictionary<string, EcmaMetadataReader> _assemblyCache;
-
+        private IAssemblyResolver _assemblyResolver;
+        private Dictionary<int, MetadataReader> _assemblyCache;
+        private Dictionary<int, DebugInfo> _runtimeFunctionToDebugInfo;
+        private MetadataReader _manifestReader;
+        private List<AssemblyReferenceHandle> _manifestReferences;
 
         /// <summary>
         /// Underlying PE image reader is used to access raw PE structures like header
         /// or section list.
         /// </summary>
-        public readonly PEReader PEReader;
+        public PEReader PEReader { get; private set; }
 
         /// <summary>
         /// MetadataReader is used to access the MSIL metadata in the R2R file.
         /// </summary>
-        public readonly MetadataReader MetadataReader;
+        public MetadataReader MetadataReader { get; private set; }
+
+        /// <summary>
+        /// Byte array containing the ReadyToRun image
+        /// </summary>
+        public byte[] Image { get; private set; }
+
+        /// <summary>
+        /// Name of the image file
+        /// </summary>
+        public string Filename { get; private set; }
 
         /// <summary>
         /// Extra reference assemblies parsed from the manifest metadata.
@@ -104,113 +116,16 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// The list originates in the top-level R2R image and is copied
         /// to all reference assemblies for the sake of simplicity.
         /// </summary>
-        public readonly List<string> ManifestReferenceAssemblies;
-
-        /// <summary>
-        /// Byte array containing the ReadyToRun image
-        /// </summary>
-        public byte[] Image { get; }
-
-        /// <summary>
-        /// Name of the image file
-        /// </summary>
-        public string Filename { get; set; }
-
-        /// <summary>
-        /// The default constructor initializes an empty metadata reader.
-        /// </summary>
-        public EcmaMetadataReader()
+        public IEnumerable<string> ManifestReferenceAssemblies
         {
-        }
-
-        public EcmaMetadataReader(IAssemblyResolver assemblyResolver, MetadataReader metadata, PEReader peReader, string filename, List<string> manifestReferenceAssemblies)
-        {
-            _assemblyResolver = assemblyResolver;
-            _assemblyCache = new Dictionary<string, EcmaMetadataReader>();
-            MetadataReader = metadata;
-            PEReader = peReader;
-            ImmutableArray<byte> content = peReader.GetEntireImage().GetContent();
-            // TODO: Avoid copying
-            Image = new byte[content.Length];
-            content.CopyTo(Image);
-            Filename = filename;
-            ManifestReferenceAssemblies = manifestReferenceAssemblies;
-        }
-
-        /// <summary>
-        /// Open an MSIL binary and locate the metadata blob.
-        /// </summary>
-        /// <param name="options">Ambient options to use</param>
-        /// <param name="filename">PE image</param>
-        /// <param name="manifestReferenceAssemblies">List of reference assemblies from the R2R metadata manifest</param>
-        /// <exception cref="BadImageFormatException">The Cor header flag must be ILLibrary</exception>
-        public unsafe EcmaMetadataReader(IAssemblyResolver assemblyResolver, string filename, List<string> manifestReferenceAssemblies)
-        {
-            _assemblyResolver = assemblyResolver;
-            _assemblyCache = new Dictionary<string, EcmaMetadataReader>();
-            Filename = filename;
-            ManifestReferenceAssemblies = manifestReferenceAssemblies;
-            Image = File.ReadAllBytes(filename);
-
-            fixed (byte* p = Image)
+            get
             {
-                IntPtr ptr = (IntPtr)p;
-                PEReader = new PEReader(p, Image.Length);
-
-                if (!PEReader.HasMetadata)
+                foreach (AssemblyReferenceHandle _manifestReference in _manifestReferences)
                 {
-                    throw new Exception($"ECMA metadata not found in file '{filename}'");
+                    yield return _manifestReader.GetString(_manifestReader.GetAssemblyReference(_manifestReference).Name);
                 }
-
-                MetadataReader = PEReader.GetMetadataReader();
             }
         }
-
-        /// <summary>
-        /// Open a given reference assembly (relative to this ECMA metadata file).
-        /// </summary>
-        /// <param name="refAsmIndex">Reference assembly index</param>
-        /// <returns>EcmaMetadataReader instance representing the reference assembly</returns>
-        public EcmaMetadataReader OpenReferenceAssembly(int refAsmIndex)
-        {
-            if (refAsmIndex == 0)
-            {
-                return this;
-            }
-
-            int assemblyRefCount = MetadataReader.GetTableRowCount(TableIndex.AssemblyRef);
-            string name;
-            if (refAsmIndex <= assemblyRefCount)
-            {
-                AssemblyReference asmRef = MetadataReader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(refAsmIndex));
-                name = MetadataReader.GetString(asmRef.Name);
-            }
-            else
-            {
-                name = ManifestReferenceAssemblies[refAsmIndex - assemblyRefCount - 2];
-            }
-
-            EcmaMetadataReader ecmaReader;
-            if (!_assemblyCache.TryGetValue(name, out ecmaReader))
-            {
-                string assemblyPath = _assemblyResolver.FindAssembly(name, Filename);
-                if (assemblyPath == null)
-                {
-                    throw new Exception($"Missing reference assembly: {name}");
-                }
-                ecmaReader = new EcmaMetadataReader(_assemblyResolver, assemblyPath, ManifestReferenceAssemblies);
-                _assemblyCache.Add(name, ecmaReader);
-            }
-            return ecmaReader;
-        }
-    }
-
-    public class R2RReader : EcmaMetadataReader
-    {
-        /// <summary>
-        /// True if the image is ReadyToRun
-        /// </summary>
-        public bool IsR2R { get; set; }
 
         /// <summary>
         /// The type of target machine
@@ -278,18 +193,17 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public Dictionary<int, string> ImportCellNames { get; private set; }
 
-        private Dictionary<int, DebugInfo> _runtimeFunctionToDebugInfo = new Dictionary<int, DebugInfo>();
-
-        public R2RReader() { }
-
         /// <summary>
         /// Initializes the fields of the R2RHeader and R2RMethods
         /// </summary>
         /// <param name="filename">PE image</param>
         /// <exception cref="BadImageFormatException">The Cor header flag must be ILLibrary</exception>
         public R2RReader(IAssemblyResolver assemblyResolver, MetadataReader metadata, PEReader peReader, string filename)
-            : base(assemblyResolver, metadata, peReader, filename, new List<string>())
         {
+            _assemblyResolver = assemblyResolver;
+            MetadataReader = metadata;
+            PEReader = peReader;            
+            Filename = filename;
             Initialize();
         }
 
@@ -298,16 +212,99 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         /// <param name="filename">PE image</param>
         /// <exception cref="BadImageFormatException">The Cor header flag must be ILLibrary</exception>
-        public R2RReader(IAssemblyResolver assemblyResolver, string filename)
-            : base(assemblyResolver, filename, new List<string>())
+        public unsafe R2RReader(IAssemblyResolver assemblyResolver, string filename)
         {
+            _assemblyResolver = assemblyResolver;
+            Filename = filename;
             Initialize();
         }
 
         private unsafe void Initialize()
         {
-            IsR2R = ((PEReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) != 0);
-            if (!IsR2R)
+            _assemblyCache = new Dictionary<int, MetadataReader>();
+            this._manifestReferences = new List<AssemblyReferenceHandle>();
+
+            if (MetadataReader == null)
+            {
+                Image = File.ReadAllBytes(Filename);
+
+                fixed (byte* p = Image)
+                {
+                    IntPtr ptr = (IntPtr)p;
+                    PEReader = new PEReader(p, Image.Length);
+
+                    if (!PEReader.HasMetadata)
+                    {
+                        throw new Exception($"ECMA metadata not found in file '{Filename}'");
+                    }
+
+                    MetadataReader = PEReader.GetMetadataReader();
+                }
+            }
+            else
+            {
+                ImmutableArray<byte> content = PEReader.GetEntireImage().GetContent();
+                // TODO: Avoid copying
+                Image = new byte[content.Length];
+                content.CopyTo(Image);
+            }
+
+            ParseHeader();
+
+            ParseDebugInfo();
+
+            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA))
+            {
+                R2RSection manifestMetadata = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA];
+                fixed (byte* image = Image)
+                {
+                    _manifestReader = new MetadataReader(image + GetOffset(manifestMetadata.RelativeVirtualAddress), manifestMetadata.Size);
+                    int assemblyRefCount = _manifestReader.GetTableRowCount(TableIndex.AssemblyRef);
+                    for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
+                    {
+                        AssemblyReferenceHandle asmRefHandle = MetadataTokens.AssemblyReferenceHandle(assemblyRefIndex);
+                        _manifestReferences.Add(asmRefHandle);
+                    }
+                }
+            }
+
+            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO))
+            {
+                R2RSection exceptionInfoSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO];
+                EHLookupTable = new EHLookupTable(Image, GetOffset(exceptionInfoSection.RelativeVirtualAddress), exceptionInfoSection.Size);
+            }
+
+            ImportSections = new List<R2RImportSection>();
+            ImportCellNames = new Dictionary<int, string>();
+            ParseImportSections();
+
+            R2RMethods = new List<R2RMethod>();
+            InstanceMethods = new List<InstanceMethod>();
+
+            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS))
+            {
+                int runtimeFunctionSize = CalculateRuntimeFunctionSize();
+                R2RSection runtimeFunctionSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS];
+
+                uint nRuntimeFunctions = (uint)(runtimeFunctionSection.Size / runtimeFunctionSize);
+                int runtimeFunctionOffset = GetOffset(runtimeFunctionSection.RelativeVirtualAddress);
+                bool[] isEntryPoint = new bool[nRuntimeFunctions];
+
+                // initialize R2RMethods
+                ParseMethodDefEntrypoints(isEntryPoint);
+                ParseInstanceMethodEntrypoints(isEntryPoint);
+                ParseRuntimeFunctions(isEntryPoint, runtimeFunctionOffset, runtimeFunctionSize);
+            }
+
+            AvailableTypes = new List<string>();
+            ParseAvailableTypes();
+
+            CompilerIdentifier = ParseCompilerIdentifier();
+        }
+
+        private unsafe void ParseHeader()
+        {
+            if ((PEReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) == 0)
             {
                 throw new BadImageFormatException("The file is not a ReadyToRun image");
             }
@@ -367,58 +364,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 throw new BadImageFormatException("The calculated size of the R2RHeader doesn't match the size saved in the ManagedNativeHeaderDirectory");
             }
-
-            ParseDebugInfo();
-
-            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA))
-            {
-                R2RSection manifestMetadata = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA];
-                fixed (byte* image = Image)
-                {
-                    MetadataReader manifestReader = new MetadataReader(image + GetOffset(manifestMetadata.RelativeVirtualAddress), manifestMetadata.Size);
-                    int assemblyRefCount = manifestReader.GetTableRowCount(TableIndex.AssemblyRef);
-                    for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
-                    {
-                        AssemblyReferenceHandle asmRefHandle = MetadataTokens.AssemblyReferenceHandle(assemblyRefIndex);
-                        AssemblyReference asmRef = manifestReader.GetAssemblyReference(asmRefHandle);
-                        string asmRefName = manifestReader.GetString(asmRef.Name);
-                        ManifestReferenceAssemblies.Add(asmRefName);
-                    }
-                }
-            }
-
-            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO))
-            {
-                R2RSection exceptionInfoSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO];
-                EHLookupTable = new EHLookupTable(Image, GetOffset(exceptionInfoSection.RelativeVirtualAddress), exceptionInfoSection.Size);
-            }
-
-            ImportSections = new List<R2RImportSection>();
-            ImportCellNames = new Dictionary<int, string>();
-            ParseImportSections();
-
-            R2RMethods = new List<R2RMethod>();
-            InstanceMethods = new List<InstanceMethod>();
-
-            if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS))
-            {
-                int runtimeFunctionSize = CalculateRuntimeFunctionSize();
-                R2RSection runtimeFunctionSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS];
-
-                uint nRuntimeFunctions = (uint)(runtimeFunctionSection.Size / runtimeFunctionSize);
-                int runtimeFunctionOffset = GetOffset(runtimeFunctionSection.RelativeVirtualAddress);
-                bool[] isEntryPoint = new bool[nRuntimeFunctions];
-
-                // initialize R2RMethods
-                ParseMethodDefEntrypoints(isEntryPoint);
-                ParseInstanceMethodEntrypoints(isEntryPoint);
-                ParseRuntimeFunctions(isEntryPoint, runtimeFunctionOffset, runtimeFunctionSize);
-            }
-
-            AvailableTypes = new List<string>();
-            ParseAvailableTypes();
-
-            CompilerIdentifier = ParseCompilerIdentifier();
         }
 
         public bool InputArchitectureSupported()
@@ -784,6 +729,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private void ParseDebugInfo()
         {
+            _runtimeFunctionToDebugInfo = new Dictionary<int, DebugInfo>();
             if (!R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_DEBUG_INFO))
             {
                 return;
@@ -824,7 +770,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Get the full name of an ExportedType, including namespace
         /// </summary>
-        public static string GetExportedTypeFullName(MetadataReader mdReader, ExportedTypeHandle handle)
+        private static string GetExportedTypeFullName(MetadataReader mdReader, ExportedTypeHandle handle)
         {
             string typeNamespace = "";
             string typeStr = "";
@@ -911,6 +857,47 @@ namespace ILCompiler.Reflection.ReadyToRun
             } // Done with all entries in this table
 
             return cells.ToArray();
+        }
+
+        /// <summary>
+        /// Open a given reference assembly (relative to this ECMA metadata file).
+        /// </summary>
+        /// <param name="refAsmIndex">Reference assembly index</param>
+        /// <returns>MetadataReader instance representing the reference assembly</returns>
+        internal MetadataReader OpenReferenceAssembly(int refAsmIndex)
+        {
+            if (refAsmIndex == 0)
+            {
+                return this.MetadataReader;
+            }
+
+            int assemblyRefCount = MetadataReader.GetTableRowCount(TableIndex.AssemblyRef);
+            MetadataReader metadataReader;
+            AssemblyReferenceHandle assemblyReferenceHandle;
+            if (refAsmIndex <= assemblyRefCount)
+            {
+                metadataReader = MetadataReader;
+                assemblyReferenceHandle = MetadataTokens.AssemblyReferenceHandle(refAsmIndex);
+            }
+            else
+            {
+                metadataReader = _manifestReader;
+                assemblyReferenceHandle = _manifestReferences[refAsmIndex - assemblyRefCount - 2];
+            }
+            
+
+            MetadataReader result;
+            if (!_assemblyCache.TryGetValue(refAsmIndex, out result))
+            {
+                result = _assemblyResolver.FindAssembly(metadataReader, assemblyReferenceHandle, Filename);
+                if (result == null)
+                {
+                    string name = metadataReader.GetString(metadataReader.GetAssemblyReference(assemblyReferenceHandle).Name);
+                    throw new Exception($"Missing reference assembly: {name}");
+                }
+                _assemblyCache.Add(refAsmIndex, result);
+            }
+            return result;
         }
     }
 }

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -377,10 +377,12 @@ namespace R2RDump
                         _writer.WriteLine($"[ID 0x{assemblyRefIndex:X2}]: {assemblyRefName}");
                     }
 
-                    _writer.WriteLine($"Manifest metadata AssemblyRef's ({_r2r.ManifestReferenceAssemblies.Count} entries):");
-                    for (int manifestAsmIndex = 0; manifestAsmIndex < _r2r.ManifestReferenceAssemblies.Count; manifestAsmIndex++)
+                    _writer.WriteLine($"Manifest metadata AssemblyRef's ({_r2r.ManifestReferenceAssemblies.Count()} entries):");
+                    int manifestAsmIndex = 0;
+                    foreach (string manifestReferenceAssembly in _r2r.ManifestReferenceAssemblies)
                     {
-                        _writer.WriteLine($"[ID 0x{manifestAsmIndex + assemblyRefCount + 2:X2}]: {_r2r.ManifestReferenceAssemblies[manifestAsmIndex]}");
+                        _writer.WriteLine($"[ID 0x{manifestAsmIndex + assemblyRefCount + 2:X2}]: {manifestReferenceAssembly}");
+                        manifestAsmIndex++;
                     }
                     break;
                 case R2RSection.SectionType.READYTORUN_SECTION_ATTRIBUTEPRESENCE:


### PR DESCRIPTION
To make it possible to (re)use the assembly resolving capabilities in ILSpy, I refactored `IAssemblyResolver` so that it takes `MetadataReader` and `AssemblyReferenceHandle` and returns a `MetadataReader` instead of the original solution based on strings.

The `name` parameters dropped the version information from the `AssemblyReference` and causes a mismatch in ILSpy, therefore we wanted to pass the full `AssemblyReference` over.

The returned string is a file name, which forces our library to load it from disk. This is wasteful in the ILSpy scenario where they already loaded the assembly, therefore I made it return a `MetadataReader`, that's all we need for a referenced assembly.

In this change, I bundled some other refactorings that I have working on for convenience (so that I don't have to pull the `IAssemblyResolver` change out of my workspace). The most notable refactoring involves eliminating the `EcmaMetadataReader` class from the inheritance hierarchy. That class doesn't serve any value from a public API perspective (e.g. we do not envision there is a useful scenario where the library user can derive from this class to do anything useful). Along this line, I made some more functions and property setters private, these should lead us closer to a good public interface.

FYI @siegfriedpammer 