### PR TITLE
[reflection] Add additional TypeInfo.FullName tests

### DIFF
--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -4,6 +4,7 @@
     <TestRuntime>true</TestRuntime>
     <!-- LoadFrom_SameIdentityAsAssemblyWithDifferentPath_ReturnsEqualAssemblies test relies on no deps.json -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Reflection\MockParameterInfo.cs">

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1186,11 +1186,33 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().ContainsGenericParameters);
         }
 
-        [Theory]
-        [InlineData(typeof(int), "System.Int32")]
-        public void FullName(Type type, string expected)
+        [Fact]
+        public void FullName()
         {
-            Assert.Equal(expected, type.GetTypeInfo().FullName);
+            Assert.Equal("System.Int32", typeof(int).GetTypeInfo().FullName);
+
+            Type t = typeof(TI_FullNameTest<>);
+
+            // a generic type parameter
+            Assert.Null(t.GetMethod("TypeParam").ReturnType.GetTypeInfo().FullName);
+
+            // an array type, pointer type, or byref type based on a type parameter
+            Assert.Null(t.GetMethod("ArrayTypeParam").ReturnType.GetTypeInfo().FullName);
+            Assert.Null(t.GetMethod("PointerTypeParam").ReturnType.GetTypeInfo().FullName);
+            Assert.Null(t.GetMethod("ByRefTypeParam").ReturnType.GetTypeInfo().FullName);
+
+            // a generic type that is not a generic type definition but contains unresolved type parameters
+            Assert.Null(t.GetMethod("ListTypeParam").ReturnType.GetTypeInfo().FullName);
+
+            t = typeof(TI_FullNameTest<int>);
+
+            Assert.Equal("System.Int32", t.GetMethod("TypeParam").ReturnType.GetTypeInfo().FullName);
+
+            Assert.Equal("System.Int32[]", t.GetMethod("ArrayTypeParam").ReturnType.GetTypeInfo().FullName);
+            Assert.Equal("System.Int32*", t.GetMethod("PointerTypeParam").ReturnType.GetTypeInfo().FullName);
+            Assert.Equal("System.Int32&", t.GetMethod("ByRefTypeParam").ReturnType.GetTypeInfo().FullName);
+
+            Assert.NotNull(t.GetMethod("ListTypeParam").ReturnType.GetTypeInfo().FullName);
         }
 
         [Fact]
@@ -1776,5 +1798,14 @@ namespace System.Reflection.Tests
     public class OutsideTypeInfoTests<T>
     {
         public class InsideTypeInfoTests<U> { }
+    }
+
+    public class TI_FullNameTest<T> where T : unmanaged
+    {
+        public static T TypeParam() => throw new Exception();
+        public static T[] ArrayTypeParam() => throw new Exception();
+        public static unsafe T* PointerTypeParam() => throw new Exception();
+        public static ref T ByRefTypeParam() => throw new Exception();
+        public static List<T> ListTypeParam() => throw new Exception();
     }
 }


### PR DESCRIPTION
Wasn't sure if I'm okay to add the AllowUnsafeBlocks, so if there's a better way to handle that please let me know.

These tests aren't exhaustive, but they should prevent a regression in Mono for my recent bugfix. Tested locally w/ CoreCLR/CoreFX and the test passes there as well.

Fixes #1276 