### PR TITLE
JIT: build basic block pred lists before morph

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1375,6 +1375,12 @@ AGAIN:
 
     if (op2->IsIntCnsFitsInI32() && (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntConCommon()->IconValue()))
     {
+        // Don't build address modes out of non-foldable constants
+        if (!op2->AsIntConCommon()->ImmedValCanBeFolded(compiler, addr->OperGet()))
+        {
+            return false;
+        }
+
         /* We're adding a constant */
 
         cns += op2->AsIntConCommon()->IconValue();

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1375,12 +1375,6 @@ AGAIN:
 
     if (op2->IsIntCnsFitsInI32() && (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntConCommon()->IconValue()))
     {
-        // Don't build address modes out of non-foldable constants
-        if (!op2->AsIntConCommon()->ImmedValCanBeFolded(compiler, addr->OperGet()))
-        {
-            return false;
-        }
-
         /* We're adding a constant */
 
         cns += op2->AsIntConCommon()->IconValue();

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4622,22 +4622,10 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     }
     EndPhase(PHASE_GS_COOKIE);
 
-    /* Compute bbNum, bbRefs and bbPreds */
-
-    JITDUMP("\nRenumbering the basic blocks for fgComputePred\n");
-    fgRenumberBlocks();
-
-    noway_assert(!fgComputePredsDone); // This is the first time full (not cheap) preds will be computed.
-    fgComputePreds();
-    EndPhase(PHASE_COMPUTE_PREDS);
-
     /* If we need to emit GC Poll calls, mark the blocks that need them now.  This is conservative and can
      * be optimized later. */
     fgMarkGCPollBlocks();
     EndPhase(PHASE_MARK_GC_POLL_BLOCKS);
-
-    /* From this point on the flowgraph information such as bbNum,
-     * bbRefs or bbPreds has to be kept updated */
 
     // Compute the block and edge weights
     fgComputeBlockAndEdgeWeights();

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4622,8 +4622,13 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     }
     EndPhase(PHASE_GS_COOKIE);
 
+    // GC Poll marking assumes block bbnums match lexical block order,
+    // so make sure this is the case.
+    fgRenumberBlocks();
+
     /* If we need to emit GC Poll calls, mark the blocks that need them now.  This is conservative and can
      * be optimized later. */
+
     fgMarkGCPollBlocks();
     EndPhase(PHASE_MARK_GC_POLL_BLOCKS);
 

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -2729,6 +2729,8 @@ inline unsigned Compiler::fgThrowHlpBlkStkLevel(BasicBlock* block)
 */
 inline void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
 {
+    JITDUMP("Converting " FMT_BB " to BBJ_THROW\n", block->bbNum);
+
     // If we're converting a BBJ_CALLFINALLY block to a BBJ_THROW block,
     // then mark the subsequent BBJ_ALWAYS block as unreferenced.
     if (block->isBBCallAlwaysPair())
@@ -2758,8 +2760,14 @@ inline void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
 #endif // defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
     }
 
+    // Scrub this block from the pred lists of any successors
+    fgRemoveBlockAsPred(block);
+
+    // Update jump kind after the scrub.
     block->bbJumpKind = BBJ_THROW;
-    block->bbSetRunRarely(); // any block with a throw is rare
+
+    // Any block with a throw is rare
+    block->bbSetRunRarely();
 }
 
 /*****************************************************************************

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -2738,10 +2738,6 @@ inline void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
         BasicBlock* leaveBlk = block->bbNext;
         noway_assert(leaveBlk->bbJumpKind == BBJ_ALWAYS);
 
-        leaveBlk->bbFlags &= ~BBF_DONT_REMOVE;
-        leaveBlk->bbRefs  = 0;
-        leaveBlk->bbPreds = nullptr;
-
 #if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
         // This function (fgConvertBBToThrowBB) can be called before the predecessor lists are created (e.g., in
         // fgMorph). The fgClearFinallyTargetBit() function to update the BBF_FINALLY_TARGET bit depends on these
@@ -2758,6 +2754,12 @@ inline void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
             fgNeedToAddFinallyTargetBits = true;
         }
 #endif // defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
+
+        // leaveBlk is now unreachable, so scrub the pred lists.
+        // Note this must happen after resetting finally target bits.
+        leaveBlk->bbFlags &= ~BBF_DONT_REMOVE;
+        leaveBlk->bbRefs  = 0;
+        leaveBlk->bbPreds = nullptr;
     }
 
     // Scrub this block from the pred lists of any successors

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -419,20 +419,31 @@ BasicBlock* Compiler::fgNewBasicBlock(BBjumpKinds jumpKind)
     return block;
 }
 
-/*****************************************************************************
- *
- *  Ensures that fgFirstBB is a scratch BasicBlock that we have added.
- *  This can be used to add initialization code (without worrying
- *  about other blocks jumping to it).
- *
- *  Callers have to be careful that they do not mess up the order of things
- *  added to fgEnsureFirstBBisScratch in a way as to change semantics.
- */
-
+//------------------------------------------------------------------------
+// fgEnsureFirstBBisScratch: Ensure that fgFirstBB is a scratch BasicBlock
+//
+// Returns:
+//   Nothing. May allocate a new block and alter the value of fgFirstBB.
+//
+// Notes:
+//   This should be called before adding on-entry initialization code to
+//   the method, to ensure that fgFirstBB is not part of a loop.
+//
+//   Does nothing, if fgFirstBB is already a scratch BB. After calling this,
+//   fgFirstBB may already contain code. Callers have to be careful
+//   that they do not mess up the order of things added to this block and
+//   inadvertently change semantics.
+//
+//   We maintain the invariant that a scratch BB ends with BBJ_NONE or
+//   BBJ_ALWAYS, so that when adding independent bits of initialization,
+//   callers can generally append to the fgFirstBB block without worring
+//   about what code is there already.
+//
+//   Can be called at any time, and can be called multiple times.
+//
 void Compiler::fgEnsureFirstBBisScratch()
 {
     // Have we already allocated a scratch block?
-
     if (fgFirstBBisScratch())
     {
         return;
@@ -485,6 +496,12 @@ void Compiler::fgEnsureFirstBBisScratch()
 #endif
 }
 
+//------------------------------------------------------------------------
+// fgFirstBBisScratch: Check if fgFirstBB is a scratch block
+//
+// Returns:
+//   true if fgFirstBB is a scratch block.
+//
 bool Compiler::fgFirstBBisScratch()
 {
     if (fgFirstBBScratch != nullptr)
@@ -506,6 +523,15 @@ bool Compiler::fgFirstBBisScratch()
     }
 }
 
+//------------------------------------------------------------------------
+// fgBBisScratch: Check if a given block is a scratch block.
+//
+// Arguments:
+//   block - block in question
+//
+// Returns:
+//   true if this block is the first block and is a scratch block.
+//
 bool Compiler::fgBBisScratch(BasicBlock* block)
 {
     return fgFirstBBisScratch() && (block == fgFirstBB);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5483,6 +5483,18 @@ bool GenTree::OperMayThrow(Compiler* comp)
         case GT_ARR_ELEM:
             return comp->fgAddrCouldBeNull(this->AsArrElem()->gtArrObj);
 
+        case GT_FIELD:
+        {
+            GenTree* fldObj = this->AsField()->gtFldObj;
+
+            if (fldObj != nullptr)
+            {
+                return comp->fgAddrCouldBeNull(fldObj);
+            }
+
+            return false;
+        }
+
         case GT_ARR_BOUNDS_CHECK:
         case GT_ARR_INDEX:
         case GT_ARR_OFFSET:

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -15194,22 +15194,30 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
     return result;
 }
 
-//*****************************************************************************
+//------------------------------------------------------------------------
+// fgMorphBlockStmt: morph a single statement in a block.
 //
-// Morphs a single statement in a block.
-// Can be called anytime, unlike fgMorphStmts() which should only be called once.
+// Arguments:
+//    block - block containing the statement
+//    stmt - statement to morph
+//    msg - string to identify caller in a dump
 //
-// Returns true  if 'stmt' was removed from the block.
-// Returns false if 'stmt' is still in the block (even if other statements were removed).
+// Returns:
+//    true if 'stmt' was removed from the block.
+//  s false if 'stmt' is still in the block (even if other statements were removed).
 //
-
+// Notes:
+//   Can be called anytime, unlike fgMorphStmts() which should only be called once.
+//
 bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg))
 {
     assert(block != nullptr);
     assert(stmt != nullptr);
 
-    compCurBB   = block;
-    compCurStmt = stmt;
+    // Reset some ambient state
+    fgRemoveRestOfBlock = false;
+    compCurBB           = block;
+    compCurStmt         = stmt;
 
     GenTree* morph = fgMorphTree(stmt->GetRootNode());
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -16635,12 +16635,14 @@ void Compiler::fgMorph()
 
     EndPhase(PHASE_CLONE_FINALLY);
 
-    /* Compute bbNum, bbRefs and bbPreds */
-
+    // Compute bbNum, bbRefs and bbPreds
+    //
     JITDUMP("\nRenumbering the basic blocks for fgComputePreds\n");
     fgRenumberBlocks();
 
-    noway_assert(!fgComputePredsDone); // This is the first time full (not cheap) preds will be computed.
+    // This is the first time full (not cheap) preds will be computed
+    //
+    noway_assert(!fgComputePredsDone);
     fgComputePreds();
 
     // Run an early flow graph simplification pass
@@ -16651,8 +16653,8 @@ void Compiler::fgMorph()
 
     EndPhase(PHASE_COMPUTE_PREDS);
 
-    /* From this point on the flowgraph information such as bbNum,
-     * bbRefs or bbPreds has to be kept updated */
+    // From this point on the flowgraph information such as bbNum,
+    // bbRefs or bbPreds has to be kept updated
 
     /* For x64 and ARM64 we need to mark irregular parameters */
     lvaRefCountState = RCS_EARLY;

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8038,6 +8038,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     fgFirstBB->bbFlags |= BBF_DONT_REMOVE;
     block->bbJumpKind = BBJ_ALWAYS;
     block->bbJumpDest = fgFirstBB->bbNext;
+    block->bbJumpDest->bbFlags |= BBF_JMP_TARGET;
     fgAddRefPred(block->bbJumpDest, block);
     block->bbFlags &= ~BBF_HAS_JMP;
 }

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -4073,6 +4073,13 @@ void Compiler::fgOptWhileLoop(BasicBlock* block)
         return;
     }
 
+    // block can't be the scratch bb, since we prefer to keep flow
+    // out of the scratch bb as BBJ_ALWAYS or BBJ_NONE.
+    if (fgBBisScratch(block))
+    {
+        return;
+    }
+
     // It has to be a forward jump
     //  TODO-CQ: Check if we can also optimize the backwards jump as well.
     //

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/EarlyFlowOptExample.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/EarlyFlowOptExample.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Test case showing that we can have "more complex"
+// IR after a tail call if we do early flow opts.
+
+interface IX
+{
+}
+
+class X : IX
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    bool P1(object o) => false;
+
+    bool P0(object o)
+    {
+        bool b = false;
+        if (b)
+        {
+            return false;
+        }
+        return P1(o);
+    }
+
+    // F3 needs to be too big to inline without being marked noinline,
+    // so that it ends up being tail called.
+    bool F3(object o)
+    {
+        int result = 0;
+        for (int i = 0; i < 100; i++)
+        {
+            result += i;
+        }
+        return result == 4950;
+    }
+
+    //  This method mainly serves to introduce are return spill temp
+    bool F2(object o)
+    {
+        bool b = false;
+        if (b)
+        {
+            return false;
+        }
+        return F3(o);
+    }
+
+    //  This method mainly serves to introduce are return spill temp
+    bool F1(object o)
+    {
+        if (P0(o))
+        {
+            return false;
+        }
+
+        return F2(o);
+    }
+
+    // F0 is the method of interest. It will end up tail calling F3,
+    // and will initially have a chain of moves and casts after the
+    // call site which may trip up post tail call validation.
+    //
+    // We want F0 to be jitted, not inlined, but can't mark it as
+    // noinline or we'll also suppress tail calls.
+    bool F0(object o)
+    {
+        if (o == null)
+        {
+            return false;
+        }
+
+        object ix = o as IX;
+
+        if (ix == null)
+        {
+            return false;
+        }
+
+        return F1(ix);
+    }
+
+    // This stops F0 from being inlined
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    public static int Main()
+    {
+        X x = new X();
+        bool b = x.F0(x);
+        return b ? 100 : -1;
+    }
+}

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/EarlyFlowOptExample.csproj
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/EarlyFlowOptExample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Build basic block pred lists before morph, instead of after, and add an early
flow optimization pass. Fix up a few places where ref counts or pred lists
were not properly maintained in morph.

The early flow opt pass enhances the local assertion prop run in morph (by
fusing blocks), allows the jit to avoid morphing some unreachable blocks
(thus saving a bit of TP), and lays the groundwork for more aggressive early
branch folding that would be useful eg dotnet/runtime#27935).