### PR TITLE
Enable TRACE_GC for the whole gc.cpp

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -35290,11 +35290,11 @@ void gc_heap::descr_generations (BOOL begin_gc_p)
 
  unsigned int PromotedObjectCount  = 0;
  unsigned int CreatedObjectCount       = 0;
- unsigned int AllocDuration            = 0;
+ int64_t  AllocDuration            = 0;
  unsigned int AllocCount               = 0;
  unsigned int AllocBigCount            = 0;
  unsigned int AllocSmallCount      = 0;
- unsigned int AllocStart             = 0;
+ int64_t AllocStart             = 0;
 #endif //TRACE_GC
 
 //Static member variables.
@@ -38257,7 +38257,7 @@ void gc_heap::do_post_gc()
 #ifdef COUNT_CYCLES
     AllocStart = GetCycleCount32();
 #else
-    AllocStart = clock();
+    AllocStart = GCToOSInterface::QueryPerformanceCounter();
 #endif //COUNT_CYCLES
 #endif //TRACE_GC
 
@@ -38477,7 +38477,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 #ifdef COUNT_CYCLES
     AllocDuration += GetCycleCount32() - AllocStart;
 #else
-    AllocDuration += clock() - AllocStart;
+    AllocDuration += GCToOSInterface::QueryPerformanceCounter() - AllocStart;
 #endif //COUNT_CYCLES
 #endif //TRACE_GC
 
@@ -38526,9 +38526,9 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
     unsigned finish;
     start = GetCycleCount32();
 #else
-    clock_t start;
-    clock_t finish;
-    start = clock();
+    int64_t start;
+    int64_t finish;
+    start = GCToOSInterface::QueryPerformanceCounter();
 #endif //COUNT_CYCLES
     PromotedObjectCount = 0;
 #endif //TRACE_GC
@@ -38570,7 +38570,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 #ifdef COUNT_CYCLES
     finish = GetCycleCount32();
 #else
-    finish = clock();
+    finish = GCToOSInterface::QueryPerformanceCounter();
 #endif //COUNT_CYCLES
     GcDuration += finish - start;
     dprintf (3,

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -37483,10 +37483,11 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, uint3
 #ifdef TRACE_GC
 #ifdef COUNT_CYCLES
     finish = GetCycleCount32();
+    AllocDuration += finish - AllocStart;
 #elif defined(ENABLE_INSTRUMENTATION)
     finish = GetInstLogTime();
-#endif //COUNT_CYCLES
     AllocDuration += finish - AllocStart;
+#endif //COUNT_CYCLES
     AllocCount++;
 #endif //TRACE_GC
     return newAlloc;
@@ -37545,11 +37546,12 @@ GCHeap::AllocLHeap( size_t size, uint32_t flags REQD_ALIGN_DCL)
 #ifdef TRACE_GC
 #ifdef COUNT_CYCLES
     finish = GetCycleCount32();
+    AllocDuration += finish - AllocStart;
 #elif defined(ENABLE_INSTRUMENTATION)
     finish = GetInstLogTime();
     AllocDuration += finish - AllocStart;
-    AllocCount++;
 #endif //COUNT_CYCLES
+    AllocCount++;
 #endif //TRACE_GC
     return newAlloc;
 }

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -35279,10 +35279,6 @@ void gc_heap::descr_generations (BOOL begin_gc_p)
 #endif //TRACE_GC
 }
 
-#undef TRACE_GC
-
-//#define TRACE_GC
-
 //-----------------------------------------------------------------------------
 //
 //                                  VM Specific support
@@ -35307,7 +35303,7 @@ VOLATILE(BOOL)    GCHeap::GcInProgress            = FALSE;
 //CMCSafeLock*      GCHeap::fGcLock;
 GCEvent            *GCHeap::WaitForGCEvent         = NULL;
 //GCTODO
-#ifdef TRACE_GC
+#if defined(TRACE_GC) && !defined(MULTIPLE_HEAPS)
 unsigned int       GCHeap::GcDuration;
 #endif //TRACE_GC
 unsigned            GCHeap::GcCondemnedGeneration   = 0;
@@ -37622,10 +37618,11 @@ GCHeap::Alloc(gc_alloc_context* context, size_t size, uint32_t flags REQD_ALIGN_
 #ifdef TRACE_GC
 #ifdef COUNT_CYCLES
     finish = GetCycleCount32();
+    AllocDuration += finish - AllocStart;
 #elif defined(ENABLE_INSTRUMENTATION)
     finish = GetInstLogTime();
-#endif //COUNT_CYCLES
     AllocDuration += finish - AllocStart;
+#endif //COUNT_CYCLES
     AllocCount++;
 #endif //TRACE_GC
     return newAlloc;

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -35289,12 +35289,12 @@ void gc_heap::descr_generations (BOOL begin_gc_p)
 #ifdef TRACE_GC
 
  unsigned int PromotedObjectCount  = 0;
- unsigned int CreatedObjectCount       = 0;
- int64_t  AllocDuration            = 0;
- unsigned int AllocCount               = 0;
- unsigned int AllocBigCount            = 0;
+ unsigned int CreatedObjectCount   = 0;
+ unsigned int AllocCount           = 0;
+ unsigned int AllocBigCount        = 0;
  unsigned int AllocSmallCount      = 0;
- int64_t AllocStart             = 0;
+ int64_t      AllocStart           = 0;
+ int64_t      AllocDuration        = 0;
 #endif //TRACE_GC
 
 //Static member variables.
@@ -35304,7 +35304,7 @@ VOLATILE(BOOL)    GCHeap::GcInProgress            = FALSE;
 GCEvent            *GCHeap::WaitForGCEvent         = NULL;
 //GCTODO
 #if defined(TRACE_GC) && !defined(MULTIPLE_HEAPS)
-unsigned int       GCHeap::GcDuration;
+uint64_t            GCHeap::GcDuration;
 #endif //TRACE_GC
 unsigned            GCHeap::GcCondemnedGeneration   = 0;
 size_t              GCHeap::totalSurvivedSize       = 0;

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -230,7 +230,7 @@ public:	// FIX
     PER_HEAP_ISOLATED   size_t  totalSurvivedSize;
 
     // Use only for GC tracing.
-    PER_HEAP    unsigned int GcDuration;
+    PER_HEAP    uint64_t GcDuration;
 
     size_t  GarbageCollectGeneration (unsigned int gen=0, gc_reason reason=reason_empty);
     // Interface with gc_heap

--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -145,8 +145,12 @@ inline void FATAL_GC_ERROR()
 
 //#define STRESS_PINNING    //Stress pinning by pinning randomly
 
-//#define TRACE_GC          //debug trace gc operation
-//#define SIMPLE_DPRINTF
+#define TRACE_GC          //debug trace gc operation
+#define SIMPLE_DPRINTF
+
+#if defined(TRACE_GC)
+#include <time.h>
+#endif
 
 //#define TIME_GC           //time allocation and garbage collection
 //#define TIME_WRITE_WATCH  //time GetWriteWatch and ResetWriteWatch calls

--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -148,10 +148,6 @@ inline void FATAL_GC_ERROR()
 #define TRACE_GC          //debug trace gc operation
 #define SIMPLE_DPRINTF
 
-#if defined(TRACE_GC)
-#include <time.h>
-#endif
-
 //#define TIME_GC           //time allocation and garbage collection
 //#define TIME_WRITE_WATCH  //time GetWriteWatch and ResetWriteWatch calls
 //#define COUNT_CYCLES  //Use cycle counter for timing

--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -145,8 +145,8 @@ inline void FATAL_GC_ERROR()
 
 //#define STRESS_PINNING    //Stress pinning by pinning randomly
 
-#define TRACE_GC          //debug trace gc operation
-#define SIMPLE_DPRINTF
+//#define TRACE_GC          //debug trace gc operation
+//#define SIMPLE_DPRINTF
 
 //#define TIME_GC           //time allocation and garbage collection
 //#define TIME_WRITE_WATCH  //time GetWriteWatch and ResetWriteWatch calls


### PR DESCRIPTION
This is my attempt to eliminate the hack where we disable `TRACE_GC` in the middle of `gc.cpp` line `35282`. The `#undef` caught me by surprise. The sole purpose of this PR is to eliminate it, and handles the repercussions of it.

**Highlights of the change:**
- Removes the `#undef`, which is the whole point of the change.
- Fix the `AllocDuration` computation logic, make sure it is computed only when we did measure the time
- Eliminate the use of `clock_t` and `clock()` as they are not available xplat and use `GCToOSInterface::QueryPerformanceCounter()` instead.
- As a consequence of the above, upgrade `AllocDuration` from `unsigned int` to `uint64_t`.

