### PR TITLE
Disable failing jobs in PR testing.

### DIFF
--- a/eng/pipelines/coreclr/pr.yml
+++ b/eng/pipelines/coreclr/pr.yml
@@ -133,7 +133,7 @@ jobs:
     - Linux_musl_x64
     - Linux_x64
     - OSX_x64
-    - Windows_NT_arm
+    # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Windows_NT_arm64
     - Windows_NT_x64
     - Windows_NT_x86
@@ -171,7 +171,7 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
     buildConfig: checked
     platforms:
-    - Linux_arm
+    # - Linux_arm Return this when https://github.com/dotnet/runtime/issues/1282 is fixed.
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -111,7 +111,7 @@ jobs:
     platforms:
     - OSX_x64
     - Linux_x64
-    - Linux_arm
+    # - Linux_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Windows_NT_x86
     - Windows_NT_x64
     - Windows_NT_arm


### PR DESCRIPTION
Disable PR testing jobs that are failing.
Revert when https://github.com/dotnet/runtime/issues/1097 and https://github.com/dotnet/runtime/issues/1282 are fixed.

Question: how can we match yml names to ADO names nowadays? I guess that `Checked JIT test executions` matches to "CoreCLR Pri0 Test Run checked", but there are no common words there.