### PR TITLE
improve cert validation diagnostic on  OSX

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -135,7 +135,8 @@ internal static partial class Interop
         private static extern int AppleCryptoNative_SslIsHostnameMatch(
             SafeSslHandle handle,
             SafeCreateHandle cfHostname,
-            SafeCFDateHandle cfValidTime);
+            SafeCFDateHandle cfValidTime,
+            out int pOSStatus);
 
         [DllImport(Interop.Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SslShutdown")]
         internal static extern int SslShutdown(SafeSslHandle sslHandle);
@@ -371,7 +372,7 @@ internal static partial class Interop
             }
         }
 
-        public static bool SslCheckHostnameMatch(SafeSslHandle handle, string hostName, DateTime notBefore)
+        public static bool SslCheckHostnameMatch(SafeSslHandle handle, string hostName, DateTime notBefore, out int osStatus)
         {
             int result;
             // The IdnMapping converts Unicode input into the IDNA punycode sequence.
@@ -388,7 +389,7 @@ internal static partial class Interop
             using (SafeCFDateHandle cfNotBefore = CoreFoundation.CFDateCreate(notBefore))
             using (SafeCreateHandle cfHostname = CoreFoundation.CFStringCreateWithCString(matchName))
             {
-                result = AppleCryptoNative_SslIsHostnameMatch(handle, cfHostname, cfNotBefore);
+                result = AppleCryptoNative_SslIsHostnameMatch(handle, cfHostname, cfNotBefore, out osStatus);
             }
 
             switch (result)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -399,6 +399,8 @@ internal static partial class Interop
                 case 1:
                     return true;
                 default:
+                    if (System.Net.NetEventSource.IsEnabled)
+                        System.Net.NetEventSource.Error(null, $"AppleCryptoNative_SslIsHostnameMatch returned '{result}' for '{hostName}'");
                     Debug.Fail($"AppleCryptoNative_SslIsHostnameMatch returned {result}");
                     throw new SslException();
             }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
@@ -399,8 +400,8 @@ internal static partial class Interop
                 case 1:
                     return true;
                 default:
-                    if (System.Net.NetEventSource.IsEnabled)
-                        System.Net.NetEventSource.Error(null, $"AppleCryptoNative_SslIsHostnameMatch returned '{result}' for '{hostName}'");
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Error(null, $"AppleCryptoNative_SslIsHostnameMatch returned '{result}' for '{hostName}'");
                     Debug.Fail($"AppleCryptoNative_SslIsHostnameMatch returned {result}");
                     throw new SslException();
             }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -356,22 +356,19 @@ PAL_TlsIo AppleCryptoNative_SslRead(SSLContextRef sslContext, uint8_t* buf, uint
 
 int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore, int32_t* pOSStatus)
 {
-    if (pOSStatus == NULL)
-        return -1;
+    if (pOSStatus != NULL)
+        *pOSStatus = noErr;
 
-    if (sslContext == NULL || notBefore == NULL)
+    if (sslContext == NULL || notBefore == NULL || pOSStatus == NULL)
     {
-        *pOSStatus = errSecInvalidData;
         return -1;
     }
 
     if (cfHostname == NULL)
     {
-        *pOSStatus = errSecInvalidData;
         return -2;
     }
 
-    *pOSStatus = noErr;
     SecPolicyRef sslPolicy = SecPolicyCreateSSL(true, cfHostname);
 
     if (sslPolicy == NULL)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -360,14 +360,10 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
         *pOSStatus = noErr;
 
     if (sslContext == NULL || notBefore == NULL || pOSStatus == NULL)
-    {
         return -1;
-    }
 
     if (cfHostname == NULL)
-    {
         return -2;
-    }
 
     SecPolicyRef sslPolicy = SecPolicyCreateSSL(true, cfHostname);
 
@@ -397,7 +393,6 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
     if (anchors == NULL)
     {
         CFRelease(certs);
-        *pOSStatus = errSecMemoryError;
         return -6;
     }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -356,13 +356,22 @@ PAL_TlsIo AppleCryptoNative_SslRead(SSLContextRef sslContext, uint8_t* buf, uint
 
 int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore, int32_t* pOSStatus)
 {
-    *pOSStatus = noErr;
+    if (pOSStatus == NULL)
+        return -1;
 
     if (sslContext == NULL || notBefore == NULL)
+    {
+        *pOSStatus = errSecInvalidData;
         return -1;
-    if (cfHostname == NULL)
-        return -2;
+    }
 
+    if (cfHostname == NULL)
+    {
+        *pOSStatus = errSecInvalidData;
+        return -2;
+    }
+
+    *pOSStatus = noErr;
     SecPolicyRef sslPolicy = SecPolicyCreateSSL(true, cfHostname);
 
     if (sslPolicy == NULL)
@@ -436,7 +445,7 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
 
         if (osStatus == noErr && trustResult != kSecTrustResultUnspecified && trustResult != kSecTrustResultProceed)
         {
-            // If evaliation suceeded but result is not trusted try to get details.
+            // If evaluation succeeded but result is not trusted try to get details.
             CFDictionaryRef detailsAndStuff = SecTrustCopyResult(trust);
 
             if (detailsAndStuff != NULL)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -205,7 +205,7 @@ the certificate being expired (or not yet valid).
 Returns 1 on match, 0 on mismatch, any other value indicates an invalid state.
 */
 DLLEXPORT int32_t
-AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore);
+AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringRef cfHostname, CFDateRef notBefore, int32_t* pOSStatus);
 
 /*
 Generate a TLS Close alert to terminate the session.

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -35,9 +35,12 @@ namespace System.Net
                 {
                     SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
 
-                    if (!Interop.AppleCrypto.SslCheckHostnameMatch(sslContext.SslContext, hostName, remoteCertificate.NotBefore))
+                    if (!Interop.AppleCrypto.SslCheckHostnameMatch(sslContext.SslContext, hostName, remoteCertificate.NotBefore, out int osStatus))
                     {
                         errors |= SslPolicyErrors.RemoteCertificateNameMismatch;
+
+                        if (NetEventSource.IsEnabled)
+                            NetEventSource.Error(sslContext, $"Cert name validation for '{hostName}' failed {osStatus}");
                     }
                 }
             }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -40,7 +40,7 @@ namespace System.Net
                         errors |= SslPolicyErrors.RemoteCertificateNameMismatch;
 
                         if (NetEventSource.IsEnabled)
-                            NetEventSource.Error(sslContext, $"Cert name validation for '{hostName}' failed {osStatus}");
+                            NetEventSource.Error(sslContext, $"Cert name validation for '{hostName}' failed with status '{osStatus}'");
                     }
                 }
             }


### PR DESCRIPTION
Right now when  OS does not like remote certificate it is quite difficult to figure out why. (like #666)
This change will try to extract reason code from OS and it will emit tracing entry so it is possible to get to it easily.
```
COMPlus_EnableEventPipe=1
COMPlus_EventPipeConfig=Microsoft-System-Net-Security:0xFFFFFFFFFFFFFFFF:3
```
will produce something like
```
<Event MSec="747.1234" PID="66553" PName="Process(66553)" TID="12435200" EventName="ErrorMessage" ProviderName="Microsoft-System-Net-Security" thisOrContextObject="SafeDeleteSslContext#3129430" memberName="VerifyCertificateProperties" message="Cert name validation for 'github.com' failed -2147408889"/>
```
In this case that can be mapped to `CSSMERR_APPLETP_INVALID_EXTENDED_KEY_USAGE` for case described in #666 or to `CSSMERR_APPLETP_CA_PIN_MISMATCH` in #805

related to #666 
related to #805
contributes to https://github.com/dotnet/corefx/issues/34905
