### PR TITLE
Update cmd and batch scripts to be crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,11 @@
 *.in text eol=lf
 *.sh text eol=lf
 
-*.cs text=auto diff=csharp 
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.cs text=auto diff=csharp
 *.vb text=auto
 *.resx text=auto
 *.c text=auto


### PR DESCRIPTION
`cmd` and `bat` files need to be checked out as `crlf`, regardless of the target, as batch labels can't be otherwise found on Windows.

This is impactful if you have configured git to "checkout as-is" or if you've previously checked out an enlistment using WSL, etc.