### PR TITLE
Updating genCodeForBinary to be VEX aware

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1336,6 +1336,7 @@ public:
 #if defined(_TARGET_XARCH_)
     void inst_RV_RV_IV(instruction ins, emitAttr size, regNumber reg1, regNumber reg2, unsigned ival);
     void inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenTree* rmOp, int ival);
+    void inst_RV_RV_TT(instruction ins, emitAttr size, regNumber targetReg, regNumber op1Reg, GenTree* op2, bool isRMW);
 #endif
 
     void inst_RV_RR(instruction ins, emitAttr size, regNumber reg1, regNumber reg2);

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -909,6 +909,18 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     regNumber op1reg = op1->isUsedFromReg() ? op1->GetRegNum() : REG_NA;
     regNumber op2reg = op2->isUsedFromReg() ? op2->GetRegNum() : REG_NA;
 
+    if (varTypeIsFloating(treeNode->TypeGet()))
+    {
+        // floating-point addition, subtraction, multiplication, and division
+        // all have RMW semantics if VEX support is not available
+
+        bool isRMW = !compiler->canUseVexEncoding();
+        inst_RV_RV_TT(ins, emitTypeSize(treeNode), targetReg, op1reg, op2, isRMW);
+
+        genProduceReg(treeNode);
+        return;
+    }
+
     GenTree* dst;
     GenTree* src;
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -214,7 +214,6 @@ bool emitter::AreUpper32BitsZero(regNumber reg)
     return false;
 }
 
-#ifdef FEATURE_HW_INTRINSICS
 //------------------------------------------------------------------------
 // IsDstSrcImmAvxInstruction: Checks if the instruction has a "reg, reg/mem, imm" or
 //                            "reg/mem, reg, imm" form for the legacy, VEX, and EVEX
@@ -250,7 +249,6 @@ static bool IsDstSrcImmAvxInstruction(instruction ins)
             return false;
     }
 }
-#endif // FEATURE_HW_INTRINSICS
 
 // -------------------------------------------------------------------
 // Is4ByteSSEInstruction: Returns true if the SSE instruction is a 4-byte opcode.
@@ -5629,7 +5627,6 @@ void emitter::emitIns_AX_R(instruction ins, emitAttr attr, regNumber ireg, regNu
     emitAdjustStackDepthPushPop(ins);
 }
 
-#ifdef FEATURE_HW_INTRINSICS
 //------------------------------------------------------------------------
 // emitIns_SIMD_R_R_I: emits the code for an instruction that takes a register operand, an immediate operand
 //                     and that returns a value in register
@@ -5810,6 +5807,7 @@ void emitter::emitIns_SIMD_R_R_S(
     }
 }
 
+#ifdef FEATURE_HW_INTRINSICS
 //------------------------------------------------------------------------
 // emitIns_SIMD_R_R_A_I: emits the code for a SIMD instruction that takes a register operand, a GenTreeIndir address,
 //                       an immediate operand, and that returns a value in register

--- a/src/coreclr/src/jit/emitxarch.h
+++ b/src/coreclr/src/jit/emitxarch.h
@@ -432,7 +432,6 @@ void emitIns_R_AX(instruction ins, emitAttr attr, regNumber ireg, regNumber reg,
 
 void emitIns_AX_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, unsigned mul, int disp);
 
-#ifdef FEATURE_HW_INTRINSICS
 void emitIns_SIMD_R_R_I(instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, int ival);
 
 void emitIns_SIMD_R_R_A(instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, GenTreeIndir* indir);
@@ -443,6 +442,7 @@ void emitIns_SIMD_R_R_C(
 void emitIns_SIMD_R_R_R(instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, regNumber op2Reg);
 void emitIns_SIMD_R_R_S(instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, int varx, int offs);
 
+#ifdef FEATURE_HW_INTRINSICS
 void emitIns_SIMD_R_R_A_I(
     instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, GenTreeIndir* indir, int ival);
 void emitIns_SIMD_R_R_AR_I(

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -600,11 +600,6 @@ void CodeGen::genHWIntrinsic_R_R_RM(GenTreeHWIntrinsic* node, instruction ins, e
 void CodeGen::genHWIntrinsic_R_R_RM(
     GenTreeHWIntrinsic* node, instruction ins, emitAttr attr, regNumber targetReg, regNumber op1Reg, GenTree* op2)
 {
-    emitter* emit = GetEmitter();
-
-    // TODO-XArch-CQ: Commutative operations can have op1 be contained
-    // TODO-XArch-CQ: Non-VEX encoded instructions can have both ops contained
-
     assert(targetReg != REG_NA);
     assert(op1Reg != REG_NA);
 
@@ -612,121 +607,10 @@ void CodeGen::genHWIntrinsic_R_R_RM(
     {
         assert(HWIntrinsicInfo::SupportsContainment(node->gtHWIntrinsicId));
         assertIsContainableHWIntrinsicOp(compiler->m_pLowering, node, op2);
-
-        TempDsc* tmpDsc = nullptr;
-        unsigned varNum = BAD_VAR_NUM;
-        unsigned offset = (unsigned)-1;
-
-        if (op2->isUsedFromSpillTemp())
-        {
-            assert(op2->IsRegOptional());
-
-            tmpDsc = getSpillTempDsc(op2);
-            varNum = tmpDsc->tdTempNum();
-            offset = 0;
-
-            regSet.tmpRlsTemp(tmpDsc);
-        }
-        else if (op2->isIndir() || op2->OperIsHWIntrinsic())
-        {
-            GenTree*      addr;
-            GenTreeIndir* memIndir = nullptr;
-
-            if (op2->isIndir())
-            {
-                memIndir = op2->AsIndir();
-                addr     = memIndir->Addr();
-            }
-            else
-            {
-                assert(op2->AsHWIntrinsic()->OperIsMemoryLoad());
-                assert(HWIntrinsicInfo::lookupNumArgs(op2->AsHWIntrinsic()) == 1);
-                addr = op2->gtGetOp1();
-            }
-
-            switch (addr->OperGet())
-            {
-                case GT_LCL_VAR_ADDR:
-                {
-                    varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
-                    break;
-                }
-
-                case GT_CLS_VAR_ADDR:
-                {
-                    emit->emitIns_SIMD_R_R_C(ins, attr, targetReg, op1Reg, addr->AsClsVar()->gtClsVarHnd, 0);
-                    return;
-                }
-
-                default:
-                {
-                    GenTreeIndir load = indirForm(op2->TypeGet(), addr);
-
-                    if (memIndir == nullptr)
-                    {
-                        // This is the HW intrinsic load case.
-                        // Until we improve the handling of addressing modes in the emitter, we'll create a
-                        // temporary GT_IND to generate code with.
-                        memIndir = &load;
-                    }
-                    emit->emitIns_SIMD_R_R_A(ins, attr, targetReg, op1Reg, memIndir);
-                    return;
-                }
-            }
-        }
-        else
-        {
-            switch (op2->OperGet())
-            {
-                case GT_LCL_FLD:
-                    varNum = op2->AsLclFld()->GetLclNum();
-                    offset = op2->AsLclFld()->GetLclOffs();
-                    break;
-
-                case GT_LCL_VAR:
-                {
-                    assert(op2->IsRegOptional() ||
-                           !compiler->lvaTable[op2->AsLclVar()->GetLclNum()].lvIsRegCandidate());
-                    varNum = op2->AsLclVar()->GetLclNum();
-                    offset = 0;
-                    break;
-                }
-
-                default:
-                    unreached();
-                    break;
-            }
-        }
-
-        // Ensure we got a good varNum and offset.
-        // We also need to check for `tmpDsc != nullptr` since spill temp numbers
-        // are negative and start with -1, which also happens to be BAD_VAR_NUM.
-        assert((varNum != BAD_VAR_NUM) || (tmpDsc != nullptr));
-        assert(offset != (unsigned)-1);
-
-        emit->emitIns_SIMD_R_R_S(ins, attr, targetReg, op1Reg, varNum, offset);
     }
-    else
-    {
-        regNumber op2Reg = op2->GetRegNum();
 
-        if ((op1Reg != targetReg) && (op2Reg == targetReg) && node->isRMWHWIntrinsic(compiler))
-        {
-            // We have "reg2 = reg1 op reg2" where "reg1 != reg2" on a RMW intrinsic.
-            //
-            // For non-commutative intrinsics, we should have ensured that op2 was marked
-            // delay free in order to prevent it from getting assigned the same register
-            // as target. However, for commutative intrinsics, we can just swap the operands
-            // in order to have "reg2 = reg2 op reg1" which will end up producing the right code.
-
-            noway_assert(node->OperIsCommutative());
-            op2Reg = op1Reg;
-            op1Reg = targetReg;
-        }
-
-        emit->emitIns_SIMD_R_R_R(ins, attr, targetReg, op1Reg, op2Reg);
-    }
+    bool isRMW = node->isRMWHWIntrinsic(compiler);
+    inst_RV_RV_TT(ins, attr, targetReg, op1Reg, op2, isRMW);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -1052,11 +1052,9 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             switch (rmOp->OperGet())
             {
                 case GT_LCL_FLD:
-                {
                     varNum = rmOp->AsLclFld()->GetLclNum();
                     offset = rmOp->AsLclFld()->GetLclOffs();
                     break;
-                }
 
                 case GT_LCL_VAR:
                 {
@@ -1068,10 +1066,7 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
                 }
 
                 default:
-                {
                     unreached();
-                    break;
-                }
             }
         }
 
@@ -1193,7 +1188,7 @@ void CodeGen::inst_RV_RV_TT(
                 case GT_LCL_VAR:
                 {
                     assert(op2->IsRegOptional() ||
-                           !compiler->lvaTable[op2->AsLclVar()->GetLclNum()].lvIsRegCandidate());
+                           !compiler->lvaGetDesc(op2->AsLclVar()->GetLclNum())->lvIsRegCandidate());
                     varNum = op2->AsLclVar()->GetLclNum();
                     offset = 0;
                     break;
@@ -1211,7 +1206,6 @@ void CodeGen::inst_RV_RV_TT(
                 default:
                 {
                     unreached();
-                    break;
                 }
             }
         }

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -963,7 +963,6 @@ void CodeGen::inst_RV_RV_IV(instruction ins, emitAttr size, regNumber reg1, regN
     GetEmitter()->emitIns_R_R_I(ins, size, reg1, reg2, ival);
 }
 
-#ifdef FEATURE_HW_INTRINSICS
 //------------------------------------------------------------------------
 // inst_RV_TT_IV: Generates an instruction that takes 3 operands:
 //                a register operand, an operand that may be memory or register and an immediate
@@ -975,10 +974,6 @@ void CodeGen::inst_RV_RV_IV(instruction ins, emitAttr size, regNumber reg1, regN
 //    reg1      -- The first operand, a register
 //    rmOp      -- The second operand, which may be a memory node or a node producing a register
 //    ival      -- The immediate operand
-//
-// Notes:
-//    This isn't really specific to HW intrinsics, but depends on other methods that are
-//    only defined for FEATURE_HW_INTRINSICS, and is currently only used in that context.
 //
 void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenTree* rmOp, int ival)
 {
@@ -1012,9 +1007,13 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             }
             else
             {
+#if defined(FEATURE_HW_INTRINSICS)
                 assert(rmOp->AsHWIntrinsic()->OperIsMemoryLoad());
                 assert(HWIntrinsicInfo::lookupNumArgs(rmOp->AsHWIntrinsic()) == 1);
                 addr = rmOp->gtGetOp1();
+#else
+                unreached();
+#endif // FEATURE_HW_INTRINSICS
             }
 
             switch (addr->OperGet())
@@ -1053,9 +1052,11 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             switch (rmOp->OperGet())
             {
                 case GT_LCL_FLD:
+                {
                     varNum = rmOp->AsLclFld()->GetLclNum();
                     offset = rmOp->AsLclFld()->GetLclOffs();
                     break;
+                }
 
                 case GT_LCL_VAR:
                 {
@@ -1067,8 +1068,10 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
                 }
 
                 default:
+                {
                     unreached();
                     break;
+                }
             }
         }
 
@@ -1086,8 +1089,161 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
         GetEmitter()->emitIns_SIMD_R_R_I(ins, attr, reg1, rmOpReg, ival);
     }
 }
-#endif // FEATURE_HW_INTRINSICS
 
+//------------------------------------------------------------------------
+// inst_RV_RV_TT: Generates an instruction that takes 2 operands:
+//                a register operand and an operand that may be in memory or register
+//                the result is returned in register
+//
+// Arguments:
+//    ins       -- The instruction being emitted
+//    size      -- The emit size attribute
+//    targetReg -- The target register
+//    op1Reg    -- The first operand register
+//    op2       -- The second operand, which may be a memory node or a node producing a register
+//    isRMW     -- true if the instruction is RMW; otherwise, false
+//
+void CodeGen::inst_RV_RV_TT(
+    instruction ins, emitAttr size, regNumber targetReg, regNumber op1Reg, GenTree* op2, bool isRMW)
+{
+    noway_assert(GetEmitter()->emitVerifyEncodable(ins, EA_SIZE(size), targetReg));
+
+    // TODO-XArch-CQ: Commutative operations can have op1 be contained
+    // TODO-XArch-CQ: Non-VEX encoded instructions can have both ops contained
+
+    if (op2->isContained() || op2->isUsedFromSpillTemp())
+    {
+        TempDsc* tmpDsc = nullptr;
+        unsigned varNum = BAD_VAR_NUM;
+        unsigned offset = (unsigned)-1;
+
+        if (op2->isUsedFromSpillTemp())
+        {
+            assert(op2->IsRegOptional());
+
+            tmpDsc = getSpillTempDsc(op2);
+            varNum = tmpDsc->tdTempNum();
+            offset = 0;
+
+            regSet.tmpRlsTemp(tmpDsc);
+        }
+        else if (op2->isIndir() || op2->OperIsHWIntrinsic())
+        {
+            GenTree*      addr;
+            GenTreeIndir* memIndir = nullptr;
+
+            if (op2->isIndir())
+            {
+                memIndir = op2->AsIndir();
+                addr     = memIndir->Addr();
+            }
+            else
+            {
+#if defined(FEATURE_HW_INTRINSICS)
+                assert(op2->AsHWIntrinsic()->OperIsMemoryLoad());
+                assert(HWIntrinsicInfo::lookupNumArgs(op2->AsHWIntrinsic()) == 1);
+                addr = op2->gtGetOp1();
+#else
+                unreached();
+#endif // FEATURE_HW_INTRINSICS
+            }
+
+            switch (addr->OperGet())
+            {
+                case GT_LCL_VAR_ADDR:
+                {
+                    varNum = addr->AsLclVarCommon()->GetLclNum();
+                    offset = 0;
+                    break;
+                }
+
+                case GT_CLS_VAR_ADDR:
+                {
+                    GetEmitter()->emitIns_SIMD_R_R_C(ins, size, targetReg, op1Reg, addr->AsClsVar()->gtClsVarHnd, 0);
+                    return;
+                }
+
+                default:
+                {
+                    GenTreeIndir load = indirForm(op2->TypeGet(), addr);
+
+                    if (memIndir == nullptr)
+                    {
+                        // This is the HW intrinsic load case.
+                        // Until we improve the handling of addressing modes in the emitter, we'll create a
+                        // temporary GT_IND to generate code with.
+                        memIndir = &load;
+                    }
+                    GetEmitter()->emitIns_SIMD_R_R_A(ins, size, targetReg, op1Reg, memIndir);
+                    return;
+                }
+            }
+        }
+        else
+        {
+            switch (op2->OperGet())
+            {
+                case GT_LCL_FLD:
+                {
+                    varNum = op2->AsLclFld()->GetLclNum();
+                    offset = op2->AsLclFld()->GetLclOffs();
+                    break;
+                }
+
+                case GT_LCL_VAR:
+                {
+                    assert(op2->IsRegOptional() ||
+                           !compiler->lvaTable[op2->AsLclVar()->GetLclNum()].lvIsRegCandidate());
+                    varNum = op2->AsLclVar()->GetLclNum();
+                    offset = 0;
+                    break;
+                }
+
+                case GT_CNS_DBL:
+                {
+                    GenTreeDblCon*       dblCns = op2->AsDblCon();
+                    CORINFO_FIELD_HANDLE cnsDblHnd =
+                        GetEmitter()->emitFltOrDblConst(dblCns->gtDconVal, emitTypeSize(dblCns));
+                    GetEmitter()->emitIns_SIMD_R_R_C(ins, size, targetReg, op1Reg, cnsDblHnd, 0);
+                    return;
+                }
+
+                default:
+                {
+                    unreached();
+                    break;
+                }
+            }
+        }
+
+        // Ensure we got a good varNum and offset.
+        // We also need to check for `tmpDsc != nullptr` since spill temp numbers
+        // are negative and start with -1, which also happens to be BAD_VAR_NUM.
+        assert((varNum != BAD_VAR_NUM) || (tmpDsc != nullptr));
+        assert(offset != (unsigned)-1);
+
+        GetEmitter()->emitIns_SIMD_R_R_S(ins, size, targetReg, op1Reg, varNum, offset);
+    }
+    else
+    {
+        regNumber op2Reg = op2->GetRegNum();
+
+        if ((op1Reg != targetReg) && (op2Reg == targetReg) && isRMW)
+        {
+            // We have "reg2 = reg1 op reg2" where "reg1 != reg2" on a RMW instruction.
+            //
+            // For non-commutative instructions, we should have ensured that op2 was marked
+            // delay free in order to prevent it from getting assigned the same register
+            // as target. However, for commutative instructions, we can just swap the operands
+            // in order to have "reg2 = reg2 op reg1" which will end up producing the right code.
+
+            op2Reg = op1Reg;
+            op1Reg = targetReg;
+        }
+
+        GetEmitter()->emitIns_SIMD_R_R_R(ins, size, targetReg, op1Reg, op2Reg);
+    }
+}
 #endif // _TARGET_XARCH_
 
 /*****************************************************************************

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -787,9 +787,22 @@ bool LinearScan::isRMWRegOper(GenTree* tree)
 #endif
             return false;
 
+        case GT_ADD:
+        case GT_SUB:
+        case GT_DIV:
+        {
+            return !varTypeIsFloating(tree->TypeGet()) || !compiler->canUseVexEncoding();
+        }
+
         // x86/x64 does support a three op multiply when op2|op1 is a contained immediate
         case GT_MUL:
+        {
+            if (varTypeIsFloating(tree->TypeGet()))
+            {
+                return !compiler->canUseVexEncoding();
+            }
             return (!tree->gtGetOp2()->isContainedIntOrIImmed() && !tree->gtGetOp1()->isContainedIntOrIImmed());
+        }
 
 #ifdef FEATURE_HW_INTRINSICS
         case GT_HWINTRINSIC:


### PR DESCRIPTION
This is a rough draft attempt at resolving https://github.com/dotnet/runtime/issues/1342

This essentially just moves some of the `genHWIntrinsic_R_R_RM` logic into a `inst_RV_RV_TT` method and updates `genCodeForBinary` to call it for floating-point types if `FEATURE_HW_INTRINSICS` is defined.

As can be seen below, the numbers are overall fairly promising.

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -3270 (-0.01% of base)
    diff is an improvement.

Top file regressions (bytes):
          39 : System.Drawing.Primitives.dasm (0.10% of base)

Top file improvements (bytes):
       -2496 : System.Private.CoreLib.dasm (-0.05% of base)
        -266 : System.Runtime.Numerics.dasm (-0.37% of base)
        -178 : System.Linq.Parallel.dasm (-0.01% of base)
        -113 : System.Data.Common.dasm (-0.01% of base)
        -108 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.00% of base)
         -64 : System.Linq.dasm (-0.01% of base)
         -40 : System.Private.Xml.dasm (-0.00% of base)
         -16 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -16 : Newtonsoft.Json.dasm (-0.00% of base)
          -8 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
          -4 : Microsoft.CSharp.dasm (-0.00% of base)

12 total files with Code Size differences (11 improved, 1 regressed), 97 unchanged.

Top method regressions (bytes):
          25 ( 6.60% of base) : System.Drawing.Primitives.dasm - RectangleF:Intersect(RectangleF,RectangleF):RectangleF
          22 ( 3.72% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ThreadTimeStackComputer:AddUnkownAsyncDurationIfNeeded(StartStopActivity,double,TraceEvent):this
          22 ( 7.61% of base) : System.Drawing.Primitives.dasm - RectangleF:Union(RectangleF,RectangleF):RectangleF
          16 ( 2.86% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - SampleProfilerThreadTimeComputer:AddUnkownAsyncDurationIfNeeded(StartStopActivity,double,TraceEvent):this
          15 ( 1.86% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:FoldFloatingBinaryOperator(int,ConstantValue,ConstantValue,TypeSymbol,TypeSymbol):ConstantValue
          12 ( 0.68% of base) : System.Private.CoreLib.dasm - DateTimeParse:ParseFormatO(ReadOnlySpan`1,byref):bool
          12 ( 5.04% of base) : System.Private.Xml.dasm - XsdDateTime:.ctor(DateTimeOffset,int):this
           4 ( 1.01% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StartStopActivityComputer:GetCurrentStartStopActivityStack(MutableTraceEventStackSource,TraceThread,TraceThread,bool):int:this

Top method improvements (bytes):
        -384 (-13.55% of base) : System.Private.CoreLib.dasm - CalendricalCalculationsHelper:SumLongSequenceOfPeriodicTerms(double):double
        -338 (-13.56% of base) : System.Private.CoreLib.dasm - Matrix4x4:Invert(Matrix4x4,byref):bool
        -134 (-15.06% of base) : System.Private.CoreLib.dasm - Matrix4x4:Transform(Matrix4x4,Quaternion):Matrix4x4
         -88 (-9.24% of base) : System.Runtime.Numerics.dasm - Complex:Asin_Internal(double,double,byref,byref,byref)
         -65 (-13.32% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateFromQuaternion(Quaternion):Matrix4x4
         -60 (-11.21% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateFromAxisAngle(Vector3,float):Matrix4x4
         -59 (-10.42% of base) : System.Private.CoreLib.dasm - Quaternion:Slerp(Quaternion,Quaternion,float):Quaternion
         -57 (-9.79% of base) : System.Private.CoreLib.dasm - Quaternion:Lerp(Quaternion,Quaternion,float):Quaternion
         -52 (-10.00% of base) : System.Private.CoreLib.dasm - Matrix4x4:GetDeterminant():float:this
         -52 (-11.98% of base) : System.Private.CoreLib.dasm - Quaternion:Divide(Quaternion,Quaternion):Quaternion
         -52 (-11.98% of base) : System.Private.CoreLib.dasm - Quaternion:op_Division(Quaternion,Quaternion):Quaternion
         -50 (-11.63% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector3,Quaternion):Vector4
         -48 (-13.75% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Matrix4x4):Plane
         -48 (-16.55% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector4,Matrix4x4):Vector4
         -48 (-14.55% of base) : System.Runtime.Numerics.dasm - Complex:Tan(Complex):Complex
         -47 (-10.63% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Quaternion):Plane
         -43 (-10.17% of base) : System.Private.CoreLib.dasm - Vector3:Transform(Vector3,Quaternion):Vector3
         -43 (-9.60% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector4,Quaternion):Vector4
         -40 (-7.84% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateShadow(Vector3,Plane):Matrix4x4
         -40 (-8.62% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateReflection(Plane):Matrix4x4

Top method regressions (percentages):
          22 ( 7.61% of base) : System.Drawing.Primitives.dasm - RectangleF:Union(RectangleF,RectangleF):RectangleF
          25 ( 6.60% of base) : System.Drawing.Primitives.dasm - RectangleF:Intersect(RectangleF,RectangleF):RectangleF
          12 ( 5.04% of base) : System.Private.Xml.dasm - XsdDateTime:.ctor(DateTimeOffset,int):this
          22 ( 3.72% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - ThreadTimeStackComputer:AddUnkownAsyncDurationIfNeeded(StartStopActivity,double,TraceEvent):this
          16 ( 2.86% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - SampleProfilerThreadTimeComputer:AddUnkownAsyncDurationIfNeeded(StartStopActivity,double,TraceEvent):this
          15 ( 1.86% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - OverloadResolution:FoldFloatingBinaryOperator(int,ConstantValue,ConstantValue,TypeSymbol,TypeSymbol):ConstantValue
           4 ( 1.01% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - StartStopActivityComputer:GetCurrentStartStopActivityStack(MutableTraceEventStackSource,TraceThread,TraceThread,bool):int:this
          12 ( 0.68% of base) : System.Private.CoreLib.dasm - DateTimeParse:ParseFormatO(ReadOnlySpan`1,byref):bool

Top method improvements (percentages):
         -12 (-21.05% of base) : System.Private.CoreLib.dasm - Quaternion:Multiply(Quaternion,float):Quaternion
         -12 (-21.05% of base) : System.Private.CoreLib.dasm - Quaternion:op_Multiply(Quaternion,float):Quaternion
         -20 (-17.09% of base) : System.Private.CoreLib.dasm - Matrix3x2:Multiply(Matrix3x2,float):Matrix3x2
         -20 (-17.09% of base) : System.Private.CoreLib.dasm - Matrix3x2:op_Multiply(Matrix3x2,float):Matrix3x2
         -48 (-16.55% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector4,Matrix4x4):Vector4
         -16 (-15.53% of base) : System.Private.Xml.dasm - NumericExpr:GetValue(int,double,double):double
          -4 (-15.38% of base) : Newtonsoft.Json.dasm - JsonValidatingReader:FloatingPointRemainder(double,double):double
          -4 (-15.38% of base) : System.Private.CoreLib.dasm - CalendricalCalculationsHelper:Reminder(double,double):double
        -134 (-15.06% of base) : System.Private.CoreLib.dasm - Matrix4x4:Transform(Matrix4x4,Quaternion):Matrix4x4
         -36 (-14.69% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector3,Matrix4x4):Vector4
         -48 (-14.55% of base) : System.Runtime.Numerics.dasm - Complex:Tan(Complex):Complex
         -24 (-14.46% of base) : System.Private.CoreLib.dasm - Vector3:TransformNormal(Vector3,Matrix4x4):Vector3
          -8 (-14.04% of base) : System.Private.CoreLib.dasm - CalendricalCalculationsHelper:AsLocalTime(double,double):double
          -4 (-13.79% of base) : System.Runtime.Numerics.dasm - Complex:Scale(Complex,double):Complex
         -48 (-13.75% of base) : System.Private.CoreLib.dasm - Plane:Transform(Plane,Matrix4x4):Plane
        -338 (-13.56% of base) : System.Private.CoreLib.dasm - Matrix4x4:Invert(Matrix4x4,byref):bool
        -384 (-13.55% of base) : System.Private.CoreLib.dasm - CalendricalCalculationsHelper:SumLongSequenceOfPeriodicTerms(double):double
         -24 (-13.48% of base) : System.Private.CoreLib.dasm - Vector4:Transform(Vector2,Matrix4x4):Vector4
         -65 (-13.32% of base) : System.Private.CoreLib.dasm - Matrix4x4:CreateFromQuaternion(Quaternion):Matrix4x4
         -16 (-13.22% of base) : System.Private.CoreLib.dasm - Quaternion:Normalize(Quaternion):Quaternion

171 total methods with Code Size differences (163 improved, 8 regressed), 201419 unchanged.
```