### PR TITLE
Add COMPlus_DiagnosticsServerTransportPath

### DIFF
--- a/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -53,14 +53,28 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     sockaddr_un serverAddress{};
     serverAddress.sun_family = AF_UNIX;
 
-    const ProcessDescriptor pd = ProcessDescriptor::FromCurrentProcess();
-    PAL_GetTransportName(
-        sizeof(serverAddress.sun_path),
-        serverAddress.sun_path,
-        pIpcName,
-        pd.m_Pid,
-        pd.m_ApplicationGroupId,
-        "socket");
+    // A user specified socket location and name supersedes the default
+    // we are in charge of freeing this memory
+    const char *customTransportPath = getenv("COMPlus_DiagnosticsServerTransportPath");
+    if (customTransportPath != nullptr)
+    {
+        int chars = snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), customTransportPath);
+        _ASSERTE(chars > 0 && (unsigned int)chars < sizeof(serverAddress.sun_path));
+        delete customTransportPath;
+    }
+    else
+    {
+        // generate the default socket name in TMP Path
+        const ProcessDescriptor pd = ProcessDescriptor::FromCurrentProcess();
+        PAL_GetTransportName(
+            sizeof(serverAddress.sun_path),
+            serverAddress.sun_path,
+            pIpcName,
+            pd.m_Pid,
+            pd.m_ApplicationGroupId,
+            "socket");
+    }
+
 
 #ifndef __APPLE__
     if (fchmod(serverSocket, S_IRUSR | S_IWUSR) == -1)

--- a/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -58,9 +58,9 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     const char *customTransportPath = getenv("COMPlus_DiagnosticsServerTransportPath");
     if (customTransportPath != nullptr)
     {
-        int chars = snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), customTransportPath);
+        int chars = snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), "%s", customTransportPath);
         _ASSERTE(chars > 0 && (unsigned int)chars < sizeof(serverAddress.sun_path));
-        delete customTransportPath;
+        free(customTransportPath);
     }
     else
     {

--- a/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -53,14 +53,10 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     sockaddr_un serverAddress{};
     serverAddress.sun_family = AF_UNIX;
 
-    // A user specified socket location and name supersedes the default
-    // we are in charge of freeing this memory
-    const char *customTransportPath = getenv("COMPlus_DiagnosticsServerTransportPath");
-    if (customTransportPath != nullptr)
+    if (pIpcName != nullptr)
     {
-        int chars = snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), "%s", customTransportPath);
+        int chars = snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), "%s", pIpcName);
         _ASSERTE(chars > 0 && (unsigned int)chars < sizeof(serverAddress.sun_path));
-        free(customTransportPath);
     }
     else
     {
@@ -69,7 +65,7 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
         PAL_GetTransportName(
             sizeof(serverAddress.sun_path),
             serverAddress.sun_path,
-            pIpcName,
+            "dotnet-diagnostic",
             pd.m_Pid,
             pd.m_ApplicationGroupId,
             "socket");

--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -26,32 +26,20 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     char namedPipeName[MaxNamedPipeNameLength]{};
     int nCharactersWritten = -1;
 
-    char *customTransportPath;
-    errno_t fSuccess = _dupenv_s(&customTransportPath, NULL, "COMPlus_DiagnosticsServerTransportPath");
-    if (fSuccess != 0)
-    {
-        if (callback != nullptr)
-            callback("Failed to read COMPlus_DiagnosticsServerTransportPath environment variable", fSuccess);
-        assert(fSuccess == 0);
-        return nullptr;
-    }
-
-    if (customTransportPath != nullptr)
+    if (pIpcName != nullptr)
     {
         nCharactersWritten = sprintf_s(
             namedPipeName,
             sizeof(namedPipeName),
             "\\\\.\\pipe\\%s",
-            customTransportPath);
-        free(customTransportPath);
+            pIpcName);
     }
     else
     {
         nCharactersWritten = sprintf_s(
             namedPipeName,
             sizeof(namedPipeName),
-            "\\\\.\\pipe\\%s-%d",
-            pIpcName,
+            "\\\\.\\pipe\\dotnet-diagnostic-%d",
             ::GetCurrentProcessId());
     }
 

--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -19,10 +19,6 @@ IpcStream::DiagnosticsIpc::~DiagnosticsIpc()
 
 IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const pIpcName, ErrorCallback callback)
 {
-    assert(pIpcName != nullptr);
-    if (pIpcName == nullptr)
-        return nullptr;
-
     char namedPipeName[MaxNamedPipeNameLength]{};
     int nCharactersWritten = -1;
 

--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -715,6 +715,11 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeCircularMB, W("EventPipeCircularMB"),
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"), 0, "Enable/disable capturing processor numbers in EventPipe event headers")
 
 //
+// Diagnostics Server
+//
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_DiagnosticsServerTransportPath, W("DiagnosticsServerTransportPath"), "The full path including filename for the OS transport (NamedPipe on Windows; Unix Domain Socket on Linux) to be used by the Diagnostics Server");
+
+//
 // LTTng
 //
 RETAIL_CONFIG_STRING_INFO(INTERNAL_LTTngConfig, W("LTTngConfig"), "Configuration for LTTng.")

--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -135,9 +135,24 @@ bool DiagnosticServer::Initialize()
                 szMessage);                                           // data2
         };
 
+        // char transportPath[MAX_PATH];
+        NewArrayHolder<char> transportPath = nullptr;
+        CLRConfigStringHolder wTransportPath = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DiagnosticsServerTransportPath);
+        int nCharactersWritten = 0;
+        if (wTransportPath != nullptr)
+        {
+            nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wTransportPath, -1, NULL, 0, NULL, NULL);
+            if (nCharactersWritten != 0)
+            {
+                transportPath = new char[nCharactersWritten];
+                nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wTransportPath, -1, transportPath, nCharactersWritten, NULL, NULL);
+                assert(nCharactersWritten != 0);
+            }
+        }
+
         // TODO: Should we handle/assert that (s_pIpc == nullptr)?
         s_pIpc = IpcStream::DiagnosticsIpc::Create(
-            "dotnet-diagnostic", ErrorCallback);
+            transportPath, ErrorCallback);
 
         if (s_pIpc != nullptr)
         {


### PR DESCRIPTION
* allows users to specify a location for the Diagnostics Server

---

This change allows users to change the location of the Diagnostics Server's OS Transport (Named Pipe on Windows and Unix Domain Socket on Linux).

I'm doing some end-to-end testing with an updated version of the .NET Global Diagnostics Tools that allows connecting to a specific pipe.  I have tested this on Windows successfully and will be checking on Linux soon (I'll update this PR with the results).

CC - @tommcdon, @mikem8361 