### PR TITLE
Add Connect Callback to SocketsHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -21,6 +21,7 @@ namespace System.Net.Http
         Manual = 0,
         Automatic = 1,
     }
+    public delegate System.Threading.Tasks.ValueTask<System.IO.Stream> ConnectCallback(string host, int port, System.Threading.CancellationToken cancellationToken);
     public abstract partial class DelegatingHandler : System.Net.Http.HttpMessageHandler
     {
         protected DelegatingHandler() { }
@@ -264,6 +265,7 @@ namespace System.Net.Http
         public SocketsHttpHandler() { }
         public bool AllowAutoRedirect { get { throw null; } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
+        public ConnectCallback ConnectCallback { get { throw null; } set { } }
         public System.TimeSpan ConnectTimeout { get { throw null; } set { } }
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
         public System.Net.ICredentials Credentials { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -41,6 +41,7 @@
     <Compile Include="System\Net\Http\NetEventSource.Http.cs" />
     <Compile Include="System\Net\Http\ReadOnlyMemoryContent.cs" />
     <Compile Include="System\Net\Http\RequestRetryType.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectCallback.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectCallback.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectCallback.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    public delegate ValueTask<Stream> ConnectCallback(string host, int port, CancellationToken cancellationToken);
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -41,6 +41,7 @@ namespace System.Net.Http
         internal TimeSpan _pooledConnectionIdleTimeout = HttpHandlerDefaults.DefaultPooledConnectionIdleTimeout;
         internal TimeSpan _expect100ContinueTimeout = HttpHandlerDefaults.DefaultExpect100ContinueTimeout;
         internal TimeSpan _connectTimeout = HttpHandlerDefaults.DefaultConnectTimeout;
+        internal ConnectCallback _connectCallback;
 
         internal Version _maxHttpVersion;
 
@@ -94,6 +95,7 @@ namespace System.Net.Http
                 _useCookies = _useCookies,
                 _useProxy = _useProxy,
                 _allowUnencryptedHttp2 = _allowUnencryptedHttp2,
+                _connectCallback = _connectCallback,
             };
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -238,6 +238,16 @@ namespace System.Net.Http
             }
         }
 
+        public ConnectCallback ConnectCallback
+        {
+            get => _settings._connectCallback;
+            set
+            {
+                CheckDisposedOrStarted();
+                _settings._connectCallback = value;
+            }
+        }
+
         public TimeSpan ConnectTimeout
         {
             get => _settings._connectTimeout;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -66,7 +66,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     byte[] postData = new byte[numBytes];
-                    while (!string.IsNullOrEmpty(await connection.ReadLineAsync().ConfigureAwait(false)));
+                    while (!string.IsNullOrEmpty(await connection.ReadLineAsync().ConfigureAwait(false))) ;
                     Assert.Equal(numBytes, await connection.ReadBlockAsync(postData, 0, numBytes));
 
                     await connection.Writer.WriteAsync(responseText).ConfigureAwait(false);


### PR DESCRIPTION
This allows to leverage the whole .net http client logic, including
connection pooling, http2, ssl, etc. on top of non TCP connections.

The typical use case would be to connect to an http server listening on
a Unix domain socket or a Windows Named Pipe. This would also come handy
for running integration tests between microservices without having to
open TCP connections.

This implements the design described here: https://github.com/dotnet/corefx/issues/35404

I has been used successfully in an internal hackathon where I ported Docker Desktop to .net Core :)

cc @karelz, @stephentoub