### PR TITLE
Several improvements to superpmi.py

### DIFF
--- a/src/coreclr/scripts/coreclr_arguments.py
+++ b/src/coreclr/scripts/coreclr_arguments.py
@@ -8,7 +8,7 @@
 # Title               : coreclr_arguments.py
 #
 # Notes:
-#  
+#
 # Setup script, to avoid re-writing argument validation between different
 # coreclr scripts.
 #
@@ -42,7 +42,7 @@ class CoreclrArguments:
     # ctor
     ############################################################################
 
-    def __init__(self, 
+    def __init__(self,
                  args,
                  require_built_test_dir=False,
                  require_built_core_root=False,
@@ -97,10 +97,10 @@ class CoreclrArguments:
 
         return True
 
-    def verify(self, 
-               args, 
+    def verify(self,
+               args,
                arg_name,
-               verify, 
+               verify,
                failure_str,
                arg_value=None,
                modify_arg=None,
@@ -108,14 +108,20 @@ class CoreclrArguments:
         """ Verify an arg
 
         Args:
-            args        (argParser)             : arg parser args
-            arg_name    (String)                : argument to verify
-            verify      (lambda: arg -> bool)   : verify method
-            failure_str (String)                : failure output if not verified
-            modify_arg  (lambda: arg -> arg)    : modify the argument before assigning
+            args        (argParser)                             : arg parser args
+            arg_name    (String)                                : argument to verify
+            verify      (lambda: arg -> bool)                   : verify method
+            failure_str (String or lambda: arg_value -> String) : failure output if not verified
+            arg_value
+            modify_arg  (lambda: arg -> arg)                    : modify the argument before assigning
+            modify_after_validation (bool)                      : If True, run the modify_arg function after validation.
+                                                                  Otherwise (default), run it before validation.
 
         Returns:
             verified (bool)
+
+        Note:
+            The CoreclrArguments object gets a new member named by `arg_name` with the argument value.
         """
         verified = False
         arg_value = None
@@ -136,14 +142,14 @@ class CoreclrArguments:
             verified = verify(arg_value)
         except:
             pass
-        
+
         if verified == False and isinstance(failure_str, str):
             print(failure_str)
             sys.exit(1)
         elif verified == False:
             print(failure_str(arg_value))
             sys.exit(1)
-        
+
         if modify_arg != None and modify_after_validation:
             arg_value = modify_arg(arg_value)
 
@@ -169,7 +175,7 @@ class CoreclrArguments:
             else:
                 print("Unknown OS: %s" % self.host_os)
                 sys.exit(1)
-            
+
             return None
 
         def check_host_os(host_os):
@@ -247,7 +253,7 @@ class CoreclrArguments:
                     "Unsupported host_os",
                     modify_arg=lambda host_os: provide_default_host_os() if host_os is None else host_os)
 
-        self.verify(args, 
+        self.verify(args,
                     "arch",
                     check_arch,
                     "Unsupported architecture.\nSupported architectures: %s" % (", ".join(self.valid_arches)))

--- a/src/coreclr/scripts/coreclr_arguments.py
+++ b/src/coreclr/scripts/coreclr_arguments.py
@@ -31,7 +31,6 @@ import string
 import xml.etree.ElementTree
 
 from collections import defaultdict
-from sys import platform as _platform
 
 ################################################################################
 ################################################################################
@@ -51,7 +50,7 @@ class CoreclrArguments:
         """ Setup the args based on the argparser obj
 
         Args:
-            args(ArgParser): Parsed arguments
+            args(argparse.Namespace return value from argparse.ArgumentParser.parse_args()): Parsed arguments
 
         Notes:
             If there is no core_root, or test location passed, create a default
@@ -75,7 +74,7 @@ class CoreclrArguments:
 
         self.valid_arches = ["x64", "x86", "arm", "arm64"]
         self.valid_build_types = ["Debug", "Checked", "Release"]
-        self.valid_host_os = ["Windows", "Windows_NT", "OSX", "Linux"]
+        self.valid_host_os = ["Windows_NT", "OSX", "Linux"]
 
         self.__initialize__(args)
 
@@ -84,18 +83,16 @@ class CoreclrArguments:
     ############################################################################
 
     def check_build_type(self, build_type):
-        if build_type != None and len(build_type) > 0:
-            # Force the build type to be capitalized
-            build_type = build_type.capitalize()
+        if build_type == None:
+            build_type = self.default_build_type
+            assert(build_type in self.valid_build_types)
             return build_type
 
-        elif build_type == None:
-            return self.default_build_type
+        if len(build_type) > 0:
+            # Force the build type to be capitalized
+            build_type = build_type.capitalize()
 
-        if not build_type in self.valid_build_types:
-            return False
-
-        return True
+        return build_type in self.valid_build_types
 
     def verify(self,
                args,
@@ -107,10 +104,25 @@ class CoreclrArguments:
                modify_after_validation=False):
         """ Verify an arg
 
+        Note that every argument must call verify() for it to have an attribute added to this class.
+        We do not use the argparse parsed argument object; we use this CoreclrArguments object instead,
+        after transferring all arguments to it. Arguments that have already been adequately verified
+        by parse_args() need no further verification, but do need to be transferred to this class for
+        future use.
+
+        `args` can also be an object (likely a string), in which case it is treated as
+        the value to assign to arg_name after the verify function is called.
+
+        The `verify` lambda returns True or False if the value is ok or not ok. It can also return a
+        non-bool result, in which case the argument value will be set to the return value of the `verify`
+        function call. This can be used to set a default.
+
         Args:
-            args        (argParser)                             : arg parser args
+            args
+                (argparse.Namespace return value from argparse.ArgumentParser.parse_args()) : Parsed arguments
+                (object)                                                                    : value to verify for arg_name
             arg_name    (String)                                : argument to verify
-            verify      (lambda: arg -> bool)                   : verify method
+            verify      (lambda: arg -> bool or value)          : verify method
             failure_str (String or lambda: arg_value -> String) : failure output if not verified
             arg_value
             modify_arg  (lambda: arg -> arg)                    : modify the argument before assigning
@@ -163,53 +175,42 @@ class CoreclrArguments:
     # Helper Methods
     ############################################################################
 
+    @staticmethod
+    def provide_default_host_os():
+        if sys.platform == "linux" or sys.platform == "linux2":
+            return "Linux"
+        elif sys.platform == "darwin":
+            return "OSX"
+        elif sys.platform == "win32":
+            return "Windows_NT"
+        else:
+            print("Unknown OS: %s" % self.host_os)
+            sys.exit(1)
+
+    @staticmethod
+    def provide_default_arch():
+        platform_machine = platform.machine().lower()
+        if platform_machine == "x86_64" or platform_machine == "amd64":
+            return "x64"
+        elif platform_machine == "i386":
+            return "x86"
+        elif platform_machine == "armhf":
+            return "arm"
+        elif platform_machine == "armel":
+            return "armel"
+        elif platform_machine == "aarch64" or platform_machine == "arm64":
+            return "arm64"
+        else:
+            print("Unknown architecture: %s" % platform_machine)
+            sys.exit(1)
+
     def __initialize__(self, args):
 
-        def provide_default_host_os():
-            if _platform == "linux" or _platform == "linux2":
-                return "Linux"
-            elif _platform == "darwin":
-                return "OSX"
-            elif _platform == "win32":
-                return "Windows_NT"
-            else:
-                print("Unknown OS: %s" % self.host_os)
-                sys.exit(1)
-
-            return None
-
         def check_host_os(host_os):
-            if host_os is None:
-                host_os = provide_default_host_os()
-                assert(host_os != None)
-
-                return host_os
-
-            else:
-                return host_os in self.valid_host_os
-
-        def provide_default_arch():
-            platform_machine = platform.machine()
-            if platform_machine == "x86_64":
-                return "x64"
-            elif platform_machine == "i386":
-                return "x86"
-            elif platform_machine == "armhf":
-                return "arm"
-            elif platform_machine == "armel":
-                return "armel"
-            elif platform_machine == "aarch64" or platform_machine == "arm64":
-                return "arm64"
-            else:
-                raise RuntimeError("Unsupported platform")
+            return (host_os is not None) and (host_os in self.valid_host_os)
 
         def check_arch(arch):
-            if arch is None:
-                arch = provide_default_arch()
-                assert(arch in self.valid_arches)
-                return arch
-            else:
-                return arch in self.valid_arches
+            return (arch is not None) and (arch in self.valid_arches)
 
         def check_and_return_test_location(test_location):
             default_test_location = os.path.join(self.artifacts_location, "tests", "coreclr", "%s.%s.%s" % (self.host_os, self.arch, self.build_type))
@@ -223,15 +224,16 @@ class CoreclrArguments:
             return test_location
 
         def check_and_return_default_core_root(core_root):
-            default_core_root = os.path.join(self.test_location, "Tests", "Core_Root")
+            if core_root is not None:
+                # core_root was specified on the command-line, so use that one. But verify it.
+                return os.path.isdir(core_root) or not self.require_built_core_root
 
+            # No core_root specified; use a default location if possible.
+            default_core_root = os.path.join(self.test_location, "Tests", "Core_Root")
             if os.path.isdir(default_core_root) or not self.require_built_core_root:
                 return default_core_root
 
-            elif not os.path.isdir(core_root) and self.require_built_core_root:
-                return False
-
-            return core_root
+            return False
 
         def check_and_return_default_product_location(product_location):
             default_product_location = os.path.join(self.artifacts_location, "bin", "coreclr", "%s.%s.%s" % (self.host_os, self.arch, self.build_type))
@@ -250,19 +252,20 @@ class CoreclrArguments:
         self.verify(args,
                     "host_os",
                     check_host_os,
-                    "Unsupported host_os",
-                    modify_arg=lambda host_os: provide_default_host_os() if host_os is None else host_os)
+                    lambda host_os: "Unknown host_os {}\nSupported OS: {}".format(host_os, (", ".join(self.valid_host_os))),
+                    modify_arg=lambda host_os: CoreclrArguments.provide_default_host_os() if host_os is None else host_os)
 
         self.verify(args,
                     "arch",
                     check_arch,
-                    "Unsupported architecture.\nSupported architectures: %s" % (", ".join(self.valid_arches)))
+                    lambda arch: "Unknown arch {}.\nSupported architectures: {}".format(arch, (", ".join(self.valid_arches))),
+                    modify_arg=lambda arch: CoreclrArguments.provide_default_arch() if arch is None else arch)
 
         self.verify(args,
                     "build_type",
                     self.check_build_type,
-                    "Unsupported configuration: %s.\nSupported configurations: %s" % (args.build_type, ", ".join(self.valid_build_types)),
-                    modify_arg=lambda arg: arg.capitalize())
+                    lambda build_type: "Unknown build_type {}.\nSupported build types: {}".format(build_type, ", ".join(self.valid_build_types)),
+                    modify_arg=lambda arg: arg.capitalize() if arg is not None else None)
 
         self.verify(args,
                     "test_location",

--- a/src/coreclr/scripts/superpmi.md
+++ b/src/coreclr/scripts/superpmi.md
@@ -1,44 +1,119 @@
 # An overview of using superpmi.py
 
-General information on [SuperPMI](../src/ToolBox/superpmi/readme.md)
+General information on SuperPMI can be found [here](../src/ToolBox/superpmi/readme.md)
 
 ## Overview
 
 Although SuperPMI has many uses, setup and use of SuperPMI is not always trivial.
 superpmi.py is a tool to help automate the use of SuperPMI, augmenting its usefulness.
-The tool has three different modes: collect, replay, and asmdiffs.
+The tool has three primary modes: collect, replay, and asmdiffs.
 Below you will find more specific information on each of the different modes.
 
-**SuperPMI has a large limitation, the replay/asmdiff functionality is sensitive to jitinterface changes. Therefore if there has been an interface change, the new JIT will not load and SuperPMI will fail.**
+## General usage
 
-**At the time of writing collections are done manually on all platforms that support libcoredistools. See before for a full list of supported platforms and where the .mch collection exists.**
+From the usage message:
+
+```
+usage: superpmi.py [-h] {collect,replay,asmdiffs,upload,list-collections} ...
+
+Script to run SuperPMI replay, ASM diffs, and collections. The script also
+manages the Azure store of precreated SuperPMI collection files. Help for each
+individual command can be shown by asking for help on the individual command,
+for example `superpmi.py collect --help`.
+
+positional arguments:
+  {collect,replay,asmdiffs,upload,list-collections}
+                        Command to invoke
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+The simplest usage is to replay using:
+
+```
+python f:\gh\runtime\src\coreclr\scripts\superpmi.py replay
+```
+
+In this case, everything needed is found using defaults:
+
+- The processor architecture is assumed to be the current default (e.g., x64).
+- The build type is assumed to be Checked.
+- Core_Root is found by assuming superpmi.py is in the normal location in the
+clone of the repo, and using the processor architecture, build type, and current
+OS, to find it.
+- The SuperPMI tool and JIT to use for replay is found in Core_Root.
+- The collection to use for replay is the default that is found in the
+precomputed collections that are stored in Azure.
+
+If you want to use a specific MCH file collection, use:
+
+```
+python f:\gh\runtime\src\coreclr\scripts\superpmi.py replay -mch_file f:\spmi\collections\tests.pmi.Windows_NT.x64.Release.mch
+```
+
+To generate ASM diffs, use the `asmdiffs` command. In this case, you must specify
+the path to a baseline JIT compiler, e.g.:
+
+```
+python f:\gh\runtime\src\coreclr\scripts\superpmi.py asmdiffs f:\jits\baseline_clrjit.dll
+```
+
+ASM diffs requires the coredistools library. The script attempts to either find
+or download an appropriate version that can be used.
+
+## Collections
+
+SuperPMI requires a collection to enable replay. You can do a collection
+yourself, but it is more convenient to use existing precomputed collections.
+Superpmi.py can automatically download existing collections
+
+Note that SuperPMI collections are sensitive to JIT/EE interface changes. If
+there has been an interface change, the new JIT will not load and SuperPMI
+will fail.
+
+**At the time of writing, collections are done manually. See below for a
+full list of supported platforms and where the .mch collection exists.**
 
 ## Supported Platforms
 
-| OS | Arch | Replay | AsmDiffs | mch location |
-| --- | --- | --- |--- | --- |
-| OSX | x64 |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
-| Windows | x64 |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
-| Windows | x86 |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
-| Windows | arm |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
+| OS      | Arch  | Replay                    | AsmDiffs                  | MCH location |
+| ---     | ---   | ---                       | ---                       | --- |
+| OSX     | x64   |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
+| Windows | x64   |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
+| Windows | x86   |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
+| Windows | arm   |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
 | Windows | arm64 |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
-| Ubuntu | x64 |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
-| Ubuntu | arm32 |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
-| Ubuntu | arm64 |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
+| Ubuntu  | x64   |  <ul><li>- [x] </li></ul> |  <ul><li>- [x] </li></ul> |  |
+| Ubuntu  | arm32 |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
+| Ubuntu  | arm64 |  <ul><li>- [ ] </li></ul> |  <ul><li>- [ ] </li></ul> | N/A |
 
 ## Default Collections
 
-See the table above for locations of default collections that exist. If there is an mch file that exists, then SuperPMI will automatically download and setup the mch using that location. Please note that, it is possible that the collection is out of date, or there is a jitinterface change which makes the collection invalid. If this is the case, then in order to use the tool a collection will have to be done manually. In order to reproduce the default collections, please see below for what command the default collections are done with.
-
-`/Users/jashoo/runtime/src/coreclr/build.sh x64 checked`
-
-`/Users/jashoo/runtime/src/coreclr/build-test.sh x64 checked -priority1`
-
-`/Users/jashoo/runtime/src/coreclr/scripts/superpmi.py collect bash "/Users/jashoo/runtime/src/coreclr/tests/runtest.sh x64 checked" --skip-cleanup`
+See the table above for locations of default collections that exist. If there
+is an MCH file that exists, then SuperPMI will automatically download and
+use the MCH from that location. Please note that it is possible that the
+collection is out of date, or there is a jitinterface change which makes the
+collection invalid. If this is the case, then in order to use the tool a
+collection will have to be done manually. In order to reproduce the default
+collections, please see below for what command the default collections are
+done with.
 
 ## Collect
 
-Given a specific command collect over all of the managed code called by the child process. Note that this allows many different invocations of any managed code. Although it does specifically require that any managed code run by the child process to handle the complus variables set by SuperPMI and defer them to the later. These are below:
+Example commands to create a collection:
+
+```
+/Users/jashoo/runtime/src/coreclr/build.sh x64 checked
+/Users/jashoo/runtime/src/coreclr/build-test.sh x64 checked -priority1
+/Users/jashoo/runtime/src/coreclr/scripts/superpmi.py collect bash "/Users/jashoo/runtime/src/coreclr/tests/runtest.sh x64 checked"
+```
+
+Given a specific command, collect over all of the managed code called by the
+child process. Note that this allows many different invocations of any
+managed code. Although it does specifically require that any managed code run
+by the child process to handle the COMPlus variables set by SuperPMI and
+defer them to the latter. These are below:
 
 ```
 SuperPMIShimLogPath=<full path to an empty temporary directory>
@@ -47,20 +122,51 @@ COMPlus_AltJit=*
 COMPlus_AltJitName=superpmi-shim-collector.dll
 ```
 
-If these variables are set and a managed exe is run, using for example the dotnetcli, the altjit settings will crash the process.
+If these variables are set and a managed exe is run, using for example the
+dotnet CLI, the altjit settings will crash the process.
 
-To avoid this, the easiest way is to unset the variables in the beginning to the root process, and then set them right before calling $CORE_ROOT/corerun.
+To avoid this, the easiest way is to unset the variables in the beginning to
+the root process, and then set them right before calling `$CORE_ROOT/corerun`.
 
-Note that collection will try to run as much managed code as possible. In order to do this, `COMPlus_ZapDisable=1` is set by default. This can be modified by passing `--use_r2r`.
+You can also collect using PMI instead of running code. Do with with the `--pmi` and `-pmi_assemblies`
+arguments. E.g.:
 
-Also note that collection generates gigabytes of data, most of this data will be removed when the collection is finished and de-dupped into a single mch file. That being said, it is worth mentioning that this process will use 3x the size of the unclean mch file, which to give an example of the size, a collection of the coreclr `priority=1` tests uses roughly `200gb` of disk space. Most of this space will be used in a temp directory, which on Windows will default to `C:\Users\blah\AppData\Temp\...`. It is recommended to set the temp variable to a different location before running collect to avoid running out of disk space. This can be done by simply running `set TEMP=D:\TEMP`.
+```
+python f:\gh\runtime\src\coreclr\scripts\superpmi.py collect --pmi -pmi_assemblies f:\assembly_store -output_mch_path f:\collections\my_collection.mch
+```
+
+Note that collection generates gigabytes of data. Most of this data will
+be removed when the collection is finished. That being said, it is worth
+mentioning that this process will use 3x the size of the unclean MCH file,
+which to give an example of the size, a collection of the coreclr
+`priority=1` tests uses roughly `200gb` of disk space. Most of this space
+will be used in a temp directory, which on Windows will default to
+`C:\Users\blah\AppData\Temp\...`. It is recommended to set the temp variable
+to a different location before running collect to avoid running out of disk
+space. This can be done by simply running `set TEMP=D:\TEMP`.
 
 ## Replay
 
-SuperPMI replay supports faster assertion checking over a collection than running the tests individually. This is useful if the collection includes a larger corpus of data that can reasonably be run against by executing the actual code. Note that this is similar to the PMI tool, with the same limitation, that runtime issues will not be caught by SuperPMI replay only assertions.
+SuperPMI replay supports faster assertion checking over a collection than
+running the tests individually. This is useful if the collection includes a
+larger corpus of data that can reasonably be run against by executing the
+actual code, or if it is difficult to invoke the JIT across all the code in
+the collection. Note that this is similar to the PMI tool, with the same
+limitation, that runtime issues will not be caught by SuperPMI replay only
+assertions.
 
 ## Asm Diffs
 
-SuperPMI will take two different JITs, a baseline and diff JIT and run the compiler accross all the methods in the mch file. It uses coredistools to do a binary difference of the two different outputs. Note that sometimes the binary will differ, and SuperPMI will be run once again dumping the asm that was output in text format. Then the text will be diffed, if there are differences, you should look for text differences. If there are some then it is worth investigating the asm differences.
+SuperPMI will take two different JITs, a baseline and diff JIT and run the
+compiler accross all the methods in the MCH file. It uses coredistools to do
+a binary difference of the two different outputs. Note that sometimes the
+binary will differ, and SuperPMI will be run once again dumping the asm that
+was output in text format. Then the text will be diffed, if there are
+differences, you should look for text differences. If there are some then it
+is worth investigating the asm differences.
 
-It is worth noting as well that SuperPMI gives more stable instructions retired counters for the JIT.
+superpmi.py can also be asked to generate JitDump differences in addition
+to the ASM diff differences generated by default.
+
+It is worth noting as well that SuperPMI gives more stable instructions
+retired counters for the JIT.

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1895,7 +1895,8 @@ def setup_args(args):
         coreclr_args.verify(args,
                             "core_root",
                             lambda core_root: (core_root is not None) and os.path.isdir(core_root),
-                            "Invalid core_root.")
+                            lambda core_root: "Invalid core_root {}".format(core_root),
+                            modify_arg=lambda arg: coreclr_args.core_root if args.core_root is None else args.core_root)
 
         coreclr_args.verify(args,
                             "collection_command",
@@ -2013,7 +2014,14 @@ def setup_args(args):
         coreclr_args.verify(args,
                             "core_root",
                             lambda core_root: (core_root is not None) and os.path.isdir(core_root),
-                            "Invalid core_root.")
+                            lambda core_root: "Invalid core_root {}".format(core_root),
+                            modify_arg=lambda arg: coreclr_args.core_root if args.core_root is None else args.core_root)
+
+        coreclr_args.verify(args,
+                            "spmi_location",
+                            lambda unused: True,
+                            "Unable to set pmi_location",
+                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
 
         coreclr_args.verify(args,
                             "collection",
@@ -2046,12 +2054,6 @@ def setup_args(args):
                             "break_on_error",
                             lambda unused: True,
                             "Unable to set break_on_error")
-
-        coreclr_args.verify(args,
-                            "spmi_location",
-                            lambda unused: True,
-                            "Unable to set pmi_location",
-                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
 
         standard_location = False
         if coreclr_args.product_location.lower() in coreclr_args.jit_path.lower():
@@ -2103,7 +2105,8 @@ def setup_args(args):
         coreclr_args.verify(args,
                             "core_root",
                             lambda core_root: (core_root is not None) and os.path.isdir(core_root),
-                            "Invalid core_root.")
+                            lambda core_root: "Invalid core_root {}".format(core_root),
+                            modify_arg=lambda arg: coreclr_args.core_root if args.core_root is None else args.core_root)
 
         coreclr_args.verify(args,
                             "base_jit_path",
@@ -2121,6 +2124,12 @@ def setup_args(args):
                             "collection",
                             lambda collection_name: collection_name in download_index(coreclr_args),
                             "Invalid collection. Please run 'superpmi.py list-collections' to see valid options.")
+
+        coreclr_args.verify(args,
+                            "spmi_location",
+                            lambda unused: True,
+                            "Unable to set pmi_location",
+                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
 
         coreclr_args.verify(args,
                             "log_file",
@@ -2175,12 +2184,6 @@ def setup_args(args):
                                 "diff_jit_dump",
                                 lambda unused: True,
                                 "Unable to set diff_jit_dump.")
-
-        coreclr_args.verify(args,
-                            "spmi_location",
-                            lambda unused: True,
-                            "Unable to set pmi_location",
-                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
 
         standard_location = False
         if coreclr_args.product_location.lower() in coreclr_args.base_jit_path.lower():
@@ -2238,7 +2241,8 @@ def setup_args(args):
         coreclr_args.verify(args,
                             "core_root",
                             lambda core_root: (core_root is not None) and os.path.isdir(core_root),
-                            "Invalid core_root.")
+                            lambda core_root: "Invalid core_root {}".format(core_root),
+                            modify_arg=lambda arg: coreclr_args.core_root if args.core_root is None else args.core_root)
 
         coreclr_args.verify(args,
                             "az_storage_key",

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -8,10 +8,10 @@
 # Title               : superpmi.py
 #
 # Notes:
-#  
+#
 # Script to handle running SuperPMI Collections, and replays. In addition, this
 # script provides support for SuperPMI ASM diffs. Note that some of the options
-# provided by this script are also provided in our SuperPMI collect test. The 
+# provided by this script are also provided in our SuperPMI collect test. The
 # test can be found here: https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/superpmi/superpmicollect.cs.
 #
 ################################################################################
@@ -66,6 +66,10 @@ core_root_help = "Core_Root location. Optional; it will be deduced if possible f
 
 product_location_help = "Built Product directory location. Optional; it will be deduced if possible from runtime repo root."
 
+spmi_location_help = """Directory in which to put SuperPMI files, such as downloaded MCH files, asm diffs, and repro .MC file.
+Optional. Default is 'spmi' within the repo 'artifacts' directory.
+"""
+
 superpmi_collect_help = """ Command to run SuperPMI collect over. Note that there
 cannot be any dotnet cli command invoked inside this command, as they will fail due
 to the shim altjit being set.
@@ -74,10 +78,6 @@ to the shim altjit being set.
 mch_file_help = """ Location of the MCH file to use for replay. Note
 that this may either be a path on disk or a URI to a MCH file to download.
 Use this MCH file instead of a named collection set in the cloud MCH file store.
-"""
-
-runtime_repo_root_help = """ Path of the dotnet/runtime repo root directory.
-Optional; by default, assumes this script is in a well-known location in a clone of the repo.
 """
 
 skip_cleanup_help = "Skip intermediate file removal."
@@ -102,11 +102,10 @@ collect_parser.add_argument("collection_args", nargs='?', help="Arguments to pas
 
 collect_parser.add_argument("-log_file", dest="log_file", default=None, help=log_file_help)
 
-collect_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help) 
+collect_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help)
 collect_parser.add_argument("-build_type", dest="build_type", nargs='?', default="Checked", help=build_type_help)
 collect_parser.add_argument("-core_root", dest="core_root", nargs='?', default=None, help=core_root_help)
-collect_parser.add_argument("-product_location", dest="product_location", nargs='?', default=None, help=product_location_help)
-collect_parser.add_argument("-runtime_repo_root", dest="runtime_repo_root", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))), help=runtime_repo_root_help)
+collect_parser.add_argument("-spmi_location", dest="spmi_location", nargs='?', default=None, help=spmi_location_help)
 
 collect_parser.add_argument("--break_on_assert", dest="break_on_assert", default=False, action="store_true", help=break_on_assert_help)
 collect_parser.add_argument("--break_on_error", dest="break_on_error", default=False, action="store_true", help=break_on_error_help)
@@ -141,11 +140,11 @@ replay_parser.add_argument("-jit_path", nargs='?', help="Path to clrjit. Default
 replay_parser.add_argument("-mch_file", nargs=1, help=mch_file_help)
 replay_parser.add_argument("-log_file", dest="log_file", default=None, help=log_file_help)
 
-replay_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help) 
+replay_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help)
 replay_parser.add_argument("-build_type", dest="build_type", nargs='?', default="Checked", help=build_type_help)
 replay_parser.add_argument("-core_root", dest="core_root", nargs='?', default=None, help=core_root_help)
 replay_parser.add_argument("-product_location", dest="product_location", nargs='?', default=None, help=product_location_help)
-replay_parser.add_argument("-runtime_repo_root", dest="runtime_repo_root", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))), help=runtime_repo_root_help)
+replay_parser.add_argument("-spmi_location", dest="spmi_location", nargs='?', default=None, help=spmi_location_help)
 
 replay_parser.add_argument("--break_on_assert", dest="break_on_assert", default=False, action="store_true", help=break_on_assert_help)
 replay_parser.add_argument("--break_on_error", dest="break_on_error", default=False, action="store_true", help=break_on_error_help)
@@ -165,11 +164,11 @@ asm_diff_parser.add_argument("-mch_file", nargs=1, help=mch_file_help)
 
 asm_diff_parser.add_argument("-log_file", dest="log_file", default=None, help=log_file_help)
 
-asm_diff_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help) 
+asm_diff_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help)
 asm_diff_parser.add_argument("-build_type", dest="build_type", nargs='?', default="Checked", help=build_type_help)
 asm_diff_parser.add_argument("-core_root", dest="core_root", nargs='?', default=None, help=core_root_help)
 asm_diff_parser.add_argument("-product_location", dest="product_location", nargs='?', default=None, help=product_location_help)
-asm_diff_parser.add_argument("-runtime_repo_root", dest="runtime_repo_root", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))), help=runtime_repo_root_help)
+asm_diff_parser.add_argument("-spmi_location", dest="spmi_location", nargs='?', default=None, help=spmi_location_help)
 
 asm_diff_parser.add_argument("--break_on_assert", dest="break_on_assert", default=False, action="store_true", help=break_on_assert_help)
 asm_diff_parser.add_argument("--break_on_error", dest="break_on_error", default=False, action="store_true", help=break_on_error_help)
@@ -180,7 +179,7 @@ asm_diff_parser.add_argument("--force_download", dest="force_download", default=
 asm_diff_parser.add_argument("--diff_with_code", dest="diff_with_code", default=False, action="store_true", help="Invoke Visual Studio Code to view any diffs.")
 asm_diff_parser.add_argument("--diff_with_code_only", dest="diff_with_code_only", default=False, action="store_true", help="Invoke Visual Studio Code to view any diffs. Only run the diff command, do not run SuperPMI to regenerate diffs.")
 
-asm_diff_parser.add_argument("--diff_jit_dump", dest="diff_jit_dump", default=False, action="store_true", help="Generate JitDump output for diffs.")
+asm_diff_parser.add_argument("--diff_jit_dump", dest="diff_jit_dump", default=False, action="store_true", help="Generate JitDump output for diffs. Default: only generate asm, not JitDump.")
 asm_diff_parser.add_argument("--diff_jit_dump_only", dest="diff_jit_dump_only", default=False, action="store_true", help="Only diff JitDump output, not asm.")
 
 # subparser for upload
@@ -191,18 +190,16 @@ upload_parser.add_argument("az_storage_key", nargs='?', help="Key for the clrjit
 upload_parser.add_argument("-mch_files", nargs='+', help="MCH files to pass")
 upload_parser.add_argument("-jit_location", nargs=1, default=None, help="Location for the base clrjit. If not passed this will be assumed to be from the Core_Root.")
 
-upload_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help) 
+upload_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help)
 upload_parser.add_argument("-build_type", dest="build_type", nargs='?', default="Checked", help=build_type_help)
-upload_parser.add_argument("-runtime_repo_root", dest="runtime_repo_root", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))), help=runtime_repo_root_help)
 
 upload_parser.add_argument("--skip_cleanup", dest="skip_cleanup", default=False, action="store_true", help=skip_cleanup_help)
 
 # subparser for list-collections
 list_parser = subparsers.add_parser("list-collections")
 
-list_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help) 
+list_parser.add_argument("-arch", dest="arch", nargs='?', default="x64", help=arch_help)
 list_parser.add_argument("-build_type", dest="build_type", nargs='?', default="Checked", help=build_type_help)
-list_parser.add_argument("-runtime_repo_root", dest="runtime_repo_root", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))), help=runtime_repo_root_help)
 
 ################################################################################
 # Helper functions
@@ -247,6 +244,17 @@ def make_safe_filename(s):
     return "".join(safe_char(c) for c in s)
 
 def _find(name, pathlist, matchFunc=os.path.isfile):
+    """ Find a name (e.g., directory name or file name) in the file system by searching the directories
+        in a semicolon-separated `pathlist` (e.g., PATH environment variable).
+
+    Args:
+        name (str)              : name to search for
+        pathlist (str)          : semicolon-separated string of directory names to search
+        matchFunc (str -> bool) : determines if the name is a match
+
+    Returns:
+        (str) The pathname of the object, or None if not found.
+    """
     for dirname in pathlist:
         candidate = os.path.join(dirname, name)
         if matchFunc(candidate):
@@ -254,10 +262,55 @@ def _find(name, pathlist, matchFunc=os.path.isfile):
     return None
 
 def findFile(filename, pathlist):
+    """ Find a filename in the file system by searching the directories
+        in a semicolon-separated `pathlist` (e.g., PATH environment variable).
+
+    Args:
+        filename (str)          : name to search for
+        pathlist (str)          : semicolon-separated string of directory names to search
+
+    Returns:
+        (str) The pathname of the object, or None if not found.
+    """
     return _find(filename, pathlist)
 
 def findDir(dirname, pathlist):
+    """ Find a directory name in the file system by searching the directories
+        in a semicolon-separated `pathlist` (e.g., PATH environment variable).
+
+    Args:
+        dirname (str)           : name to search for
+        pathlist (str)          : semicolon-separated string of directory names to search
+
+    Returns:
+        (str) The pathname of the object, or None if not found.
+    """
     return _find(dirname, pathlist, matchFunc=os.path.isdir)
+
+def create_unique_directory_name(root_directory, base_name):
+    """ Create a unique directory name by joining `root_directory` and `base_name`.
+        If this name already exists, append ".1", ".2", ".3", etc., to the final
+        name component until the full directory name is not found.
+
+    Args:
+        root_directory (str)     : root directory in which a new directory will be created
+        base_name (str)          : the base name of the new directory name component to be added
+
+    Returns:
+        (str) The full absolute path of the new directory. The directory has been created.
+    """
+
+    root_directory = os.path.abspath(root_directory)
+    full_path = os.path.join(root_directory, base_name)
+
+    count = 1
+    while os.path.isdir(full_path):
+        new_full_path = os.path.join(root_directory, base_name + "." + str(count))
+        count += 1
+        full_path = new_full_path
+
+    os.makedirs(full_path)
+    return full_path
 
 ################################################################################
 # Helper classes
@@ -364,7 +417,7 @@ class AsyncSubprocessHelper:
 
              Notes:
             Acts as a wrapper to abstract the async calls to
-            async_callback. Note that this will allow cpu_count 
+            async_callback. Note that this will allow cpu_count
             amount of running subprocesses. Each time the queue
             is emptied, another process will start. Note that
             the python code is single threaded, it will just
@@ -444,9 +497,6 @@ class SuperPMICollect:
         # Pathname for a temporary .MCL file used for noticing SuperPMI replay failures against base MCH.
         self.base_fail_mcl_file = None
 
-        # Pathname for a temporary .MCL file used for noticing SuperPMI replay failures against final MCH.
-        self.final_fail_mcl_file = None
-
         # The base .MCH file path
         self.base_mch_file = None
 
@@ -480,24 +530,24 @@ class SuperPMICollect:
             with TempDir(self.coreclr_args.existing_temp_dir) as temp_location:
                 # Setup all of the temp locations
                 self.base_fail_mcl_file = os.path.join(temp_location, "basefail.mcl")
-                self.final_fail_mcl_file = os.path.join(temp_location, "finalfail.mcl")
-                
                 self.base_mch_file = os.path.join(temp_location, "base.mch")
                 self.nodup_mch_file = os.path.join(temp_location, "nodup.mch")
 
                 self.temp_location = temp_location
 
                 if self.coreclr_args.output_mch_path is not None:
-                    self.save_the_final_mch_file = True
                     self.final_mch_file = os.path.abspath(self.coreclr_args.output_mch_path)
-                    self.toc_file = self.final_mch_file + ".mct"
+                    final_mch_dir = os.path.dirname(self.final_mch_file)
+                    if not os.path.isdir(final_mch_dir):
+                        os.makedirs(final_mch_dir)
                 else:
-                    self.save_the_final_mch_file = True
+                    default_coreclr_bin_mch_location = os.path.join(coreclr_args.spmi_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
+                    if not os.path.isdir(default_coreclr_bin_mch_location):
+                        os.makedirs(default_coreclr_bin_mch_location)
+                    self.final_mch_file = os.path.abspath(os.path.join(default_coreclr_bin_mch_location, "{}.{}.{}.mch".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type)))
 
-                    default_coreclr_bin_mch_location = self.coreclr_args.default_coreclr_bin_mch_location
-
-                    self.final_mch_file = os.path.join(default_coreclr_bin_mch_location, "{}.{}.{}.mch".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
-                    self.toc_file = "{}.mct".format(self.final_mch_file)
+                self.save_the_final_mch_file = True
+                self.toc_file = "{}.mct".format(self.final_mch_file)
 
                 # If we have passed existing_temp_dir, then we have a few flags we need
                 # to check to see where we are in the collection process. Note that this
@@ -508,7 +558,7 @@ class SuperPMICollect:
 
                 if not self.coreclr_args.has_run_collection_command:
                     self.__collect_mc_files__()
-                
+
                 if not self.coreclr_args.has_merged_mch:
                     if not self.coreclr_args.merge_mch_files:
                         self.__merge_mc_files__()
@@ -534,7 +584,7 @@ class SuperPMICollect:
 
     def __collect_mc_files__(self):
         """ Do the actual SuperPMI collection for a command
-        
+
         Returns:
             None
         """
@@ -592,7 +642,7 @@ class SuperPMICollect:
                         for item in valid_extensions:
                             if location.endswith(item):
                                 assemblies.append(location)
-                    
+
                     return assemblies
 
                 async def run_pmi(print_prefix, assembly, self):
@@ -692,7 +742,7 @@ class SuperPMICollect:
 
     def __create_thin_unique_mch__(self):
         """  Create a thin unique MCH
-        
+
         Notes:
             <mcl> -removeDup -thin <s_baseMchFile> <s_nodupMchFile>
         """
@@ -708,7 +758,7 @@ class SuperPMICollect:
         if not self.coreclr_args.skip_cleanup:
             os.remove(self.base_mch_file)
             self.base_mch_file = None
-    
+
     def __create_clean_mch_file__(self):
         """ Create a clean mch file
 
@@ -746,10 +796,10 @@ class SuperPMICollect:
             if os.path.isfile(self.nodup_mch_file):
                 os.remove(self.nodup_mch_file)
                 self.nodup_mch_file = None
-        
+
     def __create_toc__(self):
         """ Create a TOC file
-        
+
         Notes:
             <mcl> -toc <s_finalMchFile>
         """
@@ -764,9 +814,9 @@ class SuperPMICollect:
 
     def __verify_final_mch__(self):
         """ Verify the resulting MCH file is error-free when running SuperPMI against it with the same JIT used for collection.
-        
+
         Notes:
-            <superPmiPath> -p -f <s_finalFailMclFile> <s_finalMchFile> <jitPath>
+            <SuperPmiPath> -p -f <s_finalFailMclFile> <s_finalMchFile> <jitPath>
         """
 
         spmi_replay = SuperPMIReplay(self.coreclr_args, self.final_mch_file, self.jit_path)
@@ -797,9 +847,22 @@ class SuperPMIReplay:
 
         """
 
+        if coreclr_args.host_os == "OSX":
+            self.standalone_jit_name = "libclrjit.dylib"
+            self.superpmi_tool_name = "superpmi"
+        elif coreclr_args.host_os == "Linux":
+            self.standalone_jit_name = "libclrjit.so"
+            self.superpmi_tool_name = "superpmi"
+        elif coreclr_args.host_os == "Windows_NT":
+            self.standalone_jit_name = "clrjit.dll"
+            self.superpmi_tool_name = "superpmi.exe"
+        else:
+            raise RuntimeError("Unsupported OS.")
+
         self.jit_path = jit_path
         self.mch_file = mch_file
-        self.superpmi_path = os.path.join(coreclr_args.core_root, "superpmi")
+        self.jit_path = os.path.join(coreclr_args.core_root, self.standalone_jit_name)
+        self.superpmi_path = os.path.join(coreclr_args.core_root, self.superpmi_tool_name)
 
         self.coreclr_args = coreclr_args
 
@@ -823,9 +886,8 @@ class SuperPMIReplay:
         # -2 : JIT failed to initialize
         # 1  : there were compilation failures
         # 2  : there were assembly diffs
-        
+
         with TempDir() as temp_location:
-            print("Starting SuperPMI replay.")
             print("")
             print("Temp Location: {}".format(temp_location))
             print("")
@@ -852,7 +914,7 @@ class SuperPMIReplay:
                 flags += [
                     "-boa" # break on assert
                 ]
-            
+
             if self.coreclr_args.break_on_error:
                 flags += [
                     "-boe" # break on error
@@ -876,7 +938,7 @@ class SuperPMIReplay:
                 print("Clean SuperPMI replay")
                 return_code = True
 
-            if is_nonzero_length_file(self.fail_mcl_file):  
+            if is_nonzero_length_file(self.fail_mcl_file):
                 # Unclean replay.
                 #
                 # Save the contents of the fail.mcl file to dig into failures.
@@ -889,30 +951,30 @@ class SuperPMIReplay:
                     print("Jit failed to initialize.")
                 elif return_code == 1:
                     print("Compilation failures.")
+                elif return_code == 139 and self.coreclr_args != "Windows_NT":
+                    print("Fatal error, SuperPMI has returned SIG_SEV (segmentation fault).")
                 else:
                     print("Unknown error code.")
 
                 self.fail_mcl_contents = None
+                mcl_lines = []
                 with open(self.fail_mcl_file) as file_handle:
-                    self.fail_mcl_contents = file_handle.read()
+                    mcl_lines = file_handle.readlines()
+                    mcl_lines = [item.strip() for item in mcl_lines]
+                    self.fail_mcl_contents = os.linesep.join(mcl_lines)
+                    print("Method numbers with compilation failures:")
+                    print(self.fail_mcl_contents)
 
                 # If there are any .mc files, drop them into artifacts/repro/<host_os>.<arch>.<build_type>/*.mc
                 mc_files = [os.path.join(temp_location, item) for item in os.listdir(temp_location) if item.endswith(".mc")]
 
                 if len(mc_files) > 0:
-                    repro_location = os.path.join(self.coreclr_args.runtime_repo_root, "artifacts", "repro", "{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
+                    repro_location = create_unique_directory_name(self.coreclr_args.spmi_location, "repro.{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
 
-                    # Delete existing repro location
-                    if os.path.isdir(repro_location):
-                        shutil.rmtree(repro_location)
-
-                    assert(not os.path.isdir(repro_location))
-
-                    os.makedirs(repro_location)
-                    
                     repro_files = []
                     for item in mc_files:
                         repro_files.append(os.path.join(repro_location, os.path.basename(item)))
+                        print("Copying {} -> {}".format(item, repro_location))
                         shutil.copy2(item, repro_location)
 
                     print("")
@@ -921,23 +983,18 @@ class SuperPMIReplay:
 
                     for item in repro_files:
                         print(item)
-                    
+
                     print("")
 
-                    print("To run an specific failure:")
+                    print("To run a specific failure (replace .mc filename as needed):")
                     print("")
-                    print("<SuperPMI_path>/superpmi <core_root|product_dir>/clrjit.dll|libclrjit.so|libclrjit.dylib <repo_root>/artifacts/repro/<host_os>.<arch>.<build_type>/1xxxx.mc")
+                    print("{} {} {}{}xxxxx.mc".format(self.superpmi_path, self.jit_path, os.path.sep, repro_location))
                     print("")
-
-                else:
-                    print(self.fail_mcl_contents)
 
             if not self.coreclr_args.skip_cleanup:
                 if os.path.isfile(self.fail_mcl_file):
                     os.remove(self.fail_mcl_file)
                     self.fail_mcl_file = None
-
-                return_code == False
 
         return return_code
 
@@ -964,11 +1021,24 @@ class SuperPMIReplayAsmDiffs:
 
         """
 
+        if coreclr_args.host_os == "OSX":
+            self.standalone_jit_name = "libclrjit.dylib"
+            self.superpmi_tool_name = "superpmi"
+        elif coreclr_args.host_os == "Linux":
+            self.standalone_jit_name = "libclrjit.so"
+            self.superpmi_tool_name = "superpmi"
+        elif coreclr_args.host_os == "Windows_NT":
+            self.standalone_jit_name = "clrjit.dll"
+            self.superpmi_tool_name = "superpmi.exe"
+        else:
+            raise RuntimeError("Unsupported OS.")
+
         self.base_jit_path = base_jit_path
         self.diff_jit_path = diff_jit_path
 
         self.mch_file = mch_file
-        self.superpmi_path = os.path.join(coreclr_args.core_root, "superpmi")
+        self.jit_path = os.path.join(coreclr_args.core_root, self.standalone_jit_name)
+        self.superpmi_path = os.path.join(coreclr_args.core_root, self.superpmi_tool_name)
 
         self.coreclr_args = coreclr_args
 
@@ -994,7 +1064,6 @@ class SuperPMIReplayAsmDiffs:
         # 2  : there were assembly diffs
 
         with TempDir(previous_temp_location) as temp_location:
-            print("Starting SuperPMI AsmDiffs.")
             print("")
             print("Temp Location: {}".format(temp_location))
             print("")
@@ -1029,7 +1098,7 @@ class SuperPMIReplayAsmDiffs:
                     flags += [
                         "-boa" # break on assert
                     ]
-                
+
                 if self.coreclr_args.break_on_error:
                     flags += [
                         "-boe" # break on error
@@ -1052,7 +1121,7 @@ class SuperPMIReplayAsmDiffs:
                         proc.communicate()
                         return_code = proc.returncode
                         if return_code == 0:
-                            print("Clean SuperPMI Replay")
+                            print("Clean SuperPMI replay")
                 else:
                     return_code = 2
             else:
@@ -1082,20 +1151,14 @@ class SuperPMIReplayAsmDiffs:
                     mcl_lines = file_handle.readlines()
                     mcl_lines = [item.strip() for item in mcl_lines]
                     self.fail_mcl_contents = os.linesep.join(mcl_lines)
+                    print("Method numbers with compilation failures:")
+                    print(self.fail_mcl_contents)
 
                 # If there are any .mc files, drop them into artifacts/repro/<host_os>.<arch>.<build_type>/*.mc
                 mc_files = [os.path.join(temp_location, item) for item in os.listdir(temp_location) if item.endswith(".mc")]
 
                 if len(mc_files) > 0:
-                    repro_location = os.path.join(self.coreclr_args.runtime_repo_root, "artifacts", "repro", "{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
-
-                    # Delete existing repro location
-                    if os.path.isdir(repro_location):
-                        shutil.rmtree(repro_location)
-
-                    assert(not os.path.isdir(repro_location))
-
-                    os.makedirs(repro_location)
+                    repro_location = create_unique_directory_name(self.coreclr_args.spmi_location, "repro.{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
 
                     repro_files = []
                     for item in mc_files:
@@ -1109,15 +1172,13 @@ class SuperPMIReplayAsmDiffs:
 
                     for item in repro_files:
                         print(item)
-                    
+
                     print("")
 
-                    print("To run an specific failure:")
+                    print("To run a specific failure (replace .mc filename as needed):")
                     print("")
-                    print("<SuperPMI_path>/superpmi <core_root|product_dir>/clrjit.dll|libclrjit.so|libclrjit.dylib <repo_root>/artifacts/repro/<host_os>.<arch>.<build_type>/1xxxx.mc")
+                    print("{} {} {}{}xxxxx.mc".format(self.superpmi_path, self.jit_path, os.path.sep, repro_location))
                     print("")
-
-                print(self.fail_mcl_contents)
 
             # There were diffs. Go through each method that created diffs and
             # create a base/diff asm file with diffable asm. In addition, create
@@ -1126,7 +1187,7 @@ class SuperPMIReplayAsmDiffs:
                 # AsmDiffs.
                 #
                 # Save the contents of the fail.mcl file to dig into failures.
-                
+
                 assert(return_code != 0)
 
                 if return_code == -1:
@@ -1149,66 +1210,52 @@ class SuperPMIReplayAsmDiffs:
                         mcl_lines = [item.strip() for item in mcl_lines]
                         self.diff_mcl_contents = mcl_lines
 
-                bin_asm_location = os.path.join(self.coreclr_args.artifacts_location, "asm", "asm")
-
-                count = 0
-                while os.path.isdir(bin_asm_location):
-                    new_bin_asm_location = os.path.join(self.coreclr_args.artifacts_location, "asm", "asm" + str(count))
-                    count += 1
-                    print("{} location exists. Attempting to create: {}".format(bin_asm_location, new_bin_asm_location))
-                    bin_asm_location = new_bin_asm_location
-
+                bin_asm_location = create_unique_directory_name(self.coreclr_args.spmi_location, "asm.{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
                 base_asm_location = os.path.join(bin_asm_location, "base")
                 diff_asm_location = os.path.join(bin_asm_location, "diff")
 
                 if not self.coreclr_args.diff_with_code_only:
-                    # Delete the old asm.
-                    
                     # Create a diff and baseline directory
-                    if os.path.isdir(base_asm_location):
-                        shutil.rmtree(base_asm_location)
-                    if os.path.isdir(diff_asm_location):
-                        shutil.rmtree(diff_asm_location)
+                    assert(not os.path.isdir(base_asm_location))
+                    assert(not os.path.isdir(diff_asm_location))
 
                     os.makedirs(base_asm_location)
                     os.makedirs(diff_asm_location)
 
-                    assert(os.path.isdir(base_asm_location))
-                    assert(os.path.isdir(diff_asm_location))
-
-                    assert(len(os.listdir(base_asm_location)) == 0)
-                    assert(len(os.listdir(diff_asm_location)) == 0)
-
                     if self.coreclr_args.diff_jit_dump:
                         # Create a diff and baseline directory for jit_dumps
-                        bin_dump_location = os.path.join(self.coreclr_args.artifacts_location, "jit_dump", "jit_dump")
-
-                        count = 0
-                        while os.path.isdir(bin_dump_location):
-                            new_base_dump_location = os.path.join(self.coreclr_args.artifacts_location, "jit_dump", "jit_dump" + str(count))
-                            count += 1
-                            print("{} location exists. Attempting to create: {}".format(bin_dump_location, new_base_dump_location))
-                            bin_dump_location = new_base_dump_location
-
+                        bin_dump_location = create_unique_directory_name(self.coreclr_args.spmi_location, "jitdump.{}.{}.{}".format(self.coreclr_args.host_os, self.coreclr_args.arch, self.coreclr_args.build_type))
                         base_dump_location = os.path.join(bin_dump_location, "base")
                         diff_dump_location = os.path.join(bin_dump_location, "diff")
 
-                        if os.path.isdir(base_dump_location):
-                            shutil.rmtree(base_dump_location)
-                        if os.path.isdir(diff_dump_location):
-                            shutil.rmtree(diff_dump_location)
+                        assert(not os.path.isdir(base_dump_location))
+                        assert(not os.path.isdir(diff_dump_location))
 
                         os.makedirs(base_dump_location)
                         os.makedirs(diff_dump_location)
 
-                        assert(os.path.isdir(base_dump_location))
-                        assert(os.path.isdir(diff_dump_location))
-
-                        assert(len(os.listdir(base_dump_location)) == 0)
-                        assert(len(os.listdir(diff_dump_location)) == 0)
-
                 text_differences = asyncio.Queue()
                 jit_dump_differences = asyncio.Queue()
+
+                asm_complus_vars = {
+                        "COMPlus_JitDisasm": "*",
+                        "COMPlus_JitUnwindDump": "*",
+                        "COMPlus_JitEHDump": "*",
+                        "COMPlus_JitDiffableDasm": "1",
+                        "COMPlus_NgenDisasm": "*",
+                        "COMPlus_NgenDump": "*",
+                        "COMPlus_NgenUnwindDump": "*",
+                        "COMPlus_NgenEHDump": "*",
+                        "COMPlus_JitEnableNoWayAssert": "1",
+                        "COMPlus_JitNoForceFallback": "1",
+                        "COMPlus_JitRequired": "1",
+                        "COMPlus_TieredCompilation": "0" }
+
+                jit_dump_complus_vars = {
+                        "COMPlus_JitEnableNoWayAssert": "1",
+                        "COMPlus_JitNoForceFallback": "1",
+                        "COMPlus_JitRequired": "1",
+                        "COMPlus_JitDump": "*" }
 
                 async def create_asm(print_prefix, item, self, text_differences, base_asm_location, diff_asm_location):
                     """ Run superpmi over an mc to create dasm for the method.
@@ -1229,20 +1276,9 @@ class SuperPMIReplayAsmDiffs:
                         "-jitoption", "force", "AltJit=",
                         "-jitoption", "force", "AltJitNgen="
                     ]
-                    
-                    asm_env = os.environ.copy()
-                    asm_env["COMPlus_JitDisasm"] = "*"
-                    asm_env["COMPlus_JitUnwindDump"] = "*"
-                    asm_env["COMPlus_JitEHDump"] = "*"
-                    asm_env["COMPlus_JitDiffableDasm"] = "1"
-                    asm_env["COMPlus_NgenDisasm"] = "*"
-                    asm_env["COMPlus_NgenDump"] = "*"
-                    asm_env["COMPlus_NgenUnwindDump"] = "*"
-                    asm_env["COMPlus_NgenEHDump"] = "*"
-                    asm_env["COMPlus_JitEnableNoWayAssert"] = "1"
-                    asm_env["COMPlus_JitNoForceFallback"] = "1"
-                    asm_env["COMPlus_JitRequired"] = "1"
-                    asm_env["COMPlus_TieredCompilation"] = "0"
+
+                    # Add in all the COMPlus variables we need to generate asm.
+                    os.environ.update(asm_complus_vars)
 
                     # Change the working directory to the core root we will call SuperPMI from.
                     # This is done to allow libcorcedistools to be loaded correctly on unix
@@ -1255,7 +1291,6 @@ class SuperPMIReplayAsmDiffs:
                         command = [self.superpmi_path] + flags + [self.base_jit_path, self.mch_file]
 
                         with open(os.path.join(base_asm_location, "{}.dasm".format(item)), 'w') as file_handle:
-                            os.environ.update(asm_env)
                             print("{}Invoking: {}".format(print_prefix, " ".join(command)))
                             proc = await asyncio.create_subprocess_shell(" ".join(command), stdout=file_handle, stderr=asyncio.subprocess.PIPE)
                             await proc.communicate()
@@ -1266,7 +1301,6 @@ class SuperPMIReplayAsmDiffs:
                         command = [self.superpmi_path] + flags + [self.diff_jit_path, self.mch_file]
 
                         with open(os.path.join(diff_asm_location, "{}.dasm".format(item)), 'w') as file_handle:
-                            os.environ.update(asm_env)
                             print("Invoking: ".format(print_prefix) + " ".join(command))
                             proc = await asyncio.create_subprocess_shell(" ".join(command), stdout=file_handle, stderr=asyncio.subprocess.PIPE)
                             await proc.communicate()
@@ -1305,13 +1339,10 @@ class SuperPMIReplayAsmDiffs:
                         "-jitoption", "force", "AltJit=",
                         "-jitoption", "force", "AltJitNgen="
                     ]
-                    
-                    jit_dump_env = os.environ.copy()
-                    jit_dump_env["COMPlus_JitEnableNoWayAssert"] = "1"
-                    jit_dump_env["COMPlus_JitNoForceFallback"] = "1"
-                    jit_dump_env["COMPlus_JitRequired"] = "1"
-                    jit_dump_env["COMPlus_JitDump"] = "*"
-                    
+
+                    # Add in all the COMPlus variables we need to generate JitDump.
+                    os.environ.update(jit_dump_complus_vars)
+
                     # Generate jit dumps
                     base_txt = None
                     diff_txt = None
@@ -1324,7 +1355,6 @@ class SuperPMIReplayAsmDiffs:
                         command = [self.superpmi_path] + flags + [self.base_jit_path, self.mch_file]
 
                         with open(os.path.join(base_dump_location, "{}.txt".format(item)), 'w') as file_handle:
-                            os.environ.update(jit_dump_env)
                             print("{}Invoking: ".format(print_prefix) + " ".join(command))
                             proc = await asyncio.create_subprocess_shell(" ".join(command), stdout=file_handle, stderr=asyncio.subprocess.PIPE)
                             await proc.communicate()
@@ -1335,11 +1365,10 @@ class SuperPMIReplayAsmDiffs:
                         command = [self.superpmi_path] + flags + [self.diff_jit_path, self.mch_file]
 
                         with open(os.path.join(diff_dump_location, "{}.txt".format(item)), 'w') as file_handle:
-                            os.environ.update(jit_dump_env)
                             print("{}Invoking: ".format(print_prefix) + " ".join(command))
                             proc = await asyncio.create_subprocess_shell(" ".join(command), stdout=file_handle, stderr=asyncio.subprocess.PIPE)
                             await proc.communicate()
-                        
+
                         with open(os.path.join(diff_dump_location, "{}.txt".format(item)), 'r') as file_handle:
                             diff_txt = file_handle.read()
 
@@ -1359,10 +1388,12 @@ class SuperPMIReplayAsmDiffs:
                     for item in self.diff_mcl_contents:
                         diff_items.append(item)
 
+                    print("Creating asm files")
                     subproc_helper = AsyncSubprocessHelper(diff_items, verbose=True)
                     subproc_helper.run_to_completion(create_asm, self, text_differences, base_asm_location, diff_asm_location)
 
                     if self.coreclr_args.diff_jit_dump:
+                        print("Creating JitDump files")
                         subproc_helper.run_to_completion(create_jit_dump, self, jit_dump_differences, base_dump_location, diff_dump_location)
 
                 else:
@@ -1407,10 +1438,19 @@ class SuperPMIReplayAsmDiffs:
                                 jit_dump_differences.append(item[:-4])
 
                 if not self.coreclr_args.diff_with_code_only:
-                    print("Differences found, to replay SuperPMI use <path_to_SuperPMI> -jitoption force AltJit= -jitoption force AltJitNgen= -c ### <path_to_jit> <path_to_mcl>")
+                    print("Differences found. To replay SuperPMI use:")
                     print("")
-                    print("Binary differences found with superpmi -a")
+                    for var, value in asm_complus_vars.items():
+                        print("{} {}={}".format("set" if platform.system() == "Windows" else "export", var, value))
+                    print("{} -jitoption force AltJit= -jitoption force AltJitNgen= -c ### {} {}".format(self.superpmi_path, self.jit_path, self.mch_file))
                     print("")
+                    if self.coreclr_args.diff_jit_dump:
+                        print("To generate JitDump with SuperPMI use:")
+                        print("")
+                        for var, value in jit_dump_complus_vars.items():
+                            print("{} {}={}".format("set" if platform.system() == "Windows" else "export", var, value))
+                        print("{} -jitoption force AltJit= -jitoption force AltJitNgen= -c ### {} {}".format(self.superpmi_path, self.jit_path, self.mch_file))
+                        print("")
                     print("Method numbers with binary differences:")
                     print(self.diff_mcl_contents)
                     print("")
@@ -1421,7 +1461,7 @@ class SuperPMIReplayAsmDiffs:
                     current_text_diff = None
 
                 if current_text_diff is not None:
-                    print("Textual differences found, the asm is located under %s and %s" % (base_asm_location, diff_asm_location))
+                    print("Textual differences found. Asm is located under %s %s" % (base_asm_location, diff_asm_location))
                     print("Generate a diff analysis report by building jit-analyze from https://github.com/dotnet/jitutils and running:")
                     print("    jit-analyze -r --base %s --diff %s" % (base_asm_location, diff_asm_location))
 
@@ -1476,7 +1516,7 @@ class SuperPMIReplayAsmDiffs:
 
                     if self.coreclr_args.diff_with_code:
                         batch_command = ["cmd", "/c"] if platform.system() == "Windows" else []
-                        
+
                         index = 0
                         while current_jit_dump_diff is not None:
                             command = batch_command + [
@@ -1596,7 +1636,7 @@ def determine_jit_name(coreclr_args):
 
     Args:
         coreclr_args (CoreclrArguments): parsed args
-    
+
     Return:
         jit_name(str) : name of the jit for this os
     """
@@ -1629,7 +1669,7 @@ def list_superpmi_container_via_rest_api(coreclr_args, filter=lambda unused: Tru
 
     Args:
         filter (lambda: string): filter to apply to the list
-    
+
     Notes:
         This method does not require installing the azure storage python
         package.
@@ -1642,7 +1682,7 @@ def list_superpmi_container_via_rest_api(coreclr_args, filter=lambda unused: Tru
     urls = []
     for item in urls_split:
         url = item.split("</Url>")[0].strip()
-        
+
         if "{}/{}/{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type) in url and filter(url):
             urls.append(url)
 
@@ -1664,8 +1704,8 @@ def download_index(coreclr_args):
         Example:
 
         {
-            "frameworks": "Windows_NT.x64.Checked.frameworks.mch", 
-            "default": "Windows_NT.x64.Checked.mch", 
+            "frameworks": "Windows_NT.x64.Checked.frameworks.mch",
+            "default": "Windows_NT.x64.Checked.mch",
             "tests": "Windows_NT.x64.Checked.tests.mch"
         }
     """
@@ -1688,19 +1728,19 @@ def download_mch(coreclr_args, specific_mch=None, include_baseline_jit=False):
 
     Returns:
         index (defaultdict(lambda: None)): collection type -> name
-    
+
     """
 
     urls = list_superpmi_container_via_rest_api(coreclr_args)
-    default_mch_dir = os.path.join(coreclr_args.artifacts_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
+    default_mch_dir = os.path.join(coreclr_args.spmi_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
 
     if not os.path.isdir(default_mch_dir):
         os.makedirs(default_mch_dir)
 
     with TempDir() as temp_location:
         for url in urls:
-            temp_location_jtems = [os.path.join(temp_location, item) for item in os.listdir(temp_location)]
-            for item in temp_location_jtems:
+            temp_location_items = [os.path.join(temp_location, item) for item in os.listdir(temp_location)]
+            for item in temp_location_items:
                 if os.path.isdir(item):
                     shutil.rmtree(item)
                 else:
@@ -1732,15 +1772,16 @@ def download_mch(coreclr_args, specific_mch=None, include_baseline_jit=False):
             items = [os.path.join(temp_location, item) for item in os.listdir(temp_location) if not item.endswith(".zip")]
 
             for item in items:
+                print("Copying: {} -> {}".format(item, default_mch_dir))
                 shutil.copy2(item, default_mch_dir)
-    
+
 
 def upload_mch(coreclr_args):
     """ Upload the mch files
 
     Args:
         coreclr_args (CoreclrArguments): parsed args
-    
+
     """
 
     try:
@@ -1750,7 +1791,7 @@ def upload_mch(coreclr_args):
         print("Please install:")
         print("pip install azure-storage-blob")
         print("pip install cffi")
-        
+
         raise RuntimeError("Missing azure storage package.")
 
     block_blob_service = BlockBlobService(account_name="clrjit", account_key=coreclr_args.az_storage_key)
@@ -1803,13 +1844,13 @@ def upload_mch(coreclr_args):
         assert os.path.isfile(jit_location)
         print("Uploading: {} -> {}".format(jit_location, "https://clrjit.blob.core.windows.net/superpmi/" + os.path.basename(jit_location)))
         block_blob_service.create_blob_from_path(container_name, container_path, jit_location)
-    
+
 def setup_args(args):
     """ Setup the args for SuperPMI to use.
 
     Args:
         args (ArgParse): args parsed by arg parser
-    
+
     Returns:
         args (CoreclrArguments)
 
@@ -1826,10 +1867,8 @@ def setup_args(args):
                         lambda mode: mode in ["collect", "replay", "asmdiffs", "upload", "list-collections"],
                         'Incorrect mode passed, please choose from ["collect", "replay", "asmdiffs", "upload", "list-collections"]')
 
-    default_coreclr_bin_mch_location = os.path.join(coreclr_args.artifacts_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
-
     def setup_mch_arg(arg):
-        default_mch_location = os.path.join(coreclr_args.artifacts_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type), "{}.{}.{}.mch".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
+        default_mch_location = os.path.join(coreclr_args.spmi_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type), "{}.{}.{}.mch".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type))
 
         if os.path.isfile(default_mch_location) and not args.force_download and coreclr_args.collection == "default":
             return default_mch_location
@@ -1837,21 +1876,13 @@ def setup_args(args):
         # Download the mch
         else:
             index = download_index(coreclr_args)
-            
-            mch_location = os.path.join(coreclr_args.artifacts_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type), index[coreclr_args.collection])
+
+            mch_location = os.path.join(coreclr_args.spmi_location, "mch", "{}.{}.{}".format(coreclr_args.host_os, coreclr_args.arch, coreclr_args.build_type), index[coreclr_args.collection])
 
             if not os.path.isfile(mch_location):
                 download_mch(coreclr_args, specific_mch=index[coreclr_args.collection], include_baseline_jit=True)
 
             return mch_location
-
-    if not os.path.isdir(default_coreclr_bin_mch_location):
-        os.makedirs(default_coreclr_bin_mch_location)
-
-    coreclr_args.verify(default_coreclr_bin_mch_location,
-                        "default_coreclr_bin_mch_location",
-                        lambda unused: True,
-                        "Error setting default_coreclr_bin_mch_location")
 
     if coreclr_args.mode == "collect":
 
@@ -1870,7 +1901,7 @@ def setup_args(args):
                             "pmi",
                             lambda unused: True,
                             "Unable to set pmi")
-        
+
         coreclr_args.verify(args,
                             "pmi_assemblies",
                             lambda items: args.pmi is False or len(items) > 0,
@@ -1881,7 +1912,7 @@ def setup_args(args):
                             "pmi_location",
                             lambda unused: True,
                             "Unable to set pmi_location")
-        
+
         coreclr_args.verify(args,
                             "log_file",
                             lambda unused: True,
@@ -1889,9 +1920,9 @@ def setup_args(args):
 
         coreclr_args.verify(args,
                             "output_mch_path",
-                            lambda unused: True,
-                            "Unable to set output_mch_path")
-        
+                            lambda output_mch_path: not os.path.isdir(os.path.abspath(output_mch_path)) and not os.path.isfile(os.path.abspath(output_mch_path)),
+                            "Invalid output_mch_path; is it an existing directory or file?")
+
         coreclr_args.verify(args,
                             "log_file",
                             lambda unused: True,
@@ -1947,6 +1978,12 @@ def setup_args(args):
                             lambda unused: True,
                             "Unable to set use_zapdisable")
 
+        coreclr_args.verify(args,
+                            "spmi_location",
+                            lambda unused: True,
+                            "Unable to set pmi_location",
+                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
+
         jit_location = os.path.join(coreclr_args.core_root, determine_jit_name(coreclr_args))
         assert(os.path.isfile(jit_location))
 
@@ -1959,7 +1996,7 @@ def setup_args(args):
         if coreclr_args.merge_mch_files:
             assert len(coreclr_args.mch_files) > 0
             coreclr_args.has_run_collection_command = True
-    
+
     elif coreclr_args.mode == "replay":
 
         coreclr_args.verify(args,
@@ -1994,6 +2031,12 @@ def setup_args(args):
                             lambda unused: True,
                             "Unable to set break_on_error")
 
+        coreclr_args.verify(args,
+                            "spmi_location",
+                            lambda unused: True,
+                            "Unable to set pmi_location",
+                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
+
         standard_location = False
         if coreclr_args.product_location.lower() in coreclr_args.jit_path.lower():
             standard_location = True
@@ -2027,7 +2070,7 @@ def setup_args(args):
                                 "arch",
                                 lambda unused: True,
                                 "Unable to set arch")
-            
+
             coreclr_args.verify(determined_build_type,
                                 "build_type",
                                 coreclr_args.check_build_type,
@@ -2082,7 +2125,7 @@ def setup_args(args):
                             "diff_with_code_only",
                             lambda unused: True,
                             "Unable to set diff_with_code_only.")
-        
+
         coreclr_args.verify(args,
                             "previous_temp_location",
                             lambda unused: True,
@@ -2111,6 +2154,12 @@ def setup_args(args):
                                 "diff_jit_dump",
                                 lambda unused: True,
                                 "Unable to set diff_jit_dump.")
+
+        coreclr_args.verify(args,
+                            "spmi_location",
+                            lambda unused: True,
+                            "Unable to set pmi_location",
+                            modify_arg=lambda spmi_location: os.path.abspath(os.path.join(coreclr_args.artifacts_location, "spmi")) if spmi_location is None else spmi_location)
 
         standard_location = False
         if coreclr_args.product_location.lower() in coreclr_args.base_jit_path.lower():
@@ -2164,6 +2213,7 @@ def setup_args(args):
                             modify_arg=lambda arg: arg[0] if arg is not None else setup_mch_arg(arg))
 
     elif coreclr_args.mode == "upload":
+
         coreclr_args.verify(args,
                             "az_storage_key",
                             lambda item: item is not None,
@@ -2179,7 +2229,7 @@ def setup_args(args):
                             "jit_location",
                             lambda unused: True,
                             "Unable to set jit_location.")
-    
+
     return coreclr_args
 
 ################################################################################
@@ -2197,7 +2247,7 @@ def main(args):
 
         return 1
 
-    # Force tieried compilation off. It will effect both collection and replay
+    # Force tiered compilation off. It will affect both collection and replay.
     os.environ["COMPlus_TieredCompilation"] = "0"
 
     coreclr_args = setup_args(args)
@@ -2208,7 +2258,7 @@ def main(args):
 
         begin_time = datetime.datetime.now()
 
-        print("SuperPMI Collect")
+        print("SuperPMI collect")
         print("------------------------------------------------------------")
         print("Start time: {}".format(begin_time.strftime("%H:%M:%S")))
 
@@ -2231,7 +2281,7 @@ def main(args):
 
         begin_time = datetime.datetime.now()
 
-        print("SuperPMI Replay")
+        print("SuperPMI replay")
         print("------------------------------------------------------------")
         print("Start time: {}".format(begin_time.strftime("%H:%M:%S")))
 
@@ -2239,7 +2289,6 @@ def main(args):
         jit_path = coreclr_args.jit_path
 
         print("")
-
         print("MCH Path: {}".format(mch_file))
         print("JIT Path: {}".format(jit_path))
 
@@ -2268,7 +2317,6 @@ def main(args):
         diff_jit_path = coreclr_args.diff_jit_path
 
         print("")
-
         print("MCH Path: {}".format(mch_file))
         print("Base JIT Path: {}".format(base_jit_path))
         print("Diff JIT Path: {}".format(diff_jit_path))
@@ -2309,14 +2357,14 @@ def main(args):
         print("")
         print("{} different collections".format(index_count))
         print("")
-        
+
         for item in index:
             print(item)
-        
+
         print("")
     else:
         raise NotImplementedError(coreclr_args.mode)
-    
+
     return 0 if success else 1
 
 ################################################################################

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -244,7 +244,7 @@ def make_safe_filename(s):
             return "_"
     return "".join(safe_char(c) for c in s)
 
-def _find(name, pathlist, matchFunc=os.path.isfile):
+def find_in_path(name, pathlist, matchFunc=os.path.isfile):
     """ Find a name (e.g., directory name or file name) in the file system by searching the directories
         in a semicolon-separated `pathlist` (e.g., PATH environment variable).
 
@@ -262,7 +262,7 @@ def _find(name, pathlist, matchFunc=os.path.isfile):
             return candidate
     return None
 
-def findFile(filename, pathlist):
+def find_file(filename, pathlist):
     """ Find a filename in the file system by searching the directories
         in a semicolon-separated `pathlist` (e.g., PATH environment variable).
 
@@ -273,9 +273,9 @@ def findFile(filename, pathlist):
     Returns:
         (str) The pathname of the object, or None if not found.
     """
-    return _find(filename, pathlist)
+    return find_in_path(filename, pathlist)
 
-def findDir(dirname, pathlist):
+def find_dir(dirname, pathlist):
     """ Find a directory name in the file system by searching the directories
         in a semicolon-separated `pathlist` (e.g., PATH environment variable).
 
@@ -286,7 +286,7 @@ def findDir(dirname, pathlist):
     Returns:
         (str) The pathname of the object, or None if not found.
     """
-    return _find(dirname, pathlist, matchFunc=os.path.isdir)
+    return find_in_path(dirname, pathlist, matchFunc=os.path.isdir)
 
 def create_unique_directory_name(root_directory, base_name):
     """ Create a unique directory name by joining `root_directory` and `base_name`.
@@ -1435,7 +1435,7 @@ class SuperPMIReplayAsmDiffs:
                     if search_path is not None:
                         search_path = search_path.split(";")
                         jit_analyze_file = "jit-analyze.bat" if platform.system() == "Windows" else "jit-analyze.sh"
-                        jit_analyze_path = findFile(jit_analyze_file, search_path)
+                        jit_analyze_path = find_file(jit_analyze_file, search_path)
                         if jit_analyze_path is not None:
                             # It appears we have a built jit-analyze on the path, so try to run it.
                             command = [ jit_analyze_path, "-r", "--base", base_asm_location, "--diff", diff_asm_location ]


### PR DESCRIPTION
1. The "diff" JIT in asmdiffs is now assumed to be in the current
repo if not specified. (That is, a computed default is attempted.)
2. jit-analyze is run on the generated diffs, if it is found on the
PATH. This has some limitations, as we generate a file for each
function, so the "top file" sections are not interesting.
3. Elapsed time is computed and displayed at the end of the task.