### PR TITLE
Fix typo: availabe -> available

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -19,8 +19,8 @@ Param(
 
 function Get-Help() {
   Write-Host "Common settings:"
-  Write-Host "  -subset                 Build a subset, print availabe subsets with -subset help"
-  Write-Host "  -subsetCategory         Build a subsetCategory, print availabe subsetCategories with -subset help"
+  Write-Host "  -subset                 Build a subset, print available subsets with -subset help"
+  Write-Host "  -subsetCategory         Build a subsetCategory, print available subsetCategories with -subset help"
   Write-Host "  -os                     Build operating system: Windows_NT or Unix"
   Write-Host "  -arch                   Build platform: x86, x64, arm or arm64"
   Write-Host "  -configuration <value>  Build configuration: Debug or Release (short: -c)"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -17,8 +17,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 usage()
 {
   echo "Common settings:"
-  echo "  --subset                   Build a subset, print availabe subsets with -subset help"
-  echo "  --subsetCategory           Build a subsetCategory, print availabe subsetCategories with -subset help"
+  echo "  --subset                   Build a subset, print available subsets with -subset help"
+  echo "  --subsetCategory           Build a subsetCategory, print available subsetCategories with -subset help"
   echo "  --os                       Build operating system: Windows_NT or Unix"
   echo "  --arch                     Build platform: x86, x64, arm or arm64"
   echo "  --configuration <value>    Build configuration: Debug or Release (short: -c)"
@@ -127,7 +127,7 @@ while [[ $# > 0 ]]; do
       ;;
       *)
       ea=$1
-      
+
       if [[ $checkedPossibleDirectoryToBuild == false ]] && [[ $subsetCategory == "libraries" ]]; then
         checkedPossibleDirectoryToBuild=true
 

--- a/src/coreclr/src/vm/win32threadpool.cpp
+++ b/src/coreclr/src/vm/win32threadpool.cpp
@@ -3672,7 +3672,7 @@ LPOVERLAPPED ThreadpoolMgr::CompletionPortDispatchWorkWithinAppDomain(
     //Very Very Important!
     //Do not change the timeout for GetQueuedCompletionStatus to a non-zero value.
     //Selecting a non-zero value can cause the thread to block, and lead to expensive context switches.
-    //In real life scenarios, we have noticed a packet to be not availabe immediately, but very shortly
+    //In real life scenarios, we have noticed a packet to be not available immediately, but very shortly
     //(after few 100's of instructions), and falling back to the VM is good in that case as compared to
     //taking a context switch. Changing the timeout to non-zero can lead to perf degrades, that are very
     //hard to diagnose.

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -489,7 +489,7 @@ namespace System.Data
             }
         }
 
-        // Serialize constraints availabe on the table - note this function is marked internal because it is called by the DataSet deserializer.
+        // Serialize constraints available on the table - note this function is marked internal because it is called by the DataSet deserializer.
         // ***Schema for Serializing ArrayList of Constraints***
         // Unique Constraint - ["U"]->[constraintName]->[columnIndexes]->[IsPrimaryKey]->[extendedProperties]
         // Foriegn Key Constraint - ["F"]->[constraintName]->[parentTableIndex, parentcolumnIndexes]->[childTableIndex, childColumnIndexes]->[AcceptRejectRule, UpdateRule, DeleteRule]->[extendedProperties]

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
@@ -97,7 +97,7 @@ namespace System.DirectoryServices.Protocols
                     }
                 }
 
-                // Try to get the results availabe for this asynchronous operation  .
+                // Try to get the results available for this asynchronous operation  .
                 GetResultsHelper(asyncResult);
 
                 // If we are done with the asynchronous search, we need to fire callback and signal the waitable object.


### PR DESCRIPTION
Apparently it shows up in several places, although I originally noticed it in your build usage help text.