### PR TITLE
Normalize Regex char class containing a single negated character

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
@@ -88,8 +88,16 @@ namespace System.Text.RegularExpressions.Tests
         public void AllEmptySets()
         {
             var set = new HashSet<char>();
+
             ValidateSet(@"[\u0000-\uFFFF]", RegexOptions.None, null, set);
+            ValidateSet(@"[\u0000-\uFFFFa-z]", RegexOptions.None, null, set);
+            ValidateSet(@"[\u0000-\u1000\u1001-\u2002\u2003-\uFFFF]", RegexOptions.None, null, set);
+            ValidateSet(@"[\u0000-\uFFFE\u0001-\uFFFF]", RegexOptions.None, null, set);
+
             ValidateSet(@"[^\u0000-\uFFFF]", RegexOptions.None, set, null);
+            ValidateSet(@"[^\u0000-\uFFFFa-z]", RegexOptions.None, set, null);
+            ValidateSet(@"[^\u0000-\uFFFE\u0001-\uFFFF]", RegexOptions.None, set, null);
+            ValidateSet(@"[^\u0000-\u1000\u1001-\u2002\u2003-\uFFFF]", RegexOptions.None, set, null);
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
@@ -12,7 +12,6 @@ namespace System.Text.RegularExpressions.Tests
     public class RegexCharacterSetTests
     {
         [Theory]
-        [InlineData(@"a", RegexOptions.None, new[] { 'a' })]
         [InlineData(@"a", RegexOptions.IgnoreCase, new[] { 'a', 'A' })]
         [InlineData(@"\u00A9", RegexOptions.None, new[] { '\u00A9' })]
         [InlineData(@"\u00A9", RegexOptions.IgnoreCase, new[] { '\u00A9' })]
@@ -50,6 +49,55 @@ namespace System.Text.RegularExpressions.Tests
             {
                 ValidateSet($"[^{set}]", options, null, new HashSet<char>(expectedIncluded));
             }
+        }
+
+        [Theory]
+        [InlineData('\0')]
+        [InlineData('\uFFFF')]
+        [InlineData('a')]
+        [InlineData('5')]
+        public void SingleExpected(char c)
+        {
+            string s = @"\u" + ((int)c).ToString("X4");
+            var set = new HashSet<char>() { c };
+
+            // One
+            ValidateSet($"{s}", RegexOptions.None, set, null);
+            ValidateSet($"[{s}]", RegexOptions.None, set, null);
+            ValidateSet($"[^{s}]", RegexOptions.None, null, set);
+
+            // Positive lookahead
+            ValidateSet($"(?={s}){s}", RegexOptions.None, set, null);
+            ValidateSet($"(?=[^{s}])[^{s}]", RegexOptions.None, null, set);
+
+            // Negative lookahead
+            ValidateSet($"(?![^{s}]){s}", RegexOptions.None, set, null);
+            ValidateSet($"(?![{s}])[^{s}]", RegexOptions.None, null, set);
+
+            // Concatenation
+            ValidateSet($"[{s}{s}]", RegexOptions.None, set, null);
+            ValidateSet($"[^{s}{s}{s}]", RegexOptions.None, null, set);
+
+            // Alternation
+            ValidateSet($"{s}|{s}", RegexOptions.None, set, null);
+            ValidateSet($"[^{s}]|[^{s}]|[^{s}]", RegexOptions.None, null, set);
+            ValidateSet($"{s}|[^{s}]", RegexOptions.None, null, new HashSet<char>());
+        }
+
+        [Fact]
+        public void AllEmptySets()
+        {
+            var set = new HashSet<char>();
+            ValidateSet(@"[\u0000-\uFFFF]", RegexOptions.None, null, set);
+            ValidateSet(@"[^\u0000-\uFFFF]", RegexOptions.None, set, null);
+        }
+
+        [Fact]
+        public void AllButOneSets()
+        {
+            ValidateSet(@"[\u0000-\uFFFE]", RegexOptions.None, null, new HashSet<char>() { '\uFFFF' });
+            ValidateSet(@"[\u0001-\uFFFF]", RegexOptions.None, null, new HashSet<char>() { '\u0000' });
+            ValidateSet(@"[\u0000-ac-\uFFFF]", RegexOptions.None, null, new HashSet<char>() { 'b' });
         }
 
         [Fact]


### PR DESCRIPTION
When RegexFC scans the regex node tree looking for what characters can be the first character, if it encounters a negated character, it handles it by adding everything else to the set.  That then ends up defeating optimizations based on IsSingletonInverse, which expects a negated character class containing only the character, as opposed to a non-negated character class containing everything but the character.  There is already a RegexCharClass.Canonicalize method; this PR just adds the check and fix-up for this case.

| Method |           Toolchain |       Mean |   Error |  StdDev | Ratio |
|------- |-------------------- |-----------:|--------:|--------:|------:|
|   Test | \master\corerun.exe | 1,087.4 ns | 3.47 ns | 3.24 ns |  1.00 |
|   Test |     \pr\corerun.exe |   425.0 ns | 1.43 ns | 1.19 ns |  0.39 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly Regex _regex = new Regex("[^b]+b", RegexOptions.Compiled);
    private readonly string _input = new string('b', 1000);
    [Benchmark] public bool Test() => _regex.IsMatch(_input);
}
```

Best reviewed without whitespace: https://github.com/dotnet/runtime/pull/1597/files?w=1

cc: @ViktorHofer, @danmosemsft, @pgovind, @eerhardt 