### PR TITLE
Require test framework assemblies crossgen to succeed

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -32,6 +32,7 @@ set "__ProjectDir=%~dp0"
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__RepoRootDir=%__ProjectDir%\..\.."
+for %%i in ("%__RepoRootDir%") do SET "__RepoRootDir=%%~fi"
 
 set "__TestDir=%__ProjectDir%\tests"
 set "__ProjectFilesDir=%__TestDir%"
@@ -518,6 +519,10 @@ if defined __DoCrossgen (
     if "%__TargetsWindows%" == "1" (
         echo %__MsgPrefix%Running crossgen on framework assemblies in CORE_ROOT: %CORE_ROOT%
         call :PrecompileFX
+        if ERRORLEVEL 1 (
+            echo %__ErrMsgPrefix%%__MsgPrefix%Error: crossgen precompilation of framework assemblies failed
+            exit /b 1
+        )
     ) else (
         echo "%__MsgPrefix%Crossgen only supported on Windows, for now"
     )
@@ -528,6 +533,10 @@ if defined __DoCrossgen2 (
     if "%__BuildArch%" == "x64" (
         echo %__MsgPrefix%Running crossgen2 on framework assemblies in CORE_ROOT: %CORE_ROOT%
         call :PrecompileFX
+        if ERRORLEVEL 1 (
+            echo %__ErrMsgPrefix%%__MsgPrefix%Error: crossgen2 precompilation of framework assemblies failed
+            exit /b 1
+        )
     ) else (
         echo "%__MsgPrefix%Crossgen2 only supported on x64, for now"
     )
@@ -600,8 +609,22 @@ may help to copy its "DIA SDK" folder into "%VSINSTALLDIR%" manually, then try a
 exit /b 1
 
 :PrecompileFX
-for %%F in (%CORE_ROOT%\*.dll) do call :PrecompileAssembly "%%F" %%~nF%%~xF
-exit /b 0
+set __TotalPrecompiled=0
+set __FailedToPrecompile=0
+set __FailedAssemblies=
+for %%F in ("%CORE_ROOT%\System.*.dll";"%CORE_ROOT%\Microsoft.*.dll") do (
+    if not "%%~nxF"=="Microsoft.CodeAnalysis.VisualBasic.dll" if not "%%~nxF"=="Microsoft.CodeAnalysis.CSharp.dll" if not "%%~nxF"=="Microsoft.CodeAnalysis.dll" (
+        call :PrecompileAssembly "%%F" %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
+        echo Processed: !__TotalPrecompiled!, failed !__FailedToPrecompile!
+    )
+)
+
+if !__FailedToPrecompile! NEQ 0 (
+    echo Failed assemblies:
+    FOR %%G IN (!__FailedAssemblies!) do echo   %%G
+)
+
+exit /b !__FailedToPrecompile!
 
 REM Compile the managed assemblies in Core_ROOT before running the tests
 :PrecompileAssembly
@@ -634,12 +657,14 @@ set __CrossgenCmd=
 if defined __DoCrossgen (
     set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile!
 ) else (
-    set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\mscorlib.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath!
+    set __CrossgenCmd=!__CrossgenExe! -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\mscorlib.dll" -r:"!CORE_ROOT!\netstandard.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath!
 )
 
 echo %__CrossgenCmd%
 %__CrossgenCmd%
 set /a __exitCode = !errorlevel!
+
+set /a "%~3+=1"
 
 if "%__exitCode%" == "-2146230517" (
     echo %AssemblyPath% is not a managed assembly.
@@ -648,6 +673,8 @@ if "%__exitCode%" == "-2146230517" (
 
 if %__exitCode% neq 0 (
     echo Unable to precompile %AssemblyPath%, Exit Code is %__exitCode%
+    set /a "%~4+=1"
+    set "%~5=!%~5!,!AssemblyName!"
     exit /b 0
 )
 

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -613,10 +613,13 @@ set __TotalPrecompiled=0
 set __FailedToPrecompile=0
 set __FailedAssemblies=
 for %%F in ("%CORE_ROOT%\System.*.dll";"%CORE_ROOT%\Microsoft.*.dll") do (
-    if not "%%~nxF"=="Microsoft.CodeAnalysis.VisualBasic.dll" if not "%%~nxF"=="Microsoft.CodeAnalysis.CSharp.dll" if not "%%~nxF"=="Microsoft.CodeAnalysis.dll" (
+    if not "%%~nxF"=="Microsoft.CodeAnalysis.VisualBasic.dll" (
+    if not "%%~nxF"=="Microsoft.CodeAnalysis.CSharp.dll" (
+    if not "%%~nxF"=="Microsoft.CodeAnalysis.dll" (
+    if not "%%~nxF"=="System.Runtime.WindowsRuntime.dll" (
         call :PrecompileAssembly "%%F" %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
         echo Processed: !__TotalPrecompiled!, failed !__FailedToPrecompile!
-    )
+    )))))
 )
 
 if !__FailedToPrecompile! NEQ 0 (
@@ -631,14 +634,6 @@ REM Compile the managed assemblies in Core_ROOT before running the tests
 
 set AssemblyPath=%1
 set AssemblyName=%2
-
-REM Don't precompile xunit.* files
-echo "%AssemblyName%" | findstr /b "xunit." >nul && (
-  exit /b 0
-)
-
-REM Skip the Win32 API dll's
-if /i "%AssemblyName:~0,4%"=="api-" exit /b 0
 
 set __CrossgenExe="%CORE_ROOT%\crossgen.exe"
 if /i "%__BuildArch%" == "arm" ( set __CrossgenExe="%CORE_ROOT%\x86\crossgen.exe" )
@@ -672,7 +667,7 @@ if "%__exitCode%" == "-2146230517" (
 )
 
 if %__exitCode% neq 0 (
-    echo Unable to precompile %AssemblyPath%, Exit Code is %__exitCode%
+    echo Unable to precompile %AssemblyPath%, exit code is %__exitCode%
     set /a "%~4+=1"
     set "%~5=!%~5!,!AssemblyName!"
     exit /b 0


### PR DESCRIPTION
The test framework crossgen in build-test.cmd failures were ignored
before. Change that to require the crossgen of all the framework
assemblies to succeed.
I've also added a progress and status details to the output.