### PR TITLE
Change how we detect SSL3 on Windows

### DIFF
--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
@@ -59,6 +59,11 @@ namespace System
         public static bool IsWindows10Version1903OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 18362;
 
+        // >= Windows 10 20H1 Update (As of Jan. 2020 yet to be released)
+        // Per https://docs.microsoft.com/en-us/windows-insider/flight-hub/ the first 20H1 build is 18836.
+        public static bool IsWindows10Version2004OrGreater => IsWindows &&
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 18836;
+
         public static bool IsWindowsIoTCore
         {
             get

--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -168,21 +168,28 @@ namespace System
             {
                 string clientKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client";
                 string serverKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server";
-                bool enabled = true;
 
-                // This may change in future but for now, missing key means protocol is enabled.
+                object client, server;
                 try
                 {
-                    if ((int)Registry.GetValue(clientKey, "Enabled", 1) == 0 || (int)Registry.GetValue(serverKey, "Enabled", 1) == 0)
-                    {
-                        enabled = false;
-                    }
+                    client = Registry.GetValue(clientKey, "Enabled", null);
+                    server = Registry.GetValue(serverKey, "Enabled", null);
                 }
-                catch (Exception e) when (e is SecurityException || e is InvalidCastException || e is NullReferenceException)
+                catch (SecurityException)
                 {
+                    // Insufficient permission, assume that we don't have SSL3 (since we aren't exactly sure)
+                    return false;
                 }
 
-                return enabled;
+                if (client is int c && server is int s)
+                {
+                    return c == 1 && s == 1;
+                }
+
+                // Missing key. If we're pre-20H1 then assume SSL3 is enabled.
+                // Otherwise, disabled. (See Comments on dotnet/runtime#1166)
+                // Alternatively the returned values must have been some other types.
+                return !IsWindows10Version2004OrGreater;
             }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));


### PR DESCRIPTION
Fixes #1166.

SSL3 is disabled by default from Windows 10 20H1 onwards. This PR changes the SSL3 detection logic slightly to comply with the change so that SSL3 related tests don't run on 20H1.