### PR TITLE
decrease allocations during ssl handshake

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -283,14 +283,14 @@ internal static partial class Interop
                 }
             }
 
-            sendCount = Crypto.BioCtrlPending(context.OutputBio);
-            if (sendCount > 0)
+            int pendingCount = Crypto.BioCtrlPending(context.OutputBio);
+            if (pendingCount > 0)
             {
-                sendBuf = new byte[sendCount];
+                sendBuf = ArrayPool<byte>.Shared.Rent(pendingCount);
 
                 try
                 {
-                    sendCount = BioRead(context.OutputBio, sendBuf, sendCount);
+                    sendCount = BioRead(context.OutputBio, sendBuf, pendingCount);
                 }
                 catch (Exception) when (handshakeException != null)
                 {
@@ -300,6 +300,7 @@ internal static partial class Interop
                 {
                     if (sendCount <= 0)
                     {
+                        ArrayPool<byte>.Shared.Return(sendBuf);
                         // Make sure we clear out the error that is stored in the queue
                         Crypto.ErrClearError();
                         sendBuf = null;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -1282,7 +1282,6 @@ namespace System.Net.Security
         internal SecurityStatusPal Status;
         internal int Size;
         private byte[] _payload;
-        //internal byte[] Payload;
 
         internal byte[] Payload
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -376,7 +376,6 @@ namespace System.Net.Security
                 if (message.Size > 0)
                 {
                     // If there is message send it out even if call failed. It may contain TLS Alert.
-                    //Console.WriteLine("Writing second {0} bytes of data {1}", message.Size, _context.GetHashCode());
                     await InnerStream.WriteAsync(message.Payload, 0, message.Size, cancellationToken).ConfigureAwait(false);
                     message.Reset();
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -284,6 +284,7 @@ namespace System.Net.Security
             }
             catch (Exception exc)
             {
+                size = 0;
                 return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, exc);
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -27,6 +27,7 @@ namespace System.Net.Security
         // Since ST is not producing the framed empty message just call this false and avoid the
         // special case of an empty array being passed to the `fixed` statement.
         internal const bool CanEncryptEmptyMessage = false;
+        internal const bool RentsBufferForHanshake = false;
 
         public static void VerifyPackageInfo()
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -38,9 +38,10 @@ namespace System.Net.Security
             ref SafeDeleteSslContext context,
             byte[] inputBuffer, int offset, int count,
             ref byte[] outputBuffer,
+            ref int size,
             SslAuthenticationOptions sslAuthenticationOptions)
         {
-            return HandshakeInternal(credential, ref context, new ReadOnlySpan<byte>(inputBuffer, offset, count), ref outputBuffer, sslAuthenticationOptions);
+            return HandshakeInternal(credential, ref context, new ReadOnlySpan<byte>(inputBuffer, offset, count), ref outputBuffer, ref size, sslAuthenticationOptions);
         }
 
         public static SecurityStatusPal InitializeSecurityContext(
@@ -49,9 +50,10 @@ namespace System.Net.Security
             string targetName,
             byte[] inputBuffer, int offset, int count,
             ref byte[] outputBuffer,
+            ref int size,
             SslAuthenticationOptions sslAuthenticationOptions)
         {
-            return HandshakeInternal(credential, ref context, new ReadOnlySpan<byte>(inputBuffer, offset, count), ref outputBuffer, sslAuthenticationOptions);
+            return HandshakeInternal(credential, ref context, new ReadOnlySpan<byte>(inputBuffer, offset, count), ref outputBuffer, ref size, sslAuthenticationOptions);
         }
 
         public static SafeFreeCredentials AcquireCredentialsHandle(
@@ -236,6 +238,7 @@ namespace System.Net.Security
             ref SafeDeleteSslContext context,
             ReadOnlySpan<byte> inputBuffer,
             ref byte[] outputBuffer,
+            ref int size,
             SslAuthenticationOptions sslAuthenticationOptions)
         {
             Debug.Assert(!credential.IsInvalid);
@@ -275,6 +278,8 @@ namespace System.Net.Security
                 }
 
                 outputBuffer = sslContext.ReadPendingWrites();
+                size = outputBuffer == null ? 0 : outputBuffer.Length;
+
                 return status;
             }
             catch (Exception exc)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -47,7 +47,7 @@ namespace System.Net.Security
             return Interop.Sec_Application_Protocols.ToByteArray(protocols);
         }
 
-        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteSslContext context, byte[] inputBuffer, int offset, int count, ref byte[] outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
+        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteSslContext context, byte[] inputBuffer, int offset, int count, ref byte[] outputBuffer, ref int size, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Interop.SspiCli.ContextFlags unusedAttributes = default;
             ArraySegment<byte> input = inputBuffer != null ? new ArraySegment<byte>(inputBuffer, offset, count) : default;
@@ -72,10 +72,11 @@ namespace System.Net.Security
                 ref unusedAttributes);
 
             outputBuffer = resultBuffer.token;
+            size = outputBuffer == null ? 0 : outputBuffer.Length;
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 
-        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteSslContext context, string targetName, byte[] inputBuffer, int offset, int count, ref byte[] outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
+        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credentialsHandle, ref SafeDeleteSslContext context, string targetName, byte[] inputBuffer, int offset, int count, ref byte[] outputBuffer, ref int size, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Interop.SspiCli.ContextFlags unusedAttributes = default;
             ArraySegment<byte> input = inputBuffer != null ? new ArraySegment<byte>(inputBuffer, offset, count) : default;
@@ -101,6 +102,7 @@ namespace System.Net.Security
                             ref unusedAttributes);
 
             outputBuffer = resultBuffer.token;
+            size = outputBuffer == null ? 0 : outputBuffer.Length;
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -35,6 +35,7 @@ namespace System.Net.Security
 
         internal const bool StartMutualAuthAsAnonymous = true;
         internal const bool CanEncryptEmptyMessage = true;
+        internal const bool RentsBufferForHanshake = false;
 
         public static void VerifyPackageInfo()
         {


### PR DESCRIPTION
The test I'm using is essentially handshake test from Performance repo with one round of setup and 1000 test iterations:
``` c#
for (int i = 0; i < max; i++)
{
    using (var sslClient = new SslStream(_client, leaveInnerStreamOpen: true, delegate { return true; }))
    using (var sslServer = new SslStream(_server, leaveInnerStreamOpen: true, delegate { return true; }))
    {
        await Task.WhenAll(
        sslClient.AuthenticateAsClientAsync("localhost", null, SslProtocols.None, checkCertificateRevocation: false),
        sslServer.AuthenticateAsServerAsync(_cert, clientCertificateRequired: false, SslProtocols.None, checkCertificateRevocation: false));

        // Workaround for corefx#37765
        await sslServer.WriteAsync(_serverBuffer, CancellationToken.None);
        await sslClient.ReadAsync(_clientBuffer, CancellationToken.None);     
    }
}

```


When running with OpenSSL we get following allocations: 

![image](https://user-images.githubusercontent.com/14356188/71872959-bb306d80-30d2-11ea-87a0-cced6cc2c3a5.png)

There are two parts in this change: 

ProtocolToken is container to hold status and buffer. It can be allocated once and reused. That brings 5 allocation to 1. We may possibly convert it to struct in future. 

We already use shared buffers for encryption.decryption. Wit this change we will also use it for outgoing handshake messages when openssl is used.  
