### PR TITLE
Fix GC heap corruption on ARM

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -15186,7 +15186,7 @@ allocate_in_free:
 #else // FEATURE_STRUCTALIGN
         if (!((old_loc == 0) || same_large_alignment_p (old_loc, result+pad)))
         {
-            pad += switch_alignment_size (is_plug_padded (old_loc));
+            pad += switch_alignment_size (pad != 0);
             set_node_realigned (old_loc);
             dprintf (3, ("Allocation realignment old_loc: %Ix, new_loc:%Ix",
                          (size_t)old_loc, (size_t)(result+pad)));


### PR DESCRIPTION
The `allocate_in_free` code path in the `allocate_in_expanded_heap` function would incorrectly calculate the large (double) alignment padding size when limiting the plug size (`SHORT_PLUGS`) if `set_padding_on_saved_p` was `true`:
```C++
set_padding_in_expand (old_loc, set_padding_on_saved_p, pinned_plug_entry); // Sets the padding flag on the saved plug
...
pad += switch_alignment_size (is_plug_padded (old_loc)); // Reads the padding flag from the old (different!) plug
```
That caused access violation during a later heap walk since the `g_gc_pFreeObjectMethodTable` pointer marking the gap was not placed at the right address.