### PR TITLE
Use copy_file_range(2) to implement System.Native.CopyFile()

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CopyFile", SetLastError = true)]
-        internal static extern int CopyFile(SafeFileHandle source, string srcPath, string destPath, int overwrite);
+        internal static extern int CopyFile(string srcPath, string destPath, int overwrite);
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_io.h
+++ b/src/libraries/Native/Unix/System.Native/pal_io.h
@@ -668,10 +668,12 @@ PALEXPORT int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bu
 
 /**
  * Copies all data from the source file descriptor/path to the destination file path.
+ * Obtains a exclusive advisory lock on the input file while the copy is being performed.
  *
- * Returns 0 on success; otherwise, returns -1 and sets errno.
+ * Returns 0 on success; otherwise, set errno and returns a positive integer if copying failed,
+ * and a negative integer if locking failed.
  */
-PALEXPORT int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char* destPath, int32_t overwrite);
+PALEXPORT int32_t SystemNative_CopyFile(const char* srcPath, const char* destPath, int32_t overwrite);
 
 /**
 * Initializes a new inotify instance and returns a file

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -21,30 +21,31 @@ namespace System.IO
             }
 
             // Copy the contents of the file from the source to the destination, creating the destination in the process
-            using (var src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.None))
+            int result = Interop.Sys.CopyFile(sourceFullPath, destFullPath, overwrite ? 1 : 0);
+
+            if (result != 0)
             {
-                int result = Interop.Sys.CopyFile(src.SafeFileHandle, sourceFullPath, destFullPath, overwrite ? 1 : 0);
+                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
 
-                if (result < 0)
-                {
-                    Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                // If we fail to open the file due to a path not existing, we need to know whether to blame
+                // the file itself or its directory.  If we're creating the file, then we blame the directory,
+                // otherwise we blame the file.
+                //
+                // When opening, we need to align with Windows, which considers a missing path to be
+                // FileNotFound only if the containing directory exists.
 
-                    // If we fail to open the file due to a path not existing, we need to know whether to blame
-                    // the file itself or its directory.  If we're creating the file, then we blame the directory,
-                    // otherwise we blame the file.
-                    //
-                    // When opening, we need to align with Windows, which considers a missing path to be
-                    // FileNotFound only if the containing directory exists.
+                // Source file is locked by the PAL, and locking can fail (e.g. if we can't open the source
+                // file).  A negative result means the PAL couldn't lock the file; a positive means it couldn't
+                // copy the file.
+                var pathToBlame = result < 0 ? sourceFullPath : destFullPath;
+                bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
+                    (overwrite || !DirectoryExists(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(pathToBlame))!));
 
-                    bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
-                        (overwrite || !DirectoryExists(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(destFullPath))!));
-
-                    Interop.CheckIo(
-                        error.Error,
-                        destFullPath,
-                        isDirectory,
-                        errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
-                }
+                Interop.CheckIo(
+                    error.Error,
+                    destFullPath,
+                    isDirectory,
+                    errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
             }
         }
 


### PR DESCRIPTION
From the man page:

       The  copy_file_range()  system  call performs an in-kernel
       copy between two file descriptors without the addi‐ tional
       cost of transferring data from the kernel to user space and
       then back into the kernel.

       (...)

       copy_file_range()  gives  filesystems  an opportunity to
       implement "copy acceleration" techniques, such as the use of
       reflinks (i.e., two or more inodes that share pointers to the
       same copy-on-write disk blocks) or server-side-copy (in the
       case of NFS).

This builds on the work by @filipnavara to copy files using `clonefile()` on macOS and on my previous PR in the [corefx repo](https://github.com/dotnet/corefx/pull/39235).