### PR TITLE
Fix reported result in binder tracing for mismatched MVID when loading assembly by path / stream

### DIFF
--- a/src/coreclr/src/binder/bindertracing.cpp
+++ b/src/coreclr/src/binder/bindertracing.cpp
@@ -288,21 +288,27 @@ namespace BinderTracing
 
     // This function simply traces out the two stages represented by the bind result.
     // It does not change the stage/assembly of the ResolutionAttemptedOperation class instance.
-    void ResolutionAttemptedOperation::TraceBindResult(const BindResult &bindResult)
+    void ResolutionAttemptedOperation::TraceBindResult(const BindResult &bindResult, bool mvidMismatch)
     {
         if (!m_tracingEnabled)
             return;
 
-        const BindResult::AttemptResult *attempt = bindResult.GetAttempt(true /*foundInContext*/);
-        if (attempt != nullptr)
-            TraceStage(Stage::FindInLoadContext, attempt->HResult, attempt->Assembly);
+        // Use the error message that would be reported in the file load exception
+        StackSString errorMsg;
+        if (mvidMismatch)
+            errorMsg.LoadResource(CCompRC::Error, IDS_HOST_ASSEMBLY_RESOLVER_ASSEMBLY_ALREADY_LOADED_IN_CONTEXT);
 
-        attempt = bindResult.GetAttempt(false /*foundInContext*/);
-        if (attempt != nullptr)
-            TraceStage(Stage::ApplicationAssemblies, attempt->HResult, attempt->Assembly);
+        const BindResult::AttemptResult *inContextAttempt = bindResult.GetAttempt(true /*foundInContext*/);
+        const BindResult::AttemptResult *appAssembliesAttempt = bindResult.GetAttempt(false /*foundInContext*/);
+
+        if (inContextAttempt != nullptr)
+            TraceStage(Stage::FindInLoadContext, inContextAttempt->HResult, inContextAttempt->Assembly, mvidMismatch && appAssembliesAttempt == nullptr ? errorMsg.GetUnicode() : nullptr);
+
+        if (appAssembliesAttempt != nullptr)
+            TraceStage(Stage::ApplicationAssemblies, appAssembliesAttempt->HResult, appAssembliesAttempt->Assembly, mvidMismatch ? errorMsg.GetUnicode() : nullptr);
     }
 
-    void ResolutionAttemptedOperation::TraceStage(Stage stage, HRESULT hr, BINDER_SPACE::Assembly *resultAssembly)
+    void ResolutionAttemptedOperation::TraceStage(Stage stage, HRESULT hr, BINDER_SPACE::Assembly *resultAssembly, const WCHAR *customError)
     {
         if (!m_tracingEnabled || stage == Stage::NotYetStarted)
             return;
@@ -317,7 +323,12 @@ namespace BinderTracing
 
         Result result;
         StackSString errorMsg;
-        if (!m_exceptionMessage.IsEmpty())
+        if (customError != nullptr)
+        {
+            errorMsg.Set(customError);
+            result = Result::Failure;
+        }
+        else if (!m_exceptionMessage.IsEmpty())
         {
             errorMsg = m_exceptionMessage;
             result = Result::Exception;

--- a/src/coreclr/src/binder/inc/bindertracing.h
+++ b/src/coreclr/src/binder/inc/bindertracing.h
@@ -97,7 +97,7 @@ namespace BinderTracing
         // One of binder ID and managed ALC is expected to be non-zero. If the managed ALC is set, binder ID is ignored.
         ResolutionAttemptedOperation(BINDER_SPACE::AssemblyName *assemblyName, UINT_PTR binderId, INT_PTR managedALC, const HRESULT& hr);
 
-        void TraceBindResult(const BINDER_SPACE::BindResult &bindResult);
+        void TraceBindResult(const BINDER_SPACE::BindResult &bindResult, bool mvidMismatch = false);
 
         void SetFoundAssembly(BINDER_SPACE::Assembly *assembly)
         {
@@ -170,7 +170,7 @@ namespace BinderTracing
         SString m_exceptionMessage;
         BINDER_SPACE::Assembly *m_pFoundAssembly;
 
-        void TraceStage(Stage stage, HRESULT hr, BINDER_SPACE::Assembly *resultAssembly);
+        void TraceStage(Stage stage, HRESULT hr, BINDER_SPACE::Assembly *resultAssembly, const WCHAR *errorMessage = nullptr);
     };
 
     // This must match the BindingPathSource value map in ClrEtwAll.man

--- a/src/coreclr/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/AssemblyToLoad.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if ASSEMBLY_V2
+[assembly: System.Reflection.AssemblyVersion("2.0.0.0")]
+#else
 [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+#endif
 
 namespace AssemblyToLoad
 {

--- a/src/coreclr/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
+++ b/src/coreclr/tests/src/Loader/binding/tracing/AssemblyToLoad.csproj
@@ -5,6 +5,11 @@
     <AssemblyName Condition="'$(AssemblyNameSuffix)'!=''">$(AssemblyName)_$(AssemblyNameSuffix)</AssemblyName>
     <CleanFile>$(AssemblyName).FileListAbsolute.txt</CleanFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AssemblyV2)'=='true'">
+    <OutputPath>$(OutputPath)/v2</OutputPath>
+    <IntermediateOutputPath>$(IntermediateOutputPath)/v2</IntermediateOutputPath>
+    <DefineConstants>$(DefineConstants);ASSEMBLY_V2</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyToLoad.cs" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.csproj
@@ -30,6 +30,12 @@
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </ProjectReference>
+    <ProjectReference Include="AssemblyToLoad.csproj" Link="AssemblyToLoad_V2.dll">
+      <Properties>AssemblyV2=true</Properties>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="MoveDependentAssembliesToSubdirectory" AfterTargets="CopyFilesToOutputDirectory">

--- a/src/coreclr/tests/src/Loader/binding/tracing/Helpers.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/Helpers.cs
@@ -40,6 +40,12 @@ namespace BinderTracingTests
             ValidateNestedBinds(expected.NestedBinds, actual.NestedBinds);
         }
 
+        public static string GetAssemblyInAppPath(string assemblyName)
+        {
+            string appPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            return Path.Combine(appPath, $"{assemblyName}.dll");
+        }
+
         public static string GetAssemblyInSubdirectoryPath(string assemblyName)
         {
             return Path.Combine(GetSubdirectoryPath(), $"{assemblyName}.dll");


### PR DESCRIPTION
Mismatched MVID was being reported as a success before. This makes in report the stage result as a failure with the same error message that is used for the file load exception.