### PR TITLE
Fix TypeIntrinsics_il tests

### DIFF
--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.il
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.il
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime { auto }
 
-.assembly TypeIntrinsicsTests
-{
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
-}
+.assembly TypeIntrinsicsTests { }
 
 .class private auto ansi beforefieldinit Test
        extends [mscorlib]System.Object
@@ -16,20 +14,29 @@
   {
     .entrypoint
     .maxstack  1
-    // it's not currently possible to produce `ldtoken string&` in C#
+    // it's not currently possible to produce `ldtoken [type]&` in C#
     ldtoken    string&
     call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
     call       instance bool [System.Runtime]System.Type::get_IsValueType()
-    brtrue     FAILED
+    brtrue.s   FAILED
+
+    ldtoken    valuetype [System.Runtime]System.Int16&
+    call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    call       instance bool [System.Runtime]System.Type::get_IsValueType()
+    brtrue.s   FAILED
 
     ldtoken    object&
     call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
     call       instance bool [System.Runtime]System.Type::get_IsValueType()
     brtrue.s   FAILED
 
+    ldtoken    valuetype [System.Runtime]System.Decimal&
+    call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    call       instance bool [System.Runtime]System.Type::get_IsValueType()
+    brtrue.s   FAILED
+
     ldc.i4.s   100
     ret
-
 FAILED:
     ldc.i4.s   42
     ret

--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.il
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.il
@@ -17,25 +17,15 @@
     .entrypoint
     .maxstack  1
     // it's not currently possible to produce `ldtoken string&` in C#
-    ldtoken    [System.Runtime]System.String&
+    ldtoken    string&
     call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
     call       instance bool [System.Runtime]System.Type::get_IsValueType()
     brtrue     FAILED
 
-    ldtoken    [System.Runtime]System.Int16&
-    call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-    call       instance bool [System.Runtime]System.Type::get_IsValueType()
-    brfalse.s  FAILED
-
-    ldtoken    [System.Runtime]System.Object&
+    ldtoken    object&
     call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
     call       instance bool [System.Runtime]System.Type::get_IsValueType()
     brtrue.s   FAILED
-
-    ldtoken    [System.Runtime]System.Decimal&
-    call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-    call       instance bool [System.Runtime]System.Type::get_IsValueType()
-    brfalse.s  FAILED
 
     ldc.i4.s   100
     ret

--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.ilproj
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeIntrinsics_il.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1265
Sorry, didn't know what `<CLRTestPriority>1</CLRTestPriority>` is for. Also it seems I can use `&` only for string and object (?).