### PR TITLE
Generate full platform manifest in official build

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -6,18 +6,72 @@
     <LibrariesOSGroup Condition="'$(LibrariesOSGroup)' == ''">$(OSGroup)</LibrariesOSGroup>
     <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
 
+    <LibrariesOSGroupConfigurationArchitecture Condition="'$(LibrariesOSGroupConfigurationArchitecture)' == ''">$(LibrariesOSGroup)-$(LibrariesConfiguration)-$(TargetArchitecture)</LibrariesOSGroupConfigurationArchitecture>
+  </PropertyGroup>
+
+  <!-- Accept override paths for live artifacts. -->
+  <PropertyGroup>
     <CoreCLRArtifactsPath Condition="'$(CoreCLROverridePath)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLROverridePath)'))</CoreCLRArtifactsPath>
+    <LibrariesArtifactsPath Condition="'$(LibrariesOverridePath)' != ''">$([MSBuild]::NormalizeDirectory('$(LibrariesOverridePath)'))</LibrariesArtifactsPath>
+  </PropertyGroup>
+
+  <!--
+    If this is running and the output RID is not the same as the targeted RID, resolve live assets
+    for the targeted RID, if available. This is used to gather asset metadata for the platform
+    manifest. In CI (multi-machine lab) builds, CoreCLR and Libraries artifacts are all downloaded
+    onto the current machine from all platforms for the Installer portion of the build.
+
+    Higher priority than override paths: in official builds, the overrides are passed to the build,
+    but we need to point to the AllArtifacts locations when building the platform manifest.
+  -->
+  <PropertyGroup Condition="
+    '$(RuntimeIdentifier)' != '$(OutputRid)' and
+    '$(AllArtifactsDownloadPath)' != ''">
+    <!-- Assume the part of the RID before '-' is an OSGroup. Note: doesn't include '-musl'. -->
+    <RuntimeIdentifierStyleOSGroup>$(ArtifactPlatform.Split('-')[0])</RuntimeIdentifierStyleOSGroup>
+
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'win'">Windows_NT</RidOSGroup>
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'unix'">Unix</RidOSGroup>
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'linux'">Linux</RidOSGroup>
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'osx'">OSX</RidOSGroup>
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'freebsd'">FreeBSD</RidOSGroup>
+    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'netbsd'">NetBSD</RidOSGroup>
+
+    <!-- Convert the OS component in the RID into names that match the job IDs. -->
+    <ArtifactPlatform>$(RuntimeIdentifier)</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('win-', 'Windows_NT-'))</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('unix-', 'Unix-'))</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('linux-', 'Linux-'))</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('osx-', 'OSX-'))</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('freebsd-', 'FreeBSD-'))</ArtifactPlatform>
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('netbsd-', 'NetBSD-'))</ArtifactPlatform>
+    <!-- Artifact name uses '_' rather than '-'. -->
+    <ArtifactPlatform>$(ArtifactPlatform.Replace('-', '_'))</ArtifactPlatform>
+
+    <CoreCLRArtifactsPath>$([MSBuild]::NormalizeDirectory('$(AllArtifactsDownloadPath)', 'CoreCLRProduct_$(ArtifactPlatform)_$(CoreCLRConfiguration)'))</CoreCLRArtifactsPath>
+    <LibrariesArtifactsPath>$([MSBuild]::NormalizeDirectory('$(AllArtifactsDownloadPath)', 'libraries_bin_$(ArtifactPlatform)_$(LibrariesConfiguration)'))</LibrariesArtifactsPath>
+
+    <!--
+      Use '*', calculating these in a static context based on RID is hard. Note that putting '*'
+      through a dir/path normalization function makes it not work, so avoid that.
+    -->
+    <LibrariesOSGroupConfigurationArchitecture>*</LibrariesOSGroupConfigurationArchitecture>
+  </PropertyGroup>
+
+  <!-- Set up default live asset paths if no overrides provided. -->
+  <PropertyGroup>
     <CoreCLRArtifactsPath Condition="'$(CoreCLRArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'coreclr', '$(CoreCLROSGroup).$(TargetArchitecture).$(CoreCLRConfiguration)'))</CoreCLRArtifactsPath>
-
-    <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
-
     <LibrariesArtifactsPath Condition="'$(LibrariesArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</LibrariesArtifactsPath>
+    <LibrariesAllConfigurationsArtifactsPath Condition="'$(LibrariesAllConfigurationsArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</LibrariesAllConfigurationsArtifactsPath>
+  </PropertyGroup>
+
+  <!-- Set up artifact subpaths. -->
+  <PropertyGroup>
+    <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
 
     <LibrariesPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'packages', '$(LibrariesConfiguration)'))</LibrariesPackagesDir>
     <LibrariesShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesPackagesDir)', 'Shipping'))</LibrariesShippingPackagesDir>
     <LibrariesNonShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesPackagesDir)', 'NonShipping'))</LibrariesNonShippingPackagesDir>
-
-    <LibrariesAllConfigurationsArtifactsPath Condition="'$(LibrariesAllConfigurationsArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</LibrariesAllConfigurationsArtifactsPath>
 
     <LibrariesAllConfigPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesAllConfigurationsArtifactsPath)', 'packages', '$(LibrariesConfiguration)'))</LibrariesAllConfigPackagesDir>
     <LibrariesAllConfigShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesAllConfigPackagesDir)', 'Shipping'))</LibrariesAllConfigShippingPackagesDir>
@@ -25,9 +79,10 @@
 
     <LibrariesSharedFrameworkRefArtifactsPath Condition="'$(LibrariesSharedFrameworkRefArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'ref', 'microsoft.netcore.app', '$(LibrariesConfiguration)'))</LibrariesSharedFrameworkRefArtifactsPath>
     <LibrariesAllRefArtifactsPath Condition="'$(LibrariesAllRefArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'ref', '$(NetCoreAppCurrent)'))</LibrariesAllRefArtifactsPath>
-    <LibrariesSharedFrameworkBinArtifactsPath Condition="'$(LibrariesSharedFrameworkBinArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'pkg', '$(NetCoreAppCurrent)', 'runtime', '$(LibrariesOSGroup)-$(LibrariesConfiguration)-$(TargetArchitecture)'))</LibrariesSharedFrameworkBinArtifactsPath>
-    <LibrariesAllBinArtifactsPath Condition="'$(LibrariesAllBinArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'runtime', '$(NetCoreAppCurrent)-$(LibrariesOSGroup)-$(LibrariesConfiguration)-$(TargetArchitecture)'))</LibrariesAllBinArtifactsPath>
-    <LibrariesNativeArtifactsPath Condition="'$(LibrariesNativeArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'native', '$(NetCoreAppCurrent)-$(LibrariesOSGroup)-$(LibrariesConfiguration)-$(TargetArchitecture)'))</LibrariesNativeArtifactsPath>
+    <LibrariesSharedFrameworkBinArtifactsPath Condition="'$(LibrariesSharedFrameworkBinArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'pkg', '$(NetCoreAppCurrent)', 'runtime'))$(LibrariesOSGroupConfigurationArchitecture)\</LibrariesSharedFrameworkBinArtifactsPath>
+    <LibrariesAllBinArtifactsPath Condition="'$(LibrariesAllBinArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'runtime'))$(NetCoreAppCurrent)-$(LibrariesOSGroupConfigurationArchitecture)\</LibrariesAllBinArtifactsPath>
+    <LibrariesNativeArtifactsPath Condition="'$(LibrariesNativeArtifactsPath)' == ''">$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'bin', 'native'))$(NetCoreAppCurrent)-$(LibrariesOSGroupConfigurationArchitecture)\</LibrariesNativeArtifactsPath>
+
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">x64</CoreCLRCrossTargetComponentDirName>
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentDirName>
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
@@ -81,12 +136,26 @@
     <Error Condition="'@(CoreCLRFiles)' == ''" Text="The CoreCLR subset category must be built before building this project." />
   </Target>
 
-  <Target Name="ResolveLibrariesFromLocalBuild">
+  <Target Name="EnsureLocalArtifactsExist">
     <Error Condition="!Exists('$(LibrariesSharedFrameworkRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkRefArtifactsPath)" />
     <Error Condition="!Exists('$(LibrariesAllRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllRefArtifactsPath)" />
+  </Target>
+
+  <!--
+    Ensure artifacts exist for the more advanced paths. If the configuration is '*', don't emit
+    these errors: it isn't a local dev scenario.
+  -->
+  <Target Name="EnsureLocalOSGroupConfigurationArchitectureSpecificArtifactsExist"
+          Condition="'$(LibrariesOSGroupConfigurationArchitecture)' != '*'">
     <Error Condition="!Exists('$(LibrariesSharedFrameworkBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkBinArtifactsPath)" />
     <Error Condition="!Exists('$(LibrariesAllBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllBinArtifactsPath)" />
     <Error Condition="!Exists('$(LibrariesNativeArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesNativeArtifactsPath)" />
+  </Target>
+
+  <Target Name="ResolveLibrariesFromLocalBuild"
+          DependsOnTargets="
+            EnsureLocalArtifactsExist;
+            EnsureLocalOSGroupConfigurationArchitectureSpecificArtifactsExist">
     <ItemGroup>
       <LibrariesRefAssemblies Condition="'$(IncludeOOBLibraries)' != 'true'" Include="$(LibrariesSharedFrameworkRefArtifactsPath)*.dll;$(LibrariesSharedFrameworkRefArtifactsPath)*.pdb" />
       <LibrariesRefAssemblies Condition="'$(IncludeOOBLibraries)' == 'true'" Include="$(LibrariesAllRefArtifactsPath)*.dll;$(LibrariesAllRefArtifactsPath)*.pdb" />
@@ -101,6 +170,7 @@
       <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)*.dll;
         $(LibrariesNativeArtifactsPath)*.dylib;
+        $(LibrariesNativeArtifactsPath)*.a;
         $(LibrariesNativeArtifactsPath)*.so;
         $(LibrariesNativeArtifactsPath)*.dbg;
         $(LibrariesNativeArtifactsPath)*.dwarf;

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -27,16 +27,6 @@
   <PropertyGroup Condition="
     '$(RuntimeIdentifier)' != '$(OutputRid)' and
     '$(AllArtifactsDownloadPath)' != ''">
-    <!-- Assume the part of the RID before '-' is an OSGroup. Note: doesn't include '-musl'. -->
-    <RuntimeIdentifierStyleOSGroup>$(ArtifactPlatform.Split('-')[0])</RuntimeIdentifierStyleOSGroup>
-
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'win'">Windows_NT</RidOSGroup>
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'unix'">Unix</RidOSGroup>
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'linux'">Linux</RidOSGroup>
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'osx'">OSX</RidOSGroup>
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'freebsd'">FreeBSD</RidOSGroup>
-    <RidOSGroup Condition="'$(RuntimeIdentifierStyleOSGroup)' == 'netbsd'">NetBSD</RidOSGroup>
-
     <!-- Convert the OS component in the RID into names that match the job IDs. -->
     <ArtifactPlatform>$(RuntimeIdentifier)</ArtifactPlatform>
     <ArtifactPlatform>$(ArtifactPlatform.Replace('win-', 'Windows_NT-'))</ArtifactPlatform>

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -134,8 +134,9 @@ jobs:
     - name: LibrariesArtifactNameAllConfigurations
       value: libraries_bin_official_allconfigurations
 
-  # Download all upstream platforms and incorporate in the platform manifest.
-  - ${{ if ne(parameters.upstreamPlatforms, '') }}:
+  # Download all upstream platforms and incorporate in the platform manifest. Use 'each' as a
+  # makeshift condition because there is no documented way to evaluate this and duplication is ok.
+  - ${{ each platform in parameters.upstreamPlatforms }}:
     - name: AllArtifactsDownloadPath
       value: 'artifacts/transport/AllArtifacts'
     - name: AllArtifactsArgs

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -29,6 +29,7 @@ parameters:
 
   liveCoreClrBuildConfig: ''
   liveLibrariesBuildConfig: ''
+  upstreamPlatforms: []
 
 jobs:
 - job: ${{ format('installer_{0}', coalesce(parameters.name, parameters.platform)) }}
@@ -70,15 +71,18 @@ jobs:
 
   - name: LiveOverridePathArgs
     value: >-
-      $(CoreCLRArtifactsPathArg)
+      $(CoreCLRArtifactsArgs)
       $(LibrariesConfigurationArg)
       $(LibrariesAllConfigurationsArtifactsPathArg)
+      $(AllArtifactsArgs)
 
-  - name: CoreCLRArtifactsPathArg
+  - name: CoreCLRArtifactsArgs
     value: ''
   - name: LibrariesConfigurationArg
     value: ''
   - name: LibrariesAllConfigurationsArtifactsPathArg
+    value: ''
+  - name: AllArtifactsArgs
     value: ''
 
   - name: CoreClrDownloadPath
@@ -86,6 +90,8 @@ jobs:
   - name: LibrariesDownloadPath
     value: ''
   - name: LibrariesDownloadPathAllConfigurations
+    value: ''
+  - name: AllArtifactsDownloadPath
     value: ''
 
   - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
@@ -97,8 +103,10 @@ jobs:
         parameters.liveCoreClrBuildConfig) }}
     - name: CoreClrDownloadPath
       value: 'artifacts/transport/coreclr'
-    - name: CoreCLRArtifactsPathArg
-      value: /p:CoreCLROverridePath=${{ parameters.buildCommandSourcesDirectory }}$(CoreClrDownloadPath)
+    - name: CoreCLRArtifactsArgs
+      value: >-
+        /p:CoreCLROverridePath=${{ parameters.buildCommandSourcesDirectory }}$(CoreClrDownloadPath)
+        /p:CoreCLRConfiguration=${{ parameters.liveCoreClrBuildConfig }}
     - name: CoreClrArtifactName
       value: CoreCLRProduct_$(liveCoreClrLegName)
 
@@ -126,6 +134,15 @@ jobs:
     - name: LibrariesArtifactNameAllConfigurations
       value: libraries_bin_official_allconfigurations
 
+  # Download all upstream platforms and incorporate in the platform manifest.
+  - ${{ if ne(parameters.upstreamPlatforms, '') }}:
+    - name: AllArtifactsDownloadPath
+      value: 'artifacts/transport/AllArtifacts'
+    - name: AllArtifactsArgs
+      value: >-
+        /p:AllArtifactsDownloadPath=${{ parameters.buildCommandSourcesDirectory }}$(AllArtifactsDownloadPath)
+        /p:BuildFullPlatformManifest=true
+
   dependsOn:
   - checkout
   - ${{ parameters.dependsOn }}
@@ -143,6 +160,9 @@ jobs:
         parameters.liveLibrariesBuildConfig) }}
   - ${{ if eq(parameters.useOfficialAllConfigurations, true) }}:
     - libraries_build_allconfigurations_Windows_NT_x64_Release
+  - ${{ each platform in parameters.upstreamPlatforms }}:
+    - coreclr_product_build_${{ platform }}_${{ parameters.liveCoreClrBuildConfig }}
+    - libraries_build_netcoreapp_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}
 
   steps:
 
@@ -167,6 +187,33 @@ jobs:
         condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
   - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
+
+  # Download and extract artifacts for earlier subsets.
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download artifacts for all platforms'
+    inputs:
+      buildType: current
+      downloadType: specific
+      downloadPath: '$(Build.SourcesDirectory)/__download__/AllPlatforms/'
+      itemPattern: |
+        CoreCLRProduct_*/**
+        libraries_bin_*/**
+
+  - ${{ each platform in parameters.upstreamPlatforms }}:
+    - task: ExtractFiles@1
+      displayName: 'Unzip CoreCLR artifacts: ${{ platform }}'
+      inputs:
+        archiveFilePatterns: |
+          $(Build.SourcesDirectory)/__download__/AllPlatforms/CoreCLRProduct_${{ platform }}_${{ parameters.liveCoreClrBuildConfig }}.*
+        destinationFolder: $(AllArtifactsDownloadPath)/CoreCLRProduct_${{ platform }}_${{ parameters.liveCoreClrBuildConfig }}/
+        cleanUnpackFolder: false
+    - task: ExtractFiles@1
+      displayName: 'Unzip Libraries artifacts: ${{ platform }}'
+      inputs:
+        archiveFilePatterns: |
+          $(Build.SourcesDirectory)/__download__/AllPlatforms/libraries_bin_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}.*
+        destinationFolder: $(AllArtifactsDownloadPath)/libraries_bin_${{ platform }}_${{ parameters.liveLibrariesBuildConfig }}/
+        cleanUnpackFolder: false
 
   - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
     - template: /eng/pipelines/common/download-artifact-step.yml

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -106,6 +106,17 @@ stages:
       liveLibrariesBuildConfig: Release
       isOfficialBuild: ${{ variables.isOfficialBuild }}
       useOfficialAllConfigurations: true
+      upstreamPlatforms:
+      - OSX_x64
+      - Linux_x64
+      - Linux_arm
+      - Linux_arm64
+      - Linux_musl_x64
+      - Linux_musl_arm64
+      - Windows_NT_x86
+      - Windows_NT_x64
+      - Windows_NT_arm
+      - Windows_NT_arm64
 
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml

--- a/src/installer/pkg/projects/netcoreappRIDs.props
+++ b/src/installer/pkg/projects/netcoreappRIDs.props
@@ -8,7 +8,6 @@
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="linux-musl-x64" />
-    <OfficialBuildRID Include="rhel.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <!-- Not currently built by CoreFX. -->
     <!-- <OfficialBuildRID Include="freebsd-x64" /> -->


### PR DESCRIPTION
Generates a full platform manifest in the official build by downloading all platforms' artifacts from the CoreCLR and Libraries jobs for each Installer job. This is how it's always worked in Core-Setup, it's just easier now to see now how wasteful it is. 🙂

For https://github.com/dotnet/runtime/issues/1362. Should unblock dotnet/extensions and dotnet/toolset uptake.

Completed mock build for testing: https://dev.azure.com/dnceng/internal/_build/results?buildId=478304&view=results

Example result platform manifest: https://gist.github.com/dagood/378729d986f6d68d6e7dc310658ec321

This PR also removes the no longer built `rhel.6-x64` RID from NETCoreApp. Otherwise, the platform manifest infra tries to find it and fails.

---

A few bad bits of this:
* It downloads a decent amount more data during the build. This hasn't added more than 3 or so minutes in my testing builds, but could be a problem at some point.
* There's a redundant download: each Installer job downloads one of the platform's artifacts twice. Once to use to create the runtime being built on that machine, again *specifically* for platform manifest harvesting.
* The full manifest infra isn't tested in PR validation. The main runtime pipeline doesn't currently include all the platforms necessary to assemble a full platform manifest.
* It adds 21 build steps to each installer job. 1 to download all the artifacts, 20 to extract each artifact using the built-in unzip step while preserving folder names.
* It is difficult to run locally. You have to download every artifact manually, unzip/untargz them, and arrange them properly. (Let alone trying to run every local build yourself on a bunch of your own machines!)

I think that we should be careful spending time addressing those. We *should* use a baseline/template approach to avoid this flow altogether and fix source-build's platform manifest. Implementing it via template throws away any improvements to the harvesting approach. (See https://github.com/dotnet/runtime/issues/1362.)