### PR TITLE
R2RDump improvements w.r.t. GC info reporting

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -245,6 +245,8 @@ namespace ILCompiler.Reflection.ReadyToRun
         GC_SLOT_INTERIOR = 0x1,
         GC_SLOT_PINNED = 0x2,
         GC_SLOT_UNTRACKED = 0x4,
+
+        GC_SLOT_INVALID = -1
     };
 
     public enum GcStackSlotBase
@@ -272,12 +274,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
-
-            sb.AppendLine($"\t\t\t\tSpOffset: {SpOffset}");
-            sb.Append($"\t\t\t\tBase: {Enum.GetName(typeof(GcStackSlotBase), Base)}");
-
-            return sb.ToString();
+            return $@"{Enum.GetName(typeof(GcStackSlotBase), Base)}+0x{SpOffset:X2}";
         }
     };
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/R2RMethod.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/R2RMethod.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using System.Text;
 
 namespace ILCompiler.Reflection.ReadyToRun
@@ -32,6 +33,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
     public abstract class BaseGcSlot
     {
+        public abstract GcSlotFlags WriteTo(StringBuilder sb, Machine machine, GcSlotFlags prevFlags);
     }
 
     public abstract class BaseGcInfo

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
@@ -62,6 +62,11 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             return sb.ToString();
         }
 
+        public string GetRegisterName(int registerNumber)
+        {
+            return ((x86.Registers)registerNumber).ToString();
+        }
+
         private void AddNewTransition(BaseGcTransition transition)
         {
             if (!Transitions.ContainsKey(transition.CodeOffset))

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -217,46 +217,7 @@ namespace R2RDump
             if (theThis.Method.GcInfo is ILCompiler.Reflection.ReadyToRun.Amd64.GcInfo gcInfo)
             {
                 writer.WriteLine("GC info:");
-                writer.WriteLine($@"    Version:                           {gcInfo.Version}");
-                writer.WriteLine($@"    ReturnKind:                        {gcInfo.ReturnKind}");
-                writer.WriteLine($@"    ValidRangeStart:                   0x{gcInfo.ValidRangeStart:X4}");
-                writer.WriteLine($@"    ValidRangeEnd:                     0x{gcInfo.ValidRangeEnd:X4}");
-                writer.WriteLine($@"    SecurityObjectStackSlot:           0x{gcInfo.SecurityObjectStackSlot:X4}");
-                writer.WriteLine($@"    GSCookieStackSlot:                 0x{gcInfo.GSCookieStackSlot:X4}");
-                writer.WriteLine($@"    PSPSymStackSlot:                   0x{gcInfo.PSPSymStackSlot:X4}");
-                writer.WriteLine($@"    GenericsInstContextStackSlot:      0x{gcInfo.GenericsInstContextStackSlot:X4}");
-                writer.WriteLine($@"    StackBaseRegister:                 {gcInfo.StackBaseRegister}");
-                writer.WriteLine($@"    SizeOfENCPreservedArea:            0x{gcInfo.SizeOfEditAndContinuePreservedArea:X4}");
-                writer.WriteLine($@"    ReversePInvokeFrameStackSlot:      0x{gcInfo.ReversePInvokeFrameStackSlot:X4}");
-                writer.WriteLine($@"    SizeOfStackOutgoingAndScratchArea: 0x{gcInfo.SizeOfStackOutgoingAndScratchArea:X4}");
-                writer.WriteLine($@"    NumSafePoints:                     {gcInfo.NumSafePoints}");
-                writer.WriteLine($@"    NumInterruptibleRanges:            {gcInfo.NumInterruptibleRanges}");
-
-                writer.WriteLine($@"    SafePointOffsets: {gcInfo.SafePointOffsets.Count}");
-                foreach (ILCompiler.Reflection.ReadyToRun.Amd64.GcInfo.SafePointOffset safePoint in gcInfo.SafePointOffsets)
-                {
-                    writer.WriteLine($@"        Index: {safePoint.Index,2}; Value: 0x{safePoint.Value:X4}");
-                    if (gcInfo.LiveSlotsAtSafepoints != null)
-                        writer.WriteLine($@"        Live slots: {String.Join(", ", gcInfo.LiveSlotsAtSafepoints[safePoint.Index])}");
-                }
-
-                writer.WriteLine($@"    InterruptibleRanges: {gcInfo.InterruptibleRanges.Count}");
-                foreach (ILCompiler.Reflection.ReadyToRun.Amd64.InterruptibleRange range in gcInfo.InterruptibleRanges)
-                {
-                    writer.WriteLine($@"        Index: {range.Index,2}; StartOffset: 0x{range.StartOffset:X4}; StopOffset: 0x{range.StopOffset:X4}");
-                }
-
-                writer.WriteLine("    SlotTable:");
-                writer.WriteLine($@"        NumRegisters:  {gcInfo.SlotTable.NumRegisters}");
-                writer.WriteLine($@"        NumStackSlots: {gcInfo.SlotTable.NumStackSlots}");
-                writer.WriteLine($@"        NumUntracked:  {gcInfo.SlotTable.NumUntracked}");
-                writer.WriteLine($@"        NumSlots:      {gcInfo.SlotTable.NumSlots}");
-                writer.WriteLine($@"        GcSlots:       {gcInfo.SlotTable.GcSlots.Count}");
-                foreach (ILCompiler.Reflection.ReadyToRun.Amd64.GcSlotTable.GcSlot slot in gcInfo.SlotTable.GcSlots)
-                {
-                    writer.WriteLine($@"            Index: {slot.Index,2}; RegisterNumber: {slot.RegisterNumber,2}; Flags: {slot.Flags}");
-                }
-                writer.WriteLine();
+                writer.WriteLine(gcInfo.ToString());
             }
 
             if (theThis.EHInfo != null)

--- a/src/coreclr/src/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.csproj
@@ -8,6 +8,7 @@
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>

--- a/src/coreclr/src/tools/r2rdump/R2RDump.sln
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29703.146
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "R2RDump", "R2RDump.csproj", "{00CCF6D0-5905-428E-A2A2-2A6D09D8C257}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Reflection.ReadyToRun", "..\crossgen2\ILCompiler.Reflection.ReadyToRun\ILCompiler.Reflection.ReadyToRun.csproj", "{E2A577E5-7AF3-49B3-BA78-7071B75ED64B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{00CCF6D0-5905-428E-A2A2-2A6D09D8C257}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00CCF6D0-5905-428E-A2A2-2A6D09D8C257}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00CCF6D0-5905-428E-A2A2-2A6D09D8C257}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00CCF6D0-5905-428E-A2A2-2A6D09D8C257}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2A577E5-7AF3-49B3-BA78-7071B75ED64B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2A577E5-7AF3-49B3-BA78-7071B75ED64B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2A577E5-7AF3-49B3-BA78-7071B75ED64B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2A577E5-7AF3-49B3-BA78-7071B75ED64B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {61B9BC5F-9DAA-4BC6-9150-9CDFDDDBEA80}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
While I haven't yet managed to nail down the cause of hangs
in the r426654 regression test, I have at least used the opportunity
to improve R2RDump GC info reporting. I have made the reporting
much more compact and more descriptive at the same time by translating
register names and showing stack-relative addresses in a much more
straightforward manner. I'm also proposing to add a VS solution
for R2RDump - as it now depends on the ILCompiler.Reflection.ReadyToRun
project, it just sucks not to be able to work with both in the VS.

Thanks

Tomas