### PR TITLE
Add link to shared portion of CoreLib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,9 +339,14 @@ sandbox
 #IL linker for testing
 linker
 
-# Symbolic link for the shared portion of CoreLib
+# Symbolic link for the shared portion of CoreLib to make grep/findstr work for runtime devs
+#
 # On Windows, make your own by running these commands from the repo root:
 # mklink /D src\coreclr\src\System.Private.CoreLib\shared %CD%\src\libraries\System.Private.CoreLib\src
 # mklink /D src\coreclr\src\System.Private.CoreLib\common %CD%\src\libraries\Common\src
+#
+# On Unix, make your own by running these commands from the repo root:
+# ln -s $(pwd)/src/libraries/System.Private.CoreLib/src src/coreclr/src/System.Private.CoreLib/shared
+# ln -s $(pwd)/src/libraries/Common/src src/coreclr/src/System.Private.CoreLib/common
 src/coreclr/src/System.Private.CoreLib/shared
 src/coreclr/src/System.Private.CoreLib/common

--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,10 @@ sandbox
 
 #IL linker for testing
 linker
+
+# Symbolic link for the shared portion of CoreLib
+# On Windows, make your own by running these commands from the repo root:
+# mklink /D src\coreclr\src\System.Private.CoreLib\shared %CD%\src\libraries\System.Private.CoreLib\src
+# mklink /D src\coreclr\src\System.Private.CoreLib\common %CD%\src\libraries\Common\src
+src/coreclr/src/System.Private.CoreLib/shared
+src/coreclr/src/System.Private.CoreLib/common


### PR DESCRIPTION
In the coreclr repo, one could simply findstr in the System.Private.CoreLib directory to find stuff.

Since in the runtime repo the shared portion of the CoreLib moved to src/libraries/, but private portion lives in src/coreclr, the files are split. We can work around it locally by making a symbolic link.

That way runtime devs that just grep/findstr stuff don't have to suffer entering the src/libraries directory where tab completion doesn't work because there's 180 directories prefixed by `System.`.