### PR TITLE
Fix order of arguments in message box call

### DIFF
--- a/src/coreclr/src/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/src/utilcode/util_nodependencies.cpp
@@ -85,7 +85,7 @@ CHECK_SUPPORTED:
         // The current platform isn't supported. Display a message box to this effect and exit.
         // Note that this should never happen since the .NET Fx setup should not install on
         // non supported platforms (which is why the message box text isn't localized).
-        UtilMessageBoxCatastrophicNonLocalized(NON_SUPPORTED_PLATFORM_MSGBOX_TITLE, NON_SUPPORTED_PLATFORM_MSGBOX_TEXT, MB_OK | MB_ICONERROR, TRUE);
+        UtilMessageBoxCatastrophicNonLocalized(NON_SUPPORTED_PLATFORM_MSGBOX_TEXT, NON_SUPPORTED_PLATFORM_MSGBOX_TITLE, MB_OK | MB_ICONERROR, TRUE);
         TerminateProcess(GetCurrentProcess(), NON_SUPPORTED_PLATFORM_TERMINATE_ERROR_CODE);
     }
 #endif // FEATURE_PAL


### PR DESCRIPTION
The message box appears when attempting to run a .NET Core application in Wine and Wine reports itself as Windows Vista or older.