### PR TITLE
Fix fat call transform for x86

### DIFF
--- a/src/coreclr/src/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/src/jit/indirectcalltransformer.cpp
@@ -439,7 +439,14 @@ private:
                 fatCall->gtCallArgs = compiler->gtPrependNewCallArg(hiddenArgument, fatCall->gtCallArgs);
             }
 #else
-            AddArgumentToTail(fatCall->gtCallArgs, hiddenArgument);
+            if (fatCall->gtCallArgs == nullptr)
+            {
+                fatCall->gtCallArgs = compiler->gtNewCallArgs(hiddenArgument);
+            }
+            else
+            {
+                AddArgumentToTail(fatCall->gtCallArgs, hiddenArgument);
+            }
 #endif
         }
 


### PR DESCRIPTION
`AddArgumentToTail` with a null first argument will AV.

I *think* this also works with methods that take a return buffer (methods that return large structs), but might require a pair of eyes more experienced in this codebase.