### PR TITLE
Add HTTP/3

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/H2StaticTable.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/H2StaticTable.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Net.Http.HPack
 {
-    internal static class StaticTable
+    internal static class H2StaticTable
     {
         // Index of status code into s_staticDecoderTable
         private static readonly Dictionary<int, int> s_statusIndex = new Dictionary<int, int>

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackDecoder.cs
@@ -470,9 +470,9 @@ namespace System.Net.Http.HPack
         {
             try
             {
-                return index <= StaticTable.Count
-                    ? StaticTable.Get(index - 1)
-                    : _dynamicTable[index - StaticTable.Count - 1];
+                return index <= H2StaticTable.Count
+                    ? H2StaticTable.Get(index - 1)
+                    : _dynamicTable[index - H2StaticTable.Count - 1];
             }
             catch (IndexOutOfRangeException)
             {

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HPackEncoder.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http.HPack
                 case 400:
                 case 404:
                 case 500:
-                    buffer[0] = (byte)(0x80 | StaticTable.StatusIndex[statusCode]);
+                    buffer[0] = (byte)(0x80 | H2StaticTable.StatusIndex[statusCode]);
                     return 1;
                 default:
                     // Send as Literal Header Field Without Indexing - Indexed Name

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/IntegerEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/IntegerEncoder.cs
@@ -9,6 +9,11 @@ namespace System.Net.Http.HPack
     internal static class IntegerEncoder
     {
         /// <summary>
+        /// The maximum bytes required to encode a 32-bit int, regardless of prefix length.
+        /// </summary>
+        public const int MaxInt32EncodedLength = 6;
+
+        /// <summary>
         /// Encodes an integer into one or more bytes.
         /// </summary>
         /// <param name="value">The value to encode. Must not be negative.</param>

--- a/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
@@ -17,6 +17,8 @@ namespace System.Net.Http
 #endif
     interface IHttpHeadersHandler
     {
+        void OnStaticIndexedHeader(int index);
+        void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value);
         void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
         void OnHeadersComplete(bool endStream);
     }

--- a/src/libraries/Common/src/System/Net/Http/Http3/CopyToAspNetCore.cmd
+++ b/src/libraries/Common/src/System/Net/Http/Http3/CopyToAspNetCore.cmd
@@ -1,0 +1,14 @@
+@ECHO OFF
+SETLOCAL
+
+if not [%1] == [] (set remote_repo=%1) else (set remote_repo=%ASPNETCORE_REPO%)
+
+IF [%remote_repo%] == [] (
+  echo The 'ASPNETCORE_REPO' environment variable or command line parameter is not set, aborting.
+  exit /b 1
+)
+
+echo ASPNETCORE_REPO: %remote_repo%
+
+robocopy . %remote_repo%\src\Shared\Http3 /MIR
+robocopy .\..\..\..\..\..\tests\Tests\System\Net\Http3\ %remote_repo%\src\Shared\test\Shared.Tests\Http3 /MIR

--- a/src/libraries/Common/src/System/Net/Http/Http3/CopyToAspNetCore.sh
+++ b/src/libraries/Common/src/System/Net/Http/Http3/CopyToAspNetCore.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ -n "$1" ]]; then
+    remote_repo="$1"
+else
+    remote_repo="$ASPNETCORE_REPO"
+fi
+
+if [[ -z "$remote_repo" ]]; then
+    echo The 'ASPNETCORE_REPO' environment variable or command line parameter is not set, aborting.
+    exit 1
+fi
+
+cd "$(dirname "$0")" || exit 1
+
+echo "ASPNETCORE_REPO: $remote_repo"
+
+rsync -av --delete ./ "$remote_repo"/src/Shared/Http3
+rsync -av --delete ./../../../../../tests/Tests/System/Net/Http3/ "$remote_repo"/src/Shared/test/Shared.Tests/Http3

--- a/src/libraries/Common/src/System/Net/Http/Http3/CopyToRuntime.cmd
+++ b/src/libraries/Common/src/System/Net/Http/Http3/CopyToRuntime.cmd
@@ -1,0 +1,14 @@
+@ECHO OFF
+SETLOCAL
+
+if not [%1] == [] (set remote_repo=%1) else (set remote_repo=%RUNTIME_REPO%)
+
+IF [%remote_repo%] == [] (
+  echo The 'RUNTIME_REPO' environment variable or command line parameter is not set, aborting.
+  exit /b 1
+)
+
+echo RUNTIME_REPO: %remote_repo%
+
+robocopy . %remote_repo%\src\libraries\Common\src\System\Net\Http\Http3 /MIR
+robocopy .\..\test\Shared.Tests\Http3 %remote_repo%\src\libraries\Common\tests\Tests\System\Net\Http3 /MIR

--- a/src/libraries/Common/src/System/Net/Http/Http3/CopyToRuntime.sh
+++ b/src/libraries/Common/src/System/Net/Http/Http3/CopyToRuntime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ -n "$1" ]]; then
+    remote_repo="$1"
+else
+    remote_repo="$RUNTIME_REPO"
+fi
+
+if [[ -z "$remote_repo" ]]; then
+    echo The 'RUNTIME_REPO' environment variable or command line parameter is not set, aborting.
+    exit 1
+fi
+
+cd "$(dirname "$0")" || exit 1
+
+echo "RUNTIME_REPO: $remote_repo"
+
+rsync -av --delete ./ "$remote_repo"/src/libraries/Common/src/System/Net/Http/Http3
+rsync -av --delete ./../test/Shared.Tests/Http3/ "$remote_repo"/src/libraries/Common/tests/Tests/System/Net/Http3

--- a/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3ErrorCode.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3ErrorCode.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal enum Http3ErrorCode : long
+    {
+        /// <summary>
+        /// H3_NO_ERROR (0x100):
+        /// No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
+        /// </summary>
+        NoError = 0x100,
+        /// <summary>
+        /// H3_GENERAL_PROTOCOL_ERROR (0x101):
+        /// Peer violated protocol requirements in a way which doesn’t match a more specific error code,
+        /// or endpoint declines to use the more specific error code.
+        /// </summary>
+        ProtocolError = 0x101,
+        /// <summary>
+        /// H3_INTERNAL_ERROR (0x102):
+        /// An internal error has occurred in the HTTP stack.
+        /// </summary>
+        InternalError = 0x102,
+        /// <summary>
+        ///  H3_STREAM_CREATION_ERROR (0x103):
+        /// The endpoint detected that its peer created a stream that it will not accept.
+        /// </summary>
+        StreamCreationError = 0x103,
+        /// <summary>
+        /// H3_CLOSED_CRITICAL_STREAM (0x104):
+        /// A stream required by the connection was closed or reset.
+        /// </summary>
+        ClosedCriticalStream = 0x104,
+        /// <summary>
+        /// H3_FRAME_UNEXPECTED (0x105):
+        /// A frame was received which was not permitted in the current state.
+        /// </summary>
+        UnexpectedFrame = 0x105,
+        /// <summary>
+        /// H3_FRAME_ERROR (0x106):
+        /// A frame that fails to satisfy layout requirements or with an invalid size was received.
+        /// </summary>
+        FrameError = 0x106,
+        /// <summary>
+        /// H3_EXCESSIVE_LOAD (0x107):
+        /// The endpoint detected that its peer is exhibiting a behavior that might be generating excessive load.
+        /// </summary>
+        ExcessiveLoad = 0x107,
+        /// <summary>
+        /// H3_ID_ERROR (0x109):
+        /// A Stream ID, Push ID, or Placeholder ID was used incorrectly, such as exceeding a limit, reducing a limit, or being reused.
+        /// </summary>
+        IdError = 0x108,
+        /// <summary>
+        /// H3_SETTINGS_ERROR (0x10A):
+        /// An endpoint detected an error in the payload of a SETTINGS frame: a duplicate setting was detected,
+        /// a client-only setting was sent by a server, or a server-only setting by a client.
+        /// </summary>
+        SettingsError = 0x109,
+        /// <summary>
+        /// H3_MISSING_SETTINGS (0x10B):
+        /// No SETTINGS frame was received at the beginning of the control stream.
+        /// </summary>
+        MissingSettings = 0x10a,
+        /// <summary>
+        /// H3_REQUEST_REJECTED (0x10C):
+        /// A server rejected a request without performing any application processing.
+        /// </summary>
+        RequestRejected = 0x10b,
+        /// <summary>
+        /// H3_REQUEST_CANCELLED (0x10D):
+        /// The request or its response (including pushed response) is cancelled.
+        /// </summary>
+        RequestCancelled = 0x10c,
+        /// <summary>
+        /// H3_REQUEST_INCOMPLETE (0x10E):
+        /// The client’s stream terminated without containing a fully-formed request.
+        /// </summary>
+        RequestIncomplete = 0x10d,
+        /// <summary>
+        /// H3_CONNECT_ERROR (0x110):
+        /// The connection established in response to a CONNECT request was reset or abnormally closed.
+        /// </summary>
+        ConnectError = 0x10f,
+        /// <summary>
+        /// H3_VERSION_FALLBACK (0x111):
+        /// The requested operation cannot be served over HTTP/3. The peer should retry over HTTP/1.1.
+        /// </summary>
+        VersionFallback = 0x110,
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3Frame.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3Frame.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Net.Http
+{
+    internal static partial class Http3Frame
+    {
+        public const int MaximumEncodedFrameEnvelopeLength = 1 + VariableLengthIntegerHelper.MaximumEncodedLength; // Frame type + payload length.
+
+        /// <summary>
+        /// Reads two variable-length integers.
+        /// </summary>
+        public static bool TryReadIntegerPair(ReadOnlySpan<byte> buffer, out long a, out long b, out int bytesRead)
+        {
+            if (VariableLengthIntegerHelper.TryRead(buffer, out a, out int aLength))
+            {
+                buffer = buffer.Slice(aLength);
+                if (VariableLengthIntegerHelper.TryRead(buffer, out b, out int bLength))
+                {
+                    bytesRead = aLength + bLength;
+                    return true;
+                }
+            }
+
+            b = 0;
+            bytesRead = 0;
+            return false;
+        }
+
+        //  0                   1                   2                   3
+        //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                           Type (i)                          ...
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                          Length (i)                         ...
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                       Frame Payload (*)                     ...
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        public static bool TryWriteFrameEnvelope(Http3FrameType frameType, long payloadLength, Span<byte> buffer, out int bytesWritten)
+        {
+            Debug.Assert(VariableLengthIntegerHelper.GetByteCount((long)frameType) == 1, $"{nameof(TryWriteFrameEnvelope)} assumes {nameof(frameType)} will fit within a single byte varint.");
+
+            if (buffer.Length != 0)
+            {
+                buffer[0] = (byte)frameType;
+                buffer = buffer.Slice(1);
+
+                if (VariableLengthIntegerHelper.TryWrite(buffer, payloadLength, out int payloadLengthEncodedLength))
+                {
+                    bytesWritten = payloadLengthEncodedLength + 1;
+                    return true;
+                }
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3FrameType.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Frames/Http3FrameType.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal enum Http3FrameType : long
+    {
+        Data = 0x0,
+        Headers = 0x1,
+        CancelPush = 0x3,
+        Settings = 0x4,
+        PushPromise = 0x5,
+        GoAway = 0x7,
+        MaxPushId = 0xD,
+        DuplicatePush = 0xE
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -1,0 +1,209 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Variable length integer encoding and decoding methods. Based on https://tools.ietf.org/html/draft-ietf-quic-transport-24#section-16.
+    /// A variable-length integer can use 1, 2, 4, or 8 bytes.
+    /// </summary>
+    internal static class VariableLengthIntegerHelper
+    {
+        public const int MaximumEncodedLength = 8;
+
+        // The high 4 bits indicate the length of the integer.
+        // 00 = length 1
+        // 01 = length 2
+        // 10 = length 4
+        // 11 = length 8
+        private const byte LengthMask = 0xC0;
+        private const byte InitialOneByteLengthMask = 0x00;
+        private const byte InitialTwoByteLengthMask = 0x40;
+        private const byte InitialFourByteLengthMask = 0x80;
+        private const byte InitialEightByteLengthMask = 0xC0;
+
+        // Bits to subtract to remove the length.
+        private const uint TwoByteLengthMask = 0x4000;
+        private const uint FourByteLengthMask = 0x80000000;
+        private const ulong EightByteLengthMask = 0xC000000000000000;
+
+        public const uint OneByteLimit = (1U << 6) - 1;
+        private const uint TwoByteLimit = (1U << 16) - 1;
+        private const uint FourByteLimit = (1U << 30) - 1;
+        private const long EightByteLimit = (1L << 62) - 1;
+
+        public static bool TryRead(ReadOnlySpan<byte> buffer, out long value, out int bytesRead)
+        {
+            if (buffer.Length != 0)
+            {
+                byte firstByte = buffer[0];
+
+                switch (firstByte & LengthMask)
+                {
+                    case InitialOneByteLengthMask:
+                        value = firstByte;
+                        bytesRead = 1;
+                        return true;
+                    case InitialTwoByteLengthMask:
+                        if (BinaryPrimitives.TryReadUInt16BigEndian(buffer, out ushort serializedShort))
+                        {
+                            value = serializedShort - TwoByteLengthMask;
+                            bytesRead = 2;
+                            return true;
+                        }
+                        break;
+                    case InitialFourByteLengthMask:
+                        if (BinaryPrimitives.TryReadUInt32BigEndian(buffer, out uint serializedInt))
+                        {
+                            value = serializedInt - FourByteLengthMask;
+                            bytesRead = 4;
+                            return true;
+                        }
+                        break;
+                    default: // InitialEightByteLengthMask
+                        Debug.Assert((firstByte & LengthMask) == InitialEightByteLengthMask);
+                        if (BinaryPrimitives.TryReadUInt64BigEndian(buffer, out ulong serializedLong))
+                        {
+                            value = (long)(serializedLong - EightByteLengthMask);
+                            Debug.Assert(value >= 0 && value <= EightByteLimit, "Serialized values are within [0, 2^62).");
+
+                            bytesRead = 8;
+                            return true;
+                        }
+                        break;
+                }
+            }
+
+            value = 0;
+            bytesRead = 0;
+            return false;
+        }
+
+        public static bool TryRead(ref SequenceReader<byte> reader, out long value)
+        {
+            // Hot path: we probably have the entire integer in one unbroken span.
+            if (TryRead(reader.UnreadSpan, out value, out int bytesRead))
+            {
+                reader.Advance(bytesRead);
+                return true;
+            }
+
+            // Cold path: copy to a temporary buffer before calling span-based read.
+            return TryReadSlow(ref reader, out value);
+
+            static bool TryReadSlow(ref SequenceReader<byte> reader, out long value)
+            {
+                ReadOnlySpan<byte> span = reader.CurrentSpan;
+
+                if (reader.TryPeek(out byte firstByte))
+                {
+                    int length =
+                        (firstByte & LengthMask) switch
+                        {
+                            InitialOneByteLengthMask => 1,
+                            InitialTwoByteLengthMask => 2,
+                            InitialFourByteLengthMask => 4,
+                            _ => 8 // LengthEightByte
+                    };
+
+                    Span<byte> temp = (stackalloc byte[8])[..length];
+                    if (reader.TryCopyTo(temp))
+                    {
+                        bool result = TryRead(temp, out value, out int bytesRead);
+                        Debug.Assert(result == true);
+                        Debug.Assert(bytesRead == length);
+
+                        reader.Advance(bytesRead);
+                        return true;
+                    }
+                }
+
+                value = 0;
+                return false;
+            }
+        }
+
+        public static long GetInteger(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+        {
+            var reader = new SequenceReader<byte>(buffer);
+            if (TryRead(ref reader, out long value))
+            {
+                consumed = examined = buffer.GetPosition(reader.Consumed);
+                return value;
+            }
+            else
+            {
+                consumed = default;
+                examined = buffer.End;
+                return -1;
+            }
+        }
+
+        public static bool TryWrite(Span<byte> buffer, long longToEncode, out int bytesWritten)
+        {
+            Debug.Assert(longToEncode >= 0);
+            Debug.Assert(longToEncode <= EightByteLimit);
+
+            if (longToEncode < OneByteLimit)
+            {
+                if (buffer.Length != 0)
+                {
+                    buffer[0] = (byte)longToEncode;
+                    bytesWritten = 1;
+                    return true;
+                }
+            }
+            else if (longToEncode < TwoByteLimit)
+            {
+                if (BinaryPrimitives.TryWriteUInt16BigEndian(buffer, (ushort)((uint)longToEncode | TwoByteLengthMask)))
+                {
+                    bytesWritten = 2;
+                    return true;
+                }
+            }
+            else if (longToEncode < FourByteLimit)
+            {
+                if (BinaryPrimitives.TryWriteUInt32BigEndian(buffer, (uint)longToEncode | FourByteLengthMask))
+                {
+                    bytesWritten = 4;
+                    return true;
+                }
+            }
+            else // EightByteLimit
+            {
+                if (BinaryPrimitives.TryWriteUInt64BigEndian(buffer, (ulong)longToEncode | EightByteLengthMask))
+                {
+                    bytesWritten = 8;
+                    return true;
+                }
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        public static int WriteInteger(Span<byte> buffer, long longToEncode)
+        {
+            bool res = TryWrite(buffer, longToEncode, out int bytesWritten);
+            Debug.Assert(res == true);
+            return bytesWritten;
+        }
+
+        public static int GetByteCount(long value)
+        {
+            Debug.Assert(value >= 0);
+            Debug.Assert(value <= EightByteLimit);
+
+            return
+                value < OneByteLimit ? 1 :
+                value < TwoByteLimit ? 2 :
+                value < FourByteLimit ? 4 :
+                8; // EightByteLimit
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/Http3SettingType.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Http3SettingType.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal enum Http3SettingType : long
+    {
+        /// <summary>
+        /// SETTINGS_QPACK_MAX_TABLE_CAPACITY
+        /// The maximum dynamic table size. The default is 0.
+        /// https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-5
+        /// </summary>
+        QPackMaxTableCapacity = 0x1,
+
+        /// <summary>
+        /// SETTINGS_MAX_HEADER_LIST_SIZE
+        /// The maximum size of headers. The default is unlimited.
+        /// https://tools.ietf.org/html/draft-ietf-quic-http-24#section-7.2.4.1
+        /// </summary>
+        MaxHeaderListSize = 0x6,
+
+        /// <summary>
+        /// SETTINGS_QPACK_BLOCKED_STREAMS
+        /// The maximum number of request streams that can be blocked waiting for QPack instructions. The default is 0.
+        /// https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-5
+        /// </summary>
+        QPackBlockedStreams = 0x7
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/Http3StreamType.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/Http3StreamType.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Unidirectional stream types.
+    /// </summary>
+    /// <remarks>
+    /// Bidirectional streams are always a request stream.
+    /// </remarks>
+    internal enum Http3StreamType : long
+    {
+        /// <summary>
+        /// https://tools.ietf.org/html/draft-ietf-quic-http-24#section-6.2.1
+        /// </summary>
+        Control = 0x00,
+        /// <summary>
+        /// https://tools.ietf.org/html/draft-ietf-quic-http-24#section-6.2.2
+        /// </summary>
+        Push = 0x01,
+        /// <summary>
+        /// https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.2
+        /// </summary>
+        QPackEncoder = 0x02,
+        /// <summary>
+        /// https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.2
+        /// </summary>
+        QPackDecoder = 0x03
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/H3StaticTable.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/H3StaticTable.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Net.Http.QPack
+{
+    // TODO: make class static.
+    internal class H3StaticTable
+    {
+        private readonly Dictionary<int, int> _statusIndex = new Dictionary<int, int>
+        {
+            [103] = 24,
+            [200] = 25,
+            [304] = 26,
+            [404] = 27,
+            [503] = 28,
+            [100] = 63,
+            [204] = 64,
+            [206] = 65,
+            [302] = 66,
+            [400] = 67,
+            [403] = 68,
+            [421] = 69,
+            [425] = 70,
+            [500] = 71,
+        };
+
+        private readonly Dictionary<HttpMethod, int> _methodIndex = new Dictionary<HttpMethod, int>
+        {
+            // TODO connect is internal to system.net.http
+            [HttpMethod.Delete] = 16,
+            [HttpMethod.Get] = 17,
+            [HttpMethod.Head] = 18,
+            [HttpMethod.Options] = 19,
+            [HttpMethod.Post] = 20,
+            [HttpMethod.Put] = 21,
+        };
+
+        private H3StaticTable()
+        {
+        }
+
+        public static H3StaticTable Instance { get; } = new H3StaticTable();
+
+        public int Count => _staticTable.Length;
+
+        public HeaderField this[int index] => _staticTable[index];
+
+        // TODO: just use Dictionary directly to avoid interface dispatch.
+        public IReadOnlyDictionary<int, int> StatusIndex => _statusIndex;
+        public IReadOnlyDictionary<HttpMethod, int> MethodIndex => _methodIndex;
+
+        private readonly HeaderField[] _staticTable = new HeaderField[]
+        {
+            CreateHeaderField(":authority", ""), // 0
+            CreateHeaderField(":path", "/"), // 1
+            CreateHeaderField("age", "0"), // 2
+            CreateHeaderField("content-disposition", ""),
+            CreateHeaderField("content-length", "0"),
+            CreateHeaderField("cookie", ""),
+            CreateHeaderField("date", ""),
+            CreateHeaderField("etag", ""),
+            CreateHeaderField("if-modified-since", ""),
+            CreateHeaderField("if-none-match", ""),
+            CreateHeaderField("last-modified", ""), // 10
+            CreateHeaderField("link", ""),
+            CreateHeaderField("location", ""),
+            CreateHeaderField("referer", ""),
+            CreateHeaderField("set-cookie", ""),
+            CreateHeaderField(":method", "CONNECT"),
+            CreateHeaderField(":method", "DELETE"),
+            CreateHeaderField(":method", "GET"),
+            CreateHeaderField(":method", "HEAD"),
+            CreateHeaderField(":method", "OPTIONS"),
+            CreateHeaderField(":method", "POST"), // 20
+            CreateHeaderField(":method", "PUT"),
+            CreateHeaderField(":scheme", "http"),
+            CreateHeaderField(":scheme", "https"),
+            CreateHeaderField(":status", "103"),
+            CreateHeaderField(":status", "200"),
+            CreateHeaderField(":status", "304"),
+            CreateHeaderField(":status", "404"),
+            CreateHeaderField(":status", "503"),
+            CreateHeaderField("accept", "*/*"),
+            CreateHeaderField("accept", "application/dns-message"), // 30
+            CreateHeaderField("accept-encoding", "gzip, deflate, br"),
+            CreateHeaderField("accept-ranges", "bytes"),
+            CreateHeaderField("access-control-allow-headers", "cache-control"),
+            CreateHeaderField("access-control-allow-origin", "content-type"),
+            CreateHeaderField("access-control-allow-origin", "*"),
+            CreateHeaderField("cache-control", "max-age=0"),
+            CreateHeaderField("cache-control", "max-age=2592000"),
+            CreateHeaderField("cache-control", "max-age=604800"),
+            CreateHeaderField("cache-control", "no-cache"),
+            CreateHeaderField("cache-control", "no-store"), // 40
+            CreateHeaderField("cache-control", "public, max-age=31536000"),
+            CreateHeaderField("content-encoding", "br"),
+            CreateHeaderField("content-encoding", "gzip"),
+            CreateHeaderField("content-type", "application/dns-message"),
+            CreateHeaderField("content-type", "application/javascript"),
+            CreateHeaderField("content-type", "application/json"),
+            CreateHeaderField("content-type", "application/x-www-form-urlencoded"),
+            CreateHeaderField("content-type", "image/gif"),
+            CreateHeaderField("content-type", "image/jpeg"),
+            CreateHeaderField("content-type", "image/png"), // 50
+            CreateHeaderField("content-type", "text/css"),
+            CreateHeaderField("content-type", "text/html; charset=utf-8"),
+            CreateHeaderField("content-type", "text/plain"),
+            CreateHeaderField("content-type", "text/plain;charset=utf-8"),
+            CreateHeaderField("range", "bytes=0-"),
+            CreateHeaderField("strict-transport-security", "max-age=31536000"),
+            CreateHeaderField("strict-transport-security", "max-age=31536000;includesubdomains"), // TODO confirm spaces here don't matter?
+            CreateHeaderField("strict-transport-security", "max-age=31536000;includesubdomains; preload"),
+            CreateHeaderField("vary", "accept-encoding"),
+            CreateHeaderField("vary", "origin"), // 60
+            CreateHeaderField("x-content-type-options", "nosniff"),
+            CreateHeaderField("x-xss-protection", "1; mode=block"),
+            CreateHeaderField(":status", "100"),
+            CreateHeaderField(":status", "204"),
+            CreateHeaderField(":status", "206"),
+            CreateHeaderField(":status", "302"),
+            CreateHeaderField(":status", "400"),
+            CreateHeaderField(":status", "403"),
+            CreateHeaderField(":status", "421"),
+            CreateHeaderField(":status", "425"), // 70
+            CreateHeaderField(":status", "500"),
+            CreateHeaderField("accept-language", ""),
+            CreateHeaderField("access-control-allow-credentials", "FALSE"),
+            CreateHeaderField("access-control-allow-credentials", "TRUE"),
+            CreateHeaderField("access-control-allow-headers", "*"),
+            CreateHeaderField("access-control-allow-methods", "get"),
+            CreateHeaderField("access-control-allow-methods", "get, post, options"),
+            CreateHeaderField("access-control-allow-methods", "options"),
+            CreateHeaderField("access-control-expose-headers", "content-length"),
+            CreateHeaderField("access-control-request-headers", "content-type"), // 80
+            CreateHeaderField("access-control-request-method", "get"),
+            CreateHeaderField("access-control-request-method", "post"),
+            CreateHeaderField("alt-svc", "clear"),
+            CreateHeaderField("authorization", ""),
+            CreateHeaderField("content-security-policy", "script-src 'none'; object-src 'none'; base-uri 'none'"),
+            CreateHeaderField("early-data", "1"),
+            CreateHeaderField("expect-ct", ""),
+            CreateHeaderField("forwarded", ""),
+            CreateHeaderField("if-range", ""),
+            CreateHeaderField("origin", ""), // 90
+            CreateHeaderField("purpose", "prefetch"),
+            CreateHeaderField("server", ""),
+            CreateHeaderField("timing-allow-origin", "*"),
+            CreateHeaderField("upgrading-insecure-requests", "1"),
+            CreateHeaderField("user-agent", ""),
+            CreateHeaderField("x-forwarded-for", ""),
+            CreateHeaderField("x-frame-options", "deny"),
+            CreateHeaderField("x-frame-options", "sameorigin"),
+        };
+
+        private static HeaderField CreateHeaderField(string name, string value)
+            => new HeaderField(Encoding.ASCII.GetBytes(name), Encoding.ASCII.GetBytes(value));
+
+        public const int Authority = 0;
+        public const int PathSlash = 1;
+        public const int Age0 = 2;
+        public const int ContentDisposition = 3;
+        public const int ContentLength0 = 4;
+        public const int Cookie = 5;
+        public const int Date = 6;
+        public const int ETag = 7;
+        public const int IfModifiedSince = 8;
+        public const int IfNoneMatch = 9;
+        public const int LastModified = 10;
+        public const int Link = 11;
+        public const int Location = 12;
+        public const int Referer = 13;
+        public const int SetCookie = 14;
+        public const int MethodConnect = 15;
+        public const int MethodDelete = 16;
+        public const int MethodGet = 17;
+        public const int MethodHead = 18;
+        public const int MethodOptions = 19;
+        public const int MethodPost = 20;
+        public const int MethodPut = 21;
+        public const int SchemeHttps = 23;
+        public const int Status103 = 24;
+        public const int Status200 = 25;
+        public const int Status304 = 26;
+        public const int Status404 = 27;
+        public const int Status503 = 28;
+        public const int AcceptAny = 29;
+        public const int AcceptEncodingGzipDeflateBr = 31;
+        public const int AcceptRangesBytes = 32;
+        public const int AccessControlAllowHeadersCacheControl = 33;
+        public const int AccessControlAllowOriginAny = 35;
+        public const int CacheControlMaxAge0 = 36;
+        public const int ContentEncodingBr = 42;
+        public const int ContentTypeApplicationDnsMessage = 44;
+        public const int RangeBytes0ToAll = 55;
+        public const int StrictTransportSecurityMaxAge31536000 = 56;
+        public const int VaryAcceptEncoding = 59;
+        public const int XContentTypeOptionsNoSniff = 61;
+        public const int Status100 = 63;
+        public const int Status204 = 64;
+        public const int Status206 = 65;
+        public const int Status302 = 66;
+        public const int Status400 = 67;
+        public const int Status403 = 68;
+        public const int Status421 = 69;
+        public const int Status425 = 70;
+        public const int Status500 = 71;
+        public const int AcceptLanguage = 72;
+        public const int AccessControlAllowCredentials = 73;
+        public const int AccessControlAllowMethodsGet = 76;
+        public const int AccessControlExposeHeadersContentLength = 79;
+        public const int AltSvcClear = 83;
+        public const int Authorization = 84;
+        public const int ContentSecurityPolicyAllNone = 85;
+        public const int IfRange = 89;
+        public const int Origin = 90;
+        public const int Server = 92;
+        public const int UpgradeInsecureRequests1 = 94;
+        public const int UserAgent = 95;
+        public const int XFrameOptionsDeny = 97;
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/HeaderField.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/HeaderField.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http.QPack
+{
+    internal readonly struct HeaderField
+    {
+        public HeaderField(byte[] name, byte[] value)
+        {
+            Name = new byte[name.Length];
+            Value = new byte[value.Length];
+        }
+
+        public byte[] Name { get; }
+
+        public byte[] Value { get; }
+
+        public int Length => Name.Length + Value.Length;
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackDecoder.cs
@@ -1,0 +1,506 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Net.Http.HPack;
+using System.Numerics;
+
+namespace System.Net.Http.QPack
+{
+    internal class QPackDecoder : IDisposable
+    {
+        private enum State
+        {
+            RequiredInsertCount,
+            RequiredInsertCountContinue,
+            Base,
+            BaseContinue,
+            CompressedHeaders,
+            HeaderFieldIndex,
+            HeaderNameIndex,
+            HeaderNameLength,
+            HeaderNameLengthContinue,
+            HeaderName,
+            HeaderValueLength,
+            HeaderValueLengthContinue,
+            HeaderValue,
+            DynamicTableSizeUpdate,
+            PostBaseIndex,
+            LiteralHeaderFieldWithNameReference,
+            HeaderNameIndexPostBase
+        }
+
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //|   Required Insert Count(8+)   |
+        //+---+---------------------------+
+        //| S |      Delta Base(7+)       |
+        //+---+---------------------------+
+        //|      Compressed Headers     ...
+        private const int RequiredInsertCountPrefix = 8;
+        private const int BaseMask = 0x80;
+        private const int BasePrefix = 7;
+        //+-------------------------------+
+
+        //https://tools.ietf.org/html/draft-ietf-quic-qpack-09#section-4.5.2
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //| 1 | S |      Index(6+)       |
+        //+---+---+-----------------------+
+        private const byte IndexedHeaderStaticMask = 0x40;
+        private const byte IndexedHeaderStaticRepresentation = 0x40;
+        private const byte IndexedHeaderFieldPrefixMask = 0x3F;
+        private const int IndexedHeaderFieldPrefix = 6;
+
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //| 0 | 0 | 0 | 1 |  Index(4+)   |
+        //+---+---+---+---+---------------+
+        private const byte PostBaseIndexMask = 0xF0;
+        private const int PostBaseIndexPrefix = 4;
+
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //| 0 | 1 | N | S |Name Index(4+)|
+        //+---+---+---+---+---------------+
+        //| H |     Value Length(7+)     |
+        //+---+---------------------------+
+        //|  Value String(Length bytes)  |
+        //+-------------------------------+
+        private const byte LiteralHeaderFieldStaticMask = 0x10;
+        private const byte LiteralHeaderFieldPrefixMask = 0x0F;
+        private const int LiteralHeaderFieldPrefix = 4;
+
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //| 0 | 0 | 0 | 0 | N |NameIdx(3+)|
+        //+---+---+---+---+---+-----------+
+        //| H |     Value Length(7+)     |
+        //+---+---------------------------+
+        //|  Value String(Length bytes)  |
+        //+-------------------------------+
+        private const byte LiteralHeaderFieldPostBasePrefixMask = 0x07;
+        private const int LiteralHeaderFieldPostBasePrefix = 3;
+
+        //0   1   2   3   4   5   6   7
+        //+---+---+---+---+---+---+---+---+
+        //| 0 | 0 | 1 | N | H |NameLen(3+)|
+        //+---+---+---+---+---+-----------+
+        //|  Name String(Length bytes)   |
+        //+---+---------------------------+
+        //| H |     Value Length(7+)     |
+        //+---+---------------------------+
+        //|  Value String(Length bytes)  |
+        //+-------------------------------+
+        private const byte LiteralHeaderFieldWithoutNameReferenceHuffmanMask = 0x08;
+        private const byte LiteralHeaderFieldWithoutNameReferencePrefixMask = 0x07;
+        private const int LiteralHeaderFieldWithoutNameReferencePrefix = 3;
+
+        private const int StringLengthPrefix = 7;
+        private const byte HuffmanMask = 0x80;
+
+        private const int DefaultStringBufferSize = 64;
+
+        private readonly int _maxHeadersLength;
+        private State _state = State.RequiredInsertCount;
+
+        private byte[] _stringOctets;
+        private byte[] _headerNameOctets;
+        private byte[] _headerValueOctets;
+
+        // s is used for whatever s is in each field. This has multiple definition
+        private bool _huffman;
+        private int? _index;
+
+        private byte[] _headerName;
+        private int _headerNameLength;
+        private int _headerValueLength;
+        private int _stringLength;
+        private int _stringIndex;
+        private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
+
+        private static ArrayPool<byte> Pool => ArrayPool<byte>.Shared;
+
+        private static void ReturnAndGetNewPooledArray(ref byte[] buffer, int newSize)
+        {
+            byte[] old = buffer;
+            buffer = null;
+
+            Pool.Return(old, clearArray: true);
+            buffer = Pool.Rent(newSize);
+        }
+
+        public QPackDecoder(int maxHeadersLength)
+        {
+            _maxHeadersLength = maxHeadersLength;
+
+            // TODO: make allocation lazy? with static entries it's possible no buffers will be needed.
+            _stringOctets = Pool.Rent(DefaultStringBufferSize);
+            _headerNameOctets = Pool.Rent(DefaultStringBufferSize);
+            _headerValueOctets = Pool.Rent(DefaultStringBufferSize);
+        }
+
+        public void Dispose()
+        {
+            if (_stringOctets != null)
+            {
+                Pool.Return(_stringOctets, true);
+                _stringOctets = null;
+            }
+
+            if (_headerNameOctets != null)
+            {
+                Pool.Return(_headerNameOctets, true);
+                _headerNameOctets = null;
+            }
+
+            if (_headerValueOctets != null)
+            {
+                Pool.Return(_headerValueOctets, true);
+                _headerValueOctets = null;
+            }
+        }
+
+        public void Decode(in ReadOnlySequence<byte> headerBlock, IHttpHeadersHandler handler)
+        {
+            foreach (ReadOnlyMemory<byte> segment in headerBlock)
+            {
+                Decode(segment.Span, handler);
+            }
+        }
+
+        public void Decode(ReadOnlySpan<byte> headerBlock, IHttpHeadersHandler handler)
+        {
+            foreach (byte b in headerBlock)
+            {
+                OnByte(b, handler);
+            }
+        }
+
+        private void OnByte(byte b, IHttpHeadersHandler handler)
+        {
+            int intResult;
+            int prefixInt;
+            switch (_state)
+            {
+                case State.RequiredInsertCount:
+                    if (_integerDecoder.BeginTryDecode(b, RequiredInsertCountPrefix, out intResult))
+                    {
+                        OnRequiredInsertCount(intResult);
+                    }
+                    else
+                    {
+                        _state = State.RequiredInsertCountContinue;
+                    }
+                    break;
+                case State.RequiredInsertCountContinue:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnRequiredInsertCount(intResult);
+                    }
+                    break;
+                case State.Base:
+                    prefixInt = ~BaseMask & b;
+
+                    if (_integerDecoder.BeginTryDecode(b, BasePrefix, out intResult))
+                    {
+                        OnBase(intResult);
+                    }
+                    else
+                    {
+                        _state = State.BaseContinue;
+                    }
+                    break;
+                case State.BaseContinue:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnBase(intResult);
+                    }
+                    break;
+                case State.CompressedHeaders:
+                    switch (BitOperations.LeadingZeroCount(b))
+                    {
+                        case 0: // Indexed Header Field
+                            prefixInt = IndexedHeaderFieldPrefixMask & b;
+
+                            bool useStaticTable = (b & IndexedHeaderStaticMask) == IndexedHeaderStaticRepresentation;
+
+                            if (!useStaticTable)
+                            {
+                                ThrowDynamicTableNotSupported();
+                            }
+
+                            if (_integerDecoder.BeginTryDecode((byte)prefixInt, IndexedHeaderFieldPrefix, out intResult))
+                            {
+                                OnIndexedHeaderField(intResult, handler);
+                            }
+                            else
+                            {
+                                _state = State.HeaderFieldIndex;
+                            }
+                            break;
+                        case 1: // Literal Header Field With Name Reference
+                            useStaticTable = (LiteralHeaderFieldStaticMask & b) == LiteralHeaderFieldStaticMask;
+
+                            if (!useStaticTable)
+                            {
+                                ThrowDynamicTableNotSupported();
+                            }
+
+                            prefixInt = b & LiteralHeaderFieldPrefixMask;
+                            if (_integerDecoder.BeginTryDecode((byte)prefixInt, LiteralHeaderFieldPrefix, out intResult))
+                            {
+                                OnIndexedHeaderName(intResult);
+                            }
+                            else
+                            {
+                                _state = State.HeaderNameIndex;
+                            }
+                            break;
+                        case 2: // Literal Header Field Without Name Reference
+                            _huffman = (b & LiteralHeaderFieldWithoutNameReferenceHuffmanMask) != 0;
+                            prefixInt = b & LiteralHeaderFieldWithoutNameReferencePrefixMask;
+
+                            if (_integerDecoder.BeginTryDecode((byte)prefixInt, LiteralHeaderFieldWithoutNameReferencePrefix, out intResult))
+                            {
+                                OnStringLength(intResult, State.HeaderName);
+                            }
+                            else
+                            {
+                                _state = State.HeaderNameLength;
+                            }
+                            break;
+                        case 3: // Indexed Header Field With Post-Base Index
+                            prefixInt = ~PostBaseIndexMask & b;
+                            if (_integerDecoder.BeginTryDecode((byte)prefixInt, PostBaseIndexPrefix, out intResult))
+                            {
+                                OnPostBaseIndex(intResult, handler);
+                            }
+                            else
+                            {
+                                _state = State.PostBaseIndex;
+                            }
+                            break;
+                        default: // Literal Header Field With Post-Base Name Reference (at least 4 zeroes, maybe more)
+                            prefixInt = b & LiteralHeaderFieldPostBasePrefixMask;
+                            if (_integerDecoder.BeginTryDecode((byte)prefixInt, LiteralHeaderFieldPostBasePrefix, out intResult))
+                            {
+                                OnIndexedHeaderNamePostBase(intResult);
+                            }
+                            else
+                            {
+                                _state = State.HeaderNameIndexPostBase;
+                            }
+                            break;
+                    }
+                    break;
+                case State.HeaderNameLength:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnStringLength(intResult, nextState: State.HeaderName);
+                    }
+                    break;
+                case State.HeaderName:
+                    _stringOctets[_stringIndex++] = b;
+
+                    if (_stringIndex == _stringLength)
+                    {
+                        OnString(nextState: State.HeaderValueLength);
+                    }
+
+                    break;
+                case State.HeaderNameIndex:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnIndexedHeaderName(intResult);
+                    }
+                    break;
+                case State.HeaderNameIndexPostBase:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnIndexedHeaderNamePostBase(intResult);
+                    }
+                    break;
+                case State.HeaderValueLength:
+                    _huffman = (b & HuffmanMask) != 0;
+
+                    // TODO confirm this.
+                    if (_integerDecoder.BeginTryDecode((byte)(b & ~HuffmanMask), StringLengthPrefix, out intResult))
+                    {
+                        OnStringLength(intResult, nextState: State.HeaderValue);
+                        if (intResult == 0)
+                        {
+                            ProcessHeaderValue(handler);
+                        }
+                    }
+                    else
+                    {
+                        _state = State.HeaderValueLengthContinue;
+                    }
+                    break;
+                case State.HeaderValueLengthContinue:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnStringLength(intResult, nextState: State.HeaderValue);
+                        if (intResult == 0)
+                        {
+                            ProcessHeaderValue(handler);
+                        }
+                    }
+                    break;
+                case State.HeaderValue:
+                    _stringOctets[_stringIndex++] = b;
+                    if (_stringIndex == _stringLength)
+                    {
+                        ProcessHeaderValue(handler);
+                    }
+                    break;
+                case State.HeaderFieldIndex:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnIndexedHeaderField(intResult, handler);
+                    }
+                    break;
+                case State.PostBaseIndex:
+                    if (_integerDecoder.TryDecode(b, out intResult))
+                    {
+                        OnPostBaseIndex(intResult, handler);
+                    }
+                    break;
+                case State.LiteralHeaderFieldWithNameReference:
+                    break;
+            }
+        }
+
+        private void OnStringLength(int length, State nextState)
+        {
+            if (length > _stringOctets.Length)
+            {
+                if (length > _maxHeadersLength)
+                {
+                    throw new QPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
+                }
+
+                ReturnAndGetNewPooledArray(ref _stringOctets, length);
+            }
+
+            _stringLength = length;
+            _stringIndex = 0;
+            _state = nextState;
+        }
+
+        private void ProcessHeaderValue(IHttpHeadersHandler handler)
+        {
+            OnString(nextState: State.CompressedHeaders);
+
+            Span<byte> headerNameSpan;
+            Span<byte> headerValueSpan = _headerValueOctets.AsSpan(0, _headerValueLength);
+
+            if (_index is int index)
+            {
+                Debug.Assert(index >= 0 && index <= H3StaticTable.Instance.Count, $"The index should be a valid static index here. {nameof(QPackDecoder)} should have previously thrown if it read a dynamic index.");
+                handler.OnStaticIndexedHeader(index, headerValueSpan);
+                return;
+            }
+            else
+            {
+                headerNameSpan = _headerNameOctets.AsSpan(0, _headerNameLength);
+            }
+
+            handler.OnHeader(headerNameSpan, headerValueSpan);
+        }
+
+        private void OnString(State nextState)
+        {
+            int Decode(ref byte[] dst)
+            {
+                if (_huffman)
+                {
+                    return Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                }
+                else
+                {
+                    if (dst.Length < _stringLength)
+                    {
+                        ReturnAndGetNewPooledArray(ref dst, _stringLength);
+                    }
+
+                    Buffer.BlockCopy(_stringOctets, 0, dst, 0, _stringLength);
+                    return _stringLength;
+                }
+            }
+
+            try
+            {
+                if (_state == State.HeaderName)
+                {
+                    _headerNameLength = Decode(ref _headerNameOctets);
+                    _headerName = _headerNameOctets;
+                }
+                else
+                {
+                    _headerValueLength = Decode(ref _headerValueOctets);
+                }
+            }
+            catch (HuffmanDecodingException ex)
+            {
+                throw new QPackDecodingException(SR.net_http_hpack_huffman_decode_failed, ex);
+            }
+
+            _state = nextState;
+        }
+
+
+        private void OnIndexedHeaderName(int index)
+        {
+            _index = index;
+            _state = State.HeaderValueLength;
+        }
+
+        private void OnIndexedHeaderNamePostBase(int index)
+        {
+            ThrowDynamicTableNotSupported();
+            // TODO update with postbase index
+            // _index = index;
+            // _state = State.HeaderValueLength;
+        }
+
+        private void OnPostBaseIndex(int intResult, IHttpHeadersHandler handler)
+        {
+            ThrowDynamicTableNotSupported();
+            // TODO
+            // _state = State.CompressedHeaders;
+        }
+
+        private void OnBase(int deltaBase)
+        {
+            if (deltaBase != 0)
+            {
+                ThrowDynamicTableNotSupported();
+            }
+            _state = State.CompressedHeaders;
+        }
+
+        private void OnRequiredInsertCount(int requiredInsertCount)
+        {
+            if (requiredInsertCount != 0)
+            {
+                ThrowDynamicTableNotSupported();
+            }
+            _state = State.Base;
+        }
+
+        private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
+        {
+            handler.OnStaticIndexedHeader(index);
+            _state = State.CompressedHeaders;
+        }
+
+        private static void ThrowDynamicTableNotSupported()
+        {
+            throw new QPackDecodingException(SR.net_http_qpack_no_dynamic_table);
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackDecodingException.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackDecodingException.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http.QPack
+{
+    [Serializable]
+    internal sealed class QPackDecodingException : Exception
+    {
+        public QPackDecodingException()
+        {
+        }
+
+        public QPackDecodingException(string message) : base(message)
+        {
+        }
+
+        public QPackDecodingException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        private QPackDecodingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackEncoder.cs
@@ -1,0 +1,428 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http.HPack;
+
+namespace System.Net.Http.QPack
+{
+    internal class QPackEncoder
+    {
+        private IEnumerator<KeyValuePair<string, string>> _enumerator;
+
+        // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.5.2
+        //   0   1   2   3   4   5   6   7
+        // +---+---+---+---+---+---+---+---+
+        // | 1 | T |      Index (6+)       |
+        // +---+---+-----------------------+
+        //
+        // Note for this method's implementation of above:
+        // - T is constant 1 here, indicating a static table reference.
+        public static bool EncodeStaticIndexedHeaderField(int index, Span<byte> destination, out int bytesWritten)
+        {
+            if (!destination.IsEmpty)
+            {
+                destination[0] = 0b11000000;
+                return IntegerEncoder.Encode(index, 6, destination, out bytesWritten);
+            }
+            else
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+
+        public static byte[] EncodeStaticIndexedHeaderFieldToArray(int index)
+        {
+            Span<byte> buffer = stackalloc byte[IntegerEncoder.MaxInt32EncodedLength];
+
+            bool res = EncodeStaticIndexedHeaderField(index, buffer, out int bytesWritten);
+            Debug.Assert(res == true);
+
+            return buffer.Slice(0, bytesWritten).ToArray();
+        }
+
+        // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.5.4
+        //   0   1   2   3   4   5   6   7
+        // +---+---+---+---+---+---+---+---+
+        // | 0 | 1 | N | T |Name Index (4+)|
+        // +---+---+---+---+---------------+
+        // | H |     Value Length (7+)     |
+        // +---+---------------------------+
+        // |  Value String (Length bytes)  |
+        // +-------------------------------+
+        //
+        // Note for this method's implementation of above:
+        // - N is constant 0 here, indicating intermediates (proxies) can compress the header when fordwarding.
+        // - T is constant 1 here, indicating a static table reference.
+        // - H is constant 0 here, as we do not yet perform Huffman coding.
+        public static bool EncodeLiteralHeaderFieldWithStaticNameReference(int index, string value, Span<byte> destination, out int bytesWritten)
+        {
+            // Requires at least two bytes (one for name reference header, one for value length)
+            if (destination.Length >= 2)
+            {
+                destination[0] = 0b01010000;
+                if (IntegerEncoder.Encode(index, 4, destination, out int headerBytesWritten))
+                {
+                    destination = destination.Slice(headerBytesWritten);
+
+                    if (EncodeValueString(value, destination, out int valueBytesWritten))
+                    {
+                        bytesWritten = headerBytesWritten + valueBytesWritten;
+                        return true;
+                    }
+                }
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Encodes just the name part of a Literal Header Field With Static Name Reference. Must call <see cref="EncodeValueString(string, Span{byte}, out int)"/> after to encode the header's value.
+        /// </summary>
+        public static byte[] EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(int index)
+        {
+            Span<byte> temp = stackalloc byte[IntegerEncoder.MaxInt32EncodedLength];
+
+            temp[0] = 0b01110000;
+            bool res = IntegerEncoder.Encode(index, 4, temp, out int headerBytesWritten);
+            Debug.Assert(res == true);
+
+            return temp.Slice(0, headerBytesWritten).ToArray();
+        }
+
+        public static byte[] EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(int index, string value)
+        {
+            Span<byte> temp = value.Length < 256 ? stackalloc byte[256 + IntegerEncoder.MaxInt32EncodedLength * 2] : new byte[value.Length + IntegerEncoder.MaxInt32EncodedLength * 2];
+            bool res = EncodeLiteralHeaderFieldWithStaticNameReference(index, value, temp, out int bytesWritten);
+            Debug.Assert(res == true);
+            return temp.Slice(0, bytesWritten).ToArray();
+        }
+
+        // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.5.6
+        //   0   1   2   3   4   5   6   7
+        // +---+---+---+---+---+---+---+---+
+        // | 0 | 0 | 1 | N | H |NameLen(3+)|
+        // +---+---+---+---+---+-----------+
+        // |  Name String (Length bytes)   |
+        // +---+---------------------------+
+        // | H |     Value Length (7+)     |
+        // +---+---------------------------+
+        // |  Value String (Length bytes)  |
+        // +-------------------------------+
+        //
+        // Note for this method's implementation of above:
+        // - N is constant 0 here, indicating intermediates (proxies) can compress the header when fordwarding.
+        // - H is constant 0 here, as we do not yet perform Huffman coding.
+        public static bool EncodeLiteralHeaderFieldWithoutNameReference(string name, string value, Span<byte> destination, out int bytesWritten)
+        {
+            if (EncodeNameString(name, destination, out int nameLength) && EncodeValueString(value, destination.Slice(nameLength), out int valueLength))
+            {
+                bytesWritten = nameLength + valueLength;
+                return true;
+            }
+            else
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Encodes a Literal Header Field Without Name Reference, building the value by concatenating a collection of strings with separators.
+        /// </summary>
+        public static bool EncodeLiteralHeaderFieldWithoutNameReference(string name, ReadOnlySpan<string> values, string valueSeparator, Span<byte> destination, out int bytesWritten)
+        {
+            if (EncodeNameString(name, destination, out int nameLength) && EncodeValueString(values, valueSeparator, destination.Slice(nameLength), out int valueLength))
+            {
+                bytesWritten = nameLength + valueLength;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Encodes just the value part of a Literawl Header Field Without Static Name Reference. Must call <see cref="EncodeValueString(string, Span{byte}, out int)"/> after to encode the header's value.
+        /// </summary>
+        public static byte[] EncodeLiteralHeaderFieldWithoutNameReferenceToArray(string name)
+        {
+            Span<byte> temp = name.Length < 256 ? stackalloc byte[256 + IntegerEncoder.MaxInt32EncodedLength] : new byte[name.Length + IntegerEncoder.MaxInt32EncodedLength];
+
+            bool res = EncodeNameString(name, temp, out int nameLength);
+            Debug.Assert(res == true);
+
+            return temp.Slice(0, nameLength).ToArray();
+        }
+
+        public static byte[] EncodeLiteralHeaderFieldWithoutNameReferenceToArray(string name, string value)
+        {
+            Span<byte> temp = (name.Length + value.Length) < 256 ? stackalloc byte[256 + IntegerEncoder.MaxInt32EncodedLength * 2] : new byte[name.Length + value.Length + IntegerEncoder.MaxInt32EncodedLength * 2];
+
+            bool res = EncodeLiteralHeaderFieldWithoutNameReference(name, value, temp, out int bytesWritten);
+            Debug.Assert(res == true);
+
+            return temp.Slice(0, bytesWritten).ToArray();
+        }
+
+        private static bool EncodeValueString(string s, Span<byte> buffer, out int length)
+        {
+            if (buffer.Length != 0)
+            {
+                buffer[0] = 0;
+                if (IntegerEncoder.Encode(s.Length, 7, buffer, out int nameLength))
+                {
+                    buffer = buffer.Slice(nameLength);
+                    if (buffer.Length >= s.Length)
+                    {
+                        EncodeValueStringPart(s, buffer);
+
+                        length = nameLength + s.Length;
+                        return true;
+                    }
+                }
+            }
+
+            length = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Encodes a value by concatenating a collection of strings, separated by a separator string.
+        /// </summary>
+        public static bool EncodeValueString(ReadOnlySpan<string> values, string separator, Span<byte> buffer, out int length)
+        {
+            if (values.Length == 1)
+            {
+                return EncodeValueString(values[0], buffer, out length);
+            }
+
+            if (values.Length == 0)
+            {
+                // TODO: this will be called with a string array from HttpHeaderCollection. Can we ever get a 0-length array from that? Assert if not.
+                return EncodeValueString(string.Empty, buffer, out length);
+            }
+
+            if (buffer.Length > 0)
+            {
+                int valueLength = separator.Length * (values.Length - 1);
+                for (int i = 0; i < values.Length; ++i)
+                {
+                    valueLength += values[i].Length;
+                }
+
+                buffer[0] = 0;
+                if (IntegerEncoder.Encode(valueLength, 7, buffer, out int nameLength))
+                {
+                    buffer = buffer.Slice(nameLength);
+                    if (buffer.Length >= valueLength)
+                    {
+                        string value = values[0];
+                        EncodeValueStringPart(value, buffer);
+                        buffer = buffer.Slice(value.Length);
+
+                        for (int i = 1; i < values.Length; ++i)
+                        {
+                            EncodeValueStringPart(separator, buffer);
+                            buffer = buffer.Slice(separator.Length);
+
+                            value = values[i];
+                            EncodeValueStringPart(value, buffer);
+                            buffer = buffer.Slice(value.Length);
+                        }
+
+                        length = nameLength + valueLength;
+                        return true;
+                    }
+                }
+            }
+
+            length = 0;
+            return false;
+        }
+
+        private static void EncodeValueStringPart(string s, Span<byte> buffer)
+        {
+            Debug.Assert(buffer.Length >= s.Length);
+
+            for (int i = 0; i < s.Length; ++i)
+            {
+                char ch = s[i];
+
+                if (ch > 127)
+                {
+                    throw new QPackEncodingException("ASCII header value.");
+                }
+
+                buffer[i] = (byte)ch;
+            }
+        }
+
+        private static bool EncodeNameString(string s, Span<byte> buffer, out int length)
+        {
+            const int toLowerMask = 0x20;
+
+            if (buffer.Length != 0)
+            {
+                buffer[0] = 0x30;
+
+                if (IntegerEncoder.Encode(s.Length, 3, buffer, out int nameLength))
+                {
+                    buffer = buffer.Slice(nameLength);
+
+                    if (buffer.Length >= s.Length)
+                    {
+                        for (int i = 0; i < s.Length; ++i)
+                        {
+                            int ch = s[i];
+                            Debug.Assert(ch <= 127, "HttpHeaders prevents adding non-ASCII header names.");
+
+                            if ((uint)(ch - 'A') <= 'Z' - 'A')
+                            {
+                                ch |= toLowerMask;
+                            }
+
+                            buffer[i] = (byte)ch;
+                        }
+
+                        length = nameLength + s.Length;
+                        return true;
+                    }
+                }
+            }
+
+            length = 0;
+            return false;
+        }
+
+        /*
+         *     0   1   2   3   4   5   6   7
+               +---+---+---+---+---+---+---+---+
+               |   Required Insert Count (8+)  |
+               +---+---------------------------+
+               | S |      Delta Base (7+)      |
+               +---+---------------------------+
+               |      Compressed Headers     ...
+               +-------------------------------+
+         *
+         */
+        private static bool EncodeHeaderBlockPrefix(Span<byte> destination, out int bytesWritten)
+        {
+            int length;
+            bytesWritten = 0;
+            // Required insert count as first int
+            if (!IntegerEncoder.Encode(0, 8, destination, out length))
+            {
+                return false;
+            }
+
+            bytesWritten += length;
+            destination = destination.Slice(length);
+
+            // Delta base
+            if (destination.IsEmpty)
+            {
+                return false;
+            }
+
+            destination[0] = 0x00;
+            if (!IntegerEncoder.Encode(0, 7, destination, out length))
+            {
+                return false;
+            }
+
+            bytesWritten += length;
+
+            return true;
+        }
+
+        // TODO these are fairly hard coded for the first two bytes to be zero.
+        public bool BeginEncode(IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        {
+            _enumerator = headers.GetEnumerator();
+
+            bool hasValue = _enumerator.MoveNext();
+            Debug.Assert(hasValue == true);
+
+            buffer[0] = 0;
+            buffer[1] = 0;
+
+            return Encode(buffer.Slice(2), out length);
+        }
+
+        public bool BeginEncode(int statusCode, IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        {
+            _enumerator = headers.GetEnumerator();
+
+            bool hasValue = _enumerator.MoveNext();
+            Debug.Assert(hasValue == true);
+
+            // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#header-prefix
+            buffer[0] = 0;
+            buffer[1] = 0;
+
+            int statusCodeLength = EncodeStatusCode(statusCode, buffer.Slice(2));
+            bool done = Encode(buffer.Slice(statusCodeLength + 2), throwIfNoneEncoded: false, out int headersLength);
+            length = statusCodeLength + headersLength + 2;
+
+            return done;
+        }
+
+        public bool Encode(Span<byte> buffer, out int length)
+        {
+            return Encode(buffer, throwIfNoneEncoded: true, out length);
+        }
+
+        private bool Encode(Span<byte> buffer, bool throwIfNoneEncoded, out int length)
+        {
+            length = 0;
+
+            do
+            {
+                if (!EncodeLiteralHeaderFieldWithoutNameReference(_enumerator.Current.Key, _enumerator.Current.Value, buffer.Slice(length), out int headerLength))
+                {
+                    if (length == 0 && throwIfNoneEncoded)
+                    {
+                        throw new QPackEncodingException("TODO sync with corefx" /* CoreStrings.HPackErrorNotEnoughBuffer */);
+                    }
+                    return false;
+                }
+
+                length += headerLength;
+            } while (_enumerator.MoveNext());
+
+            return true;
+        }
+
+        // TODO: use H3StaticTable?
+        private int EncodeStatusCode(int statusCode, Span<byte> buffer)
+        {
+            switch (statusCode)
+            {
+                case 200:
+                case 204:
+                case 206:
+                case 304:
+                case 400:
+                case 404:
+                case 500:
+                    // TODO this isn't safe, some index can be larger than 64. Encoded here!
+                    buffer[0] = (byte)(0xC0 | H3StaticTable.Instance.StatusIndex[statusCode]);
+                    return 1;
+                default:
+                    // Send as Literal Header Field Without Indexing - Indexed Name
+                    buffer[0] = 0x08;
+
+                    ReadOnlySpan<byte> statusBytes = StatusCodes.ToStatusBytes(statusCode);
+                    buffer[1] = (byte)statusBytes.Length;
+                    statusBytes.CopyTo(buffer.Slice(2));
+
+                    return 2 + statusBytes.Length;
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackEncodingException.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/QPackEncodingException.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http.QPack
+{
+    [Serializable]
+    internal sealed class QPackEncodingException : Exception
+    {
+        public QPackEncodingException(string message)
+            : base(message)
+        {
+        }
+        public QPackEncodingException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        private QPackEncodingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/Http3/ReadMe.SharedCode.md
+++ b/src/libraries/Common/src/System/Net/Http/Http3/ReadMe.SharedCode.md
@@ -1,0 +1,36 @@
+The code in this directory is shared between dotnet/runtime and aspnet/AspNetCore. This contains HTTP/3 protocol infrastructure such as a QPACK implementation. Any changes to this dir need to be checked into both repositories.
+
+dotnet/runtime code paths:
+- runtime\src\libraries\Common\src\System\Net\Http\Http3
+- runtime\src\libraries\Common\tests\Tests\System\Net\Http3
+aspnet/AspNetCore code paths:
+- AspNetCore\src\Shared\Http3
+- AspNetCore\src\Shared\test\Shared.Tests\Http3
+
+## Copying code
+To copy code from dotnet/runtime to aspnet/AspNetCore, set ASPNETCORE_REPO to the AspNetCore repo root and then run CopyToAspNetCore.cmd.
+To copy code from aspnet/AspNetCore to dotnet/runtime, set RUNTIME_REPO to the runtime repo root and then run CopyToRuntime.cmd.
+
+## Building dotnet/runtime code:
+- https://github.com/dotnet/runtime/blob/master/docs/libraries/building/windows-instructions.md
+- https://github.com/dotnet/runtime/blob/master/docs/libraries/project-docs/developer-guide.md
+- Run libraries.cmd from the root once: `PS D:\github\runtime> .\libraries.cmd`
+- Build the individual projects:
+- `PS D:\github\dotnet\src\libraries\Common\tests> dotnet msbuild /t:rebuild`
+- `PS D:\github\dotnet\src\libraries\System.Net.Http\src> dotnet msbuild /t:rebuild`
+
+### Running dotnet/runtime tests:
+- `PS D:\github\runtime\src\libraries\Common\tests> dotnet msbuild /t:rebuildandtest`
+- `PS D:\github\runtime\src\libraries\System.Net.Http\tests\UnitTests> dotnet msbuild /t:rebuildandtest`
+
+## Building aspnet/AspNetCore code:
+- https://github.com/aspnet/AspNetCore/blob/master/docs/BuildFromSource.md
+- Run restore in the root once: `PS D:\github\AspNetCore> .\restore.cmd`
+- Activate to use the repo local runtime: `PS D:\github\AspNetCore> . .\activate.ps1`
+- Build the individual projects:
+- `(AspNetCore) PS D:\github\AspNetCore\src\Shared\test\Shared.Tests> dotnet msbuild`
+- `(AspNetCore) PS D:\github\AspNetCore\src\servers\Kestrel\core\src> dotnet msbuild`
+
+### Running aspnet/AspNetCore tests:
+- `(AspNetCore) PS D:\github\AspNetCore\src\Shared\test\Shared.Tests> dotnet test`
+- `(AspNetCore) PS D:\github\AspNetCore\src\servers\Kestrel\core\test> dotnet test`

--- a/src/libraries/Common/tests/Common.Tests.csproj
+++ b/src/libraries/Common/tests/Common.Tests.csproj
@@ -87,8 +87,8 @@
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
-      <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\H2StaticTable.cs">
+      <Link>Common\System\Net\Http\Http2\Hpack\H2StaticTable.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Security.Authentication;
 
 namespace System.Net.Test.Common
 {
@@ -14,10 +15,13 @@ namespace System.Net.Test.Common
 
     public abstract class LoopbackServerFactory
     {
+        public abstract GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null);
         public abstract Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null);
 
+        // TODO: just expose a version property.
         public abstract bool IsHttp11 { get; }
         public abstract bool IsHttp2 { get; }
+        public abstract bool IsHttp3 { get; }
 
         // Common helper methods
 
@@ -35,11 +39,15 @@ namespace System.Net.Test.Common
 
     public abstract class GenericLoopbackServer : IDisposable
     {
+        public virtual Uri Address { get; }
+
         // Accept a new connection, process a single request and send the specified response, and gracefully close the connection.
         public abstract Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "");
 
         // Accept a new connection, and hand it to provided delegate.
         public abstract Task AcceptConnectionAsync(Func<GenericLoopbackConnection, Task> funcAsync);
+
+        public abstract Task<GenericLoopbackConnection> EstablishGenericConnectionAsync();
 
         public abstract void Dispose();
 
@@ -79,6 +87,12 @@ namespace System.Net.Test.Common
     public class GenericLoopbackOptions
     {
         public IPAddress Address { get; set; } = IPAddress.Loopback;
+        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
+        public SslProtocols SslProtocols { get; set; } =
+#if !NETSTANDARD2_0
+                SslProtocols.Tls13 |
+#endif
+                SslProtocols.Tls12;
     }
 
     public struct HttpHeaderData

--- a/src/libraries/Common/tests/System/Net/Http/HPackEncoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HPackEncoder.cs
@@ -105,7 +105,7 @@ namespace System.Net.Test.Common
             return bytesGenerated;
         }
 
-        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode)
+        public static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode)
         {
             byte[] data = Encoding.ASCII.GetBytes(value);
             byte prefix;

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -315,18 +315,7 @@ namespace System.Net.Test.Common
 
         private static (int bytesConsumed, int value) DecodeInteger(ReadOnlySpan<byte> headerBlock, byte prefixMask)
         {
-            int value = headerBlock[0] & prefixMask;
-            if (value != prefixMask)
-            {
-                return (1, value);
-            }
-
-            byte b = headerBlock[1];
-            if ((b & 0b10000000) != 0)
-            {
-                throw new Exception("long integers currently not supported");
-            }
-            return (2, prefixMask + b);
+            return QPackDecoder.DecodeInteger(headerBlock, prefixMask);
         }
 
         private static (int bytesConsumed, string value) DecodeString(ReadOnlySpan<byte> headerBlock)

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -35,7 +35,7 @@ namespace System.Net.Test.Common
 
         public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
-        public Uri Address
+        public override Uri Address
         {
             get
             {
@@ -90,6 +90,11 @@ namespace System.Net.Test.Common
             _connections.Add(connection);
 
             return connection;
+        }
+
+        public override async Task<GenericLoopbackConnection> EstablishGenericConnectionAsync()
+        {
+            return await EstablishConnectionAsync();
         }
 
         public async Task<Http2LoopbackConnection> EstablishConnectionAsync(params SettingsEntry[] settingsEntries)
@@ -191,8 +196,12 @@ namespace System.Net.Test.Common
     public class Http2Options : GenericLoopbackOptions
     {
         public int ListenBacklog { get; set; } = 1;
-        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
-        public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls12;
+
+        public Http2Options()
+        {
+            UseSsl = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
+            SslProtocols = SslProtocols.Tls12;
+        }
     }
 
     public sealed class Http2LoopbackServerFactory : LoopbackServerFactory
@@ -207,15 +216,22 @@ namespace System.Net.Test.Common
             }
         }
 
-        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null)
+        public override GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null)
         {
             Http2Options http2Options = new Http2Options();
             if (options != null)
             {
                 http2Options.Address = options.Address;
+                http2Options.UseSsl = options.UseSsl;
+                http2Options.SslProtocols = options.SslProtocols;
             }
 
-            using (var server = Http2LoopbackServer.CreateServer(http2Options))
+            return Http2LoopbackServer.CreateServer(http2Options);
+        }
+
+        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null)
+        {
+            using (var server = CreateServer(options))
             {
                 await funcAsync(server, server.Address).TimeoutAfter(millisecondsTimeout).ConfigureAwait(false);
             }
@@ -223,6 +239,7 @@ namespace System.Net.Test.Common
 
         public override bool IsHttp11 => false;
         public override bool IsHttp2 => true;
+        public override bool IsHttp3 => false;
     }
 
     public enum ProtocolErrors

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Quic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+    public sealed class Http3LoopbackConnection : GenericLoopbackConnection
+    {
+        private readonly QuicConnection _connection;
+        private readonly Dictionary<int, Http3LoopbackStream> _openStreams = new Dictionary<int, Http3LoopbackStream>();
+        private Http3LoopbackStream _currentStream;
+
+        public Http3LoopbackConnection(QuicConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public override void Dispose()
+        {
+            foreach (Http3LoopbackStream stream in _openStreams.Values)
+            {
+                stream.Dispose();
+            }
+
+            _connection.Dispose();
+        }
+
+        public Http3LoopbackStream OpenUnidirectionalStream()
+        {
+            return new Http3LoopbackStream(_connection.OpenUnidirectionalStream());
+        }
+
+        public Http3LoopbackStream OpenBidirectionalStream()
+        {
+            return new Http3LoopbackStream(_connection.OpenBidirectionalStream());
+        }
+
+        public static int GetRequestId(QuicStream stream)
+        {
+            Debug.Assert(stream.CanRead && stream.CanWrite, "Stream must be a request stream.");
+
+            // TODO: QUIC streams can have IDs larger than int.MaxValue; update all our tests to use long rather than int.
+            return checked((int)stream.StreamId + 1);
+        }
+
+        public Http3LoopbackStream GetOpenRequest(int requestId = 0)
+        {
+            return requestId == 0 ? _currentStream : _openStreams[requestId - 1];
+        }
+
+        public async Task<Http3LoopbackStream> AcceptStreamAsync()
+        {
+            QuicStream quicStream = await _connection.AcceptStreamAsync().ConfigureAwait(false);
+            var stream = new Http3LoopbackStream(quicStream);
+
+            _openStreams.Add(checked((int)quicStream.StreamId), stream);
+            _currentStream = stream;
+
+            return stream;
+        }
+
+        public override async Task<byte[]> ReadRequestBodyAsync()
+        {
+            return await _currentStream.ReadRequestBodyAsync().ConfigureAwait(false);
+        }
+
+        public override async Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true)
+        {
+            Http3LoopbackStream stream = await AcceptStreamAsync().ConfigureAwait(false);
+            return await stream.ReadRequestDataAsync(readBody).ConfigureAwait(false);
+        }
+
+        public override async Task SendResponseAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "", bool isFinal = true, int requestId = 0)
+        {
+            await SendResponseHeadersAsync(statusCode, headers, requestId).ConfigureAwait(false);
+            await SendResponseBodyAsync(Encoding.UTF8.GetBytes(content ?? ""), isFinal, requestId).ConfigureAwait(false);
+        }
+
+        public override async Task SendResponseBodyAsync(byte[] content, bool isFinal = true, int requestId = 0)
+        {
+            Http3LoopbackStream stream = GetOpenRequest(requestId);
+
+            if (content?.Length != 0)
+            {
+                await stream.SendDataFrameAsync(content).ConfigureAwait(false);
+            }
+
+            if (isFinal)
+            {
+                stream.ShutdownSend();
+                stream.Dispose();
+            }
+        }
+
+        public override Task SendResponseHeadersAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, int requestId = 0)
+        {
+            return SendResponseHeadersAsync(statusCode, headers, requestId);
+        }
+
+        private async Task SendResponseHeadersAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, int requestId = 0)
+        {
+            var allHeaders = new List<HttpHeaderData>((headers?.Count ?? 0) + 1);
+
+            if (statusCode != null)
+            {
+                allHeaders.Add(new HttpHeaderData(":status", ((int)statusCode).ToString(CultureInfo.InvariantCulture)));
+            }
+
+            allHeaders.AddRange(headers);
+
+            await GetOpenRequest(requestId).SendHeadersFrameAsync(allHeaders).ConfigureAwait(false);
+        }
+
+        public override async Task WaitForCancellationAsync(bool ignoreIncomingData = true, int requestId = 0)
+        {
+            await GetOpenRequest(requestId).WaitForCancellationAsync(ignoreIncomingData).ConfigureAwait(false);
+        }
+    }
+
+}

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+    public sealed class Http3LoopbackServer : GenericLoopbackServer
+    {
+        private X509Certificate2 _cert;
+        private QuicListener _listener;
+
+        public override Uri Address => new Uri($"https://{_listener.ListenEndPoint}/");
+
+        public Http3LoopbackServer(GenericLoopbackOptions options = null)
+        {
+            options ??= new GenericLoopbackOptions();
+
+            _cert = Configuration.Certificates.GetServerCertificate();
+
+            var sslOpts = new SslServerAuthenticationOptions
+            {
+                EnabledSslProtocols = options.SslProtocols,
+                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },
+                ServerCertificate = _cert,
+                ClientCertificateRequired = false
+            };
+
+            _listener = new QuicListener(new IPEndPoint(options.Address, 0), sslOpts);
+        }
+
+        public override void Dispose()
+        {
+            _listener.Dispose();
+            _cert.Dispose();
+        }
+
+        public override async Task<GenericLoopbackConnection> EstablishGenericConnectionAsync()
+        {
+            QuicConnection con = await _listener.AcceptConnectionAsync().ConfigureAwait(false);
+            return new Http3LoopbackConnection(con);
+        }
+
+        public override async Task AcceptConnectionAsync(Func<GenericLoopbackConnection, Task> funcAsync)
+        {
+            using GenericLoopbackConnection con = await EstablishGenericConnectionAsync().ConfigureAwait(false);
+            await funcAsync(con).ConfigureAwait(false);
+        }
+
+        public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "")
+        {
+            using GenericLoopbackConnection con = await EstablishGenericConnectionAsync().ConfigureAwait(false);
+
+            HttpRequestData request = await con.ReadRequestDataAsync().ConfigureAwait(false);
+            await con.SendResponseAsync(statusCode, headers, content).ConfigureAwait(false);
+            return request;
+        }
+    }
+
+    public sealed class Http3LoopbackServerFactory : LoopbackServerFactory
+    {
+        public static Http3LoopbackServerFactory Singleton { get; } = new Http3LoopbackServerFactory();
+
+        public override bool IsHttp11 => false;
+
+        public override bool IsHttp2 => false;
+
+        public override bool IsHttp3 => true;
+
+        public override GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null)
+        {
+            return new Http3LoopbackServer(options);
+        }
+
+        public override async Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60000, GenericLoopbackOptions options = null)
+        {
+            using GenericLoopbackServer server = CreateServer(options);
+            await funcAsync(server, server.Address).TimeoutAfter(millisecondsTimeout).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -1,0 +1,330 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Quic;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+
+    public sealed class Http3LoopbackStream : IDisposable
+    {
+        private const int MaximumVarIntBytes = 8;
+        private const long VarIntMax = (1L << 62) - 1;
+
+        private const long DataFrame = 0x0;
+        private const long HeadersFrame = 0x1;
+        private const long SettingsFrame = 0x4;
+
+        private readonly QuicStream _stream;
+
+        public bool CanRead => _stream.CanRead;
+        public bool CanWrite => _stream.CanWrite;
+
+        public Http3LoopbackStream(QuicStream stream)
+        {
+            _stream = stream;
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+        }
+
+        public async Task SendUnidirectionalStreamTypeAsync(long streamType)
+        {
+            var buffer = new byte[MaximumVarIntBytes];
+            int bytesWritten = EncodeHttpInteger(streamType, buffer);
+            await _stream.WriteAsync(buffer.AsMemory(0, bytesWritten)).ConfigureAwait(false);
+        }
+
+        public async Task SendSettingsFrameAsync(ICollection<(long settingId, long settingValue)> settings)
+        {
+            var buffer = new byte[settings.Count * MaximumVarIntBytes * 2];
+
+            int bytesWritten = 0;
+
+            foreach ((long settingId, long settingValue) in settings)
+            {
+                bytesWritten += EncodeHttpInteger(settingId, buffer.AsSpan(bytesWritten));
+                bytesWritten += EncodeHttpInteger(settingValue, buffer.AsSpan(bytesWritten));
+            }
+
+            await SendFrameAsync(SettingsFrame, buffer.AsMemory(0, bytesWritten)).ConfigureAwait(false);
+        }
+
+        public async Task SendHeadersFrameAsync(ICollection<HttpHeaderData> headers)
+        {
+            int bufferLength = QPackEncoder.MaxPrefixLength;
+
+            foreach (HttpHeaderData header in headers)
+            {
+                // Two varints for length, and double the name/value lengths to account for expanding Huffman coding.
+                bufferLength += QPackEncoder.MaxVarIntLength * 2 + header.Name.Length * 2 + header.Value.Length * 2;
+            }
+
+            var buffer = new byte[bufferLength];
+            int bytesWritten = 0;
+
+            bytesWritten += QPackEncoder.EncodePrefix(buffer.AsSpan(bytesWritten), 0, 0);
+
+            foreach (HttpHeaderData header in headers)
+            {
+                bytesWritten += QPackEncoder.EncodeHeader(buffer.AsSpan(bytesWritten), header.Name, header.Value, header.HuffmanEncoded ? QPackFlags.HuffmanEncode : QPackFlags.None);
+            }
+
+            await SendFrameAsync(HeadersFrame, buffer.AsMemory(0, bytesWritten)).ConfigureAwait(false);
+        }
+
+        public async Task SendDataFrameAsync(ReadOnlyMemory<byte> data)
+        {
+            await SendFrameAsync(DataFrame, data).ConfigureAwait(false);
+        }
+
+        public async Task SendFrameAsync(long frameType, ReadOnlyMemory<byte> framePayload)
+        {
+            var buffer = new byte[MaximumVarIntBytes * 2];
+
+            int bytesWritten = 0;
+
+            bytesWritten += EncodeHttpInteger(frameType, buffer.AsSpan(bytesWritten));
+            bytesWritten += EncodeHttpInteger(framePayload.Length, buffer.AsSpan(bytesWritten));
+
+            await _stream.WriteAsync(buffer.AsMemory(0, bytesWritten)).ConfigureAwait(false);
+            await _stream.WriteAsync(framePayload).ConfigureAwait(false);
+        }
+
+        public void ShutdownSend()
+        {
+            _stream.Shutdown();
+        }
+
+        static int EncodeHttpInteger(long longToEncode, Span<byte> buffer)
+        {
+            Debug.Assert(longToEncode >= 0);
+            Debug.Assert(longToEncode <= VarIntMax);
+
+            const uint OneByteLimit = (1U << 6) - 1;
+            const uint TwoByteLimit = (1U << 14) - 1;
+            const uint FourByteLimit = (1U << 30) - 1;
+
+            if (longToEncode < OneByteLimit)
+            {
+                buffer[0] = (byte)longToEncode;
+                return 1;
+            }
+            else if (longToEncode < TwoByteLimit)
+            {
+                BinaryPrimitives.WriteUInt16BigEndian(buffer, (ushort)((uint)longToEncode | 0x4000u));
+                return 2;
+            }
+            else if (longToEncode < FourByteLimit)
+            {
+                BinaryPrimitives.WriteUInt32BigEndian(buffer, (uint)longToEncode | 0x80000000);
+                return 4;
+            }
+            else
+            {
+                BinaryPrimitives.WriteUInt64BigEndian(buffer, (ulong)longToEncode | 0xC000000000000000);
+                return 8;
+            }
+        }
+
+        public async Task<byte[]> ReadRequestBodyAsync()
+        {
+            var buffer = new MemoryStream();
+
+            while (true)
+            {
+                (long? frameType, byte[] payload) = await ReadFrameAsync().ConfigureAwait(false);
+
+                switch (frameType)
+                {
+                    case DataFrame:
+                        buffer.Write(payload);
+                        break;
+                    case null:
+                        return buffer.ToArray();
+                }
+            }
+        }
+
+        public async Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true)
+        {
+            (long? frameType, byte[] payload) = await ReadFrameAsync().ConfigureAwait(false);
+
+            if (frameType == null) throw new Exception("unable to read request headers; unexpected end of stream.");
+            if (frameType != HeadersFrame) throw new Exception($"unable to read request headers; received frame type 0x{frameType:x}.");
+
+            HttpRequestData requestData = ParseHeaders(payload);
+
+            if (readBody)
+            {
+                requestData.Body = await ReadRequestBodyAsync().ConfigureAwait(false);
+            }
+
+            return requestData;
+        }
+
+        private HttpRequestData ParseHeaders(ReadOnlySpan<byte> buffer)
+        {
+            HttpRequestData request = new HttpRequestData { RequestId = Http3LoopbackConnection.GetRequestId(_stream) };
+
+            (int prefixLength, int requiredInsertCount, int deltaBase) = QPackDecoder.DecodePrefix(buffer);
+            if (requiredInsertCount != 0 || deltaBase != 0) throw new Exception("QPack dynamic table not yet supported.");
+
+            buffer = buffer.Slice(prefixLength);
+
+            while (!buffer.IsEmpty)
+            {
+                (int headerLength, HttpHeaderData header) = QPackDecoder.DecodeHeader(buffer);
+
+                request.Headers.Add(header);
+                buffer = buffer.Slice(headerLength);
+
+                switch (header.Name)
+                {
+                    case ":method":
+                        request.Method = header.Value;
+                        break;
+                    case ":path":
+                        request.Path = header.Value;
+                        break;
+                }
+            }
+
+            return request;
+        }
+
+        public async Task WaitForCancellationAsync(bool ignoreIncomingData = true)
+        {
+            while (true)
+            {
+                (long? frameType, _) = await ReadFrameAsync().ConfigureAwait(false);
+
+                switch (frameType)
+                {
+                    case null:
+                        // end of stream reached.
+                        return;
+                    case DataFrame when ignoreIncomingData == true:
+                        break;
+                    default:
+                        Debug.Fail("Unexpected frame type while waiting for client cancellation.");
+                        throw new Exception();
+                }
+            }
+        }
+
+        public async Task<(long? frameType, byte[] payload)> ReadFrameAsync()
+        {
+            long? frameType = await ReadInteger().ConfigureAwait(false);
+            if (frameType == null) return (null, null);
+
+            long? payloadLength = await ReadInteger().ConfigureAwait(false);
+            if (payloadLength == null) throw new Exception("Unable to read frame; unexpected end of stream.");
+
+            byte[] payload = new byte[checked((int)payloadLength)];
+            int totalBytesRead = 0;
+
+            while (totalBytesRead != payloadLength)
+            {
+                int bytesRead = await _stream.ReadAsync(payload.AsMemory(totalBytesRead)).ConfigureAwait(false);
+                if (bytesRead == 0) throw new Exception("Unable to read frame; unexpected end of stream.");
+
+                totalBytesRead += bytesRead;
+            }
+
+            return (frameType, payload);
+        }
+
+        public async Task<long?> ReadInteger()
+        {
+            byte[] buffer = new byte[MaximumVarIntBytes];
+            int bufferAvailableOffset = -1;
+            int bufferActiveLength = 0;
+
+            long integerValue;
+            int bytesRead;
+
+            do
+            {
+                bytesRead = await _stream.ReadAsync(buffer.AsMemory(++bufferAvailableOffset, 1)).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    return bufferActiveLength == 0 ? (long?)null : throw new Exception("Unable to read varint; unexpected end of stream.");
+                }
+                Debug.Assert(bytesRead == 1);
+            }
+            while (!TryDecodeHttpInteger(buffer.AsSpan(0, ++bufferActiveLength), out integerValue, out bytesRead));
+
+            Debug.Assert(bytesRead == bufferActiveLength);
+
+            return integerValue;
+        }
+
+        static bool TryDecodeHttpInteger(ReadOnlySpan<byte> buffer, out long value, out int bytesRead)
+        {
+            const byte LengthMask = 0xC0;
+            const byte LengthOneByte = 0x00;
+            const byte LengthTwoByte = 0x40;
+            const byte LengthFourByte = 0x80;
+            const byte LengthEightByte = 0xC0;
+
+            const uint TwoByteSubtract = 0x4000;
+            const uint FourByteSubtract = 0x80000000;
+            const ulong EightByteSubtract = 0xC000000000000000;
+
+            if (buffer.Length != 0)
+            {
+                byte firstByte = buffer[0];
+
+                switch (firstByte & LengthMask)
+                {
+                    case LengthOneByte:
+                        value = firstByte;
+                        bytesRead = 1;
+                        return true;
+                    case LengthTwoByte:
+                        if (BinaryPrimitives.TryReadUInt16BigEndian(buffer, out ushort serializedShort))
+                        {
+                            value = serializedShort - TwoByteSubtract;
+                            bytesRead = 2;
+                            return true;
+                        }
+                        break;
+                    case LengthFourByte:
+                        if (BinaryPrimitives.TryReadUInt32BigEndian(buffer, out uint serializedInt))
+                        {
+                            value = serializedInt - FourByteSubtract;
+                            bytesRead = 4;
+                            return true;
+                        }
+                        break;
+                    default: // LengthEightByte
+                        Debug.Assert((firstByte & LengthMask) == LengthEightByte);
+                        if (BinaryPrimitives.TryReadUInt64BigEndian(buffer, out ulong serializedLong))
+                        {
+                            value = (long)(serializedLong - EightByteSubtract);
+                            Debug.Assert(value >= 0 && value <= VarIntMax, "Serialized values are within [0, 2^62).");
+
+                            bytesRead = 8;
+                            return true;
+                        }
+                        break;
+                }
+            }
+
+            value = 0;
+            bytesRead = 0;
+            return false;
+        }
+    }
+
+}

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -110,7 +110,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 await LoopbackServer.CreateServerAsync(async (origServer, origUrl) =>
                 {
-                    var request = new HttpRequestMessage(new HttpMethod(oldMethod), origUrl) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(new HttpMethod(oldMethod), origUrl) { Version = UseVersion };
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);
 
@@ -153,7 +153,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 await LoopbackServer.CreateServerAsync(async (origServer, origUrl) =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Post, origUrl) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Post, origUrl) { Version = UseVersion };
                     request.Content = new StringContent(ExpectedContent);
                     request.Headers.TransferEncodingChunked = true;
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http.Functional.Tests
 
                         var waitToSend = new TaskCompletionSource<bool>();
                         var contentSending = new TaskCompletionSource<bool>();
-                        var req = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
+                        var req = new HttpRequestMessage(HttpMethod.Post, uri) { Version = UseVersion };
                         req.Content = new ByteAtATimeContent(int.MaxValue, waitToSend.Task, contentSending, millisecondDelayBetweenBytes: 1);
                         req.Headers.TransferEncodingChunked = chunkedTransfer;
 
@@ -107,7 +107,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await ValidateClientCancellationAsync(async () =>
                     {
-                        var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = VersionFromUseHttp2 };
+                        var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                         req.Headers.ConnectionClose = connectionClose;
 
                         Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
@@ -163,7 +163,7 @@ namespace System.Net.Http.Functional.Tests
 
                     await ValidateClientCancellationAsync(async () =>
                     {
-                        var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = VersionFromUseHttp2 };
+                        var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                         req.Headers.ConnectionClose = connectionClose;
 
                         Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token);
@@ -215,7 +215,7 @@ namespace System.Net.Http.Functional.Tests
                         await clientFinished.Task;
                     });
 
-                    var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = VersionFromUseHttp2 };
+                    var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                     req.Headers.ConnectionClose = connectionClose;
                     Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
                     await ValidateClientCancellationAsync(async () =>
@@ -499,7 +499,7 @@ namespace System.Net.Http.Functional.Tests
                 async uri =>
                 {
                     using (var invoker = new HttpMessageInvoker(CreateHttpClientHandler()))
-                    using (var req = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content, Version = VersionFromUseHttp2 })
+                    using (var req = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content, Version = UseVersion })
                     try
                     {
                         using (HttpResponseMessage resp = await invoker.SendAsync(req, cancellationTokenSource.Token))

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -197,7 +197,7 @@ namespace System.Net.Http.Functional.Tests
 
                 await LoopbackServer.CreateServerAsync(async server =>
                 {
-                    Task clientTask = client.GetStringAsync(server.Uri);
+                    Task clientTask = client.GetStringAsync(server.Address);
                     Task serverTask = server.AcceptConnectionAsync(async connection =>
                     {
                         SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -134,7 +134,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     using (HttpClient client = CreateHttpClient())
                     {
-                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                         requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                         await client.SendAsync(requestMessage);
@@ -155,7 +155,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     using (HttpClient client = CreateHttpClient())
                     {
-                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                         requestMessage.Headers.Add("Cookie", "A=1");
                         requestMessage.Headers.Add("Cookie", "B=2");
                         requestMessage.Headers.Add("Cookie", "C=3");
@@ -217,7 +217,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, url) { Version = VersionFromUseHttp2 };
+                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                     requestMessage.Headers.Add("Cookie", s_customCookieHeaderValue);
 
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(requestMessage);
@@ -244,7 +244,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, url) { Version = VersionFromUseHttp2 };
+                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                     requestMessage.Headers.Add("Cookie", "A=1");
                     requestMessage.Headers.Add("Cookie", "B=2");
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -107,10 +107,10 @@ namespace System.Net.Http.Functional.Tests
                     psi.Environment.Add("http_proxy", $"http://{proxyUri.Host}:{proxyUri.Port}");
                 }
 
-                RemoteExecutor.Invoke(async (useProxyString, useHttp2String) =>
+                RemoteExecutor.Invoke(async (useProxyString, useVersionString) =>
                 {
-                    using (HttpClientHandler handler = CreateHttpClientHandler(useHttp2String))
-                    using (HttpClient client = CreateHttpClient(handler, useHttp2String))
+                    using (HttpClientHandler handler = CreateHttpClientHandler(useVersionString))
+                    using (HttpClient client = CreateHttpClient(handler, useVersionString))
                     {
                         var creds = new NetworkCredential(ExpectedUsername, ExpectedPassword);
                         handler.DefaultProxyCredentials = creds;
@@ -120,7 +120,7 @@ namespace System.Net.Http.Functional.Tests
                         // Correctness of user and password is done in server part.
                         Assert.True(response.StatusCode == HttpStatusCode.OK);
                     }
-                }, useProxy.ToString(), UseHttp2.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+                }, useProxy.ToString(), UseVersion.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
                 if (useProxy)
                 {
                     await proxyTask;

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -111,14 +111,14 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact]
         public void Proxy_UseEnvironmentVariableToSetSystemProxy_RequestGoesThruProxy()
         {
-            RemoteExecutor.Invoke(async (useHttp2String) =>
+            RemoteExecutor.Invoke(async (useVersionString) =>
             {
                 var options = new LoopbackProxyServer.Options { AddViaRequestHeader = true };
                 using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create(options))
                 {
                     Environment.SetEnvironmentVariable("http_proxy", proxyServer.Uri.AbsoluteUri.ToString());
 
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer))
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -126,7 +126,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Contains(proxyServer.ViaHeader, body);
                     }
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [ActiveIssue("https://github.com/dotnet/corefx/issues/32809")]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -344,7 +344,7 @@ namespace System.Net.Http.Functional.Tests
 
             try
             {
-                await UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(url, UseHttp2.ToString(), expectedErrors);
+                await UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(url, UseVersion.ToString(), expectedErrors);
             }
             catch (HttpRequestException e) when (e.InnerException?.GetType().Name == "WinHttpException" &&
                 e.InnerException.HResult == SEC_E_BUFFER_TOO_SMALL &&
@@ -410,15 +410,15 @@ namespace System.Net.Http.Functional.Tests
             File.WriteAllText(sslCertFile, "");
             psi.Environment.Add("SSL_CERT_FILE", sslCertFile);
 
-            RemoteExecutor.Invoke(async (useHttp2String) =>
+            RemoteExecutor.Invoke(async (useVersionString) =>
             {
                 const string Url = "https://www.microsoft.com";
 
-                using (HttpClient client = CreateHttpClient(useHttp2String))
+                using (HttpClient client = CreateHttpClient(useVersionString))
                 {
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(Url));
                 }
-            }, UseHttp2.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+            }, UseVersion.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -546,7 +546,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_ServerNeedsAuthAndNoCredential_StatusCodeUnauthorized()
         {
-            using (HttpClient client = CreateHttpClient(UseHttp2.ToString()))
+            using (HttpClient client = CreateHttpClient(UseVersion.ToString()))
             {
                 Uri uri = Configuration.Http.RemoteHttp11Server.BasicAuthUriForCreds(userName: Username, password: Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
@@ -747,7 +747,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient())
                 {
                     byte[] contentArray = Encoding.ASCII.GetBytes(content);
-                    var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = new ByteArrayContent(contentArray), Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = new ByteArrayContent(contentArray), Version = UseVersion };
 
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
                     request.Headers.AcceptCharset.Add(new StringWithQualityHeaderValue("utf-8"));
@@ -1165,7 +1165,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SendAsync_TransferEncodingSetButNoRequestContent_Throws()
         {
-            var req = new HttpRequestMessage(HttpMethod.Post, "http://bing.com") { Version = VersionFromUseHttp2 };
+            var req = new HttpRequestMessage(HttpMethod.Post, "http://bing.com") { Version = UseVersion };
             req.Headers.TransferEncodingChunked = true;
             using (HttpClient c = CreateHttpClient())
             {
@@ -1266,7 +1266,7 @@ namespace System.Net.Http.Functional.Tests
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                 using (var client = new HttpMessageInvoker(CreateHttpClientHandler()))
                 using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
                 {
@@ -1398,7 +1398,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (var client = new HttpMessageInvoker(CreateHttpClientHandler()))
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
 
                     using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
                     using (Stream responseStream = await response.Content.ReadAsStreamAsync())
@@ -1893,7 +1893,7 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = CreateHttpClientHandler())
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = UseVersion };
                     initialMessage.Content = new StringContent(TestString);
                     initialMessage.Headers.ExpectContinue = true;
                     HttpResponseMessage response = await client.SendAsync(initialMessage);
@@ -1950,7 +1950,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = UseVersion };
                     initialMessage.Content = new StringContent(TestString);
                     // No ExpectContinue header.
                     initialMessage.Headers.ExpectContinue = false;
@@ -1989,7 +1989,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = UseVersion };
                     initialMessage.Content = new StringContent(TestString);
                     initialMessage.Headers.ExpectContinue = true;
                     HttpResponseMessage response = await client.SendAsync(initialMessage);
@@ -2029,7 +2029,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
+                    HttpRequestMessage initialMessage = new HttpRequestMessage(HttpMethod.Post, uri) { Version = UseVersion };
                     initialMessage.Content = new StringContent(RequestString);
                     initialMessage.Headers.ExpectContinue = true;
                     using (HttpResponseMessage response = await client.SendAsync(initialMessage))
@@ -2270,7 +2270,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 var request = new HttpRequestMessage(
                     new HttpMethod(method),
-                    serverUri) { Version = VersionFromUseHttp2 };
+                    serverUri) { Version = UseVersion };
 
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
@@ -2290,7 +2290,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 var request = new HttpRequestMessage(
                     new HttpMethod(method),
-                    serverUri) { Version = VersionFromUseHttp2 };
+                    serverUri) { Version = UseVersion };
                 request.Content = new StringContent(ExpectedContent);
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
@@ -2321,7 +2321,7 @@ namespace System.Net.Http.Functional.Tests
                 var content = new MemoryStream();
                 content.Write(byteContent, 0, byteContent.Length);
                 content.Position = startingPosition;
-                var request = new HttpRequestMessage(HttpMethod.Post, Configuration.Http.RemoteEchoServer) { Content = new StreamContent(content), Version = VersionFromUseHttp2 };
+                var request = new HttpRequestMessage(HttpMethod.Post, Configuration.Http.RemoteEchoServer) { Content = new StreamContent(content), Version = UseVersion };
 
                 for (int iter = 0; iter < 2; iter++)
                 {
@@ -2356,7 +2356,7 @@ namespace System.Net.Http.Functional.Tests
                     serverUri)
                 {
                     Content = new StringContent(ExpectedContent),
-                    Version = VersionFromUseHttp2
+                    Version = UseVersion
                 };
 
                 using (HttpResponseMessage response = await client.SendAsync(request))

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -454,7 +454,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 using (HttpMessageInvoker client = new HttpMessageInvoker(CreateHttpClientHandler()))
-                using (HttpResponseMessage resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 }, CancellationToken.None))
+                using (HttpResponseMessage resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, CancellationToken.None))
                 using (Stream respStream = await resp.Content.ReadAsStreamAsync())
                 {
                     var actualData = new MemoryStream();
@@ -510,7 +510,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var m = new HttpRequestMessage(new HttpMethod(specifiedMethod), uri) { Version = VersionFromUseHttp2 };
+                    var m = new HttpRequestMessage(new HttpMethod(specifiedMethod), uri) { Version = UseVersion };
                     (await client.SendAsync(m)).Dispose();
                 }
             }, async server =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
@@ -86,7 +86,7 @@ namespace System.Net.Http.Functional.Tests
                     // expires, the content will start to be serialized and will signal the server to
                     // close the connection; then once the connection is closed, the send will be allowed
                     // to continue and will fail.
-                    var request = new HttpRequestMessage(HttpMethod.Post, url) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Post, url) { Version = UseVersion };
                     request.Headers.ExpectContinue = true;
                     request.Content = new SynchronizedSendContent(contentSending, connectionClosed.Task);
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));

--- a/src/libraries/Common/tests/System/Net/Http/IdnaProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/IdnaProtocolTests.cs
@@ -71,7 +71,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, serverUrl) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Get, serverUrl) { Version = UseVersion };
                     request.Headers.Host = hostname;
                     request.Headers.Referrer = uri;
                     Task<HttpResponseMessage> getResponseTask = client.SendAsync(request);

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -20,24 +20,32 @@ namespace System.Net.Test.Common
         private Options _options;
         private Uri _uri;
 
-        // Use CreateServerAsync or similar to create
-        private LoopbackServer(Socket listenSocket, Options options)
+        public LoopbackServer(Options options = null)
         {
-            _listenSocket = listenSocket;
-            _options = options;
-
-            var localEndPoint = (IPEndPoint)listenSocket.LocalEndPoint;
-            string host = options.Address.AddressFamily == AddressFamily.InterNetworkV6 ?
-                $"[{localEndPoint.Address}]" :
-                localEndPoint.Address.ToString();
-
-            string scheme = options.UseSsl ? "https" : "http";
-            if (options.WebSocketEndpoint)
+            _options = options ??= new Options();
+            try
             {
-                scheme = options.UseSsl ? "wss" : "ws";
-            }
+                _listenSocket = new Socket(options.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                _listenSocket.Bind(new IPEndPoint(options.Address, 0));
+                _listenSocket.Listen(options.ListenBacklog);
 
-            _uri = new Uri($"{scheme}://{host}:{localEndPoint.Port}/");
+                var localEndPoint = (IPEndPoint)_listenSocket.LocalEndPoint;
+                string host = options.Address.AddressFamily == AddressFamily.InterNetworkV6 ?
+                    $"[{localEndPoint.Address}]" :
+                    localEndPoint.Address.ToString();
+
+                string scheme = options.UseSsl ? "https" : "http";
+                if (options.WebSocketEndpoint)
+                {
+                    scheme = options.UseSsl ? "wss" : "ws";
+                }
+
+                _uri = new Uri($"{scheme}://{host}:{localEndPoint.Port}/");
+            }
+            catch
+            {
+                _listenSocket.Dispose();
+            }
         }
 
         public override void Dispose()
@@ -50,38 +58,35 @@ namespace System.Net.Test.Common
         }
 
         public Socket ListenSocket => _listenSocket;
-        public Uri Uri => _uri;
+        public override Uri Address => _uri;
 
         public static async Task CreateServerAsync(Func<LoopbackServer, Task> funcAsync, Options options = null)
         {
-            options = options ?? new Options();
-
-            using (var listenSocket = new Socket(options.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+            using (var server = new LoopbackServer(options))
             {
-                listenSocket.Bind(new IPEndPoint(options.Address, 0));
-                listenSocket.Listen(options.ListenBacklog);
-
-                using (var server = new LoopbackServer(listenSocket, options))
-                {
-                    await funcAsync(server).ConfigureAwait(false);
-                }
+                await funcAsync(server).ConfigureAwait(false);
             }
         }
 
         public static Task CreateServerAsync(Func<LoopbackServer, Uri, Task> funcAsync, Options options = null)
         {
-            return CreateServerAsync(server => funcAsync(server, server.Uri), options);
+            return CreateServerAsync(server => funcAsync(server, server.Address), options);
         }
 
         public static Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<LoopbackServer, Task> serverFunc, Options options = null)
         {
             return CreateServerAsync(async server =>
             {
-                Task clientTask = clientFunc(server.Uri);
+                Task clientTask = clientFunc(server.Address);
                 Task serverTask = serverFunc(server);
 
                 await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed().ConfigureAwait(false);
             }, options);
+        }
+
+        public override async Task<GenericLoopbackConnection> EstablishGenericConnectionAsync()
+        {
+            return await EstablishConnectionAsync();
         }
 
         public async Task<Connection> EstablishConnectionAsync()
@@ -378,18 +383,22 @@ namespace System.Net.Test.Common
         public class Options : GenericLoopbackOptions
         {
             public int ListenBacklog { get; set; } = 1;
-            public bool UseSsl { get; set; } = false;
-            public SslProtocols SslProtocols { get; set; } =
-#if !NETSTANDARD2_0
-                SslProtocols.Tls13 |
-#endif
-                SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
             public bool WebSocketEndpoint { get; set; } = false;
             public Func<Stream, Stream> StreamWrapper { get; set; }
             public string Username { get; set; }
             public string Domain { get; set; }
             public string Password { get; set; }
             public bool IsProxy { get; set; } = false;
+
+            public Options()
+            {
+                UseSsl = false;
+                SslProtocols =
+#if !NETSTANDARD2_0
+                SslProtocols.Tls13 |
+#endif
+                SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+            }
         }
 
         public sealed class Connection : GenericLoopbackConnection
@@ -868,18 +877,28 @@ namespace System.Net.Test.Common
     {
         public static readonly Http11LoopbackServerFactory Singleton = new Http11LoopbackServerFactory();
 
+        public override GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null)
+        {
+            return new LoopbackServer(CreateOptions(options));
+        }
+
         public override Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null)
+        {
+            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri), options: CreateOptions(options));
+        }
+
+        private static LoopbackServer.Options CreateOptions(GenericLoopbackOptions options)
         {
             LoopbackServer.Options newOptions = new LoopbackServer.Options();
             if (options != null)
             {
                 newOptions.Address = options.Address;
             }
-
-            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri), options: newOptions);
+            return newOptions;
         }
 
         public override bool IsHttp11 => true;
         public override bool IsHttp2 => false;
+        public override bool IsHttp3 => false;
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/QPackDecoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackDecoder.cs
@@ -1,0 +1,222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+using System.Text;
+
+namespace System.Net.Test.Common
+{
+    public static class QPackDecoder
+    {
+        public static (int bytesConsumed, int requiredInsertCount, int deltaBase) DecodePrefix(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer[0] != 0x00 && buffer[1] != 0x00)
+            {
+                throw new Exception("QPack dynamic table is not yet supported.");
+            }
+
+            return (2, 0, 0);
+        }
+        public static (int bytesConsumed, HttpHeaderData) DecodeHeader(ReadOnlySpan<byte> buffer)
+        {
+            int firstByte = buffer[0];
+
+            // Indexed Header Field, dynamic.
+            if ((firstByte & 0b1100_0000) == 0b1000_0000)
+            {
+                throw new Exception("QPack dynamic table is not yet supported.");
+            }
+
+            // Indexed Header Field, static.
+            if ((firstByte & 0b1100_0000) == 0b1100_0000)
+            {
+                (int bytesConsumed, int staticIndex) = DecodeInteger(buffer, 0b1100_0000);
+
+                var staticHeader = s_staticTable[staticIndex];
+                var header = new HttpHeaderData(staticHeader.Name, staticHeader.Value, raw: buffer.Slice(0, bytesConsumed).ToArray());
+
+                return (bytesConsumed, header);
+            }
+
+            // Indexed Header Field With Post-Base Index
+            if ((firstByte & 0b1111_0000) == 0b0001_0000)
+            {
+                throw new Exception("QPack dynamic table is not yet supported.");
+            }
+
+            // Literal Header Field With Name Reference
+            if ((firstByte & 0b1100_0000) == 0b0100_0000)
+            {
+                if ((firstByte & 0b0001_0000) != 0)
+                {
+                    throw new Exception("QPack dynamic table is not yet supported.");
+                }
+
+                (int nameLength, int staticIndex) = DecodeInteger(buffer, 0b1111_0000);
+                (int valueLength, string value) = DecodeString(buffer.Slice(nameLength), 0b1000_0000);
+
+                int headerLength = nameLength + valueLength;
+                var header = new HttpHeaderData(s_staticTable[staticIndex].Name, value, raw: buffer.Slice(0, headerLength).ToArray());
+
+                return (headerLength, header);
+            }
+
+            // Literal Header Field With Post-Base Name Reference.
+            if ((firstByte & 0b1111_0000) == 0b0000_0000)
+            {
+                throw new Exception("QPack dynamic table is not yet supported.");
+            }
+
+            // Literal Header Field Without Name Reference.
+            if ((firstByte & 0b1110_0000) == 0b0010_0000)
+            {
+                (int nameLength, string name) = DecodeString(buffer, 0b1111_1000);
+                (int valueLength, string value) = DecodeString(buffer.Slice(nameLength), 0b1000_0000);
+
+                int headerLength = nameLength + valueLength;
+                var header = new HttpHeaderData(name, value, raw: buffer.Slice(0, headerLength).ToArray());
+
+                return (headerLength, header);
+            }
+
+            throw new Exception("Invalid QPack.");
+        }
+
+        private static (int bytesConsumed, string value) DecodeString(ReadOnlySpan<byte> buffer, byte prefixMask)
+        {
+            bool huffman = (buffer[0] & (1 << BitOperations.TrailingZeroCount(prefixMask))) != 0;
+
+            if (huffman)
+            {
+                throw new Exception("Huffman coding not yet supported.");
+            }
+
+            (int nameLength, int stringLength) = DecodeInteger(buffer, prefixMask);
+            string value = Encoding.ASCII.GetString(buffer.Slice(nameLength));
+
+            return (nameLength + stringLength, value);
+        }
+
+        public static (int bytesConsumed, int value) DecodeInteger(ReadOnlySpan<byte> headerBlock, byte prefixMask)
+        {
+            int value = headerBlock[0] & prefixMask;
+            if (value != prefixMask)
+            {
+                return (1, value);
+            }
+
+            byte b = headerBlock[1];
+            if ((b & 0b10000000) != 0)
+            {
+                throw new Exception("long integers currently not supported");
+            }
+
+            return (2, prefixMask + b);
+        }
+
+        private static readonly HttpHeaderData[] s_staticTable = new HttpHeaderData[]
+        {
+            new HttpHeaderData(":authority", ""), // 0
+            new HttpHeaderData(":path", "/"), // 1
+            new HttpHeaderData("age", "0"), // 2
+            new HttpHeaderData("content-disposition", ""),
+            new HttpHeaderData("content-length", "0"),
+            new HttpHeaderData("cookie", ""),
+            new HttpHeaderData("date", ""),
+            new HttpHeaderData("etag", ""),
+            new HttpHeaderData("if-modified-since", ""),
+            new HttpHeaderData("if-none-match", ""),
+            new HttpHeaderData("last-modified", ""), // 10
+            new HttpHeaderData("link", ""),
+            new HttpHeaderData("location", ""),
+            new HttpHeaderData("referer", ""),
+            new HttpHeaderData("set-cookie", ""),
+            new HttpHeaderData(":method", "CONNECT"),
+            new HttpHeaderData(":method", "DELETE"),
+            new HttpHeaderData(":method", "GET"),
+            new HttpHeaderData(":method", "HEAD"),
+            new HttpHeaderData(":method", "OPTIONS"),
+            new HttpHeaderData(":method", "POST"), // 20
+            new HttpHeaderData(":method", "PUT"),
+            new HttpHeaderData(":scheme", "http"),
+            new HttpHeaderData(":scheme", "https"),
+            new HttpHeaderData(":status", "103"),
+            new HttpHeaderData(":status", "200"),
+            new HttpHeaderData(":status", "304"),
+            new HttpHeaderData(":status", "404"),
+            new HttpHeaderData(":status", "503"),
+            new HttpHeaderData("accept", "*/*"),
+            new HttpHeaderData("accept", "application/dns-message"), // 30
+            new HttpHeaderData("accept-encoding", "gzip, deflate, br"),
+            new HttpHeaderData("accept-ranges", "bytes"),
+            new HttpHeaderData("access-control-allow-headers", "cache-control"),
+            new HttpHeaderData("access-control-allow-origin", "content-type"),
+            new HttpHeaderData("access-control-allow-origin", "*"),
+            new HttpHeaderData("cache-control", "max-age=0"),
+            new HttpHeaderData("cache-control", "max-age=2592000"),
+            new HttpHeaderData("cache-control", "max-age=604800"),
+            new HttpHeaderData("cache-control", "no-cache"),
+            new HttpHeaderData("cache-control", "no-store"), // 40
+            new HttpHeaderData("cache-control", "public, max-age=31536000"),
+            new HttpHeaderData("content-encoding", "br"),
+            new HttpHeaderData("content-encoding", "gzip"),
+            new HttpHeaderData("content-type", "application/dns-message"),
+            new HttpHeaderData("content-type", "application/javascript"),
+            new HttpHeaderData("content-type", "application/json"),
+            new HttpHeaderData("content-type", "application/x-www-form-urlencoded"),
+            new HttpHeaderData("content-type", "image/gif"),
+            new HttpHeaderData("content-type", "image/jpeg"),
+            new HttpHeaderData("content-type", "image/png"), // 50
+            new HttpHeaderData("content-type", "text/css"),
+            new HttpHeaderData("content-type", "text/html; charset=utf-8"),
+            new HttpHeaderData("content-type", "text/plain"),
+            new HttpHeaderData("content-type", "text/plain;charset=utf-8"),
+            new HttpHeaderData("range", "bytes=0-"),
+            new HttpHeaderData("strict-transport-security", "max-age=31536000"),
+            new HttpHeaderData("strict-transport-security", "max-age=31536000;includesubdomains"), // TODO confirm spaces here don't matter?
+            new HttpHeaderData("strict-transport-security", "max-age=31536000;includesubdomains; preload"),
+            new HttpHeaderData("vary", "accept-encoding"),
+            new HttpHeaderData("vary", "origin"), // 60
+            new HttpHeaderData("x-content-type-options", "nosniff"),
+            new HttpHeaderData("x-xss-protection", "1; mode=block"),
+            new HttpHeaderData(":status", "100"),
+            new HttpHeaderData(":status", "204"),
+            new HttpHeaderData(":status", "206"),
+            new HttpHeaderData(":status", "302"),
+            new HttpHeaderData(":status", "400"),
+            new HttpHeaderData(":status", "403"),
+            new HttpHeaderData(":status", "421"),
+            new HttpHeaderData(":status", "425"), // 70
+            new HttpHeaderData(":status", "500"),
+            new HttpHeaderData("accept-language", ""),
+            new HttpHeaderData("access-control-allow-credentials", "FALSE"),
+            new HttpHeaderData("access-control-allow-credentials", "TRUE"),
+            new HttpHeaderData("access-control-allow-headers", "*"),
+            new HttpHeaderData("access-control-allow-methods", "get"),
+            new HttpHeaderData("access-control-allow-methods", "get, post, options"),
+            new HttpHeaderData("access-control-allow-methods", "options"),
+            new HttpHeaderData("access-control-expose-headers", "content-length"),
+            new HttpHeaderData("access-control-request-headers", "content-type"), // 80
+            new HttpHeaderData("access-control-request-method", "get"),
+            new HttpHeaderData("access-control-request-method", "post"),
+            new HttpHeaderData("alt-svc", "clear"),
+            new HttpHeaderData("authorization", ""),
+            new HttpHeaderData("content-security-policy", "script-src 'none'; object-src 'none'; base-uri 'none'"),
+            new HttpHeaderData("early-data", "1"),
+            new HttpHeaderData("expect-ct", ""),
+            new HttpHeaderData("forwarded", ""),
+            new HttpHeaderData("if-range", ""),
+            new HttpHeaderData("origin", ""), // 90
+            new HttpHeaderData("purpose", "prefetch"),
+            new HttpHeaderData("server", ""),
+            new HttpHeaderData("timing-allow-origin", "*"),
+            new HttpHeaderData("upgrading-insecure-requests", "1"),
+            new HttpHeaderData("user-agent", ""),
+            new HttpHeaderData("x-forwarded-for", ""),
+            new HttpHeaderData("x-frame-options", "deny"),
+            new HttpHeaderData("x-frame-options", "sameorigin"),
+        };
+    }
+
+}

--- a/src/libraries/Common/tests/System/Net/Http/QPackEncoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackEncoder.cs
@@ -1,0 +1,176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace System.Net.Test.Common
+{
+    public static class QPackEncoder
+    {
+        public const int MaxVarIntLength = 6;
+        public const int MaxPrefixLength = MaxVarIntLength * 2;
+
+        private const QPackFlags FlagsIndexMask = QPackFlags.StaticIndex | QPackFlags.DynamicIndex | QPackFlags.DynamicIndexPostBase;
+
+        public static int EncodePrefix(Span<byte> buffer, int requiredInsertCount, int deltaBase)
+        {
+            int bytesWritten = 0;
+
+            bytesWritten += EncodeInteger(buffer.Slice(bytesWritten), requiredInsertCount, 0, 0);
+            bytesWritten += EncodeInteger(buffer.Slice(bytesWritten), Math.Abs(deltaBase), deltaBase < 0 ? (byte)0x80 : (byte)0, 0x80);
+
+            return bytesWritten;
+        }
+
+        public static int EncodeHeader(Span<byte> buffer, int nameValueIdx, QPackFlags flags = QPackFlags.StaticIndex)
+        {
+            byte prefix, prefixMask;
+
+            switch (flags & FlagsIndexMask)
+            {
+                case QPackFlags.StaticIndex:
+                    prefix = 0b1100_0000;
+                    prefixMask = 0b1100_0000;
+                    break;
+                case QPackFlags.DynamicIndex:
+                    prefix = 0b1000_0000;
+                    prefixMask = 0b1100_0000;
+                    break;
+                case QPackFlags.DynamicIndexPostBase:
+                    prefix = 0b0001_0000;
+                    prefixMask = 0b1111_0000;
+                    break;
+                default:
+                    Debug.Fail($"Invalid {nameof(QPackFlags)}.");
+                    throw new Exception();
+            }
+
+            return EncodeInteger(buffer, nameValueIdx, prefix, prefixMask);
+        }
+
+        public static int EncodeHeader(Span<byte> buffer, int nameIdx, string value, QPackFlags flags = QPackFlags.StaticIndex)
+        {
+            byte prefix, prefixMask;
+
+            switch (flags & FlagsIndexMask)
+            {
+                case QPackFlags.StaticIndex:
+                    prefix = 0b0101_0000;
+                    prefixMask = 0b1111_0000;
+                    if (flags.HasFlag(QPackFlags.NeverIndexed)) prefix |= 0b0010_0000;
+                    break;
+                case QPackFlags.DynamicIndex:
+                    prefix = 0b0100_0000;
+                    prefixMask = 0b1111_0000;
+                    if (flags.HasFlag(QPackFlags.NeverIndexed)) prefix |= 0b0010_0000;
+                    break;
+                case QPackFlags.DynamicIndexPostBase:
+                    prefix = 0b0000_0000;
+                    prefixMask = 0b1111_1000;
+                    if (flags.HasFlag(QPackFlags.NeverIndexed)) prefix |= 0b0000_1000;
+                    break;
+                default:
+                    Debug.Fail($"Invalid {nameof(QPackFlags)}.");
+                    throw new Exception();
+            }
+
+            int nameLen = EncodeInteger(buffer, nameIdx, prefix, prefixMask);
+            int valueLen = EncodeString(buffer.Slice(nameLen), value, flags.HasFlag(QPackFlags.HuffmanEncodeValue));
+
+            return nameLen + valueLen;
+        }
+
+        public static int EncodeHeader(Span<byte> buffer, string name, string value, QPackFlags flags = QPackFlags.None)
+        {
+            byte[] data = Encoding.ASCII.GetBytes(name);
+            byte prefix;
+
+            if (!flags.HasFlag(QPackFlags.HuffmanEncodeName))
+            {
+                prefix = 0b0010_0000;
+            }
+            else
+            {
+                int len = HuffmanEncoder.GetEncodedLength(data);
+
+                byte[] huffmanData = new byte[len];
+                HuffmanEncoder.Encode(data, huffmanData);
+
+                data = huffmanData;
+                prefix = 0b0010_1000;
+            }
+
+            if (flags.HasFlag(QPackFlags.NeverIndexed))
+            {
+                prefix |= 0b0001_0000;
+            }
+
+            int bytesGenerated = 0;
+
+            // write name string header.
+            bytesGenerated += EncodeInteger(buffer, data.Length, prefix, 0b1111_1000);
+
+            // write name string.
+            data.AsSpan().CopyTo(buffer.Slice(bytesGenerated));
+            bytesGenerated += data.Length;
+
+            // write value string.
+            bytesGenerated += EncodeString(buffer.Slice(bytesGenerated), value, flags.HasFlag(QPackFlags.HuffmanEncodeValue));
+
+            return bytesGenerated;
+        }
+
+        public static int EncodeString(Span<byte> buffer, string value, bool huffmanCoded = false)
+        {
+            return HPackEncoder.EncodeString(value, buffer, huffmanCoded);
+        }
+
+        public static int EncodeInteger(Span<byte> buffer, int value, byte prefix, byte prefixMask)
+        {
+            return HPackEncoder.EncodeInteger(value, prefix, prefixMask, buffer);
+        }
+    }
+
+    [Flags]
+    public enum QPackFlags
+    {
+        None = 0,
+
+        /// <summary>
+        /// Applies Huffman encoding to the header's name.
+        /// </summary>
+        HuffmanEncodeName = 1,
+
+        /// <summary>
+        /// Applies Huffman encoding to the header's value.
+        /// </summary>
+        HuffmanEncodeValue = 2,
+
+        /// <summary>
+        /// Applies Huffman encoding to both the name and the value of the header.
+        /// </summary>
+        HuffmanEncode = HuffmanEncodeName | HuffmanEncodeValue,
+
+        /// <summary>
+        /// The header is using an indexed header from the static table.
+        /// </summary>
+        StaticIndex = 4,
+
+        /// <summary>
+        /// The header is using an indexed header from the dynamic table.
+        /// </summary>
+        DynamicIndex = 8,
+
+        /// <summary>
+        /// The header is using an indexed header from the dynamic table, adjusted from a base index.
+        /// </summary>
+        DynamicIndexPostBase = 16,
+
+        /// <summary>
+        /// Intermediaries (such as a proxy) must not index the value when forwarding the header.
+        /// </summary>
+        NeverIndexed = 32
+    }
+}

--- a/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
@@ -106,6 +106,18 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decodedHeaders[headerName] = headerValue;
         }
 
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
+        {
+            // Not yet implemented for HPACK.
+            throw new NotImplementedException();
+        }
+
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        {
+            // Not yet implemented for HPACK.
+            throw new NotImplementedException();
+        }
+
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
 
         [Fact]

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -10,16 +10,13 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected WinHttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseHttp2);
-
-        protected static WinHttpClientHandler CreateHttpClientHandler(string useHttp2LoopbackServerString) =>
-            CreateHttpClientHandler(bool.Parse(useHttp2LoopbackServerString));
-
-        protected static WinHttpClientHandler CreateHttpClientHandler(bool useHttp2LoopbackServer = false)
+        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
+            useVersion ??= HttpVersion.Version11;
+
             WinHttpClientHandler handler = new WinHttpClientHandler();
 
-            if (useHttp2LoopbackServer)
+            if (useVersion >= HttpVersion.Version20)
             {
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -85,6 +85,21 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackConnection.cs">
       <Link>Common\System\Net\Http\Http2LoopbackConnection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackDecoder.cs">
+      <Link>Common\System\Net\Http\QPackDecoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackEncoder.cs">
+      <Link>Common\System\Net\Http\QPackEncoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackServer.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackServer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackConnection.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackConnection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackStream.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackStream.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\HuffmanDecoder.cs">
       <Link>Common\System\Net\Http\HuffmanDecoder.cs</Link>
     </Compile>

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -541,9 +541,9 @@ namespace System.Net.Http.Headers
     }
     public partial class NameValueWithParametersHeaderValue : System.Net.Http.Headers.NameValueHeaderValue, System.ICloneable
     {
-        protected NameValueWithParametersHeaderValue(System.Net.Http.Headers.NameValueWithParametersHeaderValue source) : base (default(System.Net.Http.Headers.NameValueHeaderValue)) { }
-        public NameValueWithParametersHeaderValue(string name) : base (default(System.Net.Http.Headers.NameValueHeaderValue)) { }
-        public NameValueWithParametersHeaderValue(string name, string value) : base (default(System.Net.Http.Headers.NameValueHeaderValue)) { }
+        protected NameValueWithParametersHeaderValue(System.Net.Http.Headers.NameValueWithParametersHeaderValue source) : base (default(string)) { }
+        public NameValueWithParametersHeaderValue(string name) : base (default(string)) { }
+        public NameValueWithParametersHeaderValue(string name, string value) : base (default(string)) { }
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -522,4 +522,19 @@
   <data name="net_http_invalid_header_name" xml:space="preserve">
     <value>Received an invalid header name: '{0}'.</value>
   </data>
+  <data name="net_http_http3_connection_error" xml:space="preserve">
+    <value>The HTTP/3 server sent invalid data on the connection. HTTP/3 error code '{0}' (0x{1}).</value>
+  </data>
+  <data name="net_http_http3_stream_error" xml:space="preserve">
+    <value>The HTTP/3 server sent invalid data on the stream. HTTP/3 error code '{0}' (0x{1}).</value>
+  </data>
+  <data name="net_http_retry_on_older_version" xml:space="preserve">
+    <value>The server is unable to process the request using the current HTTP version and indicates the request should be retried on an older HTTP version.</value>
+  </data>
+  <data name="net_http_content_write_larger_than_content_length" xml:space="preserve">
+    <value>Unable to write content to request stream; content would exceed Content-Length.</value>
+  </data>
+  <data name="net_http_qpack_no_dynamic_table" xml:space="preserve">
+    <value>The HTTP/3 server attempted to reference a dynamic table index that does not exist.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -18,6 +18,8 @@
     <Compile Include="System\Net\Http\ClientCertificateOption.cs" />
     <Compile Include="System\Net\Http\DelegatingHandler.cs" />
     <Compile Include="System\Net\Http\FormUrlEncodedContent.cs" />
+    <Compile Include="System\Net\Http\Headers\AltSvcHeaderParser.cs" />
+    <Compile Include="System\Net\Http\Headers\AltSvcHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\KnownHeader.cs" />
     <Compile Include="System\Net\Http\Headers\HttpHeaderType.cs" />
     <Compile Include="System\Net\Http\Headers\KnownHeaders.cs" />
@@ -41,6 +43,11 @@
     <Compile Include="System\Net\Http\NetEventSource.Http.cs" />
     <Compile Include="System\Net\Http\ReadOnlyMemoryContent.cs" />
     <Compile Include="System\Net\Http\RequestRetryType.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3Connection.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ConnectionException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ProtocolException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3RequestStream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthority.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />
@@ -195,11 +202,47 @@
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
-      <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\H2StaticTable.cs">
+      <Link>Common\System\Net\Http\Http2\Hpack\H2StaticTable.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Http3SettingType.cs">
+      <Link>Common\System\Net\Http\Http3\Http3SettingType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Http3StreamType.cs">
+      <Link>Common\System\Net\Http\Http3\Http3StreamType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Helpers\VariableLengthIntegerHelper.cs">
+      <Link>Common\System\Net\Http\Http3\Helpers\VariableLengthIntegerHelper.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Frames\Http3ErrorCode.cs">
+      <Link>Common\System\Net\Http\Http3\Frames\Http3ErrorCode.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Frames\Http3Frame.cs">
+      <Link>Common\System\Net\Http\Http3\Frames\Http3Frame.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\Frames\Http3FrameType.cs">
+      <Link>Common\System\Net\Http\Http3\Frames\Http3FrameType.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\HeaderField.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\HeaderField.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackDecoder.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackDecoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackDecodingException.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackDecodingException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackEncoder.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackEncoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackEncodingException.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackEncodingException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\H3StaticTable.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\H3StaticTable.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)System\Net\SecurityStatusPal.cs">
       <Link>Common\System\Net\SecurityStatusPal.cs</Link>
@@ -236,6 +279,9 @@
     </Compile>
     <Compile Include="$(CommonPath)System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs">
+      <Link>Common\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
   </ItemGroup>
   <!-- SocketsHttpHandler platform parts -->
@@ -675,10 +721,11 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Net.NameResolution" />
-    <Reference Include="System.Net.NetworkInformation" Condition="'$(TargetsWindows)' == 'true'" />
+    <Reference Include="System.Net.NetworkInformation" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.Security" />
     <Reference Include="System.Net.Sockets" />
+    <Reference Include="System.Net.Quic" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -1,0 +1,501 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Resources;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Headers
+{
+    /// <summary>
+    /// Parses Alt-Svc header values, per RFC 7838 Section 3.
+    /// </summary>
+    internal class AltSvcHeaderParser : BaseHeaderParser
+    {
+        internal const long DefaultMaxAgeTicks = 24 * TimeSpan.TicksPerHour;
+
+        public static AltSvcHeaderParser Parser { get; } = new AltSvcHeaderParser();
+
+        private AltSvcHeaderParser()
+            : base(supportsMultipleValues: true)
+        {
+        }
+
+        protected override int GetParsedValueLength(string value, int startIndex, object storeValue,
+            out object parsedValue)
+        {
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(startIndex < value.Length);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                parsedValue = null;
+                return 0;
+            }
+
+            int idx = startIndex;
+
+            if (!TryReadPercentEncodedAlpnProtocolName(value, idx, out string alpnProtocolName, out int alpnProtocolNameLength))
+            {
+                parsedValue = null;
+                return 0;
+            }
+
+            idx += alpnProtocolNameLength;
+
+            if (alpnProtocolName == "clear")
+            {
+                if (idx != value.Length)
+                {
+                    // Clear has no parameters and should be the only Alt-Svc value present, so there should be nothing after it.
+                    parsedValue = null;
+                    return 0;
+                }
+
+                parsedValue = AltSvcHeaderValue.Clear;
+                return idx - startIndex;
+            }
+
+            if (idx == value.Length || value[idx++] != '=')
+            {
+                parsedValue = null;
+                return 0;
+            }
+
+            if (!TryReadQuotedAltAuthority(value, idx, out string altAuthorityHost, out int altAuthorityPort, out int altAuthorityLength))
+            {
+                parsedValue = null;
+                return 0;
+            }
+            idx += altAuthorityLength;
+
+            // Parse parameters: *( OWS ";" OWS parameter )
+            int? maxAge = null;
+            bool persist = false;
+
+            while (idx != value.Length)
+            {
+                // Skip OWS before semicolon.
+                while (idx != value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
+
+                if (idx == value.Length)
+                {
+                    parsedValue = null;
+                    return 0;
+                }
+
+                char ch = value[idx];
+
+                if (ch == ',')
+                {
+                    // Multi-value header: return this value; will get called again to parse the next.
+                    break;
+                }
+
+                if (ch != ';')
+                {
+                    // Expecting parameters starting with semicolon; fail out.
+                    parsedValue = null;
+                    return 0;
+                }
+
+                ++idx;
+
+                // Skip OWS after semicolon / before value.
+                while (idx != value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
+
+                // Get the parameter key length.
+                int tokenLength = HttpRuleParser.GetTokenLength(value, idx);
+                if (tokenLength == 0)
+                {
+                    parsedValue = null;
+                    return 0;
+                }
+
+                if ((idx + tokenLength) >= value.Length || value[idx + tokenLength] != '=')
+                {
+                    parsedValue = null;
+                    return 0;
+                }
+
+                if (tokenLength == 2 && value[idx] == 'm' && value[idx + 1] == 'a')
+                {
+                    // Parse "ma" (Max Age).
+
+                    idx += 3; // Skip "ma="
+                    if (!TryReadTokenOrQuotedInt32(value, idx, out int maxAgeTmp, out int parameterLength))
+                    {
+                        parsedValue = null;
+                        return 0;
+                    }
+
+                    if (maxAge == null)
+                    {
+                        maxAge = maxAgeTmp;
+                    }
+                    else
+                    {
+                        // RFC makes it unclear what to do if a duplicate parameter is found. For now, take the minimum.
+                        maxAge = Math.Min(maxAge.GetValueOrDefault(), maxAgeTmp);
+                    }
+
+                    idx += parameterLength;
+                }
+                else if (value.AsSpan(idx).StartsWith("persist="))
+                {
+                    idx += 8; // Skip "persist="
+                    if (TryReadTokenOrQuotedInt32(value, idx, out int persistInt, out int parameterLength))
+                    {
+                        persist = persistInt == 1;
+                    }
+                    else if (!TrySkipTokenOrQuoted(value, idx, out parameterLength))
+                    {
+                        // Cold path: unsupported value, just skip the parameter.
+                        parsedValue = null;
+                        return 0;
+                    }
+
+                    idx += parameterLength;
+                }
+                else
+                {
+                    // Some unknown parameter. Skip it.
+
+                    idx += tokenLength + 1;
+                    if (!TrySkipTokenOrQuoted(value, idx, out int parameterLength))
+                    {
+                        parsedValue = null;
+                        return 0;
+                    }
+                    idx += parameterLength;
+                }
+            }
+
+            // If no "ma" parameter present, use the default.
+            TimeSpan maxAgeTimeSpan = TimeSpan.FromTicks(maxAge * TimeSpan.TicksPerSecond ?? DefaultMaxAgeTicks);
+
+            parsedValue = new AltSvcHeaderValue(alpnProtocolName, altAuthorityHost, altAuthorityPort, maxAgeTimeSpan, persist);
+            return idx - startIndex;
+        }
+
+        private static bool IsOptionalWhiteSpace(char ch)
+        {
+            return ch == ' ' || ch == '\t';
+        }
+
+        private static bool TryReadPercentEncodedAlpnProtocolName(string value, int startIndex, out string result, out int readLength)
+        {
+            int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
+
+            if (tokenLength == 0)
+            {
+                result = null;
+                readLength = 0;
+                return false;
+            }
+
+            ReadOnlySpan<char> span = value.AsSpan(startIndex, tokenLength);
+
+            readLength = tokenLength;
+
+            // Special-case expected values to avoid allocating one-off strings.
+            switch (span.Length)
+            {
+                case 2:
+                    if (span[0] == 'h')
+                    {
+                        char ch = span[1];
+                        if (ch == '3')
+                        {
+                            result = "h3";
+                            return true;
+                        }
+                        if (ch == '2')
+                        {
+                            result = "h2";
+                            return true;
+                        }
+                    }
+                    break;
+                case 3:
+                    if (span[0] == 'h' && span[1] == '2' && span[2] == 'c')
+                    {
+                        result = "h2c";
+                        readLength = 3;
+                        return true;
+                    }
+                    break;
+                case 5:
+                    if (span.SequenceEqual("clear"))
+                    {
+                        result = "clear";
+                        return true;
+                    }
+                    break;
+                case 10:
+                    if (span.StartsWith("http%2F1."))
+                    {
+                        char ch = span[9];
+                        if (ch == '1')
+                        {
+                            result = "http/1.1";
+                            return true;
+                        }
+                        if (ch == '0')
+                        {
+                            result = "http/1.0";
+                            return true;
+                        }
+                    }
+                    break;
+            }
+
+            // Unrecognized ALPN protocol name. Percent-decode.
+            return TryReadUnknownPercentEncodedAlpnProtocolName(span, out result);
+        }
+
+        private static bool TryReadUnknownPercentEncodedAlpnProtocolName(ReadOnlySpan<char> value, out string result)
+        {
+            int idx = value.IndexOf('%');
+
+            if (idx == -1)
+            {
+                result = new string(value);
+                return true;
+            }
+
+            var builder = new ValueStringBuilder(value.Length <= 128 ? stackalloc char[128] : new char[value.Length]);
+
+            do
+            {
+                if (idx != 0)
+                {
+                    builder.Append(value.Slice(0, idx));
+                }
+
+                if ((value.Length - idx) < 3 || !TryReadAlpnHexDigit(value[1], out int hi) || !TryReadAlpnHexDigit(value[2], out int lo))
+                {
+                    result = null;
+                    return false;
+                }
+
+                builder.Append((char)((hi << 8) | lo));
+
+                value = value.Slice(idx + 3);
+                idx = value.IndexOf('%');
+            }
+            while (idx != -1);
+
+            if (value.Length != 0)
+            {
+                builder.Append(value);
+            }
+
+            result = builder.ToString();
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a hex nibble. Specialized for ALPN protocol names as they explicitly can not contain lower-case hex.
+        /// </summary>
+        private static bool TryReadAlpnHexDigit(char ch, out int nibble)
+        {
+            if ((uint)(ch - '0') <= '9' - '0') // ch >= '0' && ch <= '9'
+            {
+                nibble = ch - '0';
+                return true;
+            }
+
+            if ((uint)(ch - 'A') <= 'F' - 'A') // ch >= 'A' && ch <= 'F'
+            {
+                nibble = ch - 'A' + 10;
+                return true;
+            }
+
+            nibble = 0;
+            return false;
+        }
+
+        private static bool TryReadQuotedAltAuthority(string value, int startIndex, out string host, out int port, out int readLength)
+        {
+            if (HttpRuleParser.GetQuotedStringLength(value, startIndex, out int quotedLength) != HttpParseResult.Parsed)
+            {
+                goto parseError;
+            }
+
+            Debug.Assert(value[startIndex] == '"' && value[startIndex + quotedLength - 1] == '"', $"{nameof(HttpRuleParser.GetQuotedStringLength)} should return {nameof(HttpParseResult.NotParsed)} if the opening/closing quotes are missing.");
+            ReadOnlySpan<char> quoted = value.AsSpan(startIndex + 1, quotedLength - 2);
+
+            int idx = quoted.IndexOf(':');
+            if (idx == -1)
+            {
+                goto parseError;
+            }
+
+            // Parse the port. Port comes at the end of the string, but do this first so we don't allocate a host string if port fails to parse.
+            if (!TryReadQuotedInt32Value(quoted.Slice(idx + 1), out port))
+            {
+                goto parseError;
+            }
+
+            // Parse the optional host.
+            if (idx == 0)
+            {
+                host = null;
+            }
+            else if (!TryReadQuotedValue(quoted.Slice(0, idx), out host))
+            {
+                goto parseError;
+            }
+
+            readLength = quotedLength;
+            return true;
+
+        parseError:
+            host = null;
+            port = 0;
+            readLength = 0;
+            return false;
+        }
+
+        private static bool TryReadQuotedValue(ReadOnlySpan<char> value, out string result)
+        {
+            int idx = value.IndexOf('\\');
+
+            if (idx == -1)
+            {
+                // Hostnames shouldn't require quoted pairs, so this should be the hot path.
+                result = value.Length != 0 ? new string(value) : null;
+                return true;
+            }
+
+            var builder = new ValueStringBuilder(stackalloc char[128]);
+
+            do
+            {
+                if (idx + 1 == value.Length)
+                {
+                    // quoted-pair requires two characters: the quote, and the quoted character.
+                    builder.Dispose();
+                    result = null;
+                    return false;
+                }
+
+                if (idx != 0)
+                {
+                    builder.Append(value.Slice(0, idx));
+                }
+
+                builder.Append(value[idx + 1]);
+
+                value = value.Slice(idx + 2);
+                idx = value.IndexOf('\\');
+            }
+            while (idx != -1);
+
+            if (value.Length != 0)
+            {
+                builder.Append(value);
+            }
+
+            result = builder.ToString();
+            return true;
+        }
+
+        private static bool TryReadTokenOrQuotedInt32(string value, int startIndex, out int result, out int readLength)
+        {
+            if (startIndex >= value.Length)
+            {
+                result = 0;
+                readLength = 0;
+                return false;
+            }
+
+            if (HttpRuleParser.IsTokenChar(value[startIndex]))
+            {
+                // No reason for integers to be quoted, so this should be the hot path.
+
+                int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
+
+                readLength = tokenLength;
+                return HeaderUtilities.TryParseInt32(value, startIndex, tokenLength, out result);
+            }
+
+            if (HttpRuleParser.GetQuotedStringLength(value, startIndex, out int quotedLength) == HttpParseResult.Parsed)
+            {
+                readLength = quotedLength;
+                return TryReadQuotedInt32Value(value.AsSpan(1, quotedLength - 2), out result);
+            }
+
+            result = 0;
+            readLength = 0;
+            return false;
+        }
+
+        private static bool TryReadQuotedInt32Value(ReadOnlySpan<char> value, out int result)
+        {
+            if (value.Length == 0)
+            {
+                result = 0;
+                return false;
+            }
+
+            int port = 0;
+
+            foreach (char ch in value)
+            {
+                // The port shouldn't ever need a quoted-pair, but they're still valid... skip if found.
+                if (ch == '\\') continue;
+
+                if ((uint)(ch - '0') > '9' - '0') // ch < '0' || ch > '9'
+                {
+                    result = 0;
+                    return false;
+                }
+
+                long portTmp = port * 10L + (ch - '0');
+
+                if (portTmp > int.MaxValue)
+                {
+                    result = 0;
+                    return false;
+                }
+
+                port = (int)portTmp;
+            }
+
+            result = port;
+            return true;
+        }
+
+        private static bool TrySkipTokenOrQuoted(string value, int startIndex, out int readLength)
+        {
+            if (startIndex >= value.Length)
+            {
+                readLength = 0;
+                return false;
+            }
+
+            if (HttpRuleParser.IsTokenChar(value[startIndex]))
+            {
+                readLength = HttpRuleParser.GetTokenLength(value, startIndex);
+                return true;
+            }
+
+            if (HttpRuleParser.GetQuotedStringLength(value, startIndex, out int quotedLength) == HttpParseResult.Parsed)
+            {
+                readLength = quotedLength;
+                return true;
+            }
+
+            readLength = 0;
+            return false;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http.Headers
+{
+    /// <remarks>
+    /// Kept internal for now:
+    /// A user depending on this strongly-typed header is dubious, as Alt-Svc values can also be received via the ALTSVC frame in HTTP/2.
+    /// This type does not conform to the typical API for header values, and should be updated if ever made public.
+    /// </remarks>
+    internal sealed class AltSvcHeaderValue
+    {
+        public static AltSvcHeaderValue Clear { get; } = new AltSvcHeaderValue("clear", host: null, port: 0, maxAge: TimeSpan.Zero, persist: false);
+
+        public AltSvcHeaderValue(string alpnProtocolName, string host, int port, TimeSpan maxAge, bool persist)
+        {
+            AlpnProtocolName = alpnProtocolName;
+            Host = host;
+            Port = port;
+            MaxAge = maxAge;
+            Persist = persist;
+        }
+
+        public string AlpnProtocolName { get; }
+
+        /// <summary>
+        /// The name of the host serving this alternate service.
+        /// If null, the alternate service is on the same host this header was received from.
+        /// </summary>
+        public string Host { get; }
+
+        public int Port { get; }
+
+        /// <summary>
+        /// The time span this alternate service is valid for.
+        /// If not specified by the header, defaults to 24 hours.
+        /// </summary>
+        /// <remarks>TODO: if made public, should this be defaulted or nullable?</remarks>
+        public TimeSpan MaxAge { get; }
+
+        /// <summary>
+        /// If true, the service should persist across network changes.
+        /// Otherwise, the service should be invalidated if a network change is detected.
+        /// </summary>
+        /// <remarks>TODO: if made public, this should be made internal as Persist is left open-ended and can be non-boolean in the future.</remarks>
+        public bool Persist { get; }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/BaseHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/BaseHeaderParser.cs
@@ -13,6 +13,14 @@ namespace System.Net.Http.Headers
         {
         }
 
+        /// <summary>
+        /// Parses a full header or a segment of a multi-value header.
+        /// </summary>
+        /// <param name="value">The header value string to parse.</param>
+        /// <param name="startIndex">The index to begin parsing at.</param>
+        /// <param name="storeValue"></param>
+        /// <param name="parsedValue">The resulting value parsed.</param>
+        /// <returns>If a value could be parsed, the number of characters used to parse that value. Otherwise, 0.</returns>
         protected abstract int GetParsedValueLength(string value, int startIndex, object storeValue,
             out object parsedValue);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -86,6 +86,28 @@ namespace System.Net.Http.Headers
             return true;
         }
 
+        internal static bool TryGetStaticQPackHeader(int index, out HeaderDescriptor descriptor, out string knownValue)
+        {
+            Debug.Assert(index >= 0);
+            Debug.Assert(s_qpackHeaderLookup.Length == 99);
+
+            // Micro-opt: store field to variable to prevent Length re-read and use unsigned to avoid bounds check.
+            (HeaderDescriptor descriptor, string value)[] qpackStaticTable = s_qpackHeaderLookup;
+            uint uindex = (uint)index;
+
+            if (uindex < (uint)qpackStaticTable.Length)
+            {
+                (descriptor, knownValue) = qpackStaticTable[uindex];
+                return true;
+            }
+            else
+            {
+                descriptor = default;
+                knownValue = null;
+                return false;
+            }
+        }
+
         public HeaderDescriptor AsCustomHeader()
         {
             Debug.Assert(_knownHeader != null);
@@ -148,5 +170,111 @@ namespace System.Net.Http.Headers
             decoded = null;
             return false;
         }
+
+        // QPack Static Table
+        // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#appendix-A
+        // TODO: can we put some of this logic into H3StaticTable and/or generate it using data that is already there?
+        private static readonly (HeaderDescriptor descriptor, string value)[] s_qpackHeaderLookup = new (HeaderDescriptor descriptor, string value)[]
+        {
+            (new HeaderDescriptor(":authority"), ""),
+            (new HeaderDescriptor(":path"), "/"),
+            (new HeaderDescriptor(KnownHeaders.Age), "0"),
+            (new HeaderDescriptor(KnownHeaders.ContentDisposition), ""),
+            (new HeaderDescriptor(KnownHeaders.ContentLength), "0"),
+            (new HeaderDescriptor(KnownHeaders.Date), ""),
+            (new HeaderDescriptor(KnownHeaders.ETag), ""),
+            (new HeaderDescriptor(KnownHeaders.IfModifiedSince), ""),
+            (new HeaderDescriptor(KnownHeaders.IfNoneMatch), ""),
+            (new HeaderDescriptor(KnownHeaders.LastModified), ""),
+            (new HeaderDescriptor(KnownHeaders.Link), ""),
+            (new HeaderDescriptor(KnownHeaders.Location), ""),
+            (new HeaderDescriptor(KnownHeaders.Referer), ""),
+            (new HeaderDescriptor(KnownHeaders.SetCookie), ""),
+            (new HeaderDescriptor(":method"), "CONNECT"),
+            (new HeaderDescriptor(":method"), "DELETE"),
+            (new HeaderDescriptor(":method"), "GET"),
+            (new HeaderDescriptor(":method"), "HEAD"),
+            (new HeaderDescriptor(":method"), "OPTIONS"),
+            (new HeaderDescriptor(":method"), "POST"),
+            (new HeaderDescriptor(":method"), "PUT"),
+            (new HeaderDescriptor(":scheme"), "http"),
+            (new HeaderDescriptor(":scheme"), "https"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "103"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "200"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "304"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "404"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "503"),
+            (new HeaderDescriptor(KnownHeaders.Accept), "*/*"),
+            (new HeaderDescriptor(KnownHeaders.Accept), "application/dns-message"),
+            (new HeaderDescriptor(KnownHeaders.AcceptEncoding), "gzip, deflate, br"),
+            (new HeaderDescriptor(KnownHeaders.AcceptRanges), "bytes"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowHeaders), "cache-control"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowHeaders), "content-type"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowHeaders), "*"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowOrigin), "*"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "max-age=0"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "max-age=2592000"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "max-age=604800"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "no-cache"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "no-store"),
+            (new HeaderDescriptor(KnownHeaders.CacheControl), "public, max-age=31536000"),
+            (new HeaderDescriptor(KnownHeaders.ContentEncoding), "br"),
+            (new HeaderDescriptor(KnownHeaders.ContentEncoding), "gzip"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "application/dns-message"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "application/javascript"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "application/json"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "application/x-www-form-urlencoded"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "image/gif"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "image/jpeg"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "image/png"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "text/css"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "text/html; charset=utf-8"), // Whitespace is correct, see spec.
+            (new HeaderDescriptor(KnownHeaders.ContentType), "text/plain"),
+            (new HeaderDescriptor(KnownHeaders.ContentType), "text/plain;charset=utf-8"), // Whitespace is correct, see spec.
+            (new HeaderDescriptor(KnownHeaders.Range), "bytes=0-"),
+            (new HeaderDescriptor(KnownHeaders.StrictTransportSecurity), "max-age=31536000"),
+            (new HeaderDescriptor(KnownHeaders.StrictTransportSecurity), "max-age=31536000; includesubdomains"),
+            (new HeaderDescriptor(KnownHeaders.StrictTransportSecurity), "max-age=31536000; includesubdomains; preload"),
+            (new HeaderDescriptor(KnownHeaders.Vary), "accept-encoding"),
+            (new HeaderDescriptor(KnownHeaders.Vary), "origin"),
+            (new HeaderDescriptor(KnownHeaders.XContentTypeOptions), "nosniff"),
+            (new HeaderDescriptor("x-xss-protection"), "1; mode=block"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "100"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "204"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "206"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "302"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "400"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "403"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "421"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "425"),
+            (new HeaderDescriptor(KnownHeaders.PseudoStatus), "500"),
+            (new HeaderDescriptor(KnownHeaders.AcceptLanguage), ""),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowCredentials), "FALSE"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowCredentials), "TRUE"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowHeaders), "*"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowMethods), "get"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowMethods), "get, post, options"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlAllowMethods), "options"),
+            (new HeaderDescriptor(KnownHeaders.AccessControlExposeHeaders), "content-length"),
+            (new HeaderDescriptor("access-control-request-headers"), "content-type"),
+            (new HeaderDescriptor("access-control-request-method"), "get"),
+            (new HeaderDescriptor("access-control-request-method"), "post"),
+            (new HeaderDescriptor(KnownHeaders.AltSvc), "clear"),
+            (new HeaderDescriptor(KnownHeaders.Authorization), ""),
+            (new HeaderDescriptor(KnownHeaders.ContentSecurityPolicy), "script-src 'none'; object-src 'none'; base-uri 'none'"),
+            (new HeaderDescriptor("early-data"), "1"),
+            (new HeaderDescriptor("expect-ct"), ""),
+            (new HeaderDescriptor("forwarded"), ""),
+            (new HeaderDescriptor(KnownHeaders.IfRange), ""),
+            (new HeaderDescriptor(KnownHeaders.Origin), ""),
+            (new HeaderDescriptor("purpose"), "prefetch"),
+            (new HeaderDescriptor(KnownHeaders.Server), ""),
+            (new HeaderDescriptor("timing-allow-origin"), "*"),
+            (new HeaderDescriptor(KnownHeaders.UpgradeInsecureRequests), "1"),
+            (new HeaderDescriptor(KnownHeaders.UserAgent), ""),
+            (new HeaderDescriptor("x-forwarded-for"), ""),
+            (new HeaderDescriptor(KnownHeaders.XFrameOptions), "deny"),
+            (new HeaderDescriptor(KnownHeaders.XFrameOptions), "sameorigin")
+        };
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Http.HPack;
+using System.Net.Http.QPack;
 using System.Runtime.InteropServices;
 
 namespace System.Net.Http.Headers
@@ -11,87 +12,89 @@ namespace System.Net.Http.Headers
     {
         // If you add a new entry here, you need to add it to TryGetKnownHeader below as well.
 
-        public static readonly KnownHeader Accept = new KnownHeader("Accept", HttpHeaderType.Request, MediaTypeHeaderParser.MultipleValuesParser, null, StaticTable.Accept);
-        public static readonly KnownHeader AcceptCharset = new KnownHeader("Accept-Charset", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, StaticTable.AcceptCharset);
-        public static readonly KnownHeader AcceptEncoding = new KnownHeader("Accept-Encoding", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, StaticTable.AcceptEncoding);
-        public static readonly KnownHeader AcceptLanguage = new KnownHeader("Accept-Language", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, StaticTable.AcceptLanguage);
+        public static readonly KnownHeader PseudoStatus = new KnownHeader(":status", HttpHeaderType.Response, parser: null);
+        public static readonly KnownHeader Accept = new KnownHeader("Accept", HttpHeaderType.Request, MediaTypeHeaderParser.MultipleValuesParser, null, H2StaticTable.Accept, H3StaticTable.AcceptAny);
+        public static readonly KnownHeader AcceptCharset = new KnownHeader("Accept-Charset", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, H2StaticTable.AcceptCharset);
+        public static readonly KnownHeader AcceptEncoding = new KnownHeader("Accept-Encoding", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, H2StaticTable.AcceptEncoding, H3StaticTable.AcceptEncodingGzipDeflateBr);
+        public static readonly KnownHeader AcceptLanguage = new KnownHeader("Accept-Language", HttpHeaderType.Request, GenericHeaderParser.MultipleValueStringWithQualityParser, null, H2StaticTable.AcceptLanguage, H3StaticTable.AcceptLanguage);
         public static readonly KnownHeader AcceptPatch = new KnownHeader("Accept-Patch");
-        public static readonly KnownHeader AcceptRanges = new KnownHeader("Accept-Ranges", HttpHeaderType.Response, GenericHeaderParser.TokenListParser, null, StaticTable.AcceptRanges);
-        public static readonly KnownHeader AccessControlAllowCredentials = new KnownHeader("Access-Control-Allow-Credentials");
-        public static readonly KnownHeader AccessControlAllowHeaders = new KnownHeader("Access-Control-Allow-Headers");
-        public static readonly KnownHeader AccessControlAllowMethods = new KnownHeader("Access-Control-Allow-Methods");
-        public static readonly KnownHeader AccessControlAllowOrigin = new KnownHeader("Access-Control-Allow-Origin", StaticTable.AccessControlAllowOrigin);
-        public static readonly KnownHeader AccessControlExposeHeaders = new KnownHeader("Access-Control-Expose-Headers");
+        public static readonly KnownHeader AcceptRanges = new KnownHeader("Accept-Ranges", HttpHeaderType.Response, GenericHeaderParser.TokenListParser, null, H2StaticTable.AcceptRanges, H3StaticTable.AcceptRangesBytes);
+        public static readonly KnownHeader AccessControlAllowCredentials = new KnownHeader("Access-Control-Allow-Credentials", http3StaticTableIndex: H3StaticTable.AccessControlAllowCredentials);
+        public static readonly KnownHeader AccessControlAllowHeaders = new KnownHeader("Access-Control-Allow-Headers", http3StaticTableIndex: H3StaticTable.AccessControlAllowHeadersCacheControl);
+        public static readonly KnownHeader AccessControlAllowMethods = new KnownHeader("Access-Control-Allow-Methods", http3StaticTableIndex: H3StaticTable.AccessControlAllowMethodsGet);
+        public static readonly KnownHeader AccessControlAllowOrigin = new KnownHeader("Access-Control-Allow-Origin", H2StaticTable.AccessControlAllowOrigin, H3StaticTable.AccessControlAllowOriginAny);
+        public static readonly KnownHeader AccessControlExposeHeaders = new KnownHeader("Access-Control-Expose-Headers", H3StaticTable.AccessControlExposeHeadersContentLength);
         public static readonly KnownHeader AccessControlMaxAge = new KnownHeader("Access-Control-Max-Age");
-        public static readonly KnownHeader Age = new KnownHeader("Age", HttpHeaderType.Response | HttpHeaderType.NonTrailing, TimeSpanHeaderParser.Parser, null, StaticTable.Age);
-        public static readonly KnownHeader Allow = new KnownHeader("Allow", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, StaticTable.Allow);
-        public static readonly KnownHeader AltSvc = new KnownHeader("Alt-Svc");
-        public static readonly KnownHeader Authorization = new KnownHeader("Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, StaticTable.Authorization);
-        public static readonly KnownHeader CacheControl = new KnownHeader("Cache-Control", HttpHeaderType.General | HttpHeaderType.NonTrailing, CacheControlHeaderParser.Parser, null, StaticTable.CacheControl);
+        public static readonly KnownHeader Age = new KnownHeader("Age", HttpHeaderType.Response | HttpHeaderType.NonTrailing, TimeSpanHeaderParser.Parser, null, H2StaticTable.Age, H3StaticTable.Age0);
+        public static readonly KnownHeader Allow = new KnownHeader("Allow", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, H2StaticTable.Allow);
+        public static readonly KnownHeader AltSvc = new KnownHeader("Alt-Svc", HttpHeaderType.Response, AltSvcHeaderParser.Parser, http3StaticTableIndex: H3StaticTable.AltSvcClear);
+        public static readonly KnownHeader AltUsed = new KnownHeader("Alt-Used", HttpHeaderType.Request, parser: null);
+        public static readonly KnownHeader Authorization = new KnownHeader("Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, H2StaticTable.Authorization, H3StaticTable.Authorization);
+        public static readonly KnownHeader CacheControl = new KnownHeader("Cache-Control", HttpHeaderType.General | HttpHeaderType.NonTrailing, CacheControlHeaderParser.Parser, null, H2StaticTable.CacheControl, H3StaticTable.CacheControlMaxAge0);
         public static readonly KnownHeader Connection = new KnownHeader("Connection", HttpHeaderType.General, GenericHeaderParser.TokenListParser, new string[] { "close" });
-        public static readonly KnownHeader ContentDisposition = new KnownHeader("Content-Disposition", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentDispositionParser, null, StaticTable.ContentDisposition);
-        public static readonly KnownHeader ContentEncoding = new KnownHeader("Content-Encoding", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, new string[] { "gzip", "deflate" }, StaticTable.ContentEncoding);
-        public static readonly KnownHeader ContentLanguage = new KnownHeader("Content-Language", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, StaticTable.ContentLanguage);
-        public static readonly KnownHeader ContentLength = new KnownHeader("Content-Length", HttpHeaderType.Content | HttpHeaderType.NonTrailing, Int64NumberHeaderParser.Parser, null, StaticTable.ContentLength);
-        public static readonly KnownHeader ContentLocation = new KnownHeader("Content-Location", HttpHeaderType.Content | HttpHeaderType.NonTrailing, UriHeaderParser.RelativeOrAbsoluteUriParser, null, StaticTable.ContentLocation);
+        public static readonly KnownHeader ContentDisposition = new KnownHeader("Content-Disposition", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentDispositionParser, null, H2StaticTable.ContentDisposition, H3StaticTable.ContentDisposition);
+        public static readonly KnownHeader ContentEncoding = new KnownHeader("Content-Encoding", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, new string[] { "gzip", "deflate" }, H2StaticTable.ContentEncoding, H3StaticTable.ContentEncodingBr);
+        public static readonly KnownHeader ContentLanguage = new KnownHeader("Content-Language", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, H2StaticTable.ContentLanguage);
+        public static readonly KnownHeader ContentLength = new KnownHeader("Content-Length", HttpHeaderType.Content | HttpHeaderType.NonTrailing, Int64NumberHeaderParser.Parser, null, H2StaticTable.ContentLength, H3StaticTable.ContentLength0);
+        public static readonly KnownHeader ContentLocation = new KnownHeader("Content-Location", HttpHeaderType.Content | HttpHeaderType.NonTrailing, UriHeaderParser.RelativeOrAbsoluteUriParser, null, H2StaticTable.ContentLocation);
         public static readonly KnownHeader ContentMD5 = new KnownHeader("Content-MD5", HttpHeaderType.Content, ByteArrayHeaderParser.Parser);
-        public static readonly KnownHeader ContentRange = new KnownHeader("Content-Range", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentRangeParser, null, StaticTable.ContentRange);
-        public static readonly KnownHeader ContentSecurityPolicy = new KnownHeader("Content-Security-Policy");
-        public static readonly KnownHeader ContentType = new KnownHeader("Content-Type", HttpHeaderType.Content | HttpHeaderType.NonTrailing, MediaTypeHeaderParser.SingleValueParser, null, StaticTable.ContentType);
-        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", StaticTable.Cookie);
+        public static readonly KnownHeader ContentRange = new KnownHeader("Content-Range", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentRangeParser, null, H2StaticTable.ContentRange);
+        public static readonly KnownHeader ContentSecurityPolicy = new KnownHeader("Content-Security-Policy", http3StaticTableIndex: H3StaticTable.ContentSecurityPolicyAllNone);
+        public static readonly KnownHeader ContentType = new KnownHeader("Content-Type", HttpHeaderType.Content | HttpHeaderType.NonTrailing, MediaTypeHeaderParser.SingleValueParser, null, H2StaticTable.ContentType, H3StaticTable.ContentTypeApplicationDnsMessage);
+        public static readonly KnownHeader Cookie = new KnownHeader("Cookie", H2StaticTable.Cookie, H3StaticTable.Cookie);
         public static readonly KnownHeader Cookie2 = new KnownHeader("Cookie2");
-        public static readonly KnownHeader Date = new KnownHeader("Date", HttpHeaderType.General | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, StaticTable.Date);
-        public static readonly KnownHeader ETag = new KnownHeader("ETag", HttpHeaderType.Response, GenericHeaderParser.SingleValueEntityTagParser, null, StaticTable.ETag);
-        public static readonly KnownHeader Expect = new KnownHeader("Expect", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueWithParametersParser, new string[] { "100-continue" }, StaticTable.Expect);
-        public static readonly KnownHeader Expires = new KnownHeader("Expires", HttpHeaderType.Content | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, StaticTable.Expires);
-        public static readonly KnownHeader From = new KnownHeader("From", HttpHeaderType.Request, GenericHeaderParser.MailAddressParser, null, StaticTable.From);
-        public static readonly KnownHeader Host = new KnownHeader("Host", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.HostParser, null, StaticTable.Host);
-        public static readonly KnownHeader IfMatch = new KnownHeader("If-Match", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueEntityTagParser, null, StaticTable.IfMatch);
-        public static readonly KnownHeader IfModifiedSince = new KnownHeader("If-Modified-Since", HttpHeaderType.Request | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, StaticTable.IfModifiedSince);
-        public static readonly KnownHeader IfNoneMatch = new KnownHeader("If-None-Match", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueEntityTagParser, null, StaticTable.IfNoneMatch);
-        public static readonly KnownHeader IfRange = new KnownHeader("If-Range", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.RangeConditionParser, null, StaticTable.IfRange);
-        public static readonly KnownHeader IfUnmodifiedSince = new KnownHeader("If-Unmodified-Since", HttpHeaderType.Request | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, StaticTable.IfUnmodifiedSince);
+        public static readonly KnownHeader Date = new KnownHeader("Date", HttpHeaderType.General | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.Date, H3StaticTable.Date);
+        public static readonly KnownHeader ETag = new KnownHeader("ETag", HttpHeaderType.Response, GenericHeaderParser.SingleValueEntityTagParser, null, H2StaticTable.ETag, H3StaticTable.ETag);
+        public static readonly KnownHeader Expect = new KnownHeader("Expect", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueWithParametersParser, new string[] { "100-continue" }, H2StaticTable.Expect);
+        public static readonly KnownHeader Expires = new KnownHeader("Expires", HttpHeaderType.Content | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.Expires);
+        public static readonly KnownHeader From = new KnownHeader("From", HttpHeaderType.Request, GenericHeaderParser.MailAddressParser, null, H2StaticTable.From);
+        public static readonly KnownHeader Host = new KnownHeader("Host", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.HostParser, null, H2StaticTable.Host);
+        public static readonly KnownHeader IfMatch = new KnownHeader("If-Match", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueEntityTagParser, null, H2StaticTable.IfMatch);
+        public static readonly KnownHeader IfModifiedSince = new KnownHeader("If-Modified-Since", HttpHeaderType.Request | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.IfModifiedSince, H3StaticTable.IfModifiedSince);
+        public static readonly KnownHeader IfNoneMatch = new KnownHeader("If-None-Match", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueEntityTagParser, null, H2StaticTable.IfNoneMatch, H3StaticTable.IfNoneMatch);
+        public static readonly KnownHeader IfRange = new KnownHeader("If-Range", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.RangeConditionParser, null, H2StaticTable.IfRange, H3StaticTable.IfRange);
+        public static readonly KnownHeader IfUnmodifiedSince = new KnownHeader("If-Unmodified-Since", HttpHeaderType.Request | HttpHeaderType.NonTrailing, DateHeaderParser.Parser, null, H2StaticTable.IfUnmodifiedSince);
         public static readonly KnownHeader KeepAlive = new KnownHeader("Keep-Alive");
-        public static readonly KnownHeader LastModified = new KnownHeader("Last-Modified", HttpHeaderType.Content, DateHeaderParser.Parser, null, StaticTable.LastModified);
-        public static readonly KnownHeader Link = new KnownHeader("Link", StaticTable.Link);
-        public static readonly KnownHeader Location = new KnownHeader("Location", HttpHeaderType.Response | HttpHeaderType.NonTrailing, UriHeaderParser.RelativeOrAbsoluteUriParser, null, StaticTable.Location);
-        public static readonly KnownHeader MaxForwards = new KnownHeader("Max-Forwards", HttpHeaderType.Request | HttpHeaderType.NonTrailing, Int32NumberHeaderParser.Parser, null, StaticTable.MaxForwards);
-        public static readonly KnownHeader Origin = new KnownHeader("Origin");
+        public static readonly KnownHeader LastModified = new KnownHeader("Last-Modified", HttpHeaderType.Content, DateHeaderParser.Parser, null, H2StaticTable.LastModified, H3StaticTable.LastModified);
+        public static readonly KnownHeader Link = new KnownHeader("Link", H2StaticTable.Link, H3StaticTable.Link);
+        public static readonly KnownHeader Location = new KnownHeader("Location", HttpHeaderType.Response | HttpHeaderType.NonTrailing, UriHeaderParser.RelativeOrAbsoluteUriParser, null, H2StaticTable.Location, H3StaticTable.Location);
+        public static readonly KnownHeader MaxForwards = new KnownHeader("Max-Forwards", HttpHeaderType.Request | HttpHeaderType.NonTrailing, Int32NumberHeaderParser.Parser, null, H2StaticTable.MaxForwards);
+        public static readonly KnownHeader Origin = new KnownHeader("Origin", http3StaticTableIndex: H3StaticTable.Origin);
         public static readonly KnownHeader P3P = new KnownHeader("P3P");
         public static readonly KnownHeader Pragma = new KnownHeader("Pragma", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueParser);
-        public static readonly KnownHeader ProxyAuthenticate = new KnownHeader("Proxy-Authenticate", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueAuthenticationParser, null, StaticTable.ProxyAuthenticate);
-        public static readonly KnownHeader ProxyAuthorization = new KnownHeader("Proxy-Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, StaticTable.ProxyAuthorization);
+        public static readonly KnownHeader ProxyAuthenticate = new KnownHeader("Proxy-Authenticate", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueAuthenticationParser, null, H2StaticTable.ProxyAuthenticate);
+        public static readonly KnownHeader ProxyAuthorization = new KnownHeader("Proxy-Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, H2StaticTable.ProxyAuthorization);
         public static readonly KnownHeader ProxyConnection = new KnownHeader("Proxy-Connection");
         public static readonly KnownHeader ProxySupport = new KnownHeader("Proxy-Support");
         public static readonly KnownHeader PublicKeyPins = new KnownHeader("Public-Key-Pins");
-        public static readonly KnownHeader Range = new KnownHeader("Range", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.RangeParser, null, StaticTable.Range);
-        public static readonly KnownHeader Referer = new KnownHeader("Referer", HttpHeaderType.Request, UriHeaderParser.RelativeOrAbsoluteUriParser, null, StaticTable.Referer); // NB: The spelling-mistake "Referer" for "Referrer" must be matched.
-        public static readonly KnownHeader Refresh = new KnownHeader("Refresh", StaticTable.Refresh);
-        public static readonly KnownHeader RetryAfter = new KnownHeader("Retry-After", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.RetryConditionParser, null, StaticTable.RetryAfter);
+        public static readonly KnownHeader Range = new KnownHeader("Range", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.RangeParser, null, H2StaticTable.Range, H3StaticTable.RangeBytes0ToAll);
+        public static readonly KnownHeader Referer = new KnownHeader("Referer", HttpHeaderType.Request, UriHeaderParser.RelativeOrAbsoluteUriParser, null, H2StaticTable.Referer, H3StaticTable.Referer); // NB: The spelling-mistake "Referer" for "Referrer" must be matched.
+        public static readonly KnownHeader Refresh = new KnownHeader("Refresh", H2StaticTable.Refresh);
+        public static readonly KnownHeader RetryAfter = new KnownHeader("Retry-After", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.RetryConditionParser, null, H2StaticTable.RetryAfter);
         public static readonly KnownHeader SecWebSocketAccept = new KnownHeader("Sec-WebSocket-Accept");
         public static readonly KnownHeader SecWebSocketExtensions = new KnownHeader("Sec-WebSocket-Extensions");
         public static readonly KnownHeader SecWebSocketKey = new KnownHeader("Sec-WebSocket-Key");
         public static readonly KnownHeader SecWebSocketProtocol = new KnownHeader("Sec-WebSocket-Protocol");
         public static readonly KnownHeader SecWebSocketVersion = new KnownHeader("Sec-WebSocket-Version");
-        public static readonly KnownHeader Server = new KnownHeader("Server", HttpHeaderType.Response, ProductInfoHeaderParser.MultipleValueParser, null, StaticTable.Server);
-        public static readonly KnownHeader SetCookie = new KnownHeader("Set-Cookie", HttpHeaderType.Custom | HttpHeaderType.NonTrailing, null, null, StaticTable.SetCookie);
+        public static readonly KnownHeader Server = new KnownHeader("Server", HttpHeaderType.Response, ProductInfoHeaderParser.MultipleValueParser, null, H2StaticTable.Server, H3StaticTable.Server);
+        public static readonly KnownHeader SetCookie = new KnownHeader("Set-Cookie", HttpHeaderType.Custom | HttpHeaderType.NonTrailing, null, null, H2StaticTable.SetCookie, H3StaticTable.SetCookie);
         public static readonly KnownHeader SetCookie2 = new KnownHeader("Set-Cookie2", HttpHeaderType.Custom | HttpHeaderType.NonTrailing, null, null);
-        public static readonly KnownHeader StrictTransportSecurity = new KnownHeader("Strict-Transport-Security", StaticTable.StrictTransportSecurity);
+        public static readonly KnownHeader StrictTransportSecurity = new KnownHeader("Strict-Transport-Security", H2StaticTable.StrictTransportSecurity, H3StaticTable.StrictTransportSecurityMaxAge31536000);
         public static readonly KnownHeader TE = new KnownHeader("TE", HttpHeaderType.Request | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueWithQualityParser);
         public static readonly KnownHeader TSV = new KnownHeader("TSV");
         public static readonly KnownHeader Trailer = new KnownHeader("Trailer", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser);
-        public static readonly KnownHeader TransferEncoding = new KnownHeader("Transfer-Encoding", HttpHeaderType.General | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueParser, new string[] { "chunked" }, StaticTable.TransferEncoding);
+        public static readonly KnownHeader TransferEncoding = new KnownHeader("Transfer-Encoding", HttpHeaderType.General | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueParser, new string[] { "chunked" }, H2StaticTable.TransferEncoding);
         public static readonly KnownHeader Upgrade = new KnownHeader("Upgrade", HttpHeaderType.General, GenericHeaderParser.MultipleValueProductParser);
-        public static readonly KnownHeader UpgradeInsecureRequests = new KnownHeader("Upgrade-Insecure-Requests");
-        public static readonly KnownHeader UserAgent = new KnownHeader("User-Agent", HttpHeaderType.Request, ProductInfoHeaderParser.MultipleValueParser, null, StaticTable.UserAgent);
-        public static readonly KnownHeader Vary = new KnownHeader("Vary", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, null, StaticTable.Vary);
-        public static readonly KnownHeader Via = new KnownHeader("Via", HttpHeaderType.General, GenericHeaderParser.MultipleValueViaParser, null, StaticTable.Via);
-        public static readonly KnownHeader WWWAuthenticate = new KnownHeader("WWW-Authenticate", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueAuthenticationParser, null, StaticTable.WwwAuthenticate);
+        public static readonly KnownHeader UpgradeInsecureRequests = new KnownHeader("Upgrade-Insecure-Requests", http3StaticTableIndex: H3StaticTable.UpgradeInsecureRequests1);
+        public static readonly KnownHeader UserAgent = new KnownHeader("User-Agent", HttpHeaderType.Request, ProductInfoHeaderParser.MultipleValueParser, null, H2StaticTable.UserAgent, H3StaticTable.UserAgent);
+        public static readonly KnownHeader Vary = new KnownHeader("Vary", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, null, H2StaticTable.Vary, H3StaticTable.VaryAcceptEncoding);
+        public static readonly KnownHeader Via = new KnownHeader("Via", HttpHeaderType.General, GenericHeaderParser.MultipleValueViaParser, null, H2StaticTable.Via);
+        public static readonly KnownHeader WWWAuthenticate = new KnownHeader("WWW-Authenticate", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueAuthenticationParser, null, H2StaticTable.WwwAuthenticate);
         public static readonly KnownHeader Warning = new KnownHeader("Warning", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueWarningParser);
         public static readonly KnownHeader XAspNetVersion = new KnownHeader("X-AspNet-Version");
         public static readonly KnownHeader XContentDuration = new KnownHeader("X-Content-Duration");
-        public static readonly KnownHeader XContentTypeOptions = new KnownHeader("X-Content-Type-Options");
-        public static readonly KnownHeader XFrameOptions = new KnownHeader("X-Frame-Options");
+        public static readonly KnownHeader XContentTypeOptions = new KnownHeader("X-Content-Type-Options", http3StaticTableIndex: H3StaticTable.XContentTypeOptionsNoSniff);
+        public static readonly KnownHeader XFrameOptions = new KnownHeader("X-Frame-Options", http3StaticTableIndex: H3StaticTable.XFrameOptionsDeny);
         public static readonly KnownHeader XMSEdgeRef = new KnownHeader("X-MSEdge-Ref");
         public static readonly KnownHeader XPoweredBy = new KnownHeader("X-Powered-By");
         public static readonly KnownHeader XRequestID = new KnownHeader("X-Request-ID");
@@ -191,6 +194,7 @@ namespace System.Net.Http.Headers
                 case 7:
                     switch (key[0])
                     {
+                        case ':': return PseudoStatus; // [:]status
                         case 'A': case 'a': return AltSvc;  // [A]lt-Svc
                         case 'C': case 'c': return Cookie2; // [C]ookie2
                         case 'E': case 'e': return Expires; // [E]xpires

--- a/src/libraries/System.Net.Http/src/System/Net/Http/RequestRetryType.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/RequestRetryType.cs
@@ -9,8 +9,24 @@ namespace System.Net.Http
     /// </summary>
     internal enum RequestRetryType
     {
+        /// <summary>
+        /// The request must not be retried; this indicates we aren't certain the server hasn't processed the request.
+        /// </summary>
         NoRetry,
+
+        /// <summary>
+        /// The request failed on the current HTTP version, and the server requested it be retried on a lower version.
+        /// </summary>
+        RetryOnLowerHttpVersion,
+
+        /// <summary>
+        /// The request failed due to e.g. server shutting down (GOAWAY) and should be retried on a new connection.
+        /// </summary>
         RetryOnSameOrNextProxy,
+
+        /// <summary>
+        /// The proxy failed, so the request should be retried on the next proxy.
+        /// </summary>
         RetryOnNextProxy
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ArrayBuffer.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ArrayBuffer.cs
@@ -39,16 +39,17 @@ namespace System.Net.Http
 
         public void Dispose()
         {
+            _activeStart = 0;
+            _availableStart = 0;
+
             if (_usePool)
             {
-                _activeStart = _availableStart = 0;
-
                 byte[] array = _bytes;
                 _bytes = null;
 
                 if (array != null)
                 {
-                    ArrayPool<byte>.Shared.Return(array);
+                    ArrayPool<byte>.Shared.Return(array, true);
                 }
             }
         }
@@ -127,6 +128,11 @@ namespace System.Net.Http
             }
 
             Debug.Assert(byteCount <= AvailableLength);
+        }
+
+        public void Grow()
+        {
+            EnsureAvailableSpace(AvailableLength + 1);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -71,9 +72,7 @@ namespace System.Net.Http
             }
             catch (Exception error) when (!(error is OperationCanceledException))
             {
-                throw CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
-                    CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
-                    new HttpRequestException(error.Message, error, RequestRetryType.RetryOnNextProxy);
+                throw CreateWrappedException(error, cancellationToken);
             }
             finally
             {
@@ -177,6 +176,43 @@ namespace System.Net.Http
             }
 
             return sslStream;
+        }
+
+        public static async ValueTask<QuicConnection> ConnectQuicAsync(string host, int port, SslClientAuthenticationOptions clientAuthenticationOptions, CancellationToken cancellationToken)
+        {
+            IPAddress[] addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
+            Exception lastException = null;
+
+            foreach (IPAddress address in addresses)
+            {
+                QuicConnection con = new QuicConnection(new IPEndPoint(address, port), clientAuthenticationOptions);
+                try
+                {
+                    await con.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                    return con;
+                }
+                // TODO: it would be great to catch a specific exception here... QUIC implementation dependent.
+                catch (Exception ex) when (!(ex is OperationCanceledException))
+                {
+                    con.Dispose();
+                    lastException = ex;
+                }
+            }
+
+            if (lastException != null)
+            {
+                throw CreateWrappedException(lastException, cancellationToken);
+            }
+
+            // TODO: find correct exception to throw here.
+            throw new HttpRequestException("No host found.");
+        }
+
+        private static Exception CreateWrappedException(Exception error, CancellationToken cancellationToken)
+        {
+            return CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
+                CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
+                new HttpRequestException(error.Message, error, RequestRetryType.RetryOnNextProxy);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -1,0 +1,747 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Net.Quic;
+using System.IO;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+
+namespace System.Net.Http
+{
+    internal sealed class Http3Connection : HttpConnectionBase, IDisposable
+    {
+        /// <summary>
+        /// If we receive a settings frame larger than this, tear down the connection with an error.
+        /// </summary>
+        private const int MaximumSettingsPayloadLength = 4096;
+
+        /// <summary>
+        /// Unknown frame types with a payload larger than this will result in tearing down the connection with an error.
+        /// Frames smaller than this will be ignored and drained.
+        /// </summary>
+        private const int MaximumUnknownFramePayloadLength = 4096;
+
+        private readonly HttpConnectionPool _pool;
+        private readonly HttpAuthority _origin;
+        private readonly HttpAuthority _authority;
+        private readonly byte[] _altUsedEncodedHeader;
+        private QuicConnection _connection;
+
+        // Keep a collection of requests around so we can process GOAWAY.
+        private readonly Dictionary<long, Http3RequestStream> _activeRequests = new Dictionary<long, Http3RequestStream>();
+
+        // Set when GOAWAY is being processed, when aborting, or when disposing.
+        private long _lastProcessedStreamId = -1;
+
+        // Our control stream.
+        private QuicStream _clientControl;
+
+        // Current SETTINGS from the server.
+        private int _maximumHeadersLength = int.MaxValue; // TODO: this is not yet observed by Http3Stream when buffering headers.
+
+        // Once the server's streams are received, these are set to 1. Further receipt of these streams results in a connection error.
+        private int _haveServerControlStream = 0;
+        private int _haveServerQpackDecodeStream = 0;
+        private int _haveServerQpackEncodeStream = 0;
+
+        // Manages MAX_STREAM count from server.
+        private long _maximumRequestStreams;
+        private long _requestStreamsRemaining;
+        private readonly Queue<TaskCompletionSourceWithCancellation<bool>> _waitingRequests = new Queue<TaskCompletionSourceWithCancellation<bool>>();
+
+        // A connection-level error will abort any future operations.
+        private Exception _abortException;
+
+        public HttpAuthority Authority => _authority;
+        public HttpConnectionPool Pool => _pool;
+        public int MaximumRequestHeadersLength => _maximumHeadersLength;
+        public byte[] AltUsedEncodedHeaderBytes => _altUsedEncodedHeader;
+        public Exception AbortException => Volatile.Read(ref _abortException);
+        private object SyncObj => _activeRequests;
+
+        /// <summary>
+        /// If true, we've received GOAWAY, are aborting due to a connection-level error, or are disposing due to pool limits.
+        /// </summary>
+        private bool ShuttingDown
+        {
+            get
+            {
+                Debug.Assert(Monitor.IsEntered(SyncObj));
+                return _lastProcessedStreamId != -1;
+            }
+        }
+
+        public Http3Connection(HttpConnectionPool pool, HttpAuthority origin, HttpAuthority authority, QuicConnection connection)
+        {
+            _pool = pool;
+            _origin = origin;
+            _authority = authority;
+            _connection = connection;
+
+            bool altUsedDefaultPort = pool.Kind == HttpConnectionKind.Http && authority.Port == HttpConnectionPool.DefaultHttpPort || pool.Kind == HttpConnectionKind.Https && authority.Port == HttpConnectionPool.DefaultHttpsPort;
+            string altUsedValue = altUsedDefaultPort ? authority.IdnHost : authority.IdnHost + ":" + authority.Port.ToString(Globalization.CultureInfo.InvariantCulture);
+            _altUsedEncodedHeader = QPack.QPackEncoder.EncodeLiteralHeaderFieldWithoutNameReferenceToArray(KnownHeaders.AltUsed.Name, altUsedValue);
+
+            _maximumRequestStreams = _requestStreamsRemaining = connection.GetRemoteAvailableBidirectionalStreamCount();
+
+            // Errors are observed via Abort().
+            _ = SendSettingsAsync();
+
+            // This process is cleaned up when _connection is disposed, and errors are observed via Abort().
+            _ = AcceptStreamsAsync();
+        }
+
+        /// <summary>
+        /// Starts shutting down the <see cref="Http3Connection"/>. Final cleanup will happen when there are no more active requests.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (SyncObj)
+            {
+                if (_lastProcessedStreamId == -1)
+                {
+                    _lastProcessedStreamId = long.MaxValue;
+                    CheckForShutdown();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when shutting down, this checks for when shutdown is complete (no more active requests) and does actual disposal.
+        /// </summary>
+        /// <remarks>Requires <see cref="SyncObj"/> to be locked.</remarks>
+        private void CheckForShutdown()
+        {
+            Debug.Assert(Monitor.IsEntered(SyncObj));
+            Debug.Assert(ShuttingDown);
+
+            if (_activeRequests.Count != 0)
+            {
+                return;
+            }
+
+            if (_clientControl != null)
+            {
+                _clientControl.Dispose();
+                _clientControl = null;
+            }
+
+            if (_connection != null)
+            {
+                _connection.CloseAsync((long)Http3ErrorCode.NoError).GetAwaiter().GetResult(); // TODO: async...
+                _connection.Dispose();
+                _connection = null;
+            }
+        }
+
+        public override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Task waitTask = WaitForAvailableRequestStreamAsync(cancellationToken);
+
+            return waitTask.IsCompletedSuccessfully
+                ? SendWithoutWaitingAsync(request, cancellationToken)
+                : WaitThenSendAsync(waitTask, request, cancellationToken);
+        }
+
+        private async Task<HttpResponseMessage> WaitThenSendAsync(Task taskToWaitFor, HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await taskToWaitFor.ConfigureAwait(false);
+            return await SendWithoutWaitingAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task<HttpResponseMessage> SendWithoutWaitingAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            QuicStream quicStream = null;
+            Http3RequestStream stream;
+
+            try
+            {
+                // TODO: do less work in this lock, try to get rid of goto.
+                lock (SyncObj)
+                {
+                    if (_connection == null)
+                    {
+                        goto retryRequest;
+                    }
+
+                    quicStream = _connection.OpenBidirectionalStream();
+                    if (_lastProcessedStreamId != -1 && quicStream.StreamId > _lastProcessedStreamId)
+                    {
+                        goto retryRequest;
+                    }
+
+                    stream = new Http3RequestStream(request, this, quicStream);
+                    _activeRequests.Add(quicStream.StreamId, stream);
+                }
+
+                return stream.SendAsync(cancellationToken);
+            }
+            catch (QuicConnectionAbortedException ex)
+            {
+                // This will happen if we aborted _connection somewhere.
+                Abort(ex);
+            }
+
+        retryRequest:
+            // We lost a race between GOAWAY/abort and our pool sending the request to this connection.
+            quicStream?.Dispose();
+            return Task.FromException<HttpResponseMessage>(new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnSameOrNextProxy));
+        }
+
+        /// <summary>
+        /// Waits for MAX_STREAMS to be raised by the server.
+        /// </summary>
+        private Task WaitForAvailableRequestStreamAsync(CancellationToken cancellationToken)
+        {
+            TaskCompletionSourceWithCancellation<bool> tcs;
+
+            lock (SyncObj)
+            {
+                long remaining = _requestStreamsRemaining;
+
+                if (remaining > 0)
+                {
+                    _requestStreamsRemaining = remaining - 1;
+                    return Task.CompletedTask;
+                }
+
+                tcs = new TaskCompletionSourceWithCancellation<bool>();
+                _waitingRequests.Enqueue(tcs);
+            }
+
+            // Note: cancellation on connection shutdown is handled in CancelWaiters.
+            return tcs.WaitWithCancellationAsync(cancellationToken).AsTask();
+        }
+
+        /// <summary>
+        /// Cancels any waiting SendAsync calls.
+        /// </summary>
+        /// <remarks>Requires <see cref="SyncObj"/> to be held.</remarks>
+        private void CancelWaiters()
+        {
+            Debug.Assert(Monitor.IsEntered(SyncObj));
+
+            while (_waitingRequests.TryDequeue(out TaskCompletionSourceWithCancellation<bool> tcs))
+            {
+                tcs.TrySetException(new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnSameOrNextProxy));
+            }
+        }
+
+        // TODO: how do we get this event?
+        private void OnMaximumStreamCountIncrease(long newMaximumStreamCount)
+        {
+            lock (SyncObj)
+            {
+                if (newMaximumStreamCount <= _maximumRequestStreams)
+                {
+                    return;
+                }
+
+                _requestStreamsRemaining += (newMaximumStreamCount - _maximumRequestStreams);
+                _maximumRequestStreams = newMaximumStreamCount;
+
+                while (_requestStreamsRemaining != 0 && _waitingRequests.TryDequeue(out TaskCompletionSourceWithCancellation<bool> tcs))
+                {
+                    if (tcs.TrySetResult(true))
+                    {
+                        --_requestStreamsRemaining;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Aborts the connection with an error.
+        /// </summary>
+        /// <remarks>
+        /// Used for e.g. I/O or connection-level frame parsing errors.
+        /// </remarks>
+        internal Exception Abort(Exception abortException)
+        {
+            // Only observe the first exception we get.
+            Exception firstException = Interlocked.CompareExchange(ref _abortException, abortException, null);
+
+            if (firstException != null)
+            {
+                if (NetEventSource.IsEnabled && !ReferenceEquals(firstException, abortException))
+                {
+                    // Lost the race to set the field to another exception, so just trace this one.
+                    Trace($"{nameof(abortException)}=={abortException}");
+                }
+
+                return firstException;
+            }
+
+            // Stop sending requests to this connection.
+            _pool.InvalidateHttp3Connection(this);
+
+            Http3ErrorCode connectionResetErrorCode = (abortException as Http3ProtocolException)?.ErrorCode ?? Http3ErrorCode.InternalError;
+
+            lock (SyncObj)
+            {
+                // Set _lastProcessedStreamId != -1 to make ShuttingDown = true.
+                // It's possible GOAWAY is already being processed, in which case this would already be != -1.
+                if (_lastProcessedStreamId == -1)
+                {
+                    _lastProcessedStreamId = long.MaxValue;
+                }
+
+                // Abort the connection. This will cause all of our streams to abort on their next I/O.
+                _connection?.CloseAsync((long)connectionResetErrorCode).GetAwaiter().GetResult(); // TODO: async...
+
+                CancelWaiters();
+                CheckForShutdown();
+            }
+
+            return abortException;
+        }
+
+        private void OnServerGoAway(long lastProcessedStreamId)
+        {
+            // Stop sending requests to this connection.
+            _pool.InvalidateHttp3Connection(this);
+
+            var streamsToGoAway = new List<Http3RequestStream>();
+
+            lock (SyncObj)
+            {
+                if (lastProcessedStreamId > _lastProcessedStreamId)
+                {
+                    // Server can send multiple GOAWAY frames.
+                    // Spec says a server MUST NOT increase the stream ID in subsequent GOAWAYs,
+                    // but doesn't specify what client should do if that is violated. Ignore for now.
+                    if (NetEventSource.IsEnabled)
+                    {
+                        Trace("HTTP/3 server sent GOAWAY with increasing stream ID. Retried requests may have been double-processed by server.");
+                    }
+                    return;
+                }
+
+                _lastProcessedStreamId = lastProcessedStreamId;
+
+                foreach (KeyValuePair<long, Http3RequestStream> request in _activeRequests)
+                {
+                    if (request.Key > lastProcessedStreamId)
+                    {
+                        streamsToGoAway.Add(request.Value);
+                    }
+                }
+
+                CancelWaiters();
+                CheckForShutdown();
+            }
+
+            // GOAWAY each stream outside of the lock, so they can acquire the lock to remove themselves from _activeRequests.
+            foreach (Http3RequestStream stream in streamsToGoAway)
+            {
+                stream.GoAway();
+            }
+        }
+
+        public void RemoveStream(long streamId)
+        {
+            lock (SyncObj)
+            {
+                bool removed = _activeRequests.Remove(streamId);
+                Debug.Assert(removed == true);
+
+                if (ShuttingDown)
+                {
+                    CheckForShutdown();
+                }
+            }
+        }
+
+        public override void Trace(string message, [CallerMemberName] string memberName = null) =>
+            Trace(0, message, memberName);
+
+        internal void Trace(long streamId, string message, [CallerMemberName] string memberName = null) =>
+            NetEventSource.Log.HandlerMessage(
+                _pool?.GetHashCode() ?? 0,    // pool ID
+                GetHashCode(),                // connection ID
+                (int)streamId,                // stream ID
+                memberName,                   // method name
+                message);                     // message
+
+        private async ValueTask SendSettingsAsync()
+        {
+            try
+            {
+                _clientControl = _connection.OpenUnidirectionalStream();
+                await _clientControl.WriteAsync(_pool.Settings.Http3SettingsFrame, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Abort(ex);
+            }
+        }
+
+        public static byte[] BuildSettingsFrame(HttpConnectionSettings settings)
+        {
+            Span<byte> buffer = stackalloc byte[4 + VariableLengthIntegerHelper.MaximumEncodedLength];
+
+            int integerLength = VariableLengthIntegerHelper.WriteInteger(buffer.Slice(4), settings._maxResponseHeadersLength * 1024L);
+            int payloadLength = 1 + integerLength; // includes the setting ID and the integer value.
+            Debug.Assert(payloadLength <= VariableLengthIntegerHelper.OneByteLimit);
+
+            buffer[0] = (byte)Http3StreamType.Control;
+            buffer[1] = (byte)Http3FrameType.Settings;
+            buffer[2] = (byte)payloadLength;
+            buffer[3] = (byte)Http3SettingType.MaxHeaderListSize;
+
+            return buffer.Slice(4 + integerLength).ToArray();
+        }
+
+        /// <summary>
+        /// Accepts unidirectional streams (control, QPack, ...) from the server.
+        /// </summary>
+        private async Task AcceptStreamsAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    ValueTask<QuicStream> streamTask;
+
+                    lock (SyncObj)
+                    {
+                        if (ShuttingDown)
+                        {
+                            return;
+                        }
+
+                        // No cancellation token is needed here; we expect the operation to cancel itself when _connection is disposed.
+                        streamTask = _connection.AcceptStreamAsync(CancellationToken.None);
+                    }
+
+                    QuicStream stream = await streamTask.ConfigureAwait(false);
+
+                    // This process is cleaned up when _connection is disposed, and errors are observed via Abort().
+                    _ = ProcessServerStreamAsync(stream);
+                }
+            }
+            catch (Exception ex)
+            {
+                Abort(ex);
+            }
+        }
+
+        /// <summary>
+        /// Routes a stream to an appropriate stream-type-specific processor
+        /// </summary>
+        private async Task ProcessServerStreamAsync(QuicStream stream)
+        {
+            try
+            {
+                await using (stream.ConfigureAwait(false))
+                using (var buffer = new ArrayBuffer(initialSize: 32, usePool: true))
+                {
+                    if (stream.CanWrite)
+                    {
+                        // Server initiated bidirectional streams are either push streams or extensions, and we support neither.
+                        throw new Http3ConnectionException(Http3ErrorCode.StreamCreationError);
+                    }
+
+                    int bytesRead;
+
+                    try
+                    {
+                        bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (QuicStreamAbortedException)
+                    {
+                        // Treat identical to receiving 0. See below comment.
+                        bytesRead = 0;
+                    }
+
+                    if (bytesRead == 0)
+                    {
+                        // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#name-unidirectional-streams
+                        // A sender can close or reset a unidirectional stream unless otherwise specified. A receiver MUST
+                        // tolerate unidirectional streams being closed or reset prior to the reception of the unidirectional
+                        // stream header.
+                        return;
+                    }
+
+                    buffer.Commit(bytesRead);
+
+                    // Stream type is a variable-length integer, but we only check the first byte. There is no known type requiring more than 1 byte.
+                    switch (buffer.ActiveSpan[0])
+                    {
+                        case (byte)Http3StreamType.Control:
+                            if (Interlocked.Exchange(ref _haveServerControlStream, 1) != 0)
+                            {
+                                // A second control stream has been received.
+                                throw new Http3ConnectionException(Http3ErrorCode.StreamCreationError);
+                            }
+
+                            // Discard the stream type header.
+                            buffer.Discard(1);
+
+                            await ProcessServerControlStreamAsync(stream, buffer).ConfigureAwait(false);
+                            return;
+                        case (byte)Http3StreamType.QPackDecoder:
+                            if (Interlocked.Exchange(ref _haveServerQpackDecodeStream, 1) != 0)
+                            {
+                                // A second QPack decode stream has been received.
+                                throw new Http3ConnectionException(Http3ErrorCode.StreamCreationError);
+                            }
+
+                            // The stream must not be closed, but we aren't using QPACK right now -- ignore.
+                            buffer.Dispose();
+                            await stream.CopyToAsync(Stream.Null).ConfigureAwait(false);
+                            return;
+                        case (byte)Http3StreamType.QPackEncoder:
+                            if (Interlocked.Exchange(ref _haveServerQpackEncodeStream, 1) != 0)
+                            {
+                                // A second QPack encode stream has been received.
+                                throw new Http3ConnectionException(Http3ErrorCode.StreamCreationError);
+                            }
+
+                            // The stream must not be closed, but we aren't using QPACK right now -- ignore.
+                            buffer.Dispose();
+                            await stream.CopyToAsync(Stream.Null).ConfigureAwait(false);
+                            return;
+                        case (byte)Http3StreamType.Push:
+                            // We don't support push streams.
+                            // Because no maximum push stream ID was negotiated via a MAX_PUSH_ID frame, server should not have sent this. Abort the connection with H3_ID_ERROR.
+                            throw new Http3ConnectionException(Http3ErrorCode.IdError);
+                        default:
+                            // Unknown stream type. Per spec, these must be ignored and aborted but not be considered a connection-level error.
+
+                            if (NetEventSource.IsEnabled)
+                            {
+                                // Read the rest of the integer, which might be more than 1 byte, so we can log it.
+
+                                long unknownStreamType;
+                                while (!VariableLengthIntegerHelper.TryRead(buffer.ActiveSpan, out unknownStreamType, out _))
+                                {
+                                    buffer.EnsureAvailableSpace(VariableLengthIntegerHelper.MaximumEncodedLength);
+                                    bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+
+                                    if (bytesRead == 0)
+                                    {
+                                        unknownStreamType = -1;
+                                        break;
+                                    }
+
+                                    buffer.Commit(bytesRead);
+                                }
+
+                                NetEventSource.Info(this, $"Ignoring server-initiated stream of unknown type {unknownStreamType}.");
+                            }
+
+                            stream.AbortWrite((long)Http3ErrorCode.StreamCreationError);
+                            return;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Abort(ex);
+            }
+        }
+
+        /// <summary>
+        /// Reads the server's control stream.
+        /// </summary>
+        private async Task ProcessServerControlStreamAsync(QuicStream stream, ArrayBuffer buffer)
+        {
+            (Http3FrameType? frameType, long payloadLength) = await ReadFrameEnvelopeAsync().ConfigureAwait(false);
+
+            if (frameType == null)
+            {
+                // Connection closed prematurely, expected SETTINGS frame.
+                throw new Http3ConnectionException(Http3ErrorCode.ClosedCriticalStream);
+            }
+
+            if (frameType != Http3FrameType.Settings)
+            {
+                // Expected SETTINGS as first frame of control stream.
+                throw new Http3ConnectionException(Http3ErrorCode.MissingSettings);
+            }
+
+            await ProcessSettingsFrameAsync(payloadLength).ConfigureAwait(false);
+
+            while (true)
+            {
+                (frameType, payloadLength) = await ReadFrameEnvelopeAsync().ConfigureAwait(false);
+
+                switch (frameType)
+                {
+                    case Http3FrameType.GoAway:
+                        await ProcessGoAwayFameAsync(payloadLength).ConfigureAwait(false);
+                        break;
+                    case Http3FrameType.Settings:
+                        // Only a single SETTINGS frame is supported.
+                        throw new Http3ConnectionException(Http3ErrorCode.UnexpectedFrame);
+                    case Http3FrameType.Headers:
+                    case Http3FrameType.Data:
+                    case Http3FrameType.MaxPushId:
+                    case Http3FrameType.DuplicatePush:
+                        // Servers should not send these frames to a control stream.
+                        throw new Http3ConnectionException(Http3ErrorCode.UnexpectedFrame);
+                    case Http3FrameType.PushPromise:
+                    case Http3FrameType.CancelPush:
+                        // Because we haven't sent any MAX_PUSH_ID frame, it is invalid to receive any push-related frames as they will all reference a too-large ID.
+                        throw new Http3ConnectionException(Http3ErrorCode.IdError);
+                    case null:
+                        // End of stream reached. If we're shutting down, stop looping. Otherwise, this is an error (this stream should not be closed for life of connection).
+                        bool shuttingDown;
+                        lock (SyncObj)
+                        {
+                            shuttingDown = ShuttingDown;
+                        }
+                        if (!shuttingDown)
+                        {
+                            throw new Http3ConnectionException(Http3ErrorCode.ClosedCriticalStream);
+                        }
+                        return;
+                    default:
+                        await SkipUnknownPayloadAsync(frameType.GetValueOrDefault(), payloadLength).ConfigureAwait(false);
+                        break;
+                }
+            }
+
+            async ValueTask<(Http3FrameType? frameType, long payloadLength)> ReadFrameEnvelopeAsync()
+            {
+                long frameType, payloadLength;
+                int bytesRead;
+
+                while (!Http3Frame.TryReadIntegerPair(buffer.ActiveSpan, out frameType, out payloadLength, out bytesRead))
+                {
+                    buffer.EnsureAvailableSpace(VariableLengthIntegerHelper.MaximumEncodedLength * 2);
+                    bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+
+                    if (bytesRead != 0)
+                    {
+                        buffer.Commit(bytesRead);
+                    }
+                    else if (buffer.ActiveLength == 0)
+                    {
+                        // End of stream.
+                        return (null, 0);
+                    }
+                    else
+                    {
+                        // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                        throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                    }
+                }
+
+                buffer.Discard(bytesRead);
+
+                return ((Http3FrameType)frameType, payloadLength);
+            }
+
+            async ValueTask ProcessSettingsFrameAsync(long settingsPayloadLength)
+            {
+                if (settingsPayloadLength > MaximumSettingsPayloadLength)
+                {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        Trace($"Received SETTINGS frame with {settingsPayloadLength} byte payload exceeding the {MaximumSettingsPayloadLength} byte maximum.");
+                    }
+                    throw new Http3ConnectionException(Http3ErrorCode.ExcessiveLoad);
+                }
+
+                while (settingsPayloadLength != 0)
+                {
+                    long settingId, settingValue;
+                    int bytesRead;
+
+                    while (!Http3Frame.TryReadIntegerPair(buffer.ActiveSpan, out settingId, out settingValue, out bytesRead))
+                    {
+                        buffer.EnsureAvailableSpace(VariableLengthIntegerHelper.MaximumEncodedLength * 2);
+                        bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+
+                        if (bytesRead != 0)
+                        {
+                            buffer.Commit(bytesRead);
+                        }
+                        else
+                        {
+                            // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                            throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                        }
+                    }
+
+                    settingsPayloadLength -= bytesRead;
+
+                    // Only support this single setting. Skip others.
+                    if (settingId == (long)Http3SettingType.MaxHeaderListSize)
+                    {
+                        _maximumHeadersLength = (int)Math.Min(settingValue, int.MaxValue);
+                    }
+                }
+            }
+
+            async ValueTask ProcessGoAwayFameAsync(long goawayPayloadLength)
+            {
+                long lastStreamId;
+                int bytesRead;
+
+                while (!VariableLengthIntegerHelper.TryRead(buffer.AvailableSpan, out lastStreamId, out bytesRead))
+                {
+                    buffer.EnsureAvailableSpace(VariableLengthIntegerHelper.MaximumEncodedLength);
+                    bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+
+                    if (bytesRead != 0)
+                    {
+                        buffer.Commit(bytesRead);
+                    }
+                    else
+                    {
+                        // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                        throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                    }
+                }
+
+                buffer.Discard(bytesRead);
+                if (bytesRead != goawayPayloadLength)
+                {
+                    // Frame contains unknown extra data after the integer.
+                    throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                }
+
+                OnServerGoAway(lastStreamId);
+            }
+
+            async ValueTask SkipUnknownPayloadAsync(Http3FrameType frameType, long payloadLength)
+            {
+                if (payloadLength > MaximumUnknownFramePayloadLength)
+                {
+                    Trace($"Received unknown frame type 0x{(long)frameType:x} with {payloadLength} byte payload exceeding the {MaximumUnknownFramePayloadLength} byte maximum.");
+                    throw new Http3ConnectionException(Http3ErrorCode.ExcessiveLoad);
+                }
+
+                while (payloadLength != 0)
+                {
+                    if (buffer.ActiveLength == 0)
+                    {
+                        int bytesRead = await stream.ReadAsync(buffer.AvailableMemory, CancellationToken.None).ConfigureAwait(false);
+
+                        if (bytesRead != 0)
+                        {
+                            buffer.Commit(bytesRead);
+                        }
+                        else
+                        {
+                            // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                            throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                        }
+                    }
+
+                    long readLength = Math.Min(payloadLength, buffer.ActiveLength);
+                    buffer.Discard((int)readLength);
+                    payloadLength -= readLength;
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ConnectionException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ConnectionException.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http
+{
+    [Serializable]
+    internal sealed class Http3ConnectionException : Http3ProtocolException
+    {
+        public Http3ConnectionException(Http3ErrorCode errorCode)
+            : base(SR.Format(SR.net_http_http3_connection_error, GetName(errorCode), ((long)errorCode).ToString("x")), errorCode)
+        {
+        }
+
+        private Http3ConnectionException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ProtocolException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3ProtocolException.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http
+{
+    [Serializable]
+    internal class Http3ProtocolException : Exception
+    {
+        public Http3ErrorCode ErrorCode { get; }
+
+        protected Http3ProtocolException(string message, Http3ErrorCode errorCode) : base(message)
+        {
+            ErrorCode = errorCode;
+        }
+
+        protected Http3ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            ErrorCode = (Http3ErrorCode)info.GetUInt32(nameof(ErrorCode));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(ErrorCode), (uint)ErrorCode);
+            base.GetObjectData(info, context);
+        }
+
+        protected static string GetName(Http3ErrorCode errorCode) =>
+            // These strings come from the H3 spec and should not be localized.
+            errorCode switch
+            {
+                Http3ErrorCode.NoError => "H3_NO_ERROR (0x100)",
+                Http3ErrorCode.ProtocolError => "H3_GENERAL_PROTOCOL_ERROR (0x101)",
+                Http3ErrorCode.InternalError => "H3_INTERNAL_ERROR (0x102)",
+                Http3ErrorCode.StreamCreationError => "H3_STREAM_CREATION_ERROR (0x103)",
+                Http3ErrorCode.ClosedCriticalStream => "H3_CLOSED_CRITICAL_STREAM (0x104)",
+                Http3ErrorCode.UnexpectedFrame => "H3_FRAME_UNEXPECTED (0x105)",
+                Http3ErrorCode.FrameError => "H3_FRAME_ERROR (0x106)",
+                Http3ErrorCode.ExcessiveLoad => "H3_EXCESSIVE_LOAD (0x107)",
+                Http3ErrorCode.IdError => "H3_ID_ERROR (0x108)",
+                Http3ErrorCode.SettingsError => "H3_SETTINGS_ERROR (0x109)",
+                Http3ErrorCode.MissingSettings => "H3_MISSING_SETTINGS (0x10A)",
+                Http3ErrorCode.RequestRejected => "H3_REQUEST_REJECTED (0x10B)",
+                Http3ErrorCode.RequestCancelled => "H3_REQUEST_CANCELLED (0x10C)",
+                Http3ErrorCode.RequestIncomplete => "H3_REQUEST_INCOMPLETE (0x10D)",
+                Http3ErrorCode.ConnectError => "H3_CONNECT_ERROR (0x10F)",
+                Http3ErrorCode.VersionFallback => "H3_VERSION_FALLBACK (0x110)",
+                _ => "(unknown error)"
+            };
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1,0 +1,1265 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Net.Quic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Net.Http.QPack;
+using System.Runtime.ExceptionServices;
+using System.Buffers;
+
+namespace System.Net.Http
+{
+    internal sealed class Http3RequestStream : IHttpHeadersHandler, IAsyncDisposable, IDisposable
+    {
+        private readonly HttpRequestMessage _request;
+        private Http3Connection _connection;
+        private readonly long _streamId;
+        private QuicStream _stream;
+        private ArrayBuffer _sendBuffer;
+        private readonly ReadOnlyMemory<byte>[] _gatheredSendBuffer = new ReadOnlyMemory<byte>[2];
+        private ArrayBuffer _recvBuffer;
+        private TaskCompletionSource<bool> _expect100ContinueCompletionSource; // True indicates we should send content (e.g. received 100 Continue).
+
+        private CancellationTokenSource _goawayCancellationSource;
+        private CancellationToken _goawayCancellationToken;
+
+        // Allocated when we receive a :status header.
+        private HttpResponseMessage _response;
+
+        // Header decoding.
+        private QPackDecoder _headerDecoder;
+        private HeaderState _headerState;
+        private long _headerBudgetRemaining;
+
+        /// <summary>Reusable array used to get the values for each header being written to the wire.</summary>
+        private string[] _headerValues = Array.Empty<string>();
+
+        /// <summary>Any trailing headers.</summary>
+        private List<(HeaderDescriptor name, string value)> _trailingHeaders;
+
+        // When reading response content, keep track of the number of bytes left in the current data frame.
+        private long _responseDataPayloadRemaining = 0;
+
+        // When our request content has a precomputed length, it is sent over a single DATA frame.
+        // Keep track of how much is remaining in that frame.
+        private long _requestContentLengthRemaining = 0;
+
+        public Http3RequestStream(HttpRequestMessage request, Http3Connection connection, QuicStream stream)
+        {
+            _request = request;
+            _connection = connection;
+            _stream = stream;
+            _streamId = stream.StreamId;
+            _sendBuffer = new ArrayBuffer(initialSize: 64, usePool: true);
+            _recvBuffer = new ArrayBuffer(initialSize: 64, usePool: true);
+
+            _headerBudgetRemaining = connection.Pool.Settings._maxResponseHeadersLength * 1024L; // _maxResponseHeadersLength is in KiB.
+            _headerDecoder = new QPackDecoder(maxHeadersLength: (int)Math.Min(int.MaxValue, _headerBudgetRemaining));
+
+            _goawayCancellationSource = new CancellationTokenSource();
+            _goawayCancellationToken = _goawayCancellationSource.Token;
+        }
+
+        public void Dispose()
+        {
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+
+                DisposeSyncHelper();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_stream != null)
+            {
+                await _stream.DisposeAsync().ConfigureAwait(false);
+                _stream = null;
+
+                DisposeSyncHelper();
+            }
+        }
+
+        private void DisposeSyncHelper()
+        {
+            _connection.RemoveStream(_streamId);
+            _connection = null;
+
+            _sendBuffer.Dispose();
+            _recvBuffer.Dispose();
+
+            // Dispose() might be called concurrently with GoAway(), we need to make sure to not Dispose/Cancel the CTS concurrently.
+            Interlocked.Exchange(ref _goawayCancellationSource, null)?.Dispose();
+        }
+
+        public void GoAway()
+        {
+            // Dispose() might be called concurrently with GoAway(), we need to make sure to not Dispose/Cancel the CTS concurrently.
+            using CancellationTokenSource cts = Interlocked.Exchange(ref _goawayCancellationSource, null);
+            cts?.Cancel();
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(CancellationToken cancellationToken)
+        {
+            // If true, dispose the stream upon return. Will be set to false if we're duplex or returning content.
+            bool disposeSelf = true;
+
+            // Link the input token with _resetCancellationTokenSource, so cancellation will trigger on GoAway() or Abort().
+            using CancellationTokenSource requestCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _goawayCancellationToken);
+
+            try
+            {
+                BufferHeaders(_request);
+
+                // If using Expect 100 Continue, setup a TCS to wait to send content until we get a response.
+                if (_request.HasHeaders && _request.Headers.ExpectContinue == true)
+                {
+                    _expect100ContinueCompletionSource = new TaskCompletionSource<bool>();
+                }
+
+                if (_expect100ContinueCompletionSource != null || _request.Content == null)
+                {
+                    // Ideally, headers will be sent out in a gathered write inside of SendContentAsync().
+                    // If we don't have content, or we are doing Expect 100 Continue, then we can't rely on
+                    // this and must send our headers immediately.
+
+                    await _stream.WriteAsync(_sendBuffer.ActiveMemory, requestCancellationSource.Token).ConfigureAwait(false);
+                    _sendBuffer.Discard(_sendBuffer.ActiveLength);
+
+                    if (_expect100ContinueCompletionSource != null)
+                    {
+                        // Flush to ensure we get a response.
+                        // TODO: MsQuic may not need any flushing.
+                        await _stream.FlushAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _stream.Shutdown();
+                    }
+                }
+
+                // If using duplex content, the content will continue sending after this method completes.
+                // So, only observe the cancellation token if not using duplex.
+                CancellationToken sendContentCancellationToken = _request.Content?.AllowDuplex == false ? requestCancellationSource.Token : default;
+
+                // In parallel, send content and read response.
+                // Depending on Expect 100 Continue usage, one will depend on the other making progress.
+                Task sendContentTask = _request.Content != null ? SendContentAsync(_request.Content, sendContentCancellationToken) : Task.CompletedTask;
+                Task readResponseTask = ReadResponseAsync(requestCancellationSource.Token);
+                bool sendContentObserved = false;
+
+                // If we're not doing duplex, wait for content to finish sending here.
+                // If we are doing duplex and have the unlikely event that it completes here, observe the result.
+                // See Http2Connection.SendAsync for a full comment on this logic -- it is identical behavior.
+                if (sendContentTask.IsCompleted ||
+                    _request.Content?.AllowDuplex != true ||
+                    sendContentTask == await Task.WhenAny(sendContentTask, readResponseTask).ConfigureAwait(false) ||
+                    sendContentTask.IsCompleted)
+                {
+                    try
+                    {
+                        await sendContentTask.ConfigureAwait(false);
+                        sendContentObserved = true;
+                    }
+                    catch
+                    {
+                        // Exceptions will be bubbled up from sendContentTask here,
+                        // which means the result of readResponseTask won't be observed directly:
+                        // Do a background await to log any exceptions.
+                        _connection.LogExceptions(readResponseTask);
+                        throw;
+                    }
+                }
+                else
+                {
+                    // Duplex is being used, so we can't wait for content to finish sending.
+                    // Do a background await to log any exceptions.
+                    _connection.LogExceptions(sendContentTask);
+                }
+
+                // Wait for the response headers to be read.
+                await readResponseTask.ConfigureAwait(false);
+
+                // Now that we've received the response, we no longer need to observe GOAWAY.
+                // Use an atomic exchange to avoid a race to Cancel()/Dispose().
+                Interlocked.Exchange(ref _goawayCancellationSource, null)?.Dispose();
+
+                // Set our content stream.
+                var responseContent = (HttpConnectionResponseContent)_response.Content;
+
+                // If we have received Content-Length: 0 and have completed sending content (which may not be the case if duplex),
+                // we can close our Http3RequestStream immediately and return a singleton empty content stream. Otherwise, we
+                // need to return a Http3ReadStream which will be responsible for disposing the Http3RequestStream.
+                bool useEmptyResponseContent = responseContent.Headers.ContentLength == 0 && sendContentObserved;
+                if (useEmptyResponseContent)
+                {
+                    // Drain the response frames to read any trailing headers.
+                    await DrainContentLength0Frames(requestCancellationSource.Token).ConfigureAwait(false);
+                    responseContent.SetStream(EmptyReadStream.Instance);
+                }
+                else
+                {
+                    // A read stream is required to finish up the request.
+                    responseContent.SetStream(new Http3ReadStream(this));
+                }
+
+                // Process any Set-Cookie headers.
+                if (_connection.Pool.Settings._useCookies)
+                {
+                    CookieHelper.ProcessReceivedCookies(_response, _connection.Pool.Settings._cookieContainer);
+                }
+
+                // To avoid a circular reference (stream->response->content->stream), null out the stream's response.
+                HttpResponseMessage response = _response;
+                _response = null;
+
+                // If we're 100% done with the stream, dispose.
+                disposeSelf = useEmptyResponseContent;
+
+                return response;
+            }
+            catch (QuicStreamAbortedException ex) when (ex.ErrorCode == (long)Http3ErrorCode.VersionFallback)
+            {
+                // The server is requesting us fall back to an older HTTP version.
+                throw new HttpRequestException(SR.net_http_retry_on_older_version, ex, RequestRetryType.RetryOnLowerHttpVersion);
+            }
+            catch (QuicStreamAbortedException ex)
+            {
+                // Our stream was reset.
+
+                Exception abortException = _connection.AbortException;
+                throw new HttpRequestException(SR.net_http_client_execution_error, abortException ?? ex);
+            }
+            catch (QuicConnectionAbortedException ex)
+            {
+                // Our connection was reset. Start shutting down the connection.
+
+                Exception abortException = _connection.Abort(ex);
+                throw new HttpRequestException(SR.net_http_client_execution_error, abortException);
+            }
+            catch (OperationCanceledException ex)
+                when (ex.CancellationToken == requestCancellationSource.Token) // It is possible for user's Content code to throw an unexpected OperationCanceledException.
+            {
+                // We're either observing GOAWAY, or the cancellationToken parameter has been canceled.
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _stream.AbortWrite((long)Http3ErrorCode.RequestCancelled);
+                    throw new OperationCanceledException(ex.Message, ex, cancellationToken);
+                }
+                else
+                {
+                    Debug.Assert(_goawayCancellationToken.IsCancellationRequested == true);
+                    throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnSameOrNextProxy);
+                }
+            }
+            catch (Http3ConnectionException ex)
+            {
+                // A connection-level protocol error has occurred on our stream.
+                _connection.Abort(ex);
+                throw new HttpRequestException(SR.net_http_client_execution_error, ex);
+            }
+            catch (Exception ex)
+            {
+                _stream.AbortWrite((long)Http3ErrorCode.InternalError);
+                throw new HttpRequestException(SR.net_http_client_execution_error, ex);
+            }
+            finally
+            {
+                if (disposeSelf)
+                {
+                    await DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Waits for the initial response headers to be completed, including e.g. Expect 100 Continue.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task ReadResponseAsync(CancellationToken cancellationToken)
+        {
+            do
+            {
+                _headerState = HeaderState.StatusHeader;
+
+                (Http3FrameType? frameType, long payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);
+
+                if (frameType != Http3FrameType.Headers)
+                {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        Trace($"Expected HEADERS as first response frame; recieved {frameType}.");
+                    }
+                    throw new HttpRequestException(SR.net_http_invalid_response);
+                }
+
+                await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+            }
+            while ((int)_response.StatusCode < 200);
+
+            _headerState = HeaderState.TrailingHeaders;
+        }
+
+        private async Task SendContentAsync(HttpContent content, CancellationToken cancellationToken)
+        {
+            // If we're using Expect 100 Continue, wait to send content
+            // until we get a response back or until our timeout elapses.
+            if (_expect100ContinueCompletionSource != null)
+            {
+                Timer timer = null;
+
+                try
+                {
+                    if (_connection.Pool.Settings._expect100ContinueTimeout != Timeout.InfiniteTimeSpan)
+                    {
+                        timer = new Timer(o =>
+                        {
+                            ((Http3RequestStream)o)._expect100ContinueCompletionSource.TrySetResult(true);
+                        }, this, _connection.Pool.Settings._expect100ContinueTimeout, Timeout.InfiniteTimeSpan);
+                    }
+
+                    if (!await _expect100ContinueCompletionSource.Task.ConfigureAwait(false))
+                    {
+                        // We received an error response code, so the body should not be sent.
+                        return;
+                    }
+                }
+                finally
+                {
+                    if (timer != null)
+                    {
+                        await timer.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
+            }
+
+            // If we have a Content-Length, keep track of it so we don't over-send and so we can send in a single DATA frame.
+            _requestContentLengthRemaining = content.Headers.ContentLength ?? -1;
+
+            using (var writeStream = new Http3WriteStream(this))
+            {
+                await content.CopyToAsync(writeStream, null, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_sendBuffer.ActiveLength != 0)
+            {
+                // Our initial send buffer, which has our headers, are normally sent out on the first write to the Http3WriteStream.
+                // If we get here, it means the content didn't actually do any writing. Send out the headers now.
+                await _stream.WriteAsync(_sendBuffer.ActiveMemory, cancellationToken).ConfigureAwait(false);
+                _sendBuffer.Discard(_sendBuffer.ActiveLength);
+            }
+
+            _stream.Shutdown();
+        }
+
+        private async ValueTask WriteRequestContentAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (buffer.Length == 0)
+            {
+                return;
+            }
+
+            long remaining = _requestContentLengthRemaining;
+            if (remaining != -1)
+            {
+                // This HttpContent had a precomputed length, and a DATA frame was written as part of the headers. We can write directly without framing.
+
+                if (buffer.Length > _requestContentLengthRemaining)
+                {
+                    string msg = SR.net_http_content_write_larger_than_content_length;
+                    throw new IOException(msg, new HttpRequestException(msg));
+                }
+                _requestContentLengthRemaining -= buffer.Length;
+
+                if (_sendBuffer.ActiveLength != 0)
+                {
+                    // We haven't sent out headers yet, so write them together with the user's content buffer.
+
+                    // Because we have a Content-Length, we can write it in a single DATA frame.
+                    BufferFrameEnvelope(Http3FrameType.Data, remaining);
+
+                    _gatheredSendBuffer[0] = _sendBuffer.ActiveMemory;
+                    _gatheredSendBuffer[1] = buffer;
+                    await _stream.WriteAsync(_gatheredSendBuffer, cancellationToken).ConfigureAwait(false);
+
+                    _sendBuffer.Discard(_sendBuffer.ActiveLength);
+                }
+                else
+                {
+                    // Headers already sent, send just the content buffer directly.
+                    await _stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                // Variable-length content: write both a DATA frame and buffer. (and headers, which will still be in _sendBuffer if this is the first content write)
+                // It's up to the HttpContent to give us sufficiently large writes to avoid excessively small DATA frames.
+                BufferFrameEnvelope(Http3FrameType.Data, buffer.Length);
+
+                _gatheredSendBuffer[0] = _sendBuffer.ActiveMemory;
+                _gatheredSendBuffer[1] = buffer;
+                await _stream.WriteAsync(_gatheredSendBuffer, cancellationToken).ConfigureAwait(false);
+
+                _sendBuffer.Discard(_sendBuffer.ActiveLength);
+            }
+        }
+
+        private async ValueTask DrainContentLength0Frames(CancellationToken cancellationToken)
+        {
+            Http3FrameType? frameType;
+            long payloadLength;
+
+            while (true)
+            {
+                (frameType, payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);
+
+                switch (frameType)
+                {
+                    case Http3FrameType.Headers:
+                        // Pick up any trailing headers.
+                        _trailingHeaders = new List<(HeaderDescriptor name, string value)>();
+                        await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+
+                        // Stop looping after a trailing header.
+                        // There may be extra frames after this one, but they would all be unknown extension
+                        // frames that can be safely ignored. Just stop reading here.
+                        // Note: this does leave us open to a bad server sending us an out of order DATA frame.
+                        goto case null;
+                    case null:
+                        // Done receiving: copy over trailing headers.
+                        CopyTrailersToResponseMessage(_response);
+                        return;
+                    case Http3FrameType.Data:
+                        // The sum of data frames must equal content length. Because this method is only
+                        // called for a Content-Length of 0, anything other than 0 here would be an error.
+                        // Per spec, 0-length payload is allowed.
+                        if (payloadLength != 0)
+                        {
+                            if (NetEventSource.IsEnabled)
+                            {
+                                Trace("Response content exceeded Content-Length.");
+                            }
+                            throw new HttpRequestException(SR.net_http_invalid_response);
+                        }
+                        break;
+                    default:
+                        Debug.Fail($"Recieved unexpected frame type {frameType}.");
+                        return;
+                }
+            }
+        }
+
+        private void CopyTrailersToResponseMessage(HttpResponseMessage responseMessage)
+        {
+            if (_trailingHeaders?.Count > 0)
+            {
+                foreach ((HeaderDescriptor name, string value) in _trailingHeaders)
+                {
+                    responseMessage.TrailingHeaders.TryAddWithoutValidation(name, value);
+                }
+                _trailingHeaders.Clear();
+            }
+        }
+
+        private void BufferHeaders(HttpRequestMessage request)
+        {
+            // Reserve space for the header frame envelope.
+            // The envelope needs to be written after headers are serialized, as we need to know the payload length first.
+            const int PreHeadersReserveSpace = Http3Frame.MaximumEncodedFrameEnvelopeLength;
+
+            // This should be the first write to our buffer. The trick of reserving space won't otherwise work.
+            Debug.Assert(_sendBuffer.ActiveLength == 0);
+
+            // Reserve space for header frame envelope.
+            _sendBuffer.Commit(PreHeadersReserveSpace);
+
+            // Add header block prefix. We aren't using dynamic table, so these are simple zeroes.
+            // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.5.1
+            _sendBuffer.EnsureAvailableSpace(2);
+            _sendBuffer.AvailableSpan[0] = 0x00; // required insert count.
+            _sendBuffer.AvailableSpan[1] = 0x00; // s + delta base.
+            _sendBuffer.Commit(2);
+
+            HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
+            if (normalizedMethod.Http3EncodedBytes != null)
+            {
+                BufferBytes(normalizedMethod.Http3EncodedBytes);
+            }
+            else
+            {
+                BufferLiteralHeaderWithStaticNameReference(H3StaticTable.MethodGet, normalizedMethod.Method);
+            }
+
+            BufferIndexedHeader(H3StaticTable.SchemeHttps);
+
+            if (request.HasHeaders && request.Headers.Host != null)
+            {
+                BufferLiteralHeaderWithStaticNameReference(H3StaticTable.Authority, request.Headers.Host);
+            }
+            else
+            {
+                BufferBytes(_connection.Pool._http3EncodedAuthorityHostHeader);
+            }
+
+            // The only way to reach H3 is to upgrade via an Alt-Svc header, so we can encode Alt-Used for every connection.
+            BufferBytes(_connection.AltUsedEncodedHeaderBytes);
+
+            string pathAndQuery = request.RequestUri.PathAndQuery;
+            if (pathAndQuery == "/")
+            {
+                BufferIndexedHeader(H3StaticTable.PathSlash);
+            }
+            else
+            {
+                BufferLiteralHeaderWithStaticNameReference(H3StaticTable.PathSlash, pathAndQuery);
+            }
+
+            if (request.HasHeaders)
+            {
+                // H3 does not support Transfer-Encoding: chunked.
+                request.Headers.TransferEncodingChunked = false;
+
+                BufferHeaderCollection(request.Headers);
+            }
+
+            if (_connection.Pool.Settings._useCookies)
+            {
+                string cookiesFromContainer = _connection.Pool.Settings._cookieContainer.GetCookieHeader(request.RequestUri);
+                if (cookiesFromContainer != string.Empty)
+                {
+                    BufferLiteralHeaderWithStaticNameReference(H3StaticTable.Cookie, cookiesFromContainer);
+                }
+            }
+
+            if (request.Content == null || request.Content.Headers.ContentLength == 0)
+            {
+                // Expect 100 Continue requires content.
+                request.Headers.ExpectContinue = null;
+
+                if (normalizedMethod.MustHaveRequestBody)
+                {
+                    BufferIndexedHeader(H3StaticTable.ContentLength0);
+                }
+            }
+            else
+            {
+                BufferHeaderCollection(request.Content.Headers);
+            }
+
+            // Determine our header envelope size.
+            // The reserved space was the maximum required; discard what wasn't used.
+            int headersLength = _sendBuffer.ActiveLength - PreHeadersReserveSpace;
+            int headersLengthEncodedSize = VariableLengthIntegerHelper.GetByteCount(headersLength);
+            _sendBuffer.Discard(PreHeadersReserveSpace - headersLengthEncodedSize - 1);
+
+            // Encode header type in first byte, and payload length in subsequent bytes.
+            _sendBuffer.ActiveSpan[0] = (byte)Http3FrameType.Headers;
+            int actualHeadersLengthEncodedSize = VariableLengthIntegerHelper.WriteInteger(_sendBuffer.ActiveSpan.Slice(1, headersLengthEncodedSize), headersLength);
+            Debug.Assert(actualHeadersLengthEncodedSize == headersLengthEncodedSize);
+        }
+
+        // TODO: special-case Content-Type for static table values values?
+        private void BufferHeaderCollection(HttpHeaders headers)
+        {
+            if (headers.HeaderStore == null)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+            {
+                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
+                Debug.Assert(headerValuesCount > 0, "No values for header??");
+                ReadOnlySpan<string> headerValues = _headerValues.AsSpan(0, headerValuesCount);
+
+                KnownHeader knownHeader = header.Key.KnownHeader;
+                if (knownHeader != null)
+                {
+                    // The Host header is not sent for HTTP/3 because we send the ":authority" pseudo-header instead
+                    // (see pseudo-header handling below in WriteHeaders).
+                    // The Connection, Upgrade and ProxyConnection headers are also not supported in HTTP/3.
+                    if (knownHeader != KnownHeaders.Host && knownHeader != KnownHeaders.Connection && knownHeader != KnownHeaders.Upgrade && knownHeader != KnownHeaders.ProxyConnection)
+                    {
+                        if (header.Key.KnownHeader == KnownHeaders.TE)
+                        {
+                            // HTTP/2 allows only 'trailers' TE header. rfc7540 8.1.2.2
+                            // HTTP/3 does not mention this one way or another; assume it has the same rule.
+                            foreach (string value in headerValues)
+                            {
+                                if (string.Equals(value, "trailers", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    BufferLiteralHeaderWithoutNameReference("TE", value);
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
+
+                        // For all other known headers, send them via their pre-encoded name and the associated value.
+                        BufferBytes(knownHeader.Http3EncodedName);
+                        string separator = null;
+                        if (headerValues.Length > 1)
+                        {
+                            HttpHeaderParser parser = header.Key.Parser;
+                            if (parser != null && parser.SupportsMultipleValues)
+                            {
+                                separator = parser.Separator;
+                            }
+                            else
+                            {
+                                separator = HttpHeaderParser.DefaultSeparator;
+                            }
+                        }
+
+                        BufferLiteralHeaderValues(headerValues, separator);
+                    }
+                }
+                else
+                {
+                    // The header is not known: fall back to just encoding the header name and value(s).
+                    BufferLiteralHeaderWithoutNameReference(header.Key.Name, headerValues, ", ");
+                }
+            }
+        }
+
+        private void BufferIndexedHeader(int index)
+        {
+            int bytesWritten;
+            while (!QPackEncoder.EncodeStaticIndexedHeaderField(index, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferLiteralHeaderWithStaticNameReference(int nameIndex, string value)
+        {
+            int bytesWritten;
+            while (!QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReference(nameIndex, value, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferLiteralHeaderWithoutNameReference(string name, ReadOnlySpan<string> values, string separator)
+        {
+            int bytesWritten;
+            while (!QPackEncoder.EncodeLiteralHeaderFieldWithoutNameReference(name, values, separator, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferLiteralHeaderWithoutNameReference(string name, string value)
+        {
+            int bytesWritten;
+            while (!QPackEncoder.EncodeLiteralHeaderFieldWithoutNameReference(name, value, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferLiteralHeaderValues(ReadOnlySpan<string> values, string separator)
+        {
+            int bytesWritten;
+            while (!QPackEncoder.EncodeValueString(values, separator, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferFrameEnvelope(Http3FrameType frameType, long payloadLength)
+        {
+            int bytesWritten;
+            while (!Http3Frame.TryWriteFrameEnvelope(frameType, payloadLength, _sendBuffer.AvailableSpan, out bytesWritten))
+            {
+                _sendBuffer.Grow();
+            }
+            _sendBuffer.Commit(bytesWritten);
+        }
+
+        private void BufferBytes(ReadOnlySpan<byte> span)
+        {
+            _sendBuffer.EnsureAvailableSpace(span.Length);
+            span.CopyTo(_sendBuffer.AvailableSpan);
+            _sendBuffer.Commit(span.Length);
+        }
+
+        private async ValueTask<(Http3FrameType? frameType, long payloadLength)> ReadFrameEnvelopeAsync(CancellationToken cancellationToken)
+        {
+            long frameType, payloadLength;
+            int bytesRead;
+
+            while (true)
+            {
+                while (!Http3Frame.TryReadIntegerPair(_recvBuffer.ActiveSpan, out frameType, out payloadLength, out bytesRead))
+                {
+                    _recvBuffer.EnsureAvailableSpace(VariableLengthIntegerHelper.MaximumEncodedLength * 2);
+                    bytesRead = await _stream.ReadAsync(_recvBuffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
+
+                    if (bytesRead != 0)
+                    {
+                        _recvBuffer.Commit(bytesRead);
+                    }
+                    else if (_recvBuffer.ActiveLength == 0)
+                    {
+                        // End of stream.
+                        return (null, 0);
+                    }
+                    else
+                    {
+                        // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                        throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
+                    }
+                }
+
+                _recvBuffer.Discard(bytesRead);
+
+                switch ((Http3FrameType)frameType)
+                {
+                    case Http3FrameType.Headers:
+                    case Http3FrameType.Data:
+                        return ((Http3FrameType)frameType, payloadLength);
+                    case Http3FrameType.Settings:
+                    case Http3FrameType.GoAway:
+                    case Http3FrameType.MaxPushId:
+                        // These frames should only be received on a control stream, not a response stream.
+                        throw new Http3ConnectionException(Http3ErrorCode.UnexpectedFrame);
+                    case Http3FrameType.DuplicatePush:
+                    case Http3FrameType.PushPromise:
+                    case Http3FrameType.CancelPush:
+                        // Because we haven't sent any MAX_PUSH_ID frames, any of these push-related
+                        // frames that the server sends will have an out-of-range push ID.
+                        throw new Http3ConnectionException(Http3ErrorCode.IdError);
+                    default:
+                        // Unknown frame types should be skipped.
+                        await SkipUnknownPayloadAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+                        break;
+                }
+            }
+        }
+
+        private async ValueTask ReadHeadersAsync(long headersLength, CancellationToken cancellationToken)
+        {
+            // TODO: this header budget is sent as SETTINGS_MAX_HEADER_LIST_SIZE, so it should not use frame payload but rather 32 bytes + uncompressed size per entry.
+            // https://tools.ietf.org/html/draft-ietf-quic-http-24#section-4.1.1
+            if (headersLength > _headerBudgetRemaining)
+            {
+                _stream.AbortWrite((long)Http3ErrorCode.ExcessiveLoad);
+                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection.Pool.Settings._maxResponseHeadersLength * 1024L));
+            }
+
+            _headerBudgetRemaining -= headersLength;
+
+            while (headersLength != 0)
+            {
+                if (_recvBuffer.ActiveLength == 0)
+                {
+                    _recvBuffer.EnsureAvailableSpace(1);
+
+                    int bytesRead = await _stream.ReadAsync(_recvBuffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
+                    if (bytesRead != 0)
+                    {
+                        _recvBuffer.Commit(bytesRead);
+                    }
+                    else
+                    {
+                        throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
+                    }
+                }
+
+                int processLength = (int)Math.Min(headersLength, _recvBuffer.ActiveLength);
+
+                _headerDecoder.Decode(_recvBuffer.ActiveSpan.Slice(processLength), this);
+                _recvBuffer.Discard(processLength);
+                headersLength -= processLength;
+            }
+        }
+
+        private static ReadOnlySpan<byte> StatusHeaderNameBytes => new byte[] { (byte)'s', (byte)'t', (byte)'a', (byte)'t', (byte)'u', (byte)'s' };
+
+        void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            Debug.Assert(name.Length > 0);
+            if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
+            {
+                // Invalid header name
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+            }
+            OnHeader(staticIndex: null, descriptor, staticValue: default, literalValue: value);
+        }
+
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
+        {
+            GetStaticQPackHeader(index, out HeaderDescriptor descriptor, out string knownValue);
+            OnHeader(index, descriptor, knownValue, literalValue: default);
+        }
+
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        {
+            GetStaticQPackHeader(index, out HeaderDescriptor descriptor, knownValue: out _);
+            OnHeader(index, descriptor, staticValue: null, literalValue: value);
+        }
+
+        private void GetStaticQPackHeader(int index, out HeaderDescriptor descriptor, out string knownValue)
+        {
+            if (!HeaderDescriptor.TryGetStaticQPackHeader(index, out descriptor, out knownValue))
+            {
+                if (NetEventSource.IsEnabled) Trace($"Response contains invalid static header index '{index}'.");
+                throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
+            }
+        }
+
+        /// <param name="staticIndex">The static index of the header, if any.</param>
+        /// <param name="descriptor">A descriptor for either a known header or unknown header.</param>
+        /// <param name="staticValue">The static indexed value, if any.</param>
+        /// <param name="literalValue">The literal ASCII value, if any.</param>
+        /// <remarks>One of <paramref name="staticValue"/> or <paramref name="literalValue"/> will be set.</remarks>
+        private void OnHeader(int? staticIndex, HeaderDescriptor descriptor, string staticValue, ReadOnlySpan<byte> literalValue)
+        {
+            if (descriptor.Name[0] == ':')
+            {
+                if (descriptor.KnownHeader != KnownHeaders.PseudoStatus)
+                {
+                    if (NetEventSource.IsEnabled) Trace($"Received unknown pseudo-header '{descriptor.Name}'.");
+                    throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
+                }
+
+                if (_headerState != HeaderState.StatusHeader)
+                {
+                    if (NetEventSource.IsEnabled) Trace("Received extra status header.");
+                    throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
+                }
+
+                int statusCode = staticIndex switch
+                {
+                    H3StaticTable.Status103 => 103,
+                    H3StaticTable.Status200 => 200,
+                    H3StaticTable.Status304 => 304,
+                    H3StaticTable.Status404 => 404,
+                    H3StaticTable.Status503 => 503,
+                    H3StaticTable.Status100 => 100,
+                    H3StaticTable.Status204 => 204,
+                    H3StaticTable.Status206 => 206,
+                    H3StaticTable.Status302 => 302,
+                    H3StaticTable.Status400 => 400,
+                    H3StaticTable.Status403 => 403,
+                    H3StaticTable.Status421 => 421,
+                    H3StaticTable.Status425 => 425,
+                    H3StaticTable.Status500 => 500,
+                    _ => HttpConnectionBase.ParseStatusCode(literalValue),
+                };
+
+                _response = new HttpResponseMessage()
+                {
+                    Version = HttpVersion.Version30,
+                    RequestMessage = _request,
+                    Content = new HttpConnectionResponseContent(),
+                    StatusCode = (HttpStatusCode)statusCode
+                };
+
+                if (statusCode < 200)
+                {
+                    // Informational responses should not contain headers -- skip them.
+                    _headerState = HeaderState.SkipExpect100Headers;
+
+                    if (_response.StatusCode == HttpStatusCode.Continue && _expect100ContinueCompletionSource != null)
+                    {
+                        _expect100ContinueCompletionSource.TrySetResult(true);
+                    }
+                }
+                else
+                {
+                    _headerState = HeaderState.ResponseHeaders;
+                    if (_expect100ContinueCompletionSource != null)
+                    {
+                        // If the final status code is >= 300, skip sending the body.
+                        bool shouldSendBody = (statusCode < 300);
+
+                        if (NetEventSource.IsEnabled) Trace($"Expecting 100 Continue but received final status {statusCode}.");
+                        _expect100ContinueCompletionSource.TrySetResult(shouldSendBody);
+                    }
+                }
+            }
+            else if (_headerState == HeaderState.SkipExpect100Headers)
+            {
+                // Ignore any headers that came as part of an informational (i.e. 100 Continue) response.
+                return;
+            }
+            else
+            {
+                string headerValue = staticValue ?? descriptor.GetHeaderValue(literalValue);
+
+                switch (_headerState)
+                {
+                    case HeaderState.StatusHeader:
+                        if (NetEventSource.IsEnabled) Trace($"Received headers without :status.");
+                        throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
+                    case HeaderState.ResponseHeaders when descriptor.HeaderType.HasFlag(HttpHeaderType.Content):
+                        _response.Content.Headers.TryAddWithoutValidation(descriptor, headerValue);
+                        break;
+                    case HeaderState.ResponseHeaders:
+                        _response.Headers.TryAddWithoutValidation(descriptor.HeaderType.HasFlag(HttpHeaderType.Request) ? descriptor.AsCustomHeader() : descriptor, headerValue);
+                        break;
+                    case HeaderState.TrailingHeaders:
+                        _trailingHeaders.Add((descriptor.HeaderType.HasFlag(HttpHeaderType.Request) ? descriptor.AsCustomHeader() : descriptor, headerValue));
+                        break;
+                    default:
+                        Debug.Fail($"Unexpected {nameof(Http3RequestStream)}.{nameof(_headerState)} '{_headerState}'.");
+                        break;
+                }
+            }
+        }
+
+        void IHttpHeadersHandler.OnHeadersComplete(bool endStream)
+        {
+            Debug.Fail($"This has no use in HTTP/3 and should never be called by {nameof(QPackDecoder)}.");
+        }
+
+        private async ValueTask SkipUnknownPayloadAsync(long payloadLength, CancellationToken cancellationToken)
+        {
+            while (payloadLength != 0)
+            {
+                if (_recvBuffer.ActiveLength == 0)
+                {
+                    _recvBuffer.EnsureAvailableSpace(1);
+                    int bytesRead = await _stream.ReadAsync(_recvBuffer.AvailableMemory, cancellationToken).ConfigureAwait(false);
+
+                    if (bytesRead != 0)
+                    {
+                        _recvBuffer.Commit(bytesRead);
+                    }
+                    else
+                    {
+                        // Our buffer has partial frame data in it but not enough to complete the read: bail out.
+                        throw new Http3ConnectionException(Http3ErrorCode.FrameError);
+                    }
+                }
+
+                long readLength = Math.Min(payloadLength, _recvBuffer.ActiveLength);
+                _recvBuffer.Discard((int)readLength);
+                payloadLength -= readLength;
+            }
+        }
+
+        private int ReadResponseContent(HttpResponseMessage response, Span<byte> buffer)
+        {
+            // Response headers should be done reading by the time this is called. _response is nulled out as part of this.
+            // Verify that this is being called in correct order.
+            Debug.Assert(_response == null);
+
+            try
+            {
+                int totalBytesRead = 0;
+
+                while (buffer.Length != 0)
+                {
+                    // Sync over async here -- QUIC implementation does it per-I/O already; this is at least more coarse-grained.
+                    if (_responseDataPayloadRemaining <= 0 && !ReadNextDataFrameAsync(response, CancellationToken.None).GetAwaiter().GetResult())
+                    {
+                        // End of stream.
+                        break;
+                    }
+
+                    if (_recvBuffer.ActiveLength != 0)
+                    {
+                        // Some of the payload is in our receive buffer, so copy it.
+
+                        int copyLen = (int)Math.Min(buffer.Length, _recvBuffer.ActiveLength);
+                        _recvBuffer.ActiveSpan.Slice(copyLen).CopyTo(buffer);
+
+                        totalBytesRead += copyLen;
+                        _responseDataPayloadRemaining -= copyLen;
+                        _recvBuffer.Discard(copyLen);
+                        buffer = buffer.Slice(copyLen);
+                    }
+                    else
+                    {
+                        // Receive buffer is empty -- bypass it and read directly into user's buffer.
+
+                        int copyLen = (int)Math.Min(buffer.Length, _responseDataPayloadRemaining);
+                        int bytesRead = _stream.Read(buffer.Slice(0, copyLen));
+
+                        totalBytesRead += bytesRead;
+                        _responseDataPayloadRemaining -= bytesRead;
+                        buffer = buffer.Slice(bytesRead);
+                    }
+                }
+
+                return totalBytesRead;
+            }
+            catch (Exception ex)
+            {
+                HandleReadResponseContentException(ex, CancellationToken.None);
+                return 0; // never reached.
+            }
+        }
+
+        private async ValueTask<int> ReadResponseContentAsync(HttpResponseMessage response, Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            // Response headers should be done reading by the time this is called. _response is nulled out as part of this.
+            // Verify that this is being called in correct order.
+            Debug.Assert(_response == null);
+
+            try
+            {
+                int totalBytesRead = 0;
+
+                while (buffer.Length != 0)
+                {
+                    if (_responseDataPayloadRemaining <= 0 && !await ReadNextDataFrameAsync(response, cancellationToken).ConfigureAwait(false))
+                    {
+                        // End of stream.
+                        break;
+                    }
+
+                    if (_recvBuffer.ActiveLength != 0)
+                    {
+                        // Some of the payload is in our receive buffer, so copy it.
+
+                        int copyLen = (int)Math.Min(buffer.Length, _recvBuffer.ActiveLength);
+                        _recvBuffer.ActiveSpan.Slice(copyLen).CopyTo(buffer.Span);
+
+                        totalBytesRead += copyLen;
+                        _responseDataPayloadRemaining -= copyLen;
+                        _recvBuffer.Discard(copyLen);
+                        buffer = buffer.Slice(copyLen);
+                    }
+                    else
+                    {
+                        // Receive buffer is empty -- bypass it and read directly into user's buffer.
+
+                        int copyLen = (int)Math.Min(buffer.Length, _responseDataPayloadRemaining);
+                        int bytesRead = await _stream.ReadAsync(buffer.Slice(0, copyLen), cancellationToken).ConfigureAwait(false);
+
+                        totalBytesRead += bytesRead;
+                        _responseDataPayloadRemaining -= bytesRead;
+                        buffer = buffer.Slice(bytesRead);
+                    }
+                }
+
+                return totalBytesRead;
+            }
+            catch (Exception ex)
+            {
+                HandleReadResponseContentException(ex, cancellationToken);
+                return 0; // never reached.
+            }
+        }
+
+        private void HandleReadResponseContentException(Exception ex, CancellationToken cancellationToken)
+        {
+            switch (ex)
+            {
+                case QuicStreamAbortedException _:
+                    throw new IOException(SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, ex));
+                case QuicConnectionAbortedException _:
+                    // Our connection was reset. Start aborting the connection.
+                    Exception abortException = _connection.Abort(ex);
+                    throw new IOException(SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, abortException));
+                case Http3ConnectionException _:
+                    // A connection-level protocol error has occurred on our stream.
+                    _connection.Abort(ex);
+                    throw new IOException(SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, ex));
+                case OperationCanceledException oce when oce.CancellationToken == cancellationToken:
+                    _stream.AbortWrite((long)Http3ErrorCode.RequestCancelled);
+                    ExceptionDispatchInfo.Throw(ex); // Rethrow.
+                    return; // Never reached.
+                default:
+                    _stream.AbortWrite((long)Http3ErrorCode.InternalError);
+                    throw new IOException(SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, ex));
+            }
+        }
+
+        private async ValueTask<bool> ReadNextDataFrameAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            if (_responseDataPayloadRemaining == -1)
+            {
+                // EOS -- this branch will only be taken if user calls Read again after EOS.
+                return false;
+            }
+
+            Http3FrameType? frameType;
+            long payloadLength;
+
+            while (true)
+            {
+                (frameType, payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);
+
+                switch (frameType)
+                {
+                    case Http3FrameType.Data:
+                        _responseDataPayloadRemaining = payloadLength;
+                        return true;
+                    case Http3FrameType.Headers:
+                        // Read any trailing headers.
+                        _trailingHeaders = new List<(HeaderDescriptor name, string value)>();
+                        await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+
+                        // There may be more frames after this one, but they would all be unknown extension
+                        // frames that we are allowed to skip. Just close the stream early.
+
+                        // Note: if a server sends additional HEADERS or DATA frames at this point, it
+                        // would be a connection error -- not draining the stream means we won't catch this.
+                        goto case null;
+                    case null:
+                        // End of stream.
+                        CopyTrailersToResponseMessage(response);
+
+                        _responseDataPayloadRemaining = -1; // Set to -1 to indicate EOS.
+                        return false;
+                }
+            }
+        }
+
+        public void Trace(string message, [CallerMemberName] string memberName = null) =>
+            _connection.Trace(_stream.StreamId, message, memberName);
+
+        // TODO: it may be possible for Http3RequestStream to implement Stream directly and avoid this allocation.
+        private sealed class Http3ReadStream : HttpBaseStream
+        {
+            private Http3RequestStream _stream;
+            private HttpResponseMessage _response;
+
+            public override bool CanRead => true;
+
+            public override bool CanWrite => false;
+
+            public Http3ReadStream(Http3RequestStream stream)
+            {
+                _stream = stream;
+            }
+
+            ~Http3ReadStream()
+            {
+                Dispose(false);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (_stream != null)
+                {
+                    if (disposing)
+                    {
+                        // This will remove the stream from the connection properly.
+                        _stream.Dispose();
+                    }
+                    else
+                    {
+                        // We shouldn't be using a managed instance here, but don't have much choice -- we
+                        // need to remove the stream from the connection's GOAWAY collection.
+                        _stream._connection.RemoveStream(_stream._streamId);
+                        _stream._connection = null;
+                    }
+
+                    _stream = null;
+                    _response = null;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            public override async ValueTask DisposeAsync()
+            {
+                if (_stream != null)
+                {
+                    await _stream.DisposeAsync().ConfigureAwait(false);
+                    _stream = null;
+                    _response = null;
+                }
+
+                await base.DisposeAsync().ConfigureAwait(false);
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                if (_stream == null)
+                {
+                    throw new ObjectDisposedException(nameof(Http3RequestStream));
+                }
+
+                return _stream.ReadResponseContent(_response, buffer);
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            {
+                if (_stream == null)
+                {
+                    return new ValueTask<int>(Task.FromException<int>(new ObjectDisposedException(nameof(Http3RequestStream))));
+                }
+
+                return _stream.ReadResponseContentAsync(_response, buffer, cancellationToken);
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        // TODO: it may be possible for Http3RequestStream to implement Stream directly and avoid this allocation.
+        private sealed class Http3WriteStream : HttpBaseStream
+        {
+            private Http3RequestStream _stream;
+
+            public override bool CanRead => false;
+
+            public override bool CanWrite => true;
+
+            public Http3WriteStream(Http3RequestStream stream)
+            {
+                _stream = stream;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                _stream = null;
+                base.Dispose(disposing);
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            {
+                if (_stream == null)
+                {
+                    return new ValueTask(Task.FromException(new ObjectDisposedException(nameof(Http3WriteStream))));
+                }
+
+                return _stream.WriteRequestContentAsync(buffer, cancellationToken);
+            }
+        }
+
+        private enum HeaderState
+        {
+            StatusHeader,
+            SkipExpect100Headers,
+            ResponseHeaders,
+            TrailingHeaders
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Net.Http
+{
+
+    internal sealed class HttpAuthority : IEquatable<HttpAuthority>
+    {
+        // ALPN Protocol Name should also be part of an authority, but we are special-casing for HTTP/3, so this can be assumed to be "H3".
+        // public string AlpnProtocolName { get; }
+
+        public string IdnHost { get; }
+        public int Port { get; }
+
+        public HttpAuthority(string host, int port)
+        {
+            Debug.Assert(host != null);
+
+            // This is very rarely called, but could be optimized to avoid the URI-specific stuff by bringing in DomainNameHelpers from System.Private.Uri.
+            var builder = new UriBuilder(Uri.UriSchemeHttp, host, port);
+            Uri uri = builder.Uri;
+
+            // TODO https://github.com/dotnet/corefx/issues/28863:
+            // Uri.IdnHost is missing '[', ']' characters around IPv6 address.
+            // So, we need to add them manually for now.
+            IdnHost = uri.HostNameType == UriHostNameType.IPv6 ? "[" + uri.IdnHost + "]" : uri.IdnHost;
+            Port = port;
+        }
+
+        public bool Equals(HttpAuthority other)
+        {
+            return string.Equals(IdnHost, other.IdnHost) && Port == other.Port;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HttpAuthority other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(IdnHost, Port);
+        }
+
+        // For diagnostics
+        public override string ToString()
+        {
+            return IdnHost != null ? $"{IdnHost}:{Port}" : "<empty>";
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -58,6 +58,20 @@ namespace System.Net.Http
 
         internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';
 
+        internal static int ParseStatusCode(ReadOnlySpan<byte> value)
+        {
+            byte status1, status2, status3;
+            if (value.Length != 3 ||
+                !IsDigit(status1 = value[0]) ||
+                !IsDigit(status2 = value[1]) ||
+                !IsDigit(status3 = value[2]))
+            {
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, System.Text.Encoding.ASCII.GetString(value)));
+            }
+
+            return 100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0');
+        }
+
         /// <summary>Awaits a task, ignoring any resulting exceptions.</summary>
         internal static void IgnoreExceptions(ValueTask<int> task)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -2,14 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Net.Http.HPack;
+using System.Net.Http.QPack;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
@@ -25,10 +30,36 @@ namespace System.Net.Http
 
         private readonly HttpConnectionPoolManager _poolManager;
         private readonly HttpConnectionKind _kind;
-        private readonly string _host;
-        private readonly int _port;
         private readonly Uri _proxyUri;
-        internal readonly byte[] _encodedAuthorityHostHeader;
+
+        /// <summary>The origin authority used to construct the <see cref="HttpConnectionPool"/>.</summary>
+        private readonly HttpAuthority _originAuthority;
+
+        /// <summary>Initially set identical to <see cref="_originAuthority"/> (i.e. what came in the request URL), this can be updated based on Alt-Svc.</summary>
+        private volatile HttpAuthority _http3Authority;
+
+        /// <summary>A timer to expire <see cref="_http3Authority"/> and return the pool to <see cref="_originAuthority"/>. Initialized on first use.</summary>
+        private Timer _authorityExpireTimer;
+
+        /// <summary>If true, the <see cref="_http3Authority"/> will persist across a network change. If false, it will be reset to <see cref="_originAuthority"/>.</summary>
+        private bool _persistAuthority;
+
+        /// <summary>
+        /// When an Alt-Svc authority fails due to 421 Misdirected Request, it is placed in the blacklist to be ignored
+        /// for <see cref="AltSvcBlacklistTimeoutInMilliseconds"/> milliseconds. Initialized on first use.
+        /// </summary>
+        private volatile HashSet<HttpAuthority> _altSvcBlacklist;
+        private CancellationTokenSource _altSvcBlacklistTimerCancellation;
+        private volatile bool _altSvcEnabled = true;
+
+        /// <summary>
+        /// If <see cref="_altSvcBlacklist"/> exceeds this size, Alt-Svc will be disabled entirely for <see cref="AltSvcBlacklistTimeoutInMilliseconds"/> milliseconds.
+        /// This is to prevent a failing server from bloating the dictionary beyond a reasonable value.
+        /// </summary>
+        private const int MaxAltSvcIgnoreListSize = 8;
+
+        /// <summary>The time, in milliseconds, that an authority should remain in <see cref="_altSvcBlacklist"/>.</summary>
+        private const int AltSvcBlacklistTimeoutInMilliseconds = 10 * 60 * 1000;
 
         /// <summary>List of idle connections stored in the pool.</summary>
         private readonly List<CachedConnection> _idleConnections = new List<CachedConnection>();
@@ -38,12 +69,20 @@ namespace System.Net.Http
         private bool _http2Enabled;
         private Http2Connection _http2Connection;
         private SemaphoreSlim _http2ConnectionCreateLock;
+        private byte[] _http2AltSvcOriginUri;
+        internal readonly byte[] _http2EncodedAuthorityHostHeader;
+
+        private readonly bool _http3Enabled;
+        private Http3Connection _http3Connection;
+        private SemaphoreSlim _http3ConnectionCreateLock;
+        internal readonly byte[] _http3EncodedAuthorityHostHeader;
 
         /// <summary>For non-proxy connection pools, this is the host name in bytes; for proxies, null.</summary>
         private readonly byte[] _hostHeaderValueBytes;
         /// <summary>Options specialized and cached for this pool and its key.</summary>
         private readonly SslClientAuthenticationOptions _sslOptionsHttp11;
         private readonly SslClientAuthenticationOptions _sslOptionsHttp2;
+        private readonly SslClientAuthenticationOptions _sslOptionsHttp3;
 
         /// <summary>Queue of waiters waiting for a connection.  Created on demand.</summary>
         private Queue<TaskCompletionSourceWithCancellation<HttpConnection>> _waiters;
@@ -55,8 +94,8 @@ namespace System.Net.Http
         /// <summary>Whether the pool has been disposed.</summary>
         private bool _disposed;
 
-        private const int DefaultHttpPort = 80;
-        private const int DefaultHttpsPort = 443;
+        public const int DefaultHttpPort = 80;
+        public const int DefaultHttpsPort = 443;
 
         /// <summary>Initializes the pool.</summary>
         /// <param name="maxConnections">The maximum number of connections allowed to be associated with the pool at any given time.</param>
@@ -64,12 +103,17 @@ namespace System.Net.Http
         {
             _poolManager = poolManager;
             _kind = kind;
-            _host = host;
-            _port = port;
             _proxyUri = proxyUri;
             _maxConnections = maxConnections;
 
-            _http2Enabled = (_poolManager.Settings._maxHttpVersion == HttpVersion.Version20);
+            if (host != null)
+            {
+                _originAuthority = new HttpAuthority(host, port);
+                _http3Authority = _originAuthority;
+            }
+
+            _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
+            _http3Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version30;
 
             switch (kind)
             {
@@ -79,6 +123,7 @@ namespace System.Net.Http
                     Debug.Assert(sslHostName == null);
                     Debug.Assert(proxyUri == null);
                     _http2Enabled = _poolManager.Settings._allowUnencryptedHttp2;
+                    _http3Enabled = false;
                     break;
 
                 case HttpConnectionKind.Https:
@@ -95,6 +140,7 @@ namespace System.Net.Http
                     Debug.Assert(proxyUri != null);
 
                     _http2Enabled = false;
+                    _http3Enabled = false;
                     break;
 
                 case HttpConnectionKind.ProxyTunnel:
@@ -104,6 +150,7 @@ namespace System.Net.Http
                     Debug.Assert(proxyUri != null);
 
                     _http2Enabled = false;
+                    _http3Enabled = false;
                     break;
 
                 case HttpConnectionKind.SslProxyTunnel:
@@ -111,6 +158,7 @@ namespace System.Net.Http
                     Debug.Assert(port != 0);
                     Debug.Assert(sslHostName != null);
                     Debug.Assert(proxyUri != null);
+                    _http3Enabled = false; // TODO: how do we tunnel HTTP3?
                     break;
 
                 case HttpConnectionKind.ProxyConnect:
@@ -120,6 +168,7 @@ namespace System.Net.Http
                     Debug.Assert(proxyUri != null);
 
                     _http2Enabled = false;
+                    _http3Enabled = false;
                     break;
 
                 default:
@@ -128,21 +177,22 @@ namespace System.Net.Http
             }
 
             string hostHeader = null;
-            if (_host != null)
+            if (_originAuthority != null)
             {
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
                 hostHeader =
-                    (_port != (sslHostName == null ? DefaultHttpPort : DefaultHttpsPort)) ?
-                    $"{_host}:{_port}" :
-                    _host;
+                    (_originAuthority.Port != (sslHostName == null ? DefaultHttpPort : DefaultHttpsPort)) ?
+                    $"{_originAuthority.IdnHost}:{_originAuthority.Port}" :
+                    _originAuthority.IdnHost;
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 _hostHeaderValueBytes = Encoding.ASCII.GetBytes(hostHeader);
                 Debug.Assert(Encoding.ASCII.GetString(_hostHeaderValueBytes) == hostHeader);
                 if (sslHostName == null)
                 {
-                    _encodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(StaticTable.Authority, hostHeader);
+                    _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
+                    _http3EncodedAuthorityHostHeader = QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(H3StaticTable.Authority, hostHeader);
                 }
             }
 
@@ -154,7 +204,7 @@ namespace System.Net.Http
                 if (_http2Enabled)
                 {
                     _sslOptionsHttp2 = ConstructSslOptions(poolManager, sslHostName);
-                    _sslOptionsHttp2.ApplicationProtocols = Http2ApplicationProtocols;
+                    _sslOptionsHttp2.ApplicationProtocols = s_http2ApplicationProtocols;
 
                     // Note:
                     // The HTTP/2 specification states:
@@ -171,7 +221,15 @@ namespace System.Net.Http
                     // allow it.
 
                     Debug.Assert(hostHeader != null);
-                    _encodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(StaticTable.Authority, hostHeader);
+                    _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
+                    _http3EncodedAuthorityHostHeader = QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(H3StaticTable.Authority, hostHeader);
+
+                }
+
+                if (_http3Enabled)
+                {
+                    _sslOptionsHttp3 = ConstructSslOptions(poolManager, sslHostName);
+                    _sslOptionsHttp3.ApplicationProtocols = s_http3ApplicationProtocols;
                 }
             }
 
@@ -184,7 +242,8 @@ namespace System.Net.Http
             if (NetEventSource.IsEnabled) Trace($"{this}");
         }
 
-        private static readonly List<SslApplicationProtocol> Http2ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
+        private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http3 };
+        private static readonly List<SslApplicationProtocol> s_http2ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
 
         private static SslClientAuthenticationOptions ConstructSslOptions(HttpConnectionPoolManager poolManager, string sslHostName)
         {
@@ -212,6 +271,7 @@ namespace System.Net.Http
             return sslOptions;
         }
 
+        public HttpAuthority OriginAuthority => _originAuthority;
         public HttpConnectionSettings Settings => _poolManager.Settings;
         public bool IsSecure => _sslOptionsHttp11 != null;
         public HttpConnectionKind Kind => _kind;
@@ -221,12 +281,53 @@ namespace System.Net.Http
         public byte[] HostHeaderValueBytes => _hostHeaderValueBytes;
         public CredentialCache PreAuthCredentials { get; }
 
+        /// <summary>
+        /// An ASCII origin string per RFC 6454 Section 6.2, in format &lt;scheme&gt;://&lt;host&gt;[:&lt;port&gt;]
+        /// </summary>
+        /// <remarks>
+        /// Used by <see cref="Http2Connection"/> to test ALTSVC frames for our origin.
+        /// </remarks>
+        public byte[] Http2AltSvcOriginUri
+        {
+            get
+            {
+                if (_http2AltSvcOriginUri == null)
+                {
+                    var sb = new StringBuilder();
+
+                    sb
+                        .Append(_kind == HttpConnectionKind.Https ? "https://" : "http://")
+                        .Append(_originAuthority.IdnHost);
+
+                    if (_originAuthority.Port != (_kind == HttpConnectionKind.Https ? DefaultHttpsPort : DefaultHttpPort))
+                    {
+                        sb
+                            .Append(':')
+                            .Append(_originAuthority.Port.ToString(CultureInfo.InvariantCulture));
+                    }
+
+                    _http2AltSvcOriginUri = Encoding.ASCII.GetBytes(sb.ToString());
+                }
+
+                return _http2AltSvcOriginUri;
+            }
+        }
+
         /// <summary>Object used to synchronize access to state in the pool.</summary>
         private object SyncObj => _idleConnections;
 
         private ValueTask<(HttpConnectionBase connection, bool isNewConnection, HttpResponseMessage failureResponse)>
             GetConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (_http3Enabled && request.Version.Major >= 3)
+            {
+                HttpAuthority authority = _http3Authority;
+                if (authority != null)
+                {
+                    return GetHttp3ConnectionAsync(request, authority, cancellationToken);
+                }
+            }
+
             if (_http2Enabled && request.Version.Major >= 2)
             {
                 return GetHttp2ConnectionAsync(request, cancellationToken);
@@ -514,6 +615,88 @@ namespace System.Net.Http
             return await GetHttpConnectionAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
+        private async ValueTask<(HttpConnectionBase connection, bool isNewConnection, HttpResponseMessage failureResponse)>
+            GetHttp3ConnectionAsync(HttpRequestMessage request, HttpAuthority authority, CancellationToken cancellationToken)
+        {
+            Debug.Assert(_kind == HttpConnectionKind.Https);
+            Debug.Assert(_http3Enabled == true);
+
+            Http3Connection http3Connection = Volatile.Read(ref _http3Connection);
+
+            if (http3Connection != null)
+            {
+                TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
+                if (http3Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime) && http3Connection.Authority == _http3Authority)
+                {
+                    // Connection expired.
+                    http3Connection.Dispose();
+                    InvalidateHttp3Connection(http3Connection);
+                }
+                else
+                {
+                    // Connection exists and it is still good to use.
+                    if (NetEventSource.IsEnabled) Trace("Using existing HTTP3 connection.");
+                    _usedSinceLastCleanup = true;
+                    return (http3Connection, false, null);
+                }
+            }
+
+            // Ensure that the connection creation semaphore is created
+            if (_http3ConnectionCreateLock == null)
+            {
+                lock (SyncObj)
+                {
+                    if (_http3ConnectionCreateLock == null)
+                    {
+                        _http3ConnectionCreateLock = new SemaphoreSlim(1);
+                    }
+                }
+            }
+
+            await _http3ConnectionCreateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_http3Connection != null)
+                {
+                    // Someone beat us to creating the connection.
+
+                    if (NetEventSource.IsEnabled)
+                    {
+                        Trace("Using existing HTTP3 connection.");
+                    }
+
+                    return (_http3Connection, false, null);
+                }
+
+                if (NetEventSource.IsEnabled)
+                {
+                    Trace("Attempting new HTTP3 connection.");
+                }
+
+                QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(authority.IdnHost, authority.Port, _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
+
+                if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
+                {
+                    BlacklistAuthority(authority);
+                    throw new HttpRequestException("QUIC connected but no HTTP/3 indicated via ALPN.", null, RequestRetryType.RetryOnSameOrNextProxy);
+                }
+
+                http3Connection = new Http3Connection(this, _originAuthority, authority, quicConnection);
+                _http3Connection = http3Connection;
+
+                if (NetEventSource.IsEnabled)
+                {
+                    Trace("New HTTP3 connection established.");
+                }
+
+                return (http3Connection, true, null);
+            }
+            finally
+            {
+                _http3ConnectionCreateLock.Release();
+            }
+        }
+
         public async Task<HttpResponseMessage> SendWithRetryAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
         {
             while (true)
@@ -529,16 +712,31 @@ namespace System.Net.Http
                     return failureResponse;
                 }
 
+                HttpResponseMessage response;
+
                 try
                 {
                     if (connection is HttpConnection)
                     {
-                        return await SendWithNtConnectionAuthAsync((HttpConnection)connection, request, doRequestAuth, cancellationToken).ConfigureAwait(false);
+                        response = await SendWithNtConnectionAuthAsync((HttpConnection)connection, request, doRequestAuth, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        return await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                        response = await connection.SendAsync(request, cancellationToken).ConfigureAwait(false);
                     }
+                }
+                catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnLowerHttpVersion)
+                {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        Trace($"Retrying request after exception on existing connection: {e}");
+                    }
+
+                    // Eat exception and try again on a lower protocol version.
+
+                    Debug.Assert(connection is HttpConnection == false, $"{nameof(RequestRetryType.RetryOnLowerHttpVersion)} should not be thrown by HTTP/1 connections.");
+                    request.Version = HttpVersion.Version11;
+                    continue;
                 }
                 catch (HttpRequestException e) when (!isNewConnection && e.AllowRetry == RequestRetryType.RetryOnSameOrNextProxy)
                 {
@@ -548,6 +746,210 @@ namespace System.Net.Http
                     }
 
                     // Eat exception and try again.
+                    continue;
+                }
+
+                // Check for the Alt-Svc header, to upgrade to HTTP/3.
+                if (_altSvcEnabled && response.Headers.TryGetValues(KnownHeaders.AltSvc.Descriptor, out IEnumerable<string> altSvcHeaderValues))
+                {
+                    HandleAltSvc(altSvcHeaderValues, response.Headers.Age);
+                }
+
+                // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
+                // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
+                // In this case, we blacklist the authority and retry the request at the origin.
+                if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection is Http3Connection h3Connection && h3Connection.Authority != _originAuthority)
+                {
+                    response.Dispose();
+                    BlacklistAuthority(h3Connection.Authority);
+                    continue;
+                }
+
+                return response;
+            }
+        }
+
+        /// <summary>
+        /// Inspects a collection of Alt-Svc headers to find the first eligible upgrade path.
+        /// </summary>
+        /// <remarks>TODO: common case will likely be a single value. Optimize for that.</remarks>
+        internal void HandleAltSvc(IEnumerable<string> altSvcHeaderValues, TimeSpan? responseAge)
+        {
+            HttpAuthority nextAuthority = null;
+            TimeSpan nextAuthorityMaxAge = default;
+            bool nextAuthorityPersist = false;
+
+            foreach (string altSvcHeaderValue in altSvcHeaderValues)
+            {
+                int parseIdx = 0;
+
+                while (AltSvcHeaderParser.Parser.TryParseValue(altSvcHeaderValue, null, ref parseIdx, out object parsedValue))
+                {
+                    var value = (AltSvcHeaderValue)parsedValue;
+
+                    // 'clear' should be the only value present.
+                    if (value == AltSvcHeaderValue.Clear)
+                    {
+                        _http3Authority = _originAuthority;
+                        _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                        break;
+                    }
+
+                    if (nextAuthority == null && value.AlpnProtocolName == "h3")
+                    {
+                        var authority = new HttpAuthority(value.Host, value.Port);
+
+                        if (_altSvcBlacklist != null)
+                        {
+                            lock (_altSvcBlacklist)
+                            {
+                                if (_altSvcBlacklist.Contains(authority))
+                                {
+                                    // Skip authorities in our blacklist.
+                                    continue;
+                                }
+                            }
+                        }
+
+                        TimeSpan authorityMaxAge = value.MaxAge;
+
+                        if (responseAge != null)
+                        {
+                            authorityMaxAge -= responseAge.GetValueOrDefault();
+                        }
+
+                        if (authorityMaxAge > TimeSpan.Zero)
+                        {
+                            nextAuthority = authority;
+                            nextAuthorityMaxAge = authorityMaxAge;
+                            nextAuthorityPersist = value.Persist;
+                        }
+                    }
+                }
+            }
+
+            // There's a race here in checking _http3Authority outside of the lock,
+            // but there's really no bad behavior if _http3Authority changes in the mean time.
+            if (nextAuthority != null && !nextAuthority.Equals(_http3Authority))
+            {
+                // Clamp the max age to 30 days... this is arbitrary but prevents passing a too-large TimeSpan to the Timer.
+                if (nextAuthorityMaxAge.Ticks > (30 * TimeSpan.TicksPerDay))
+                {
+                    nextAuthorityMaxAge = TimeSpan.FromTicks(30 * TimeSpan.TicksPerDay);
+                }
+
+                lock (SyncObj)
+                {
+                    if (_authorityExpireTimer == null)
+                    {
+                        var thisRef = new WeakReference<HttpConnectionPool>(this);
+
+                        _authorityExpireTimer = new Timer(o =>
+                        {
+                            var wr = (WeakReference<HttpConnectionPool>)o;
+                            if (wr.TryGetTarget(out HttpConnectionPool @this))
+                            {
+                                @this._http3Authority = @this._originAuthority;
+                            }
+                        }, thisRef, nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
+                    }
+                    else
+                    {
+                        _authorityExpireTimer.Change(nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
+                    }
+
+                    _http3Authority = nextAuthority;
+                    _persistAuthority = nextAuthorityPersist;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Blacklists an authority and resets the current authority back to origin.
+        /// If the number of blacklisted authorities exceeds <see cref="MaxAltSvcIgnoreListSize"/>,
+        /// Alt-Svc will be disabled entirely for a period of time.
+        /// </summary>
+        /// <remarks>
+        /// This is called when we get a "421 Misdirected Request" from an alternate authority.
+        /// A future strategy would be to retry the individual request on an older protocol, we'd want to have
+        /// some logic to blacklist after some number of failures to avoid doubling our request latency.
+        ///
+        /// For now, the spec states alternate authorities should be able to handle ALL requests, so this
+        /// is treated as an exceptional error by immediately blacklisting the authority.
+        /// </remarks>
+        internal void BlacklistAuthority(HttpAuthority badAuthority)
+        {
+            Debug.Assert(badAuthority != null);
+            Debug.Assert(badAuthority != _originAuthority);
+
+            HashSet<HttpAuthority> altSvcBlacklist = _altSvcBlacklist;
+
+            if (altSvcBlacklist == null)
+            {
+                lock (SyncObj)
+                {
+                    altSvcBlacklist = _altSvcBlacklist;
+                    if (altSvcBlacklist == null)
+                    {
+                        altSvcBlacklist = new HashSet<HttpAuthority>();
+                        _altSvcBlacklistTimerCancellation = new CancellationTokenSource();
+                        _altSvcBlacklist = altSvcBlacklist;
+                    }
+                }
+            }
+
+            bool added, disabled = false;
+
+            lock (altSvcBlacklist)
+            {
+                added = altSvcBlacklist.Add(badAuthority);
+
+                if (added && altSvcBlacklist.Count >= MaxAltSvcIgnoreListSize && _altSvcEnabled)
+                {
+                    _altSvcEnabled = false;
+                    disabled = true;
+                }
+            }
+
+            lock (SyncObj)
+            {
+                if (_http3Authority == badAuthority)
+                {
+                    _http3Authority = _originAuthority;
+                    _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                }
+            }
+
+            if (added)
+            {
+                _ = Task.Delay(AltSvcBlacklistTimeoutInMilliseconds)
+                    .ContinueWith(t =>
+                    {
+                        lock (altSvcBlacklist)
+                        {
+                            altSvcBlacklist.Remove(badAuthority);
+                        }
+                    }, _altSvcBlacklistTimerCancellation.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+
+            if (disabled)
+            {
+                _ = Task.Delay(AltSvcBlacklistTimeoutInMilliseconds)
+                    .ContinueWith(t =>
+                    {
+                        _altSvcEnabled = true;
+                    }, _altSvcBlacklistTimerCancellation.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+        }
+
+        public void OnNetworkChanged()
+        {
+            lock (SyncObj)
+            {
+                if (_http3Authority != _originAuthority && _persistAuthority == false)
+                {
+                    _http3Authority = _originAuthority;
+                    _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 }
             }
         }
@@ -622,7 +1024,7 @@ namespace System.Net.Http
                     case HttpConnectionKind.Http:
                     case HttpConnectionKind.Https:
                     case HttpConnectionKind.ProxyConnect:
-                        stream = await ConnectHelper.ConnectAsync(_host, _port, cancellationToken).ConfigureAwait(false);
+                        stream = await ConnectHelper.ConnectAsync(_originAuthority.IdnHost, _originAuthority.Port, cancellationToken).ConfigureAwait(false);
                         break;
 
                     case HttpConnectionKind.Proxy:
@@ -685,7 +1087,7 @@ namespace System.Net.Http
         {
             // Send a CONNECT request to the proxy server to establish a tunnel.
             HttpRequestMessage tunnelRequest = new HttpRequestMessage(HttpMethod.Connect, _proxyUri);
-            tunnelRequest.Headers.Host = $"{_host}:{_port}";    // This specifies destination host/port to connect to
+            tunnelRequest.Headers.Host = $"{_originAuthority.IdnHost}:{_originAuthority.Port}";    // This specifies destination host/port to connect to
 
             if (headers != null && headers.TryGetValues(HttpKnownHeaderNames.UserAgent, out IEnumerable<string> values))
             {
@@ -880,6 +1282,17 @@ namespace System.Net.Http
             }
         }
 
+        public void InvalidateHttp3Connection(Http3Connection connection)
+        {
+            lock (SyncObj)
+            {
+                if (_http3Connection == connection)
+                {
+                    _http3Connection = null;
+                }
+            }
+        }
+
         /// <summary>
         /// Disposes the connection pool.  This is only needed when the pool currently contains
         /// or has associated connections.
@@ -900,6 +1313,19 @@ namespace System.Net.Http
                     {
                         _http2Connection.Dispose();
                         _http2Connection = null;
+                    }
+
+                    if (_authorityExpireTimer != null)
+                    {
+                        _authorityExpireTimer.Dispose();
+                        _authorityExpireTimer = null;
+                    }
+
+                    if (_altSvcBlacklistTimerCancellation != null)
+                    {
+                        _altSvcBlacklistTimerCancellation.Cancel();
+                        _altSvcBlacklistTimerCancellation.Dispose();
+                        _altSvcBlacklistTimerCancellation = null;
                     }
                 }
                 Debug.Assert(list.Count == 0, $"Expected {nameof(list)}.{nameof(list.Count)} == 0");
@@ -1032,11 +1458,11 @@ namespace System.Net.Http
             $"{nameof(HttpConnectionPool)} " +
             (_proxyUri == null ?
                 (_sslOptionsHttp11 == null ?
-                    $"http://{_host}:{_port}" :
-                    $"https://{_host}:{_port}" + (_sslOptionsHttp11.TargetHost != _host ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)) :
+                    $"http://{_originAuthority}" :
+                    $"https://{_originAuthority}" + (_sslOptionsHttp11.TargetHost != _originAuthority.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)) :
                 (_sslOptionsHttp11 == null ?
                     $"Proxy {_proxyUri}" :
-                    $"https://{_host}:{_port}/ tunnelled via Proxy {_proxyUri}" + (_sslOptionsHttp11.TargetHost != _host ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)));
+                    $"https://{_originAuthority}/ tunnelled via Proxy {_proxyUri}" + (_sslOptionsHttp11.TargetHost != _originAuthority.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)));
 
         private void Trace(string message, [CallerMemberName] string memberName = null) =>
             NetEventSource.Log.HandlerMessage(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -14,6 +14,8 @@ namespace System.Net.Http
         private const string Http2SupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2Support";
         private const string Http2UnencryptedSupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2UNENCRYPTEDSUPPORT";
         private const string Http2UnencryptedSupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport";
+        private const string Http3DraftSupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3DRAFTSUPPORT";
+        private const string Http3DraftSupportAppCtxSettingName = "System.Net.SocketsHttpHandler.Http3DraftSupport";
 
         internal DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
@@ -53,7 +55,10 @@ namespace System.Net.Http
         public HttpConnectionSettings()
         {
             bool allowHttp2 = AllowHttp2;
-            _maxHttpVersion = allowHttp2 ? HttpVersion.Version20 : HttpVersion.Version11;
+            _maxHttpVersion =
+                AllowDraftHttp3 && allowHttp2 ? HttpVersion.Version30 :
+                allowHttp2 ? HttpVersion.Version20 :
+                HttpVersion.Version11;
             _allowUnencryptedHttp2 = allowHttp2 && AllowUnencryptedHttp2;
             _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials);
             _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials;
@@ -148,5 +153,34 @@ namespace System.Net.Http
                 return false;
             }
         }
+
+        private static bool AllowDraftHttp3
+        {
+            get
+            {
+                // Default to not allowing draft HTTP/3, but enable that to be overridden
+                // by an AppContext switch, or by an environment variable being to to true/1.
+
+                // First check for the AppContext switch, giving it priority over the environment variable.
+                if (AppContext.TryGetSwitch(Http3DraftSupportAppCtxSettingName, out bool allowHttp3))
+                {
+                    return allowHttp3;
+                }
+
+                // AppContext switch wasn't used. Check the environment variable.
+                string envVar = Environment.GetEnvironmentVariable(Http3DraftSupportEnvironmentVariableSettingName);
+                if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+                {
+                    // Allow HTTP/3 protocol for HTTP endpoints.
+                    return true;
+                }
+
+                // Default to disallow.
+                return false;
+            }
+        }
+
+        private byte[] _http3SettingsFrame;
+        internal byte[] Http3SettingsFrame => _http3SettingsFrame ??= Http3Connection.BuildSettingsFrame(this);
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -56,7 +56,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool requestLogged = false;
                 Guid requestGuid = Guid.Empty;
@@ -99,7 +99,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => !s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -113,7 +113,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(activityLogged, "HttpOutReq was logged while HttpOutReq logging was disabled");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         /// <remarks>
@@ -124,7 +124,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceNoLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool requestLogged = false;
                 bool responseLogged = false;
@@ -153,7 +153,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
@@ -172,7 +172,7 @@ namespace System.Net.Http.Functional.Tests
                         "Response was logged while logging disabled.");
                     Assert.False(activityStopLogged, "HttpRequestOut.Stop was logged while logging disabled.");
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [ActiveIssue("https://github.com/dotnet/corefx/issues/23771", TestPlatforms.AnyUnix)]
@@ -182,7 +182,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         public void SendAsync_HttpTracingEnabled_Succeeds(bool useSsl)
         {
-            RemoteExecutor.Invoke(async (useHttp2String, useSslString) =>
+            RemoteExecutor.Invoke(async (useVersionString, useSslString) =>
             {
                 using (var listener = new TestEventListener("Microsoft-System-Net-Http", EventLevel.Verbose))
                 {
@@ -190,7 +190,7 @@ namespace System.Net.Http.Functional.Tests
                     await listener.RunWithCallbackAsync(events.Enqueue, async () =>
                     {
                         // Exercise various code paths to get coverage of tracing
-                        using (HttpClient client = CreateHttpClient(useHttp2String))
+                        using (HttpClient client = CreateHttpClient(useVersionString))
                         {
                             // Do a get to a loopback server
                             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -221,14 +221,14 @@ namespace System.Net.Http.Functional.Tests
                         ev => ev.EventId == 0); // make sure there are no event source error messages
                     Assert.InRange(events.Count, 1, int.MaxValue);
                 }
-            }, UseHttp2.ToString(), useSsl.ToString()).Dispose();
+            }, UseVersion.ToString(), useSsl.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool exceptionLogged = false;
                 bool responseLogged = false;
@@ -255,7 +255,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => !s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync($"http://_{Guid.NewGuid().ToString("N")}.com"))
                             .GetAwaiter().GetResult();
@@ -267,7 +267,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.True(exceptionLogged, "Exception was not logged");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [ActiveIssue("https://github.com/dotnet/corefx/issues/23209")]
@@ -275,7 +275,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool cancelLogged = false;
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
@@ -293,7 +293,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => !s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
@@ -314,13 +314,13 @@ namespace System.Net.Http.Functional.Tests
                 WaitForTrue(() => Volatile.Read(ref cancelLogged), TimeSpan.FromSeconds(1),
                     "Cancellation was not logged within 1 second timeout.");
                 diagnosticListenerObserver.Disable();
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLoggingRequestId()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool requestLogged = false;
                 bool responseLogged = false;
@@ -376,7 +376,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
@@ -398,13 +398,13 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(responseLogged, "Response was logged when Activity logging was enabled.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLoggingW3C()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool requestLogged = false;
                 bool responseLogged = false;
@@ -459,7 +459,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
@@ -481,14 +481,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(responseLogged, "Response was logged when Activity logging was enabled.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLogging_InvalidBaggage()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool activityStopLogged = false;
                 bool exceptionLogged = false;
@@ -529,7 +529,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => s.Contains("HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -539,14 +539,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(exceptionLogged, "Exception was logged for successful request");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLoggingDoesNotOverwriteHeader()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool activityStartLogged = false;
                 bool activityStopLogged = false;
@@ -582,7 +582,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable();
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -594,15 +594,15 @@ namespace System.Net.Http.Functional.Tests
                         "HttpRequestOut.Stop was not logged within 1 second timeout.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceActivityLoggingDoesNotOverwriteW3CTraceParentHeader()
         {
-            Assert.False(UseHttp2, "The test currently ignores UseHttp2.");
-            RemoteExecutor.Invoke(useHttp2String =>
+            Assert.True(UseVersion.Major < 2, "The test currently only supports HTTP/1.");
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool activityStartLogged = false;
                 bool activityStopLogged = false;
@@ -637,7 +637,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     diagnosticListenerObserver.Enable();
                     using (var request = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.RemoteEchoServer))
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         request.Headers.Add("traceparent", customTraceParentHeader);
                         client.SendAsync(request).Result.Dispose();
@@ -650,14 +650,14 @@ namespace System.Net.Http.Functional.Tests
                         "HttpRequestOut.Stop was not logged within 1 second timeout.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceUrlFilteredActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool activityStartLogged = false;
                 bool activityStopLogged = false;
@@ -687,7 +687,7 @@ namespace System.Net.Http.Functional.Tests
 
                         return true;
                     });
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -697,14 +697,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(activityStopLogged, "HttpRequestOut.Stop was logged while URL disabled.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool exceptionLogged = false;
                 bool activityStopLogged = false;
@@ -732,7 +732,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable();
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync($"http://_{Guid.NewGuid().ToString("N")}.com"))
                             .GetAwaiter().GetResult();
@@ -744,14 +744,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.True(exceptionLogged, "Exception was not logged");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSynchronousExceptionActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool exceptionLogged = false;
                 bool activityStopLogged = false;
@@ -779,8 +779,8 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable();
-                    using (HttpClientHandler handler = CreateHttpClientHandler(useHttp2String))
-                    using (HttpClient client = CreateHttpClient(handler, useHttp2String))
+                    using (HttpClientHandler handler = CreateHttpClientHandler(useVersionString))
+                    using (HttpClient client = CreateHttpClient(handler, useVersionString))
                     {
                         // Set a https proxy.
                         handler.Proxy = new WebProxy($"https://_{Guid.NewGuid().ToString("N")}.com", false);
@@ -806,14 +806,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.True(exceptionLogged, "Exception was not logged");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticSourceNewAndDeprecatedEventsLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool requestLogged = false;
                 bool responseLogged = false;
@@ -843,7 +843,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable();
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -856,14 +856,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.True(responseLogged, "Response was not logged.");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticExceptionOnlyActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool exceptionLogged = false;
                 bool activityLogged = false;
@@ -885,7 +885,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => s.Equals("System.Net.Http.Exception"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync($"http://_{Guid.NewGuid().ToString("N")}.com"))
                             .GetAwaiter().GetResult();
@@ -897,14 +897,14 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(activityLogged, "HttpOutReq was logged when logging was disabled");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticStopOnlyActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool activityStartLogged = false;
                 bool activityStopLogged = false;
@@ -925,7 +925,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable(s => s.Equals("System.Net.Http.HttpRequestOut"));
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         client.GetAsync(Configuration.Http.RemoteEchoServer).Result.Dispose();
                     }
@@ -937,16 +937,16 @@ namespace System.Net.Http.Functional.Tests
                         "HttpRequestOut.Start was logged when start logging was disabled");
                     diagnosticListenerObserver.Disable();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedActivityPropagationWithoutListener()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
-                using (HttpClient client = CreateHttpClient(useHttp2String))
+                using (HttpClient client = CreateHttpClient(useVersionString))
                 {
                     Activity parent = new Activity("parent").Start();
                     using HttpResponseMessage response = client.GetAsync(Configuration.Http.RemoteEchoServer).Result;
@@ -954,16 +954,16 @@ namespace System.Net.Http.Functional.Tests
                     Assert.True(response.RequestMessage.Headers.Contains(parent.IdFormat == ActivityIdFormat.Hierarchical ? "Request-Id" : "traceparent"));
                     parent.Stop();
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedActivityPropagationWithoutListenerOrParentActivity()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
-                using (HttpClient client = CreateHttpClient(useHttp2String))
+                using (HttpClient client = CreateHttpClient(useVersionString))
                 {
                     using HttpResponseMessage response = client.GetAsync(Configuration.Http.RemoteEchoServer).Result;
 
@@ -972,7 +972,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(response.RequestMessage.Headers.Contains("tracestate"));
                     Assert.False(response.RequestMessage.Headers.Contains("Correlation-Context"));
                 }
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [OuterLoop("Uses external server")]
@@ -1051,7 +1051,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledActivityLogging()
         {
-            RemoteExecutor.Invoke(useHttp2String =>
+            RemoteExecutor.Invoke(useVersionString =>
             {
                 bool cancelLogged = false;
                 var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
@@ -1070,7 +1070,7 @@ namespace System.Net.Http.Functional.Tests
                 using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
                 {
                     diagnosticListenerObserver.Enable();
-                    using (HttpClient client = CreateHttpClient(useHttp2String))
+                    using (HttpClient client = CreateHttpClient(useVersionString))
                     {
                         LoopbackServer.CreateServerAsync(async (server, url) =>
                         {
@@ -1091,7 +1091,7 @@ namespace System.Net.Http.Functional.Tests
                 WaitForTrue(() => Volatile.Read(ref cancelLogged), TimeSpan.FromSeconds(1),
                     "Cancellation was not logged within 1 second timeout.");
                 diagnosticListenerObserver.Disable();
-            }, UseHttp2.ToString()).Dispose();
+            }, UseVersion.ToString()).Dispose();
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HPackTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HPackTest.cs
@@ -21,7 +21,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HPackTest : HttpClientHandlerTestBase
     {
-        protected override bool UseHttp2 => true;
+        protected override Version UseVersion => HttpVersion.Version20;
 
         public HPackTest(ITestOutputHelper output) : base(output)
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using System.Net.Test.Common;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class HttpClientHandler_AltSvc_Test : HttpClientHandlerTestBase
+    {
+        public HttpClientHandler_AltSvc_Test(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task AltSvc_Header_UpgradeFrom11_Success()
+        {
+            await AltSvc_Header_Upgrade_Success(HttpVersion.Version11).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task AltSvc_Header_UpgradeFrom20_Success()
+        {
+            await AltSvc_Header_Upgrade_Success(HttpVersion.Version20).ConfigureAwait(false);
+        }
+
+        private async Task AltSvc_Header_Upgrade_Success(Version fromVersion)
+        {
+            using GenericLoopbackServer firstServer = GetFactoryForVersion(fromVersion).CreateServer();
+            using Http3LoopbackServer secondServer = new Http3LoopbackServer();
+            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+
+            Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
+
+            await firstServer.AcceptConnectionSendResponseAndCloseAsync(additionalHeaders: new[]
+            {
+                new HttpHeaderData("Alt-Svc", $"h3={secondServer.Address.IdnHost}:{secondServer.Address.Port}")
+            });
+
+            HttpResponseMessage firstResponse = await firstResponseTask;
+            Assert.True(firstResponse.IsSuccessStatusCode);
+
+            await AltSvc_Upgrade_Success(firstServer, secondServer, client);
+        }
+
+        [Fact]
+        public async Task AltSvc_ConnectionFrame_UpgradeFrom20_Success()
+        {
+            using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
+            using Http3LoopbackServer secondServer = new Http3LoopbackServer();
+            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+
+            Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
+
+            using (Http2LoopbackConnection connection = await firstServer.EstablishConnectionAsync())
+            {
+                int streamId = await connection.ReadRequestHeaderAsync();
+                await connection.SendDefaultResponseAsync(streamId);
+                await connection.WriteFrameAsync(new AltSvcFrame($"https://{firstServer.Address.IdnHost}:{firstServer.Address.Port}", $"h3={secondServer.Address.IdnHost}:{secondServer.Address.Port}", 0));
+            }
+
+            HttpResponseMessage firstResponse = await firstResponseTask;
+            Assert.True(firstResponse.IsSuccessStatusCode);
+
+            await AltSvc_Upgrade_Success(firstServer, secondServer, client);
+        }
+
+        [Fact]
+        public async Task AltSvc_ResponseFrame_UpgradeFrom20_Success()
+        {
+            using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
+            using Http3LoopbackServer secondServer = new Http3LoopbackServer();
+            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+
+            Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
+
+            using (Http2LoopbackConnection connection = await firstServer.EstablishConnectionAsync())
+            {
+                int streamId = await connection.ReadRequestHeaderAsync();
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+                await connection.WriteFrameAsync(new AltSvcFrame("", $"h3={secondServer.Address.IdnHost}:{secondServer.Address.Port}", streamId));
+                await connection.SendResponseDataAsync(streamId, Array.Empty<byte>(), true);
+            }
+
+            HttpResponseMessage firstResponse = await firstResponseTask;
+            Assert.True(firstResponse.IsSuccessStatusCode);
+
+            await AltSvc_Upgrade_Success(firstServer, secondServer, client);
+        }
+
+        private async Task AltSvc_Upgrade_Success(GenericLoopbackServer firstServer, Http3LoopbackServer secondServer, HttpClient client)
+        {
+            Task<HttpResponseMessage> secondResponseTask = client.GetAsync(firstServer.Address);
+
+            HttpRequestData secondRequest = await secondServer.AcceptConnectionSendResponseAndCloseAsync();
+            string altUsed = secondRequest.GetSingleHeaderValue("Alt-Used");
+            Assert.Equal($"{secondServer.Address.IdnHost}:{secondServer.Address.Port}", altUsed);
+
+            HttpResponseMessage secondResponse = await secondResponseTask;
+            Assert.True(secondResponse.IsSuccessStatusCode);
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     message.Headers.TryAddWithoutValidation("User-Agent", userAgent);
                     (await client.SendAsync(message).ConfigureAwait(false)).Dispose();
                 }
@@ -55,7 +55,7 @@ namespace System.Net.Http.Functional.Tests
                 HttpClientHandler handler = CreateHttpClientHandler();
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     Assert.True(request.Headers.TryAddWithoutValidation("bad", value));
 
                     await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
@@ -86,7 +86,7 @@ namespace System.Net.Http.Functional.Tests
                 bool contentHeader = false;
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     if (!message.Headers.TryAddWithoutValidation(key, value))
                     {
                         message.Content = new StringContent("");
@@ -195,7 +195,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     HttpResponseMessage response = await client.SendAsync(message);
                     Assert.NotNull(response.Content.Headers.Expires);
                     // Invalid date should be converted to MinValue so everything is expired.
@@ -233,7 +233,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
                     HttpResponseMessage response = await client.SendAsync(message);
 
                     Assert.Equal(value, response.Headers.GetValues(name).First());
@@ -253,7 +253,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         public async Task SendAsync_GetWithValidHostHeader_Success(bool withPort)
         {
-            var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = VersionFromUseHttp2 };
+            var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = UseVersion };
             m.Headers.Host = withPort ? Configuration.Http.SecureHost + ":443" : Configuration.Http.SecureHost;
 
             using (HttpClient client = CreateHttpClient())
@@ -280,7 +280,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = VersionFromUseHttp2 };
+            var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = UseVersion };
             m.Headers.Host = "hostheaderthatdoesnotmatch";
 
             using (HttpClient client = CreateHttpClient())

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public abstract class HttpClientHandlerTest_Http2 : HttpClientHandlerTestBase
     {
-        protected override bool UseHttp2 => true;
+        protected override Version UseVersion => HttpVersion.Version20;
 
         public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Security;
+using System.Net.Test.Common;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class HttpClientHandlerTest_Http3 : HttpClientHandlerTestBase
+    {
+        protected override Version UseVersion => HttpVersion.Version30;
+
+        public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;
+
+        public HttpClientHandlerTest_Http3(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -11,16 +11,13 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => false;
 
-        protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseHttp2);
-
-        protected static HttpClientHandler CreateHttpClientHandler(string useHttp2LoopbackServerString) =>
-            CreateHttpClientHandler(bool.Parse(useHttp2LoopbackServerString));
-
-        protected static HttpClientHandler CreateHttpClientHandler(bool useHttp2LoopbackServer = false)
+        protected static HttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
+            useVersion ??= HttpVersion.Version11;
+
             HttpClientHandler handler = new HttpClientHandler();
 
-            if (useHttp2LoopbackServer)
+            if (useVersion >= HttpVersion.Version20)
             {
                 TestHelper.EnableUnencryptedHttp2IfNecessary(handler);
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -30,10 +30,17 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    // TODO: public to test HTTP/3.
+    internal sealed class SocketsHttpHandler_HttpClientMiniStress_Http3 : HttpClientMiniStress
+    {
+        public SocketsHttpHandler_HttpClientMiniStress_Http3(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version30;
+    }
+
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http2 : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_Http2(ITestOutputHelper output) : base(output) { }
-        protected override bool UseHttp2 => true;
+        protected override Version UseVersion => HttpVersion.Version20;
     }
 
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http11 : HttpClientMiniStress
@@ -234,7 +241,7 @@ namespace System.Net.Http.Functional.Tests
         protected (List<HttpHeaderData> Headers, string Content) CreateResponse(string asciiBody)
         {
             var headers = new List<HttpHeaderData>();
-            if (!UseHttp2)
+            if (UseVersion.Major < 2)
             {
                 headers.Add(new HttpHeaderData("Content-Length", asciiBody.Length.ToString()));
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.DefaultProxyCredentials.cs">
       <Link>Common\System\Net\Http\HttpClientHandlerTest.DefaultProxyCredentials.cs</Link>
     </Compile>
+    <Compile Include="HttpClientHandlerTest.AltSvc.cs" />
     <Compile Include="HttpClientHandlerTest.Finalization.cs" />
     <Compile Include="HttpClientHandlerTest.Headers.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.MaxConnectionsPerServer.cs">
@@ -143,6 +144,8 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.Proxy.cs">
       <Link>Common\System\Net\Http\HttpClientHandlerTest.Proxy.cs</Link>
     </Compile>
+    <Compile Include="HttpClientHandlerTest.Http3.cs" />
+
     <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.ServerCertificates.cs">
       <Link>Common\System\Net\Http\HttpClientHandlerTest.ServerCertificates.cs</Link>
@@ -221,11 +224,26 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\HPackEncoder.cs">
       <Link>Common\System\Net\Http\HPackEncoder.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackDecoder.cs">
+      <Link>Common\System\Net\Http\QPackDecoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackEncoder.cs">
+      <Link>Common\System\Net\Http\QPackEncoder.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackServer.cs">
       <Link>Common\System\Net\Http\Http2LoopbackServer.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackConnection.cs">
       <Link>Common\System\Net\Http\Http2LoopbackConnection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackServer.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackServer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackConnection.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackConnection.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackStream.cs">
+      <Link>Common\System\Net\Http\Http3LoopbackStream.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\HuffmanDecoder.cs">
       <Link>Common\System\Net\Http\HuffmanDecoder.cs</Link>

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -162,6 +162,16 @@ namespace System.Net.Http.Unit.Tests.HPack
             {
                 throw new NotImplementedException();
             }
+
+            public void OnStaticIndexedHeader(int index)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/AltSvcHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/AltSvcHeaderParserTest.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.Http.Headers;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Net.Http.Tests
+{
+    public class AltSvcHeaderParserTest
+    {
+        [Theory]
+        [MemberData(nameof(SuccessfulParseData))]
+        public void TryParse_Success(string value, object[] expectedServicesObj)
+        {
+            var expectedServices = (AltSvcHeaderValue[])expectedServicesObj;
+
+            HttpHeaderParser parser = AltSvcHeaderParser.Parser;
+
+            int parseIdx = 0;
+            int expectedIdx = 0;
+
+            while (parseIdx < value.Length)
+            {
+                Assert.True(parser.TryParseValue(value, null, ref parseIdx, out object result));
+                AltSvcHeaderValue actual = Assert.IsType<AltSvcHeaderValue>(result);
+
+                Assert.True(expectedIdx != expectedServices.Length, "More services than expected.");
+                AltSvcHeaderValue expected = expectedServices[expectedIdx++];
+
+                Assert.Equal(expected.AlpnProtocolName, actual.AlpnProtocolName);
+                Assert.Equal(expected.Host, actual.Host);
+                Assert.Equal(expected.Port, actual.Port);
+                Assert.Equal(expected.MaxAge, actual.MaxAge);
+                Assert.Equal(expected.Persist, actual.Persist);
+            }
+
+            Assert.Equal(expectedServices.Length, expectedIdx);
+        }
+
+        public static IEnumerable<object[]> SuccessfulParseData()
+        {
+            TimeSpan defaultAge = TimeSpan.FromTicks(AltSvcHeaderParser.DefaultMaxAgeTicks);
+
+            // Example from RFC 7838, Section 3: change of port.
+            yield return new object[]
+            {
+                "h2=\":8000\"", new []
+                {
+                    new AltSvcHeaderValue("h2", host: null, port: 8000, defaultAge, persist: false)
+                }
+            };
+
+            // Example from RFC 7838, Section 3: change of host/port.
+            yield return new object[]
+            {
+                "h2=\"new.example.org:80\"", new []
+                {
+                    new AltSvcHeaderValue("h2", "new.example.org", port: 80, defaultAge, persist: false)
+                }
+            };
+
+            // Example from RFC 7838, Section 3: multiple services in one line.
+            yield return new object[]
+            {
+                "h2=\"alt.example.com:8000\", h2=\":443\"", new []
+                {
+                    new AltSvcHeaderValue("h2", "alt.example.com", port: 8000, defaultAge, persist: false),
+                    new AltSvcHeaderValue("h2", host: null, port: 443, defaultAge, persist: false)
+                }
+            };
+
+            // Example from RFC 7838, Section 3.1: change of port with max age.
+            yield return new object[]
+            {
+                "h2=\":443\"; ma=3600", new []
+                {
+                    new AltSvcHeaderValue("h2", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 3600), persist: false)
+                }
+            };
+
+            // Example from RFC 7838, Section 3.1: change of port with max age and persist.
+            yield return new object[]
+            {
+                "h2=\":443\"; ma=2592000; persist=1", new []
+                {
+                    new AltSvcHeaderValue("h2", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 2592000), persist: true)
+                }
+            };
+
+            // "clear".
+            yield return new object[]
+            {
+                "clear", new []
+                {
+                    AltSvcHeaderValue.Clear
+                }
+            };
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -110,6 +110,12 @@
     <Compile Include="..\..\src\System\Net\Http\FormUrlEncodedContent.cs">
       <Link>ProductionCode\System\Net\Http\FormUrlEncodedContent.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\Headers\AltSvcHeaderParser.cs">
+      <Link>ProductionCode\System\Net\Http\Headers\AltSvcHeaderParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\Headers\AltSvcHeaderValue.cs">
+      <Link>ProductionCode\System\Net\Http\Headers\AltSvcHeaderValue.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\Headers\AuthenticationHeaderValue.cs">
       <Link>ProductionCode\System\Net\Http\Headers\AuthenticationHeaderValue.cs</Link>
     </Compile>
@@ -335,6 +341,7 @@
     <Compile Include="DigestAuthenticationTests.cs" />
     <Compile Include="Fakes\HttpClientHandler.cs" />
     <Compile Include="Fakes\MacProxy.cs" Condition=" '$(TargetsOSX)' == 'true' and '$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
+    <Compile Include="Headers\AltSvcHeaderParserTest.cs" />
     <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />
     <Compile Include="Headers\ByteArrayHeaderParserTest.cs" />
     <Compile Include="Headers\CacheControlHeaderParserTest.cs" />
@@ -485,11 +492,26 @@
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\IntegerEncoder.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\IntegerEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StaticTable.cs">
-      <Link>Common\System\Net\Http\Http2\Hpack\StaticTable.cs</Link>
+    <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\H2StaticTable.cs">
+      <Link>Common\System\Net\Http\Http2\Hpack\H2StaticTable.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\Http2\Hpack\StatusCodes.cs">
       <Link>Common\System\Net\Http\Http2\Hpack\StatusCodes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\H3StaticTable.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\H3StaticTable.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\HeaderField.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\HeaderField.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackEncoder.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackEncoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Net\Http\Http3\QPack\QPackEncodingException.cs">
+      <Link>Common\System\Net\Http\Http3\QPack\QPackEncodingException.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs">
+      <Link>Common\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeInterop.cs">
       <Link>WinHttpHandler\UnitTests\FakeInterop.cs</Link>

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -203,6 +203,7 @@ namespace System.Net
         public static readonly System.Version Version10;
         public static readonly System.Version Version11;
         public static readonly System.Version Version20;
+        public static readonly System.Version Version30;
     }
     public partial interface ICredentials
     {

--- a/src/libraries/System.Net.Primitives/src/System/Net/HttpVersion.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/HttpVersion.cs
@@ -10,5 +10,6 @@ namespace System.Net
         public static readonly Version Version10 = new Version(1, 0);
         public static readonly Version Version11 = new Version(1, 1);
         public static readonly Version Version20 = new Version(2, 0);
+        public static readonly Version Version30 = new Version(3, 0);
     }
 }

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1262,7 +1262,7 @@ namespace System.Net.Tests
                 }
             }, async server =>
             {
-                string host = server.Uri.Host + ":" + server.Uri.Port;
+                string host = server.Address.Host + ":" + server.Address.Port;
                 HttpRequestData requestData = await server.HandleRequestAsync(headers: new HttpHeaderData[] { new HttpHeaderData("Host", host) });
                 string serverReceivedHost = requestData.GetSingleHeaderValue("Host");
                 Assert.Equal(host, serverReceivedHost);

--- a/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -10,6 +10,9 @@
     <Compile Include="HttpWebResponseTest.cs" />
     <Compile Include="RequestStreamTest.cs" />
     <Compile Include="WebRequestTest.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs">
+      <Link>Common\System\Net\Capability.Security.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
@@ -18,6 +21,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs">
+      <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -109,6 +109,7 @@ namespace System.Net.Security
         private readonly int _dummyPrimitive;
         public static readonly System.Net.Security.SslApplicationProtocol Http11;
         public static readonly System.Net.Security.SslApplicationProtocol Http2;
+        public static readonly System.Net.Security.SslApplicationProtocol Http3;
         public SslApplicationProtocol(byte[] protocol) { throw null; }
         public SslApplicationProtocol(string protocol) { throw null; }
         public System.ReadOnlyMemory<byte> Protocol { get { throw null; } }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -10,10 +10,13 @@ namespace System.Net.Security
     public readonly struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
     {
         private static readonly Encoding s_utf8 = Encoding.GetEncoding(Encoding.UTF8.CodePage, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
+        private static readonly byte[] s_http3Utf8 = new byte[] { 0x68, 0x33 }; // "h3"
         private static readonly byte[] s_http2Utf8 = new byte[] { 0x68, 0x32 }; // "h2"
         private static readonly byte[] s_http11Utf8 = new byte[] { 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 }; // "http/1.1"
 
         // Refer to IANA on ApplicationProtocols: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+        // h3
+        public static readonly SslApplicationProtocol Http3 = new SslApplicationProtocol(s_http3Utf8, copy: false);
         // h2
         public static readonly SslApplicationProtocol Http2 = new SslApplicationProtocol(s_http2Utf8, copy: false);
         // http/1.1

--- a/src/libraries/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
+++ b/src/libraries/System.Net.WebClient/tests/System.Net.WebClient.Tests.csproj
@@ -5,6 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WebClientTest.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs">
+      <Link>Common\System\Net\Capability.Security.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">
       <Link>Common\System\Net\Configuration.cs</Link>
     </Compile>
@@ -13,6 +16,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs">
+      <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>


### PR DESCRIPTION
This adds HTTP/3 (draft 24) support to SocketsHttpHandler.

Marked NO MERGE for now because it a) depends on some QUIC APIs that don't exist yet, and b) due to that hasn't been tested against a live server.

This adds the APIs in https://github.com/dotnet/runtime/issues/1293.

There are some minor optimization opportunities (mostly in removing some async allocations) that will be investigated once things are in a state that we can benchmark.

Some of the initial H3 code from Kestrel is shared and thus included in this PR. @jkotalik this code has had some changes mostly to support `Span`, but also some optimizations.