### PR TITLE
Fix local test failures for System.Xml.Xsl.XslTransformApi.Tests & Rename old build variable in csproj

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlReader/ReadContentAs/System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/ReadContentAs/System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configurations>$(TargetFrameworkVNext)-Debug;$(TargetFrameworkVNext)-Release</Configurations>
+    <Configurations>$(NetCoreAppCurrent)-Debug;$(NetCoreAppCurrent)-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ReadAsArrayTests.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -478,7 +478,7 @@ namespace System.Xml.Tests
         {
             TestUsingTemporaryCopyOfResolverDocument(() =>
             {
-                LoadXSL("xmlResolver_document_function_absolute_uri.xsl", inputType, readerType);
+                LoadXSL("xmlResolver_document_function_absolute_uri_replaced.xsl", inputType, readerType);
                 xslt.XmlResolver = new XmlUrlResolver();
                 Transform("fruits.xml", transformType, docType);
                 VerifyResult(@"<?xml version=""1.0"" encoding=""utf-8""?><result>123</result>");
@@ -2102,7 +2102,7 @@ namespace System.Xml.Tests
         {
             TestUsingTemporaryCopyOfResolverDocument(() =>
             {
-                LoadXSL("xmlResolver_document_function_absolute_uri.xsl", inputType, readerType);
+                LoadXSL("xmlResolver_document_function_absolute_uri_replaced.xsl", inputType, readerType);
                 TransformResolver("fruits.xml", transformType, docType, new XmlUrlResolver());
                 VerifyResult(@"<?xml version=""1.0"" encoding=""utf-8""?><result>123</result>");
             });

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
@@ -89,13 +89,15 @@ namespace System.Xml.Tests
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(s_temporaryResolverDocumentFullName));
 
-                // Replace absolute URI in xmlResolver_document_function.xml based on the environment
+                // Replace absolute URI in xmlResolver_document_function.xml based on the environment, and store it under a different name
                 string xslFile = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApi", "xmlResolver_document_function_absolute_uri.xsl");
+                string replacedXslFile = Path.Combine("TestFiles", FilePathUtil.GetTestDataPath(), "XsltApi", "xmlResolver_document_function_absolute_uri_replaced.xsl");
+                File.Copy(xslFile, replacedXslFile, true);
                 XmlDocument doc = new XmlDocument();
-                doc.Load(xslFile);
+                doc.Load(replacedXslFile);
                 string xslString = doc.OuterXml.Replace("ABSOLUTE_URI", s_temporaryResolverDocumentFullName);
                 doc.LoadXml(xslString);
-                doc.Save(xslFile);
+                doc.Save(replacedXslFile);
             }
         }
 


### PR DESCRIPTION
Fixes #1170 and fixes #1267.

The old test modifies the test data file at the output folder. This works fine when the test is run only once (e.g. CI runs) however when the test is run multiple times after it has been built the tests fail because the modified test data isn't reverted. Here, this fixes that by creating/overwriting a temporary file in the output folder & modifying that so that the test data is successfully modified in every run.

In addition, I noticed that one of the variables in `System.Xml.RW.XmlReader.ReadContentAs.Tests.csproj`'s hasn't been changed in a previous refactoring (https://github.com/dotnet/runtime/commit/3b9abae5aae537258611b5750dc7e2963cfc73ed). This PR also addresses that.