### PR TITLE
Fix stack overflow in PhysicalAddress.TryParse taking out CI

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -121,7 +121,7 @@ namespace System.Net.NetworkInformation
                 return true;
             }
 
-            return TryParse(address, out value);
+            return TryParse(address.AsSpan(), out value);
         }
 
         public static bool TryParse(ReadOnlySpan<char> address, out PhysicalAddress value)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/1386
https://github.com/dotnet/runtime/pull/1057 was merged with an erroneous recursive call.
cc: @alnikola, @wfurt 