### PR TITLE
improve ALPN handling

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -846,13 +846,6 @@ namespace System.Net.Security
             }
 
             output = result;
-            if (_negotiatedApplicationProtocol == default)
-            {
-                // try to get ALPN info unless we already have it. (this function can be called multiple times)
-                byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
-                _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
-            }
-
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Exit(this);
@@ -872,6 +865,13 @@ namespace System.Net.Security
         {
             if (NetEventSource.IsEnabled)
                 NetEventSource.Enter(this);
+
+            if (_negotiatedApplicationProtocol == default)
+            {
+                // try to get ALPN info unless we already have it. (renegotiation)
+                byte[] alpnResult = SslStreamPal.GetNegotiatedApplicationProtocol(_securityContext);
+                _negotiatedApplicationProtocol = alpnResult == null ? default : new SslApplicationProtocol(alpnResult, false);
+            }
 
             SslStreamPal.QueryContextStreamSizes(_securityContext, out StreamSizes streamSizes);
 


### PR DESCRIPTION
There seems to be no reason why we need to call ALPN processing  code multiple times in GenerateToken(). User has no access to it anyway until handshake is done. This change moves it to ProcessHandshakeSuccess() so it is called once.  (before remote certificate callback)