### PR TITLE
Add Library builds for release-testing job

### DIFF
--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -17,27 +17,15 @@ jobs:
 - template: /eng/pipelines/common/checkout-job.yml
 
 #
-# Release builds
+# Release CoreCLR and Library builds
 #
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: release
     platformGroup: all
     jobParameters:
-      timeoutInMinutes: 120
-
-#
-# Release library builds
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platformGroup: all
-    jobParameters:
       isOfficialBuild: false
-      liveCoreClrBuildConfig: release
 
 #
 # Release test builds

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -28,6 +28,18 @@ jobs:
       timeoutInMinutes: 120
 
 #
+# Release library builds
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    buildConfig: Release
+    platformGroup: all
+    jobParameters:
+      isOfficialBuild: false
+      liveCoreClrBuildConfig: release
+
+#
 # Release test builds
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -35,7 +47,9 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
     buildConfig: release
     platformGroup: all
-    testGroup: outerloop
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
 
 #
 # Release test runs
@@ -49,6 +63,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
       testGroup: outerloop
+      liveLibrariesBuildConfig: Release
 
 #
 # Release R2R test runs
@@ -62,9 +77,9 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
       testGroup: outerloop
+      liveLibrariesBuildConfig: Release
       readyToRun: true
       displayNameArgs: R2R
-
 
 #
 # Crossgen-comparison jobs
@@ -77,3 +92,6 @@ jobs:
     - Linux_arm
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release


### PR DESCRIPTION
Add library-build steps to the release-testing job
to adapt live-live builds.