### PR TITLE
Add LibrariesAllConfigurationsOverridePath for improved live asset arg consistency

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -13,6 +13,7 @@
   <PropertyGroup>
     <CoreCLRArtifactsPath Condition="'$(CoreCLROverridePath)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLROverridePath)'))</CoreCLRArtifactsPath>
     <LibrariesArtifactsPath Condition="'$(LibrariesOverridePath)' != ''">$([MSBuild]::NormalizeDirectory('$(LibrariesOverridePath)'))</LibrariesArtifactsPath>
+    <LibrariesAllConfigurationsArtifactsPath Condition="'$(LibrariesAllConfigurationsOverridePath)' != ''">$([MSBuild]::NormalizeDirectory('$(LibrariesAllConfigurationsOverridePath)'))</LibrariesAllConfigurationsArtifactsPath>
   </PropertyGroup>
 
   <!--

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -73,14 +73,14 @@ jobs:
     value: >-
       $(CoreCLRArtifactsArgs)
       $(LibrariesConfigurationArg)
-      $(LibrariesAllConfigurationsArtifactsPathArg)
+      $(LibrariesAllConfigurationsOverridePathArg)
       $(AllArtifactsArgs)
 
   - name: CoreCLRArtifactsArgs
     value: ''
   - name: LibrariesConfigurationArg
     value: ''
-  - name: LibrariesAllConfigurationsArtifactsPathArg
+  - name: LibrariesAllConfigurationsOverridePathArg
     value: ''
   - name: AllArtifactsArgs
     value: ''
@@ -129,8 +129,8 @@ jobs:
   - ${{ if eq(parameters.useOfficialAllConfigurations, true) }}:
     - name: LibrariesDownloadPathAllConfigurations
       value: 'artifacts/transport/librariesallconfigurations'
-    - name: LibrariesAllConfigurationsArtifactsPathArg
-      value: /p:LibrariesAllConfigurationsArtifactsPath=${{ parameters.buildCommandSourcesDirectory }}$(LibrariesDownloadPathAllConfigurations)
+    - name: LibrariesAllConfigurationsOverridePathArg
+      value: /p:LibrariesAllConfigurationsOverridePath=${{ parameters.buildCommandSourcesDirectory }}$(LibrariesDownloadPathAllConfigurations)
     - name: LibrariesArtifactNameAllConfigurations
       value: libraries_bin_official_allconfigurations
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1615

Adds `LibrariesAllConfigurationsOverridePath`, alongside `CoreCLROverridePath` and `LibrariesOverridePath`. Use `LibrariesAllConfigurationsOverridePath` in the build, making search results for `LibrariesAllConfigurationsArtifactsPath` crisp.