### PR TITLE
Make sure we update nextByte when we decode NEXT_OPCODE in x86 GCinfo

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -276,7 +276,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 break;
 
                             case (byte)InfoHdrAdjust.NEXT_OPCODE:
-                                encoding = (byte)(image[offset++] & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
+                                encoding = (byte)((nextByte = image[offset++]) & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
                                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
 
                                 if (encoding < (int)InfoHdrAdjustConstants.SET_RET_KIND_MAX)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -276,7 +276,8 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 break;
 
                             case (byte)InfoHdrAdjust.NEXT_OPCODE:
-                                encoding = (byte)((nextByte = image[offset++]) & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
+                                nextByte = image[offset++];
+                                encoding = (byte)(nextByte & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
                                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
 
                                 if (encoding < (int)InfoHdrAdjustConstants.SET_RET_KIND_MAX)


### PR DESCRIPTION
This change fixes R2RDump so that it won't crash on `System.Private.CoreLib.dll` built using crossgen, x86, debug.

Hinted by the comment, `DecodeHeader` in [`InfoHdr.cs`](https://github.com/dotnet/runtime/blob/b174fdce50303f7aad53022ae623b5a9629289b1/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs#L176) is simply a port of `decodeHeader` in [`gcdecode.cpp`](https://github.com/dotnet/coreclr/blob/a9f3fc16483eecfc47fb79c362811d870be02249/src/inc/gcdecoder.cpp#L94)

The port missed an assignment to the `nextByte` variable [here](https://github.com/dotnet/coreclr/blob/a9f3fc16483eecfc47fb79c362811d870be02249/src/inc/gcdecoder.cpp#L205), so I added it back.

The fixed version can decode `System.Private.CoreLib.dll` built using crossgen, x86, debug without crashing.