### PR TITLE
Disable failing BasicTest_AccessInstanceProperties_NoExceptions_Bsd test

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -85,6 +85,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
+        [ActiveIssue(1332)]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()


### PR DESCRIPTION
This is taking out a bunch of PRs. Disabling.
https://github.com/dotnet/runtime/issues/1332
cc: @wfurt