### PR TITLE
Implement WaitForExitAsync for System.Diagnostics.Process

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace System.Net.Http
+namespace System.Threading.Tasks
 {
+    /// <summary>
+    /// A <see cref="TaskCompletionSource{TResult}"/> that supports cancellation registration so that any
+    /// <seealso cref="OperationCanceledException"/>s contain the relevant <see cref="CancellationToken"/>,
+    /// while also avoiding unnecessary allocations for closure captures.
+    /// </summary>
     internal class TaskCompletionSourceWithCancellation<T> : TaskCompletionSource<T>
     {
         private CancellationToken _cancellationToken;

--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -124,7 +124,7 @@ namespace System.Diagnostics
         public override string ToString() { throw null; }
         public void WaitForExit() { }
         public bool WaitForExit(int milliseconds) { throw null; }
-        public System.Threading.Tasks.Task<bool> WaitForExitAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
+        public System.Threading.Tasks.Task WaitForExitAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
         public bool WaitForInputIdle() { throw null; }
         public bool WaitForInputIdle(int milliseconds) { throw null; }
     }

--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -124,6 +124,7 @@ namespace System.Diagnostics
         public override string ToString() { throw null; }
         public void WaitForExit() { }
         public bool WaitForExit(int milliseconds) { throw null; }
+        public System.Threading.Tasks.Task<bool> WaitForExitAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
         public bool WaitForInputIdle() { throw null; }
         public bool WaitForInputIdle(int milliseconds) { throw null; }
     }

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -329,4 +329,7 @@
   <data name="InvalidSysctl" xml:space="preserve">
     <value>sysctl {0} failed with {1} error.</value>
   </data>
+  <data name="EnableRaisingEventsRequired" xml:space="preserve">
+    <value>EnableRaisingEvents must be true before waiting for exit asynchronously.</value>
+  </data>
 </root>

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -329,7 +329,4 @@
   <data name="InvalidSysctl" xml:space="preserve">
     <value>sysctl {0} failed with {1} error.</value>
   </data>
-  <data name="EnableRaisingEventsRequired" xml:space="preserve">
-    <value>EnableRaisingEvents must be true before waiting for exit asynchronously.</value>
-  </data>
 </root>

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -44,6 +44,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs">
       <Link>Common\Interop\Windows\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs">
+      <Link>Common\System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.EnumProcessModules.cs">

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1350,7 +1350,7 @@ namespace System.Diagnostics
             if (!Associated) { throw new InvalidOperationException(SR.NoAssociatedProcess); }
             if (!EnableRaisingEvents) { throw new InvalidOperationException(SR.EnableRaisingEventsRequired); }
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSourceWithCancellation<object>();
 
             EventHandler handler = (s, e) => tcs.TrySetResult(null);
             Exited += handler;
@@ -1363,10 +1363,7 @@ namespace System.Diagnostics
                     return;
                 }
 
-                using (cancellationToken.Register(() => tcs.TrySetCanceled()))
-                {
-                    await tcs.Task.ConfigureAwait(false);
-                }
+                await tcs.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1349,7 +1349,8 @@ namespace System.Diagnostics
         /// Calling this method will set <see cref="EnableRaisingEvents"/> to <see langword="true" />.
         /// </remarks>
         /// <returns>
-        /// A task that will complete when the process has exited.
+        /// A task that will complete when the process has exited, cancellation has been requested,
+        /// or an error occurs.
         /// </returns>
         public async Task WaitForExitAsync(CancellationToken cancellationToken = default)
         {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1388,6 +1388,12 @@ namespace System.Diagnostics
 
             if (!Associated) { throw new InvalidOperationException(SR.NoAssociatedProcess); }
 
+            if (!HasExited)
+            {
+                // Early out for cancellation before doing more expensive work
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
             try
             {
                 // CASE 1: We enable events

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1345,10 +1345,67 @@ namespace System.Diagnostics
         /// Instructs the Process component to wait for the associated process to exit, or
         /// for the <paramref name="cancellationToken"/> to be canceled.
         /// </summary>
+        /// <remarks>
+        /// Calling this method will set <see cref="EnableRaisingEvents"/> to true.
+        /// </remarks>
         public async Task WaitForExitAsync(CancellationToken cancellationToken = default)
         {
+            // Because the process has already started by the time this method is called,
+            // we're in a race against the process to set up our exit handlers before the process
+            // exits. As a result, there are several different flows that must be handled:
+            //
+            // CASE 1: WE ENABLE EVENTS
+            // This is the "happy path". In this case we enable events.
+            //
+            // CASE 1.1: PROCESS EXITS OR IS CANCELED AFTER REGISTERING HANDLER
+            // This case continues the "happy path". The process exits or waiting is canceled after
+            // registering the handler and no special cases are needed.
+            //
+            // CASE 1.2: PROCESS EXITS BEFORE REGISTERING HANDLER
+            // It's possible that the process can exit after we enable events but before we reigster
+            // the handler. In that case we must check for exit after registering the handler.
+            //
+            //
+            // CASE 2: PROCESS EXITS BEFORE ENABLING EVENTS
+            // The process may exit before we attempt to enable events. In that case EnableRaisingEvents
+            // will throw an exception like this:
+            //     System.InvalidOperationException : Cannot process request because the process (42) has exited.
+            // In this case we catch the InvalidOperationException. If the process has exited, our work
+            // is done and we return. If for any reason (now or in the future) enabling events fails
+            // and the process has not exited, bubble the exception up to the user.
+            //
+            //
+            // CASE 3: USER ALREADY ENABLED EVENTS
+            // In this case the user has already enabled raising events. Re-enabling events is a no-op
+            // as the value hasn't changed. However, no-op also means that if the process has already
+            // exited, EnableRaisingEvents won't throw an exception.
+            //
+            // CASE 3.1: PROCESS EXITS OR IS CANCELED AFTER REGISTERING HANDLER
+            // (See CASE 1.1)
+            //
+            // CASE 3.2: PROCESS EXITS BEFORE REGISTERING HANDLER
+            // (See CASE 1.2)
+
             if (!Associated) { throw new InvalidOperationException(SR.NoAssociatedProcess); }
-            if (!EnableRaisingEvents) { throw new InvalidOperationException(SR.EnableRaisingEventsRequired); }
+
+            try
+            {
+                // CASE 1: We enable events
+                // CASE 2: Process exits before enabling events (and throws an exception)
+                // CASE 3: User already enabled events (no-op)
+                EnableRaisingEvents = true;
+            }
+            catch (InvalidOperationException)
+            {
+                // CASE 2: If the process has exited, our work is done, otherwise bubble the
+                // exception up to the user
+                if (HasExited)
+                {
+                    return;
+                }
+
+                throw;
+            }
 
             var tcs = new TaskCompletionSourceWithCancellation<object>();
 
@@ -1359,10 +1416,11 @@ namespace System.Diagnostics
             {
                 if (HasExited)
                 {
-                    // Handle the race where the process exited prior to registering the event handler
+                    // CASE 1.2 & CASE 3.2: Handle race where the process exits before registering the handler
                     return;
                 }
 
+                // CASE 1.1 & CASE 3.1: Process exits or is canceled here
                 await tcs.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
             }
             finally

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1345,19 +1345,16 @@ namespace System.Diagnostics
         /// Instructs the Process component to wait for the associated process to exit, or
         /// for the <paramref name="cancellationToken"/> to be canceled.
         /// </summary>
-        /// <returns>
-        /// Return true if the process has exited, false otherwise.
-        /// </returns>
-        public async Task<bool> WaitForExitAsync(CancellationToken cancellationToken = default)
+        public async Task WaitForExitAsync(CancellationToken cancellationToken = default)
         {
             if (!Associated) { throw new InvalidOperationException(SR.NoAssociatedProcess); }
             if (!EnableRaisingEvents) { throw new InvalidOperationException(SR.EnableRaisingEventsRequired); }
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             void ExitedHandler(object sender, EventArgs e)
             {
-                tcs.TrySetResult(true);
+                tcs.TrySetResult(null);
             }
 
             Exited += ExitedHandler;
@@ -1366,13 +1363,13 @@ namespace System.Diagnostics
             {
                 if (HasExited)
                 {
-                    // Catch the race where the process exited prior to registering the event handler
-                    tcs.TrySetResult(true);
+                    // Handle the race where the process exited prior to registering the event handler
+                    return;
                 }
 
-                using (cancellationToken.Register(() => tcs.TrySetResult(false)))
+                using (cancellationToken.Register(() => tcs.TrySetCanceled()))
                 {
-                    return await tcs.Task.ConfigureAwait(false);
+                    await tcs.Task.ConfigureAwait(false);
                 }
             }
             finally

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1346,8 +1346,11 @@ namespace System.Diagnostics
         /// for the <paramref name="cancellationToken"/> to be canceled.
         /// </summary>
         /// <remarks>
-        /// Calling this method will set <see cref="EnableRaisingEvents"/> to true.
+        /// Calling this method will set <see cref="EnableRaisingEvents"/> to <see langword="true" />.
         /// </remarks>
+        /// <returns>
+        /// A task that will complete when the process has exited.
+        /// </returns>
         public async Task WaitForExitAsync(CancellationToken cancellationToken = default)
         {
             // Because the process has already started by the time this method is called,

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1390,7 +1390,10 @@ namespace System.Diagnostics
             // CASE 3.2: PROCESS EXITS BEFORE REGISTERING HANDLER
             // (See CASE 1.2)
 
-            if (!Associated) { throw new InvalidOperationException(SR.NoAssociatedProcess); }
+            if (!Associated)
+            {
+                throw new InvalidOperationException(SR.NoAssociatedProcess);
+            }
 
             if (!HasExited)
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1352,12 +1352,8 @@ namespace System.Diagnostics
 
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            void ExitedHandler(object sender, EventArgs e)
-            {
-                tcs.TrySetResult(null);
-            }
-
-            Exited += ExitedHandler;
+            EventHandler handler = (s, e) => tcs.TrySetResult(null);
+            Exited += handler;
 
             try
             {
@@ -1374,7 +1370,7 @@ namespace System.Diagnostics
             }
             finally
             {
-                Exited -= ExitedHandler;
+                Exited -= handler;
             }
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -86,20 +86,6 @@ namespace System.Diagnostics.Tests
             return p;
         }
 
-        protected Process CreateProcess(Func<string, Task<int>> method, string arg, bool autoDispose = true)
-        {
-            Process p = null;
-            using (RemoteInvokeHandle handle = RemoteExecutor.Invoke(method, arg, new RemoteInvokeOptions {Start = false}))
-            {
-                p = handle.Process;
-                handle.Process = null;
-            }
-            if (autoDispose)
-                AddProcessForDispose(p);
-
-            return p;
-        }
-
         protected Process CreateProcess(Func<string, Task<int>> method, string arg)
         {
             Process p = null;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -60,10 +60,36 @@ namespace System.Diagnostics.Tests
             return p;
         }
 
+        protected Process CreateProcess(Func<Task<int>> method)
+        {
+            Process p = null;
+            using (RemoteInvokeHandle handle = RemoteExecutor.Invoke(method, new RemoteInvokeOptions { Start = false }))
+            {
+                p = handle.Process;
+                handle.Process = null;
+            }
+            AddProcessForDispose(p);
+            return p;
+        }
+
         protected Process CreateProcess(Func<string, int> method, string arg, bool autoDispose = true)
         {
             Process p = null;
             using (RemoteInvokeHandle handle = RemoteExecutor.Invoke(method, arg, new RemoteInvokeOptions { Start = false }))
+            {
+                p = handle.Process;
+                handle.Process = null;
+            }
+            if (autoDispose)
+                AddProcessForDispose(p);
+
+            return p;
+        }
+
+        protected Process CreateProcess(Func<string, Task<int>> method, string arg, bool autoDispose = true)
+        {
+            Process p = null;
+            using (RemoteInvokeHandle handle = RemoteExecutor.Invoke(method, arg, new RemoteInvokeOptions {Start = false}))
             {
                 p = handle.Process;
                 handle.Process = null;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -25,6 +25,24 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public async Task MultipleProcesses_StartAllKillAllWaitAllAsync()
+        {
+            const int Iters = 10;
+            Process[] processes = Enumerable.Range(0, Iters).Select(_ => CreateProcessLong()).ToArray();
+
+            foreach (Process p in processes) p.EnableRaisingEvents = true;
+            foreach (Process p in processes) p.Start();
+            foreach (Process p in processes) p.Kill();
+            foreach (Process p in processes)
+            {
+                using (var cts = new CancellationTokenSource(WaitInMS))
+                {
+                    Assert.True(await p.WaitForExitAsync(cts.Token));
+                }
+            }
+        }
+
+        [Fact]
         public void MultipleProcesses_SerialStartKillWait()
         {
             const int Iters = 10;
@@ -33,7 +51,24 @@ namespace System.Diagnostics.Tests
                 Process p = CreateProcessLong();
                 p.Start();
                 p.Kill();
-                p.WaitForExit(WaitInMS);
+                Assert.True(p.WaitForExit(WaitInMS));
+            }
+        }
+
+        [Fact]
+        public async Task MultipleProcesses_SerialStartKillWaitAsync()
+        {
+            const int Iters = 10;
+            for (int i = 0; i < Iters; i++)
+            {
+                Process p = CreateProcessLong();
+                p.EnableRaisingEvents = true;
+                p.Start();
+                p.Kill();
+                using (var cts = new CancellationTokenSource(WaitInMS))
+                {
+                    Assert.True(await p.WaitForExitAsync(cts.Token));
+                }
             }
         }
 
@@ -54,12 +89,47 @@ namespace System.Diagnostics.Tests
             Task.WaitAll(Enumerable.Range(0, Tasks).Select(_ => Task.Run(work)).ToArray());
         }
 
+        [Fact]
+        public async Task MultipleProcesses_ParallelStartKillWaitAsync()
+        {
+            const int Tasks = 4, ItersPerTask = 10;
+            Action work = async () =>
+            {
+                for (int i = 0; i < ItersPerTask; i++)
+                {
+                    Process p = CreateProcessLong();
+                    p.EnableRaisingEvents = true;
+                    p.Start();
+                    p.Kill();
+                    using (var cts = new CancellationTokenSource(WaitInMS))
+                    {
+                        Assert.True(await p.WaitForExitAsync(cts.Token));
+                    }
+                }
+            };
+
+            await Task.WhenAll(Enumerable.Range(0, Tasks).Select(_ => Task.Run(work)).ToArray());
+        }
+
         [Theory]
         [InlineData(0)]  // poll
         [InlineData(10)] // real timeout
         public void CurrentProcess_WaitNeverCompletes(int milliseconds)
         {
             Assert.False(Process.GetCurrentProcess().WaitForExit(milliseconds));
+        }
+
+        [Theory]
+        [InlineData(0)]  // poll
+        [InlineData(10)] // real timeout
+        public async Task CurrentProcess_WaitAsyncNeverCompletes(int milliseconds)
+        {
+            using (var cts = new CancellationTokenSource(milliseconds))
+            {
+                var process = Process.GetCurrentProcess();
+                process.EnableRaisingEvents = true;
+                Assert.False(await process.WaitForExitAsync(cts.Token));
+            }
         }
 
         [Fact]
@@ -80,6 +150,39 @@ namespace System.Diagnostics.Tests
             Task.Delay(10).ContinueWith(_ => p.Kill());
             Assert.True(p.WaitForExit(WaitInMS));
             Assert.True(p.WaitForExit(0));
+        }
+
+        [Fact]
+        public async Task SingleProcess_TryWaitAsyncMultipleTimesBeforeCompleting()
+        {
+            Process p = CreateProcessLong();
+            p.EnableRaisingEvents = true;
+            p.Start();
+
+            // Verify we can try to wait for the process to exit multiple times
+            using (var cts = new CancellationTokenSource(0))
+            {
+                Assert.False(await p.WaitForExitAsync(cts.Token));
+                Assert.False(await p.WaitForExitAsync(cts.Token));
+            }
+
+            // Then wait until it exits and concurrently kill it.
+            // There's a race condition here, in that we really want to test
+            // killing it while we're waiting, but we could end up killing it
+            // before hand, in which case we're simply not testing exactly
+            // what we wanted to test, but everything should still work.
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            Task.Delay(10).ContinueWith(_ => p.Kill());
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await p.WaitForExitAsync(cts.Token));
+            }
+            using (var cts = new CancellationTokenSource(0))
+            {
+                Assert.True(await p.WaitForExitAsync(cts.Token));
+            }
         }
 
         [Theory]
@@ -105,6 +208,38 @@ namespace System.Diagnostics.Tests
             Assert.True(await tcs.Task);
 
             Assert.True(p.WaitForExit(0));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SingleProcess_WaitAsyncAfterExited(bool addHandlerBeforeStart)
+        {
+            Process p = CreateProcessLong();
+            p.EnableRaisingEvents = true;
+
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (addHandlerBeforeStart)
+            {
+                p.Exited += delegate
+                { tcs.SetResult(true); };
+            }
+            p.Start();
+            if (!addHandlerBeforeStart)
+            {
+                p.Exited += delegate
+                { tcs.SetResult(true); };
+            }
+
+            p.Kill();
+            Assert.True(await tcs.Task);
+
+            using (var cts = new CancellationTokenSource(0))
+            {
+                Assert.True(await p.WaitForExitAsync(cts.Token));
+            }
+
+            Assert.True(await p.WaitForExitAsync());
         }
 
         [Theory]
@@ -144,6 +279,39 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public async Task SingleProcess_CopiesShareExitAsyncInformation()
+        {
+            Process p = CreateProcessLong();
+            p.EnableRaisingEvents = true;
+            p.Start();
+
+            Process[] copies = Enumerable.Range(0, 3).Select(_ =>
+            {
+                var copy = Process.GetProcessById(p.Id);
+                copy.EnableRaisingEvents = true;
+                return copy;
+            }).ToArray();
+
+            using (var cts = new CancellationTokenSource(0))
+            {
+                Assert.False(await p.WaitForExitAsync(cts.Token));
+            }
+            p.Kill();
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await p.WaitForExitAsync(cts.Token));
+            }
+
+            using (var cts = new CancellationTokenSource(0))
+            {
+                foreach (Process copy in copies)
+                {
+                    Assert.True(await copy.WaitForExitAsync(cts.Token));
+                }
+            }
+        }
+
+        [Fact]
         public void WaitForPeerProcess()
         {
             Process child1 = CreateProcessLong();
@@ -165,6 +333,44 @@ namespace System.Diagnostics.Tests
             child1.Kill();
             Assert.True(child1.WaitForExit(WaitInMS));
             Assert.True(child2.WaitForExit(WaitInMS));
+
+            Assert.Equal(RemoteExecutor.SuccessExitCode, child2.ExitCode);
+        }
+
+        [Fact]
+        public async Task WaitAsyncForPeerProcess()
+        {
+            Process child1 = CreateProcessLong();
+            child1.EnableRaisingEvents = true;
+            child1.Start();
+
+            Process child2 = CreateProcess(async peerId =>
+            {
+                Process peer = Process.GetProcessById(int.Parse(peerId));
+                peer.EnableRaisingEvents = true;
+                Console.WriteLine("Signal");
+                using (var cts = new CancellationTokenSource(WaitInMS))
+                {
+                    Assert.True(await peer.WaitForExitAsync(cts.Token));
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }, child1.Id.ToString());
+            child2.StartInfo.RedirectStandardOutput = true;
+            child2.EnableRaisingEvents = true;
+            child2.Start();
+            char[] output = new char[6];
+            child2.StandardOutput.Read(output, 0, output.Length);
+            Assert.Equal("Signal", new string(output)); // wait for the signal before killing the peer
+
+            child1.Kill();
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await child1.WaitForExitAsync(cts.Token));
+            }
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await child2.WaitForExitAsync(cts.Token));
+            }
 
             Assert.Equal(RemoteExecutor.SuccessExitCode, child2.ExitCode);
         }
@@ -215,6 +421,55 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public async Task WaitAsyncForSignal()
+        {
+            const string expectedSignal = "Signal";
+            const string successResponse = "Success";
+            const int timeout = 5 * 1000;
+
+            Process p = CreateProcessPortable(RemotelyInvokable.WriteLineReadLine);
+            p.StartInfo.RedirectStandardInput = true;
+            p.StartInfo.RedirectStandardOutput = true;
+            var mre = new ManualResetEventSlim(false);
+
+            int linesReceived = 0;
+            p.OutputDataReceived += (s, e) =>
+            {
+                if (e.Data != null)
+                {
+                    linesReceived++;
+
+                    if (e.Data == expectedSignal)
+                    {
+                        mre.Set();
+                    }
+                }
+            };
+
+            p.EnableRaisingEvents = true;
+            p.Start();
+            p.BeginOutputReadLine();
+
+            Assert.True(mre.Wait(timeout));
+            Assert.Equal(1, linesReceived);
+
+            // Wait a little bit to make sure process didn't exit on itself
+            Thread.Sleep(100);
+            Assert.False(p.HasExited, "Process has prematurely exited");
+
+            using (StreamWriter writer = p.StandardInput)
+            {
+                writer.WriteLine(successResponse);
+            }
+
+            using (var cts = new CancellationTokenSource(timeout))
+            {
+                Assert.True(await p.WaitForExitAsync(cts.Token), "Process has not exited");
+            }
+            Assert.Equal(RemotelyInvokable.SuccessExitCode, p.ExitCode);
+        }
+
+        [Fact]
         public void WaitChain()
         {
             Process root = CreateProcess(() =>
@@ -242,11 +497,70 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public async Task WaitAsyncChain()
+        {
+            Process root = CreateProcess(async () =>
+            {
+                Process child1 = CreateProcess(async () =>
+                {
+                    Process child2 = CreateProcess(async () =>
+                    {
+                        Process child3 = CreateProcess(() => RemoteExecutor.SuccessExitCode);
+                        child3.EnableRaisingEvents = true;
+                        child3.Start();
+                        using (var cts = new CancellationTokenSource(WaitInMS))
+                        {
+                            Assert.True(await child3.WaitForExitAsync(cts.Token));
+                        }
+
+                        return child3.ExitCode;
+                    });
+                    child2.EnableRaisingEvents = true;
+                    child2.Start();
+                    using (var cts = new CancellationTokenSource(WaitInMS))
+                    {
+                        Assert.True(await child2.WaitForExitAsync(cts.Token));
+                    }
+
+                    return child2.ExitCode;
+                });
+                child1.EnableRaisingEvents = true;
+                child1.Start();
+                using (var cts = new CancellationTokenSource(WaitInMS))
+                {
+                    Assert.True(await child1.WaitForExitAsync(cts.Token));
+                }
+
+                return child1.ExitCode;
+            });
+            root.EnableRaisingEvents = true;
+            root.Start();
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await root.WaitForExitAsync(cts.Token));
+            }
+            Assert.Equal(RemoteExecutor.SuccessExitCode, root.ExitCode);
+        }
+
+        [Fact]
         public void WaitForSelfTerminatingChild()
         {
             Process child = CreateProcessPortable(RemotelyInvokable.SelfTerminate);
             child.Start();
             Assert.True(child.WaitForExit(WaitInMS));
+            Assert.NotEqual(RemoteExecutor.SuccessExitCode, child.ExitCode);
+        }
+
+        [Fact]
+        public async Task WaitAsyncForSelfTerminatingChild()
+        {
+            Process child = CreateProcessPortable(RemotelyInvokable.SelfTerminate);
+            child.EnableRaisingEvents = true;
+            child.Start();
+            using (var cts = new CancellationTokenSource(WaitInMS))
+            {
+                Assert.True(await child.WaitForExitAsync(cts.Token));
+            }
             Assert.NotEqual(RemoteExecutor.SuccessExitCode, child.ExitCode);
         }
 
@@ -262,6 +576,19 @@ namespace System.Diagnostics.Tests
         {
             var process = new Process();
             Assert.Throws<InvalidOperationException>(() => process.WaitForExit());
+        }
+
+        [Fact]
+        public async Task WaitForExitAsync_NotDirected_ThrowsInvalidOperationException()
+        {
+            var process = new Process();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await process.WaitForExitAsync());
+        }
+
+        [Fact]
+        public async Task WaitForExitAsync_NotEnabledRaisingEvents_ThrowsInvalidOperationException()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await Process.GetCurrentProcess().WaitForExitAsync());
         }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -95,7 +95,7 @@ namespace System.Diagnostics.Tests
         public async Task MultipleProcesses_ParallelStartKillWaitAsync()
         {
             const int Tasks = 4, ItersPerTask = 10;
-            Action work = async () =>
+            Func<Task> work = async () =>
             {
                 for (int i = 0; i < ItersPerTask; i++)
                 {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -37,10 +37,7 @@ namespace System.Diagnostics.Tests
             {
                 using (var cts = new CancellationTokenSource(WaitInMS))
                 {
-                    var task = p.WaitForExitAsync(cts.Token);
-                    await task;
-                    Assert.True(task.IsCompletedSuccessfully);
-                    Assert.False(task.IsCanceled);
+                    await p.WaitForExitAsync(cts.Token);
                     Assert.True(p.HasExited);
                 }
             }
@@ -71,10 +68,7 @@ namespace System.Diagnostics.Tests
                 p.Kill();
                 using (var cts = new CancellationTokenSource(WaitInMS))
                 {
-                    var task = p.WaitForExitAsync(cts.Token);
-                    await task;
-                    Assert.True(task.IsCompletedSuccessfully);
-                    Assert.False(task.IsCanceled);
+                    await p.WaitForExitAsync(cts.Token);
                     Assert.True(p.HasExited);
                 }
             }
@@ -111,10 +105,7 @@ namespace System.Diagnostics.Tests
                     p.Kill();
                     using (var cts = new CancellationTokenSource(WaitInMS))
                     {
-                        var task = p.WaitForExitAsync(cts.Token);
-                        await task;
-                        Assert.True(task.IsCompletedSuccessfully);
-                        Assert.False(task.IsCanceled);
+                        await p.WaitForExitAsync(cts.Token);
                         Assert.True(p.HasExited);
                     }
                 }
@@ -140,10 +131,7 @@ namespace System.Diagnostics.Tests
             {
                 var process = Process.GetCurrentProcess();
                 process.EnableRaisingEvents = true;
-                var task = process.WaitForExitAsync(cts.Token);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
-                Assert.False(task.IsCompletedSuccessfully);
-                Assert.True(task.IsCanceled);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => process.WaitForExitAsync(cts.Token));
                 Assert.False(process.HasExited);
             }
         }
@@ -180,10 +168,7 @@ namespace System.Diagnostics.Tests
             {
                 for (var i = 0; i < 2; i++)
                 {
-                    var task = p.WaitForExitAsync(cts.Token);
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
-                    Assert.False(task.IsCompletedSuccessfully);
-                    Assert.True(task.IsCanceled);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(cts.Token));
                     Assert.False(p.HasExited);
                 }
             }
@@ -199,18 +184,12 @@ namespace System.Diagnostics.Tests
 
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync(cts.Token);
                 Assert.True(p.HasExited);
             }
             using (var cts = new CancellationTokenSource(0))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync(cts.Token);
                 Assert.True(p.HasExited);
             }
         }
@@ -266,18 +245,12 @@ namespace System.Diagnostics.Tests
 
             using (var cts = new CancellationTokenSource(0))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync(cts.Token);
                 Assert.True(p.HasExited);
             }
 
             {
-                var task = p.WaitForExitAsync();
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync();
                 Assert.True(p.HasExited);
             }
         }
@@ -334,19 +307,13 @@ namespace System.Diagnostics.Tests
 
             using (var cts = new CancellationTokenSource(0))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
-                Assert.False(task.IsCompletedSuccessfully);
-                Assert.True(task.IsCanceled);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(cts.Token));
                 Assert.False(p.HasExited);
             }
             p.Kill();
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync(cts.Token);
                 Assert.True(p.HasExited);
             }
 
@@ -354,10 +321,7 @@ namespace System.Diagnostics.Tests
             {
                 foreach (Process copy in copies)
                 {
-                    var task = copy.WaitForExitAsync(cts.Token);
-                    await task;
-                    Assert.True(task.IsCompletedSuccessfully);
-                    Assert.False(task.IsCanceled);
+                    await copy.WaitForExitAsync(cts.Token);
                     Assert.True(copy.HasExited);
                 }
             }
@@ -403,10 +367,7 @@ namespace System.Diagnostics.Tests
                 Console.WriteLine("Signal");
                 using (var cts = new CancellationTokenSource(WaitInMS))
                 {
-                    var task = peer.WaitForExitAsync(cts.Token);
-                    await task;
-                    Assert.True(task.IsCompletedSuccessfully);
-                    Assert.False(task.IsCanceled);
+                    await peer.WaitForExitAsync(cts.Token);
                     Assert.True(peer.HasExited);
                 }
                 return RemoteExecutor.SuccessExitCode;
@@ -421,18 +382,12 @@ namespace System.Diagnostics.Tests
             child1.Kill();
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = child1.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await child1.WaitForExitAsync(cts.Token);
                 Assert.True(child1.HasExited);
             }
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = child2.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await child2.WaitForExitAsync(cts.Token);
                 Assert.True(child2.HasExited);
             }
 
@@ -528,10 +483,7 @@ namespace System.Diagnostics.Tests
 
             using (var cts = new CancellationTokenSource(timeout))
             {
-                var task = p.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await p.WaitForExitAsync(cts.Token);
                 Assert.True(p.HasExited, "Process has not exited");
             }
             Assert.Equal(RemotelyInvokable.SuccessExitCode, p.ExitCode);
@@ -578,10 +530,7 @@ namespace System.Diagnostics.Tests
                         child3.Start();
                         using (var cts = new CancellationTokenSource(WaitInMS))
                         {
-                            var task = child3.WaitForExitAsync(cts.Token);
-                            await task;
-                            Assert.True(task.IsCompletedSuccessfully);
-                            Assert.False(task.IsCanceled);
+                            await child3.WaitForExitAsync(cts.Token);
                             Assert.True(child3.HasExited);
                         }
 
@@ -591,10 +540,7 @@ namespace System.Diagnostics.Tests
                     child2.Start();
                     using (var cts = new CancellationTokenSource(WaitInMS))
                     {
-                        var task = child2.WaitForExitAsync(cts.Token);
-                        await task;
-                        Assert.True(task.IsCompletedSuccessfully);
-                        Assert.False(task.IsCanceled);
+                        await child2.WaitForExitAsync(cts.Token);
                         Assert.True(child2.HasExited);
                     }
 
@@ -604,10 +550,7 @@ namespace System.Diagnostics.Tests
                 child1.Start();
                 using (var cts = new CancellationTokenSource(WaitInMS))
                 {
-                    var task = child1.WaitForExitAsync(cts.Token);
-                    await task;
-                    Assert.True(task.IsCompletedSuccessfully);
-                    Assert.False(task.IsCanceled);
+                    await child1.WaitForExitAsync(cts.Token);
                     Assert.True(child1.HasExited);
                 }
 
@@ -617,10 +560,7 @@ namespace System.Diagnostics.Tests
             root.Start();
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = root.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await root.WaitForExitAsync(cts.Token);
                 Assert.True(root.HasExited);
             }
             Assert.Equal(RemoteExecutor.SuccessExitCode, root.ExitCode);
@@ -643,10 +583,7 @@ namespace System.Diagnostics.Tests
             child.Start();
             using (var cts = new CancellationTokenSource(WaitInMS))
             {
-                var task = child.WaitForExitAsync(cts.Token);
-                await task;
-                Assert.True(task.IsCompletedSuccessfully);
-                Assert.False(task.IsCanceled);
+                await child.WaitForExitAsync(cts.Token);
                 Assert.True(child.HasExited);
             }
             Assert.NotEqual(RemoteExecutor.SuccessExitCode, child.ExitCode);

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -129,9 +129,11 @@ namespace System.Diagnostics.Tests
         {
             using (var cts = new CancellationTokenSource(milliseconds))
             {
+                var token = cts.Token;
                 var process = Process.GetCurrentProcess();
                 process.EnableRaisingEvents = true;
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => process.WaitForExitAsync(cts.Token));
+                var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => process.WaitForExitAsync(token));
+                Assert.Equal(token, ex.CancellationToken);
                 Assert.False(process.HasExited);
             }
         }
@@ -166,9 +168,11 @@ namespace System.Diagnostics.Tests
             // Verify we can try to wait for the process to exit multiple times
             using (var cts = new CancellationTokenSource(0))
             {
+                var token = cts.Token;
                 for (var i = 0; i < 2; i++)
                 {
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(cts.Token));
+                    var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(token));
+                    Assert.Equal(token, ex.CancellationToken);
                     Assert.False(p.HasExited);
                 }
             }
@@ -307,7 +311,9 @@ namespace System.Diagnostics.Tests
 
             using (var cts = new CancellationTokenSource(0))
             {
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(cts.Token));
+                var token = cts.Token;
+                var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => p.WaitForExitAsync(token));
+                Assert.Equal(token, ex.CancellationToken);
                 Assert.False(p.HasExited);
             }
             p.Kill();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -572,6 +572,20 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public async Task WaitAsyncForProcess()
+        {
+            Process p = CreateSleepProcess(WaitInMS);
+            p.Start();
+
+            Task processTask = p.WaitForExitAsync();
+            Task delayTask = Task.Delay(WaitInMS * 2);
+
+            Task result = await Task.WhenAny(processTask, delayTask);
+            Assert.Equal(processTask, result);
+            Assert.True(p.HasExited);
+        }
+
+        [Fact]
         public void WaitForInputIdle_NotDirected_ThrowsInvalidOperationException()
         {
             var process = new Process();

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -159,7 +159,6 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\TaskCompletionSourceWithCancellation.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\FailedProxyCache.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IMultiWebProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\MultiProxy.cs" />
@@ -564,6 +563,9 @@
     </Compile>
     <Compile Include="$(CommonPath)System\Net\Mail\WhitespaceReader.cs">
       <Link>Common\System\Net\Mail\WhitespaceReader.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs">
+      <Link>Common\System\Threading\Tasks\TaskCompletionSourceWithCancellation.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">


### PR DESCRIPTION
This PR implements the API proposal dotnet/corefx#34689: Add a task-based `WaitForExitAsync()` for the `Process` class.

In order to ensure that the `Exited` event is never lost, it is the caller's responsibility to ensure that `EnableRaisingEvents` is `true` _prior_ to calling `WaitForExitAsync()`. A new `InvalidOperationException` with an appropriate error message is introduced to enforce those semantics.

Additionally, per feedback, `WaitForExitAsync` returns a `Task` instead of more closely matching the sync version and returning `Task<bool>`. To determine if the process has exited,
callers can check `HasExited` after the await (also cancellation follows the async pattern of throwing an `OperationCanceledException` and setting canceled on the task).

Unit tests for `WaitForExit()` were duplicated to add async versions, and one sync test was missing an assert, so I added it.

