### PR TITLE
Update the path to built runtime for `build -vs`

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -76,7 +76,7 @@ if ($vs) {
   $archTestHost = if ($arch) { $arch } else { "x64" }
 
   # This tells .NET Core to use the same dotnet.exe that build scripts use
-  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp-Windows_NT-$configuration-$archTestHost";
+  $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-$configuration-$archTestHost";
 
   # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
   $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=InitializeDotNetCli -install:$false


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/issues/280
* After 3b9abae, the script was not updated to reflect the changes and was still setting the old path. This resulted in VSTest failing with `It was not possible to find any compatible framework version...`. This commit updates the path (albeit hard-coded; though, this is done in a few other scripts as well) to fix this for now.