### PR TITLE
All System.Private.Corelib.csproj to build successfully in VS

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -321,7 +321,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\XplatEventLogger.cs" Condition="'$(FeatureXplatEventSource)' == 'true'" />
-    <Compile Include="$(IntermediateOutputPath)..\..\..\Eventing\$(BuildArch)\$(Configuration)\NativeRuntimeEventSource.cs" Condition="'$(FeaturePerfTracing)' == 'true' AND '$(BuildingInsideVisualStudio)' != 'true' " />
+
+    <!-- This file should be generated in such a way that VS can regenerate it, rather than with python (src\coreclr\src\scripts\genRuntimeEventSources.py) -->
+    <!-- For now, help VS users figure out how to be successful -->
+    <Compile Include="### Build from the command line once to generate NativeRuntimeEventSource.cs ###"
+            Condition="'$(FeaturePerfTracing)' == 'true' and
+                       '$(BuildingInsideVisualStudio)' == 'true' and
+                       !exists('$(IntermediateOutputPath)..\..\..\Eventing\$(BuildArch)\$(Configuration)\NativeRuntimeEventSource.cs')"/>
+    <Compile Include="$(IntermediateOutputPath)..\..\..\Eventing\$(BuildArch)\$(Configuration)\NativeRuntimeEventSource.cs" Condition="'$(FeaturePerfTracing)' == 'true' ">
+      <Link>src\System\Diagnostics\Eventing\Generated\NativeRuntimeEventSource.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\WindowsRuntime\ExceptionSupport.cs" />
@@ -424,7 +433,8 @@
   <PropertyGroup>
     <CheckCDefines Condition="'$(CheckCDefines)'==''">true</CheckCDefines>
   </PropertyGroup>
-  <Target Name="CDefineChecker" BeforeTargets="Build" Condition="'$(CheckCDefines)'=='true'">
+  <!-- PYTHON will not be defined when building in VS-->
+  <Target Name="CDefineChecker" BeforeTargets="Build" Condition="'$(CheckCDefines)'=='true' and '$(BuildingInsideVisualStudio)' != 'true'">
     <!-- Compiler Definition Verification -->
     <PropertyGroup>
       <CMakeDefinitionSaveFile>$(IntermediateOutputPath)\cmake.definitions</CMakeDefinitionSaveFile>


### PR DESCRIPTION
These two changes are necessary for the project to open and build in VS for me.

1. NativeRuntimeEventSource.cs is necessary for compilation when FEATURE_PERFTRACING is defined. FEATURE_PERFTRACING is defined by default. So the file must be visible to VS.

Why did `'$(BuildingInsideVisualStudio)' != 'true' "` exist here? @stephentoub added it in https://github.com/dotnet/coreclr/pull/26076 to fix https://github.com/dotnet/coreclr/issues/26075 because it required that a build had to happen outside VS to generate the file - this does not use T4 or something VS understands.

Why did that not cause these compilation errors at that time? If I sync back to that point in coreclr and open the corelib project, I see that VS does not consider FEATURE_PERFTRACING defined. It is not clear why. I see the define present in $(DefineConstants) and I see it going to the compiler in the build log that VS produces, but nevertheless the VS "squiggle" build is apparently not receiving this define. Using the same version of VS against the head of dotnet/runtime, it is defined. Something changed in the build between those times that means VS now gets initialized correctly.

I figure it is better to have to build that file outside VS, and have build then work in VS, than have build always broken in VS.

The message explaining how to create it is a hack. I can remove it, but the debt already exists (a file that VS cannot create) and it seems better to help contributors be successful.

2. $(PYTHON) is set in build.cmd, but typically not defined in a VS context. It is not clear to me why this was not causing problems in the past, but it seems we can skip this build step inside VS. I did not condition on $(PYTHON) being defined, since that could mask a future problem outside VS.