### PR TITLE
Improve CollectionExtensions.GetValueOrDefault nullable annotations

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -15,6 +15,7 @@ namespace System.Collections.Generic
         }
 
         [return: MaybeNull]
+        [return: NotNullIfNotNull("defaultValue")]
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, [AllowNull] TValue defaultValue)
         {
             if (dictionary == null)


### PR DESCRIPTION
The current nullable annotations for the overload of `CollectionExtensions.GetValueOrDefault` taking a default value are a bit too strict and incorrectly report the returned value as possibly null even when the specified default value is non-null:
```csharp
using System.Collections.Generic;
using System.Diagnostics.CodeAnalysis;

namespace ConsoleAppX
{
    public static class Program
    {
        public static void Main()
        {
            var dictionary = new Dictionary<string, string>();

            var result1 = dictionary.GetValueOrDefault("key", "defaultValue");
            _ = result1.GetType();
            //  ~~~~~~~ Dereference of a possibly null reference (incorrect; result will be "defaultValue" here).

            var result2 = dictionary.GetValueOrDefaultAnnotated("key", "defaultValue");
            _ = result2.GetType();
            //  ------- No warning.

            var result3 = dictionary.GetValueOrDefaultAnnotated("key", null);
            _ = result3.GetType();
            //  ~~~~~~~ Dereference of a possibly null reference (expected, because the default value is null).
        }

        [return: MaybeNull]
        [return: NotNullIfNotNull("defaultValue")]
        public static TValue GetValueOrDefaultAnnotated<TKey, TValue>(
            this IReadOnlyDictionary<TKey, TValue> dictionary,
            TKey key,
            [AllowNull] TValue defaultValue)
            where TKey : notnull
            => dictionary.GetValueOrDefault(key, defaultValue);
    }
}
```

Annotating the method `[return: NotNullIfNotNull("defaultValue")]` fixes this.

An alternative to this change would be to remove the `[AllowNull]` annotation from the `defaultValue` parameter, but because the method is already out in the wild with this annotation, doing so would technically be a (tiny, but still) breaking change.

Please let me know which of the two you'd prefer.

(If it helps you make a decision, `ImmutableDictionary.GetValueOrDefault` and similar methods do not annotate `defaultValue` with `[AllowNull]`, so removing this annotation would make the methods more unified.)