### PR TITLE
Fix all GC stress failures in Pri1 tests on Unix with crossgen2

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -128,32 +128,31 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return CorElementType.ELEMENT_TYPE_BYREF;
             }
 
-            // The core redhawk runtime has a slightly different concept of what CorElementType should be for a type. It matches for primitive and enum types
-            // but for other types, it doesn't match the needs in this file.
-            Internal.TypeSystem.TypeFlags typeFlags = _type.Category;
+            // We use the UnderlyingType to handle Enums properly
+            return _type.UnderlyingType.Category switch
+            {
+                Internal.TypeSystem.TypeFlags.Boolean => CorElementType.ELEMENT_TYPE_BOOLEAN,
+                Internal.TypeSystem.TypeFlags.Char => CorElementType.ELEMENT_TYPE_CHAR,
+                Internal.TypeSystem.TypeFlags.SByte => CorElementType.ELEMENT_TYPE_I1,
+                Internal.TypeSystem.TypeFlags.Byte => CorElementType.ELEMENT_TYPE_U1,
+                Internal.TypeSystem.TypeFlags.Int16 => CorElementType.ELEMENT_TYPE_I2,
+                Internal.TypeSystem.TypeFlags.UInt16 => CorElementType.ELEMENT_TYPE_U2,
+                Internal.TypeSystem.TypeFlags.Int32 => CorElementType.ELEMENT_TYPE_I4,
+                Internal.TypeSystem.TypeFlags.UInt32 => CorElementType.ELEMENT_TYPE_U4,
+                Internal.TypeSystem.TypeFlags.Int64 => CorElementType.ELEMENT_TYPE_I8,
+                Internal.TypeSystem.TypeFlags.UInt64 => CorElementType.ELEMENT_TYPE_U8,
+                Internal.TypeSystem.TypeFlags.IntPtr => CorElementType.ELEMENT_TYPE_I,
+                Internal.TypeSystem.TypeFlags.UIntPtr => CorElementType.ELEMENT_TYPE_U,
+                Internal.TypeSystem.TypeFlags.Single => CorElementType.ELEMENT_TYPE_R4,
+                Internal.TypeSystem.TypeFlags.Double => CorElementType.ELEMENT_TYPE_R8,
+                Internal.TypeSystem.TypeFlags.ValueType => CorElementType.ELEMENT_TYPE_VALUETYPE,
+                Internal.TypeSystem.TypeFlags.Nullable => CorElementType.ELEMENT_TYPE_VALUETYPE,
+                Internal.TypeSystem.TypeFlags.Void => CorElementType.ELEMENT_TYPE_VOID,
+                Internal.TypeSystem.TypeFlags.Pointer => CorElementType.ELEMENT_TYPE_PTR,
+                Internal.TypeSystem.TypeFlags.FunctionPointer => CorElementType.ELEMENT_TYPE_FNPTR,
 
-            if (((typeFlags >= Internal.TypeSystem.TypeFlags.Boolean) && (typeFlags <= Internal.TypeSystem.TypeFlags.Double)) ||
-                    (typeFlags == Internal.TypeSystem.TypeFlags.IntPtr) ||
-                    (typeFlags == Internal.TypeSystem.TypeFlags.UIntPtr))
-            {
-                return (CorElementType)typeFlags; // If Redhawk thinks the corelementtype is a primitive type, then it agree with the concept of corelement type needed in this codebase.
-            }
-            else if (_type.IsVoid)
-            {
-                return CorElementType.ELEMENT_TYPE_VOID;
-            }
-            else if (IsValueType())
-            {
-                return CorElementType.ELEMENT_TYPE_VALUETYPE;
-            }
-            else if (_type.IsPointer)
-            {
-                return CorElementType.ELEMENT_TYPE_PTR;
-            }
-            else
-            {
-                return CorElementType.ELEMENT_TYPE_CLASS;
-            }
+                _ => CorElementType.ELEMENT_TYPE_CLASS
+            };
         }
 
         private static int[] s_elemSizes = new int[]
@@ -342,8 +341,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         Debug.Assert((genRegDest & 7) == 0);
 
                         CORCOMPILE_GCREFMAP_TOKENS token = (eightByteClassification == SystemVClassificationType.SystemVClassificationTypeIntegerByRef) ? CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_INTERIOR : CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_REF;
-                        int eightByteIndex = (genRegDest >> 3) + i;
-                        frame[delta + eightByteIndex] = token;
+                        frame[delta + genRegDest] = token;
                     }
 
                     genRegDest += eightByteSize;
@@ -900,6 +898,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TargetArchitecture.X64:
                     if (_transitionBlock.IsX64UnixABI)
                     {
+                        int cbArg = _transitionBlock.StackElemSize(argSize);
+
                         _hasArgLocDescForStructInRegs = false;
                         _fX64UnixArgInRegisters = true;
                         int cFPRegs = 0;
@@ -969,11 +969,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             }
 
                             default:
+                                cGenRegs = cbArg / 8; // GP reg size
                                 break;
                         }
-
-                        int cbArg = _transitionBlock.StackElemSize(argSize);
-                        int cArgSlots = cbArg / _transitionBlock.StackElemSize();
 
                         if (cFPRegs > 0)
                         {
@@ -984,12 +982,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                 return argOfsInner;
                             }
                         }
-                        else
+                        else if (cGenRegs > 0)
                         {
-                            if (_x64UnixIdxGenReg + cArgSlots <= _transitionBlock.NumArgumentRegisters)
+                            if (_x64UnixIdxGenReg + cGenRegs <= _transitionBlock.NumArgumentRegisters)
                             {
                                 int argOfsInner = _transitionBlock.OffsetOfArgumentRegisters + _x64UnixIdxGenReg * 8;
-                                _x64UnixIdxGenReg += cArgSlots;
+                                _x64UnixIdxGenReg += cGenRegs;
                                 return argOfsInner;
                             }
                         }
@@ -997,6 +995,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         _fX64UnixArgInRegisters = false;
 
                         argOfs = _transitionBlock.OffsetOfArgs + _x64UnixIdxStack * 8;
+                        int cArgSlots = cbArg / _transitionBlock.StackElemSize();
+
                         _x64UnixIdxStack += cArgSlots;
                         return argOfs;
                     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -283,7 +283,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 if (!field.IsStatic)
                 {
-                    GcScanRoots(field.FieldType, argDest, field.Offset.AsInt, frame);
+                    GcScanRoots(field.FieldType, argDest, delta + field.Offset.AsInt, frame);
                 }
             }
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 
 using Internal.TypeSystem;
 using Internal.CorConstants;
+using Internal.JitInterface;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -265,45 +266,79 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     {
                         Debug.Assert(!thRetType.IsNull() && thRetType.IsValueType());
 
-                        if (thRetType.IsHFA() && !isVarArgMethod)
+                        if ((Architecture == TargetArchitecture.X64) && IsX64UnixABI)
                         {
-                            CorElementType hfaType = thRetType.GetHFAType();
+                            SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR descriptor;
+                            SystemVStructClassificator.GetSystemVAmd64PassStructInRegisterDescriptor(thRetType.GetRuntimeTypeHandle(), out descriptor);
 
-                            switch (Architecture)
+                            if (descriptor.passedInRegisters)
                             {
-                                case TargetArchitecture.ARM:
-                                    fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ?
-                                        (4 * (uint)sizeof(float)) :
-                                        (4 * (uint)sizeof(double));
-                                    break;
+                                if (descriptor.eightByteCount == 1)
+                                {
+                                    if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
+                                    {
+                                        fpReturnSize = sizeof(double);
+                                    }
+                                }
+                                else
+                                {
+                                    fpReturnSize = 16;
+                                    if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
+                                    {
+                                        fpReturnSize += 1;
+                                    }
 
-                                case TargetArchitecture.ARM64:
-                                    // DESKTOP BEHAVIOR fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ? (4 * (uint)sizeof(float)) : (4 * (uint)sizeof(double));
-                                    // S and D registers overlap. Since we copy D registers in the UniversalTransitionThunk, we'll
-                                    // thread floats like doubles during copying.
-                                    fpReturnSize = 4 * (uint)sizeof(double);
-                                    break;
+                                    if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
+                                    {
+                                        fpReturnSize += 2;
+                                    }
+                                }
 
-                                default:
-                                    throw new NotImplementedException();
-                            }
-                            break;
-                        }
-
-                        uint size = (uint)thRetType.GetSize();
-
-                        if (IsX86 || IsX64)
-                        {
-                            // Return value types of size which are not powers of 2 using a RetBuffArg
-                            if ((size & (size - 1)) != 0)
-                            {
-                                usesRetBuffer = true;
                                 break;
                             }
                         }
+                        else
+                        {
+                            if (thRetType.IsHFA() && !isVarArgMethod)
+                            {
+                                CorElementType hfaType = thRetType.GetHFAType();
 
-                        if (size <= EnregisteredReturnTypeIntegerMaxSize)
-                            break;
+                                switch (Architecture)
+                                {
+                                    case TargetArchitecture.ARM:
+                                        fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ?
+                                            (4 * (uint)sizeof(float)) :
+                                            (4 * (uint)sizeof(double));
+                                        break;
+
+                                    case TargetArchitecture.ARM64:
+                                        // DESKTOP BEHAVIOR fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ? (4 * (uint)sizeof(float)) : (4 * (uint)sizeof(double));
+                                        // S and D registers overlap. Since we copy D registers in the UniversalTransitionThunk, we'll
+                                        // thread floats like doubles during copying.
+                                        fpReturnSize = 4 * (uint)sizeof(double);
+                                        break;
+
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+                                break;
+                            }
+
+                            uint size = (uint)thRetType.GetSize();
+
+                            if (IsX86 || IsX64)
+                            {
+                                // Return value types of size which are not powers of 2 using a RetBuffArg
+                                if ((size & (size - 1)) != 0)
+                                {
+                                    usesRetBuffer = true;
+                                    break;
+                                }
+                            }
+
+                            if (size <= EnregisteredReturnTypeIntegerMaxSize)
+                                break;
+                        }
                     }
 
                     // Value types are returned using return buffer by default

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -314,7 +314,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                     case TargetArchitecture.ARM64:
                                         // DESKTOP BEHAVIOR fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ? (4 * (uint)sizeof(float)) : (4 * (uint)sizeof(double));
                                         // S and D registers overlap. Since we copy D registers in the UniversalTransitionThunk, we'll
-                                        // thread floats like doubles during copying.
+                                        // treat floats like doubles during copying.
                                         fpReturnSize = 4 * (uint)sizeof(double);
                                         break;
 


### PR DESCRIPTION
Without this PR, 90% of the CoreCLR Pri1 tests are failing due to GC
holes. All of the errors are caused by various bugs in the GCRefMap
generation that this PR fixes. With this PR, all the tests that pass
without GC stress also pass with it.

1. GetCorElementType() was incorrectly casting from TypeFlags to
CoreElementType. It was checking for a range of TypeFlags, but that
range didn't map to CorElementType 1:1. That resulted e.g. in getting
ELEMENT_TYPE_R4 for TypeFlags.IntPtr.
2. Besides that, the GetCorElementType() was also incorrectly mapping
Enum to ELEMENT_TYPE_CLASS.
3. The ReportPointersFromStructInRegisters function was incorrectly
assuming that the false stack entries correspond to stack slots while
they in fact correspond to bytes.
4. Arguments that are passed on stack were incorrectly reported as being
passed in registers (if there were still any registers available)
5. Members of structs embedded in other structs were reporting wrong
offsets (we were missing updating the offset by the delta parameter in
the GcScanValueType when calling GCScanRoots)
6. The code that determines if return values are passed in registers or
on stack was completely missing handling of structs returned in
registers.