### PR TITLE
Fix build on Void Linux musl

### DIFF
--- a/src/coreclr/init-distro-rid.sh
+++ b/src/coreclr/init-distro-rid.sh
@@ -153,13 +153,9 @@ initDistroRidGlobal()
         export __PortableBuild=1
         local distroRid=""
 
-        # Check for alpine. It is the only portable build that will will have
-        # its name in the portable build rid.
-        if [ -e "${rootfsDir}/etc/os-release" ]; then
-            source "${rootfsDir}/etc/os-release"
-            if [ "${ID}" = "alpine" ]; then
-                distroRid="linux-musl-${buildArch}"
-            fi
+        # Check for musl-based distros (e.g Alpine Linux, Void Linux).
+        if (ldd --version 2>&1 || true) | grep -q musl; then
+            distroRid="linux-musl-${buildArch}"
         fi
 
         if [ "${distroRid}" == "" ]; then

--- a/src/coreclr/src/pal/src/config.h.in
+++ b/src/coreclr/src/pal/src/config.h.in
@@ -68,6 +68,7 @@
 #cmakedefine01 HAVE_XSWDEV
 #cmakedefine01 HAVE_XSW_USAGE
 #cmakedefine01 HAVE_PUBLIC_XSTATE_STRUCT
+#cmakedefine01 HAVE__FPX_SW_BYTES_WITH_XSTATE_BV
 #cmakedefine01 HAVE_PR_SET_PTRACER
 
 #cmakedefine01 HAVE_STAT_TIMESPEC

--- a/src/coreclr/src/pal/src/configure.cmake
+++ b/src/coreclr/src/pal/src/configure.cmake
@@ -1098,6 +1098,10 @@ int main(int argc, char **argv)
     return 0;
 }" HAVE_PUBLIC_XSTATE_STRUCT)
 
+if(HAVE_PUBLIC_XSTATE_STRUCT)
+    check_struct_has_member ("struct _fpx_sw_bytes" xstate_bv "signal.h" HAVE__FPX_SW_BYTES_WITH_XSTATE_BV)
+endif()
+
 check_cxx_source_compiles("
 #include <sys/prctl.h>
 

--- a/src/coreclr/src/pal/src/include/pal/context.h
+++ b/src/coreclr/src/pal/src/include/pal/context.h
@@ -157,8 +157,8 @@ using asm_sigcontext::_xstate;
 #define FPSTATE_RESERVED padding
 #endif
 
-// The mask for YMM registers presence flag stored in the xstate_bv. On current Linuxes, this definition is
-// only in internal headers, so we define it here. The xstate_bv is extracted from the processor xstate bit
+// The mask for YMM registers presence flag stored in the xfeatures (formerly xstate_bv). On current Linuxes, this definition is
+// only in internal headers, so we define it here. The xfeatures (formerly xstate_bv) is extracted from the processor xstate bit
 // vector register, so the value is OS independent.
 #ifndef XSTATE_YMM
 #define XSTATE_YMM 4
@@ -204,7 +204,11 @@ inline bool FPREG_HasYmmRegisters(const ucontext_t *uc)
         return false;
     }
 
+#if HAVE__FPX_SW_BYTES_WITH_XSTATE_BV
     return (FPREG_FpxSwBytes(uc)->xstate_bv & XSTATE_YMM) != 0;
+#else
+    return (FPREG_FpxSwBytes(uc)->xfeatures & XSTATE_YMM) != 0;
+#endif
 }
 
 inline void *FPREG_Xstate_Ymmh(const ucontext_t *uc)


### PR DESCRIPTION
* xstate_bv was renamed to xfeatures in torvalds/linux@400e4b2, also
  see https://lore.kernel.org/patchwork/patch/939801/. Added a cmake
  check to detect if old header is available on the build machine.
* Make musl-libc based distro RID detection more permissive by adapting
  condition used by public-facing dotnet-install script:
  https://github.com/dotnet/toolset/blob/a229608/scripts/obtain/dotnet-install.sh#L163