### PR TITLE
SocketAsyncEngine.Unix: Use eventfd(2) to signal shutdown

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Eventfd.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Eventfd.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        //
+        // Since eventfd is a Linux-only feature, there's no need to define our own
+        // flag values: pass these values through as the Linux system call expects.
+        //
+        [Flags]
+        internal enum EventFdFlags
+        {
+            EFD_SEMAPHORE = 0x1,
+            EFD_CLOEXEC = 0x80000,
+            EFD_NONBLOCK = 0x800,
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_EventFD", SetLastError = true)]
+        internal static extern unsafe int EventFD(uint initialVal, EventFdFlags flags = 0);
+    }
+}

--- a/src/libraries/Native/Unix/Common/pal_config.h.in
+++ b/src/libraries/Native/Unix/Common/pal_config.h.in
@@ -96,6 +96,7 @@
 #cmakedefine01 HAVE_TCP_H_TCP_KEEPALIVE
 #cmakedefine01 HAVE_BUILTIN_MUL_OVERFLOW
 #cmakedefine01 HAVE_DISCONNECTX
+#cmakedefine01 HAVE_EVENTFD
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -38,6 +38,9 @@
 #if HAVE_INOTIFY
 #include <sys/inotify.h>
 #endif
+#if HAVE_EVENTFD
+#include <sys/eventfd.h>
+#endif
 
 #ifdef _AIX
 #include <alloca.h>
@@ -474,6 +477,21 @@ int32_t SystemNative_CloseDir(DIR* dir)
 {
     return closedir(dir);
 }
+
+#if HAVE_EVENTFD
+int32_t SystemNative_EventFD(uint32_t initialVal, int32_t flags)
+{
+    return eventfd(initialVal, flags);
+}
+#else
+int32_t SystemNative_EventFD(uint32_t initialVal, int32_t flags)
+{
+    (void)initialVal;
+    (void)flags;
+    errno = ENOTSUP;
+    return -1;
+}
+#endif
 
 int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
 {

--- a/src/libraries/Native/Unix/System.Native/pal_io.h
+++ b/src/libraries/Native/Unix/System.Native/pal_io.h
@@ -421,6 +421,14 @@ DLLEXPORT int32_t SystemNative_CloseDir(DIR* dir);
 DLLEXPORT int32_t SystemNative_Pipe(int32_t pipefd[2], // [out] pipefds[0] gets read end, pipefd[1] gets write end.
                         int32_t flags);    // 0 for defaults or PAL_O_CLOEXEC for close-on-exec
 
+/**
+ * Creates an eventfd on Linux.  Returns error everywhere else.
+ *
+ * Returns 0 for success, -1 for failure. Sets errno on failure.
+ */
+DLLEXPORT int32_t SystemNative_EventFD(uint32_t initialValue,
+                                       int32_t flags); // Passes through to eventfd() without conversion
+
 // NOTE: Rather than a general fcntl shim, we opt to export separate functions
 // for each command. This allows use to have strongly typed arguments and saves
 // complexity around converting command codes.

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -105,6 +105,11 @@ check_symbol_exists(
     HAVE_GETIFADDRS)
 
 check_symbol_exists(
+    eventfd
+    sys/eventfd.h
+    HAVE_EVENTFD)
+
+check_symbol_exists(
     lseek64
     unistd.h
     HAVE_LSEEK64)

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -374,6 +374,9 @@
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Pipe.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Pipe.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Eventfd.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.Eventfd.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Write.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Write.cs</Link>
     </Compile>


### PR DESCRIPTION
Since we don't really care what is being written to the pipe to wake up the event loop, we can substitute it for an eventfd(2) on Linux and save ourselves a file descriptor per SocketAsyncEngine.  (For manycore systems, that's potentially dozens of file descriptors that aren't needed anymore.)

(It's a tiny wee little bit more efficient to write to an eventfd than it is writing to a pipe, although in this case it doesn't matter that much as we're shutting down the engines.)

Also, I don't know C# very well, so the changes in `SocketAsyncEngine.RequestEventLoopShutdown()` might not be correct.