### PR TITLE
Unify cmake_minimum_required to 3.14.2

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -62,7 +62,7 @@ Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs (
 Toolchain Setup
 ---------------
 
-Add Kitware's APT feed to your configuration for a newer version of CMake. See their instructions at <https://apt.kitware.com/>. Also, add LLVM/s APT feed to your configuration for a newer version of CMake. See their instructions as <http://apt.llvm.org/>.
+Building the repo requires CMake 3.14.2 or newer on Linux. Add Kitware's APT feed to your configuration for a newer version of CMake. See their instructions at <https://apt.kitware.com/>. Also, add LLVM/s APT feed to your configuration for a newer version of CMake. See their instructions as <http://apt.llvm.org/>.
 
 Install the following packages for the toolchain:
 

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14.2)
 
 cmake_policy(SET CMP0042 NEW)
 

--- a/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.8) # This project is only included on Win32 platforms so we can have a higher CMake version requirement since we already require a newer CMake version on Windows for various reasons.
 # Quick note: The CMake C# support is using the CSC bundled with the MSBuild that the native build runs on, not the one supplied by the local .NET SDK.
 
 project(DacTableGen LANGUAGES CSharp)

--- a/src/coreclr/src/pal/CMakeLists.txt
+++ b/src/coreclr/src/pal/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 project(COREPAL)
 
 include(../../clrfeatures.cmake)

--- a/src/coreclr/src/pal/prebuilt/inc/CMakeLists.txt
+++ b/src/coreclr/src/pal/prebuilt/inc/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 project(COREPAL)
 
 _install (FILES corerror.h corprof.h DESTINATION inc)

--- a/src/coreclr/src/pal/src/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   # On OSX and *BSD, we use the libunwind that's part of the OS
   set(CLR_CMAKE_USE_SYSTEM_LIBUNWIND 1)

--- a/src/coreclr/src/pal/src/eventprovider/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/eventprovider/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 set(EVENT_MANIFEST ${VM_DIR}/ClrEtwAll.man)
 
 if(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_FREEBSD)

--- a/src/coreclr/src/pal/src/eventprovider/dummyprovider/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/eventprovider/dummyprovider/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 include(FindPython)
 
 set (GENERATE_SCRIPT ${CLR_DIR}/src/scripts/genDummyProvider.py)

--- a/src/coreclr/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 include(FindPython)
 set (GENERATE_SCRIPT ${CLR_DIR}/src/scripts/genLttngProvider.py)
 

--- a/src/coreclr/src/pal/src/libunwind/src/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/libunwind/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 project(unwind)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/coreclr/src/pal/tests/CMakeLists.txt
+++ b/src/coreclr/src/pal/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12.2)
+cmake_minimum_required(VERSION 3.14.2)
 
 if(CLR_CMAKE_PLATFORM_ARCH_I386)
     set(PAL_CMAKE_PLATFORM_ARCH_I386 1)

--- a/src/coreclr/src/pal/tests/palsuite/CMakeLists.txt
+++ b/src/coreclr/src/pal/tests/palsuite/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 project(PALTESTSUITE)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/coreclr/src/vm/eventing/CMakeLists.txt
+++ b/src/coreclr/src/vm/eventing/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 set(EVENT_MANIFEST ${VM_DIR}/ClrEtwAll.man)
 set(EVENT_EXCLUSIONS ${VM_DIR}/ClrEtwAllMeta.lst)
 

--- a/src/coreclr/src/vm/eventing/EtwProvider/CMakeLists.txt
+++ b/src/coreclr/src/vm/eventing/EtwProvider/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-
 include(FindPython)
 
 set(ETW_PROVIDER_SCRIPT ${CLR_DIR}/src/scripts/genEtwProvider.py)

--- a/src/coreclr/src/vm/eventing/eventpipe/CMakeLists.txt
+++ b/src/coreclr/src/vm/eventing/eventpipe/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12.2)
-
 include(FindPython)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/coreclr/tests/CMakeLists.txt
+++ b/src/coreclr/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14.2)
 
 cmake_policy(SET CMP0042 NEW)
 project(Tests)

--- a/src/coreclr/tests/src/Common/Platform/CMakeLists.txt
+++ b/src/coreclr/tests/src/Common/Platform/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (platformdefines)
 set(SOURCES platformdefines.cpp)
 

--- a/src/coreclr/tests/src/Common/hostpolicymock/CMakeLists.txt
+++ b/src/coreclr/tests/src/Common/hostpolicymock/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project (hostpolicy)
 
 include_directories(${INC_PLATFORM_DIR})

--- a/src/coreclr/tests/src/Exceptions/ForeignThread/CMakeLists.txt
+++ b/src/coreclr/tests/src/Exceptions/ForeignThread/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
-
 project (ForeignThreadExceptionsNative)
 
 include_directories(${INC_PLATFORM_DIR})

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (MarshalBoolArrayNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES MarshalBoolArrayNative.cpp)

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (MarshalArrayByValNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES MarshalArrayByValNative.cpp)

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/SafeArray/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/SafeArray/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (SafeArrayNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES SafeArrayNative.cpp RecordNative.cpp)

--- a/src/coreclr/tests/src/Interop/BestFitMapping/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/BestFitMapping/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (BestFitMappingNative)
 set(SOURCES BestFitMappingNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
-
 project (COMClientDefaultInterfaces)
 include_directories( ${INC_PLATFORM_DIR} )
 include_directories( "../../ServerContracts" )

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
-
 include_directories( ${INC_PLATFORM_DIR} )
 include_directories( "../../ServerContracts" )
 include_directories( "../../NativeServer" )

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
-
 project (COMClientLicensing)
 include_directories( ${INC_PLATFORM_DIR} )
 include_directories( "../../ServerContracts" )

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
-
 project (COMClientPrimitives)
 include_directories( ${INC_PLATFORM_DIR} )
 include_directories( "../../ServerContracts" )

--- a/src/coreclr/tests/src/Interop/COM/NativeServer/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/COM/NativeServer/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (COMNativeServer)
 include_directories( ${INC_PLATFORM_DIR} )
 include_directories( "../ServerContracts" )

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (DllImportPath) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (ExactSpellingNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")  

--- a/src/coreclr/tests/src/Interop/ExecInDefAppDom/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/ExecInDefAppDom/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (ExecInDefAppDomDll)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES ExecInDefAppDomDll.cpp )

--- a/src/coreclr/tests/src/Interop/FuncPtrAsDelegateParam/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/FuncPtrAsDelegateParam/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (FuncPtrAsDelegateParamNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES FuncPtrAsDelegateParamNative.cpp )

--- a/src/coreclr/tests/src/Interop/ICustomMarshaler/ConflictingNames/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/ICustomMarshaler/ConflictingNames/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (CustomMarshalersConflictingNames)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES CustomMarshalerNative.cpp )

--- a/src/coreclr/tests/src/Interop/IJW/CopyConstructorMarshaler/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/IJW/CopyConstructorMarshaler/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (CopyConstructorMarshaler)
 include("../IJW.cmake")
 

--- a/src/coreclr/tests/src/Interop/IJW/IjwNativeCallingManagedDll/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/IJW/IjwNativeCallingManagedDll/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (IjwNativeCallingManagedDll)
 include("../IJW.cmake")
 

--- a/src/coreclr/tests/src/Interop/IJW/IjwNativeDll/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/IJW/IjwNativeDll/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (IjwNativeDll)
 include("../IJW.cmake")
 

--- a/src/coreclr/tests/src/Interop/IJW/NativeVarargs/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/IJW/NativeVarargs/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (IjwNativeVarargs)
 include("../IJW.cmake")
 

--- a/src/coreclr/tests/src/Interop/IJW/ijwhostmock/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/IJW/ijwhostmock/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (mscoree)
 include_directories( ${INC_PLATFORM_DIR} )
 set(SOURCES mscoree.cpp)

--- a/src/coreclr/tests/src/Interop/LayoutClass/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/LayoutClass/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (LayoutClassNative)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES LayoutClassNative.cpp )

--- a/src/coreclr/tests/src/Interop/MarshalAPI/FunctionPointer/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/MarshalAPI/FunctionPointer/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (FunctionPointerNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES FunctionPointerNative.cpp)

--- a/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/MarshalAPI/IUnknown/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (IUnknownNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES IUnknownNative.cpp)

--- a/src/coreclr/tests/src/Interop/NativeCallable/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/NativeCallable/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (NativeCallableDll)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES NativeCallableDll.cpp )

--- a/src/coreclr/tests/src/Interop/NativeLibrary/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (NativeLibrary)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES NativeLibrary.cpp)

--- a/src/coreclr/tests/src/Interop/NativeLibraryResolveCallback/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/NativeLibraryResolveCallback/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (ResolveLib)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES ResolveLib.cpp)

--- a/src/coreclr/tests/src/Interop/NativeLibraryResolveEvent/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/NativeLibraryResolveEvent/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (ResolvedLib)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES ResolvedLib.cpp)

--- a/src/coreclr/tests/src/Interop/PInvoke/Array/MarshalArrayAsField/LPArrayNative/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Array/MarshalArrayAsField/LPArrayNative/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (MarshalArrayByValArrayNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("../..")

--- a/src/coreclr/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (MarshalArrayLPArrayNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 include_directories("../..")

--- a/src/coreclr/tests/src/Interop/PInvoke/ArrayWithOffset/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/ArrayWithOffset/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (ArrayWithOffsetNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/AsAny/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/AsAny/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (AsAnyNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Attributes/LCID/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Attributes/LCID/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (LCIDNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (SuppressGCTransitionNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/BestFitMapping/Char/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/BestFitMapping/Char/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (Char_BestFitMappingNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/BestFitMapping/LPStr/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/BestFitMapping/LPStr/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (LPStr_BestFitMappingNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/CriticalHandles/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/CriticalHandles/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (CriticalHandlesNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/CustomMarshalers/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/CustomMarshalers/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (CustomMarshalersNative)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES CustomMarshalersNative.cpp )

--- a/src/coreclr/tests/src/Interop/PInvoke/DateTime/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/DateTime/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (NativeDateTime) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Decimal/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Decimal/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 
     DecimalTestNative.cpp 

--- a/src/coreclr/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 
     DelegateTestNative.cpp

--- a/src/coreclr/tests/src/Interop/PInvoke/Generics/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Generics/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (GenericsNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 if(CLR_CMAKE_TARGET_ARCH_I386)

--- a/src/coreclr/tests/src/Interop/PInvoke/IEnumerator/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/IEnumerator/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (IEnumeratorNative)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES IEnumeratorNative.cpp )

--- a/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (HandleRefNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (MAWSPINative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (ThisCallNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/NativeCallManagedComVisible/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/NativeCallManagedComVisible/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 project (ComVisibleNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/PInvoke/Primitives/Int/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Primitives/Int/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (PInvokeIntNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES PInvokeIntNative.cpp) 

--- a/src/coreclr/tests/src/Interop/PInvoke/Primitives/RuntimeHandles/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Primitives/RuntimeHandles/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (RuntimeHandlesNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES RuntimeHandlesNative.cpp) 

--- a/src/coreclr/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
@@ -1,5 +1,4 @@
  
-cmake_minimum_required (VERSION 2.6) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 
     SafeHandleNative.cpp 

--- a/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (PInvokePassingByOutNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 

--- a/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (PInvokePassingByRefNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 

--- a/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (RPIP_ByOutNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 

--- a/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (RPIP_ByRefNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 include_directories("..") 

--- a/src/coreclr/tests/src/Interop/PInvoke/Varargs/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Varargs/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (VarargsNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES VarargsNative.cpp )

--- a/src/coreclr/tests/src/Interop/PInvoke/Variant/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PInvoke/Variant/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (VariantNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES VariantNative.cpp)

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/Bool/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/Bool/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (NativeBool)
 set(SOURCES BoolNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (MarshalEnumNative)
 set(SOURCES MarshalEnumNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")

--- a/src/coreclr/tests/src/Interop/PrimitiveMarshalling/UIntPtr/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/PrimitiveMarshalling/UIntPtr/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (UIntPtrNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES UIntPtrNative.cpp )

--- a/src/coreclr/tests/src/Interop/RefCharArray/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/RefCharArray/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (RefCharArrayNative)
 set(SOURCES RefCharArrayNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")

--- a/src/coreclr/tests/src/Interop/RefInt/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/RefInt/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (RefIntNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES RefIntNative.cpp )

--- a/src/coreclr/tests/src/Interop/SimpleStruct/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/SimpleStruct/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (SimpleStructNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES SimpleStructNative.cpp )

--- a/src/coreclr/tests/src/Interop/SizeConst/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/SizeConst/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (SizeConstNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES SizeConstNative.cpp)

--- a/src/coreclr/tests/src/Interop/StringMarshalling/AnsiBSTR/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/AnsiBSTR/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (AnsiBStrTestNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES AnsiBStrTestNative.cpp)

--- a/src/coreclr/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES BStrTestNative.cpp)
 

--- a/src/coreclr/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 set(SOURCES LPStrTestNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 

--- a/src/coreclr/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 set(SOURCES LPTStrTestNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 

--- a/src/coreclr/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (UTF8TestNative)
 set(SOURCES UTF8TestNative.cpp )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")

--- a/src/coreclr/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (VBByRefStrNative)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES VBByRefStrNative.cpp )

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (MarshalStructAsParam)
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES MarshalStructAsParamDLL.cpp)

--- a/src/coreclr/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-cmake_minimum_required (VERSION 2.6) 
 project (ReversePInvokeNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (SeqPInvokeNative) 
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 
 set(SOURCES 

--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.8.12)
 project (WinRTNativeComponent)
 include_directories( ${INC_PLATFORM_DIR} )
 include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake") 

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (StructABILib)
 include_directories(${INC_PLATFORM_DIR})
 

--- a/src/coreclr/tests/src/JIT/Directed/arglist/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Directed/arglist/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (varargnative)
 include_directories(${INC_PLATFORM_DIR})
 

--- a/src/coreclr/tests/src/JIT/Directed/pinning/object-pin/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Directed/pinning/object-pin/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(object_pin_mirror)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/JIT/Directed/pinvoke/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Directed/pinvoke/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(PInvokeExampleNative)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/JIT/Methodical/gc_poll/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Methodical/gc_poll/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6) 
 project (GCPollNative)
 
 set(SOURCES 

--- a/src/coreclr/tests/src/JIT/Methodical/structs/systemvbringup/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Methodical/structs/systemvbringup/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(jitstructtests)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(b108129_test2)
 include_directories(${INC_PLATFORM_DIR})
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/JIT/SIMD/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/SIMD/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 project (Vector3TestNative)
 include_directories(${INC_PLATFORM_DIR})
 set(SOURCES Vector3TestNative.cpp )

--- a/src/coreclr/tests/src/JIT/jit64/hfa/main/dll/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/jit64/hfa/main/dll/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(hfa_interop)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/JIT/jit64/mcc/interop/CMakeLists.txt
+++ b/src/coreclr/tests/src/JIT/jit64/mcc/interop/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(mcc_native)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/Loader/NativeLibs/CMakeLists.txt
+++ b/src/coreclr/tests/src/Loader/NativeLibs/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 project(FromNativePaths_lib)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")

--- a/src/coreclr/tests/src/baseservices/exceptions/regressions/Dev11/147911/CMakeLists.txt
+++ b/src/coreclr/tests/src/baseservices/exceptions/regressions/Dev11/147911/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 if(WIN32)
 project (fpcw)
 include_directories(${INC_PLATFORM_DIR})

--- a/src/coreclr/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/CMakeLists.txt
+++ b/src/coreclr/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required (VERSION 2.6)
 if (WIN32)
 project (Unmanaged)
 include_directories(${INC_PLATFORM_DIR})

--- a/src/installer/corehost/CMakeLists.txt
+++ b/src/installer/corehost/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required(VERSION 3.14.2)
 
 project(corehost)
 

--- a/src/installer/corehost/cli/apphost/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(apphost)	
 set(DOTNET_PROJECT_NAME "apphost")
 

--- a/src/installer/corehost/cli/comhost/CMakeLists.txt
+++ b/src/installer/corehost/cli/comhost/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(comhost)
 
 set(DOTNET_PROJECT_NAME "comhost")

--- a/src/installer/corehost/cli/dotnet/CMakeLists.txt
+++ b/src/installer/corehost/cli/dotnet/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(dotnet)
 set(DOTNET_PROJECT_NAME "dotnet")
 

--- a/src/installer/corehost/cli/fxr/CMakeLists.txt
+++ b/src/installer/corehost/cli/fxr/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(hostfxr)
 
 set(DOTNET_PROJECT_NAME "hostfxr")

--- a/src/installer/corehost/cli/hostpolicy/CMakeLists.txt
+++ b/src/installer/corehost/cli/hostpolicy/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(hostpolicy)
 
 set(DOTNET_PROJECT_NAME "hostpolicy")

--- a/src/installer/corehost/cli/nethost/CMakeLists.txt
+++ b/src/installer/corehost/cli/nethost/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(nethost)
 
 set(DOTNET_PROJECT_NAME "nethost")

--- a/src/installer/corehost/cli/test/mockcoreclr/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/mockcoreclr/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(mockcoreclr)
 
 set(DOTNET_PROJECT_NAME "mockcoreclr")

--- a/src/installer/corehost/cli/test/mockhostpolicy/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/mockhostpolicy/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.6)
 project(mockhostpolicy)
 
 set(DOTNET_PROJECT_NAME "mockhostpolicy")

--- a/src/installer/corehost/cli/test/nativehost/CMakeLists.txt
+++ b/src/installer/corehost/cli/test/nativehost/CMakeLists.txt
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-cmake_minimum_required (VERSION 2.8.12)
 project(nativehost)
 
 set(DOTNET_PROJECT_NAME "nativehost")

--- a/src/installer/corehost/cli/test_fx_ver/CMakeLists.txt
+++ b/src/installer/corehost/cli/test_fx_ver/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required (VERSION 2.6)
 project(test_fx_ver)
 
 set(EXE_NAME "test_fx_ver")

--- a/src/installer/corehost/cli/winrthost/CMakeLists.txt
+++ b/src/installer/corehost/cli/winrthost/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required (VERSION 2.6)
 project(winrthost)
 
 set(DOTNET_PROJECT_NAME "winrthost")

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14.2)
 cmake_policy(SET CMP0042 NEW)
 
 project(CoreFX C)

--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.14.2)
 
 # C Compiler flags
 SET (CMAKE_C_FLAGS_INIT                     "/W0 /FC")


### PR DESCRIPTION
-  Set cmake_minimum_required in top level projects to 3.14.2 (the lowest version used by the CI currently)
- Delete cmake_minimum_required from child projects
- Leave the cmake_minimum_required alone in vendored projects (zlib)

Fixed #1311