### PR TITLE
Relax some asserts in SpanHelpers.T.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -405,12 +405,22 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOf<T>(this Span<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOf(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    span.Length,
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    value.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                    return SpanHelpers.LastIndexOf(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
+                        value.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(char))
+                    return SpanHelpers.LastIndexOf(
+                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(value)),
+                        value.Length);
+            }
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(value), value.Length);
         }
@@ -550,12 +560,22 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value) where T : IEquatable<T>
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOf(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    span.Length,
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
-                    value.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                    return SpanHelpers.LastIndexOf(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
+                        value.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(char))
+                    return SpanHelpers.LastIndexOf(
+                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(value)),
+                        value.Length);
+            }
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(value), value.Length);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -897,8 +897,13 @@ namespace System
                     break;
 
                 // Found the first element of "value". See if the tail matches.
-                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, relativeIndex + 1), ref valueTail, valueTailLength))
+                if (SequenceEqual(
+                    ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, relativeIndex + 1)),
+                    ref Unsafe.As<char, byte>(ref valueTail),
+                    (nuint)valueTailLength * 2))
+                {
                     return relativeIndex;  // The tail matched. Return a successful find.
+                }
 
                 index += remainingSearchSpaceLength - relativeIndex;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -456,6 +456,9 @@ namespace System
 
         public static int LastIndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength) where T : IEquatable<T>
         {
+            // The optimized implementation should be used for these types
+            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || !(Unsafe.SizeOf<T>() == sizeof(byte) || Unsafe.SizeOf<T>() == sizeof(char)));
+
             Debug.Assert(searchSpaceLength >= 0);
             Debug.Assert(valueLength >= 0);
 
@@ -574,8 +577,8 @@ namespace System
 
         public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, int length) where T : IEquatable<T>
         {
-            // The optimized implementation should be used for these types
-            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || !(Unsafe.SizeOf<T>() == sizeof(byte) || Unsafe.SizeOf<T>() == sizeof(char)));
+            // The optimized implementation should be used for byte
+            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || Unsafe.SizeOf<T>() != sizeof(byte));
 
             Debug.Assert(length >= 0);
 
@@ -680,8 +683,8 @@ namespace System
 
         public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : IEquatable<T>
         {
-            // The optimized implementation should be used for these types
-            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || !(Unsafe.SizeOf<T>() == sizeof(byte) || Unsafe.SizeOf<T>() == sizeof(char)));
+            // The optimized implementation should be used for byte
+            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || Unsafe.SizeOf<T>() != sizeof(byte));
 
             Debug.Assert(length >= 0);
 
@@ -786,8 +789,8 @@ namespace System
 
         public static int LastIndexOfAny<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength) where T : IEquatable<T>
         {
-            // The optimized implementation should be used for these types
-            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || !(Unsafe.SizeOf<T>() == sizeof(byte) || Unsafe.SizeOf<T>() == sizeof(char)));
+            // The optimized implementation should be used for byte
+            Debug.Assert(!RuntimeHelpers.IsBitwiseEquatable<T>() || Unsafe.SizeOf<T>() != sizeof(byte));
 
             Debug.Assert(searchSpaceLength >= 0);
             Debug.Assert(valueLength >= 0);


### PR DESCRIPTION
I saw the following assert failure in System.Memory.Tests

```
  Starting:    System.Memory.Tests (parallel test collections = off, max threads = 12)
Process terminated. Assertion failed.
   at System.SpanHelpers.LastIndexOf[T](T& searchSpace, T value, Int32 length) in C:\dev\dotnet\runtime\src\libraries\System.Private.CoreLib\src\System\SpanHelpers.T.cs:line 494
   at System.SpanHelpers.LastIndexOf[T](T& searchSpace, Int32 searchSpaceLength, T& value, Int32 valueLength) in C:\dev\dotnet\runtime\src\libraries\System.Private.CoreLib\src\System\SpanHelpers.T.cs:line 478
   at System.SpanTests.SpanTests.LastIndexOfSequenceLengthOneValue_Char() in C:\dev\dotnet\runtime\src\libraries\System.Memory\tests\Span\LastIndexOfSequence.char.cs:line 99
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) in C:\dev\dotnet\runtime\src\coreclr\src\System.Private.CoreLib\src\System\Reflection\RuntimeMethodInfo.cs:line 391
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) in C:\dev\dotnet\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBase.cs:line 50
   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass48_1.<<InvokeTestMethodAsync>b__1>d.MoveNext() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 257
   ...
```

Because of the aggressive inlining, MemoryExtensions.LastIndexOf (a public extension method on Span) doesn't show up in the stack trace, but that's what was calling into the generic SpanHelpers.LastIndexOf method instead of a char-specialized version. I fixed MemoryExtensions.LastIndexOf to call a newly-added char-specialized SpanHelpers.LastIndexOf method.

I also noticed that here are no char-specialized SpanHelpers.LastIndexOfAny methods, so I relaxed the asserts in the generic SpanHelpers.LastIndexOfAny methods.

@jkotas This is a follow up to #1200. Is there an easy way to discover if there are any more assert failures before merging?

