### PR TITLE
pal_random: Open /dev/urandom with O_CLOEXEC

### DIFF
--- a/src/coreclr/src/pal/src/misc/miscpalapi.cpp
+++ b/src/coreclr/src/pal/src/misc/miscpalapi.cpp
@@ -245,7 +245,7 @@ PAL_Random(
     {
         do
         {
-            rand_des = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+            rand_des = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
         }
         while ((rand_des == -1) && (errno == EINTR));
 

--- a/src/libraries/Native/Unix/System.Native/pal_random.c
+++ b/src/libraries/Native/Unix/System.Native/pal_random.c
@@ -41,7 +41,7 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
             do
             {
 #if HAVE_O_CLOEXEC
-                fd = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+                fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
 #else
                 fd = open("/dev/urandom", O_RDONLY);
                 fcntl(fd, F_SETFD, FD_CLOEXEC);


### PR DESCRIPTION
The third argument to open(2) is ignored by the system call unless
O_CREAT is passed in the second argument.  O_CLOEXEC should be OR-ed
with the second argument.