### PR TITLE
Add minimum length optimization to RegexCompiler

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -154,16 +154,13 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// Yet another related computation: it takes a RegexTree and computes
-        /// the leading anchors that it encounters.
+        /// the leading anchor that it encounters.
         /// </summary>
         public static int Anchors(RegexTree tree)
         {
-            RegexNode curNode;
+            RegexNode curNode = tree.Root;
             RegexNode? concatNode = null;
             int nextChild = 0;
-            int result = 0;
-
-            curNode = tree.Root;
 
             while (true)
             {
@@ -191,7 +188,7 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Start:
                     case RegexNode.EndZ:
                     case RegexNode.End:
-                        return result | AnchorFromType(curNode.Type);
+                        return AnchorFromType(curNode.Type);
 
                     case RegexNode.Empty:
                     case RegexNode.Require:
@@ -199,11 +196,11 @@ namespace System.Text.RegularExpressions
                         break;
 
                     default:
-                        return result;
+                        return 0;
                 }
 
                 if (concatNode == null || nextChild >= concatNode.ChildCount())
-                    return result;
+                    return 0;
 
                 curNode = concatNode.Child(nextChild++);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -387,6 +387,23 @@ namespace System.Text.RegularExpressions
 
         protected override bool FindFirstChar()
         {
+            if (!_code.RightToLeft)
+            {
+                if (runtextpos > runtextend - _code.Tree.MinRequiredLength)
+                {
+                    runtextpos = runtextend;
+                    return false;
+                }
+            }
+            else
+            {
+                if (runtextpos - _code.Tree.MinRequiredLength < runtextbeg)
+                {
+                    runtextpos = runtextbeg;
+                    return false;
+                }
+            }
+
             if (0 != (_code.Anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)))
             {
                 if (!_code.RightToLeft)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -850,6 +850,112 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Computes a min bound on the required length of any string that could possibly match.</summary>
+        /// <returns>The min computed length.  If the result is 0, there is no minimum we can enforce.</returns>
+        public int ComputeMinLength()
+        {
+            return ComputeMinLength(this, 20); // arbitrary cut-off to avoid stack overflow with degenerate expressions
+
+            static int ComputeMinLength(RegexNode node, int maxDepth)
+            {
+                if (maxDepth == 0)
+                {
+                    return 0;
+                }
+
+                switch (node.Type)
+                {
+                    case One:
+                    case Notone:
+                    case Set:
+                        // Single character.
+                        return 1;
+
+                    case Multi:
+                        // Every character in the string needs to match.
+                        return node.Str!.Length;
+
+                    case Notonelazy:
+                    case Notoneloop:
+                    case Notoneloopatomic:
+                    case Onelazy:
+                    case Oneloop:
+                    case Oneloopatomic:
+                    case Setlazy:
+                    case Setloop:
+                    case Setloopatomic:
+                        // One character repeated at least M times.
+                        return node.M;
+
+                    case Lazyloop:
+                    case Loop:
+                        // A node graph repeated at least M times.
+                        return node.M * ComputeMinLength(node.Child(0), maxDepth - 1);
+
+                    case Alternate:
+                        // The minimum required length for any of the alternation's branches.
+                        {
+                            int childCount = node.ChildCount();
+                            Debug.Assert(childCount >= 2);
+                            int min = ComputeMinLength(node.Child(0), maxDepth - 1);
+                            for (int i = 1; i < childCount && min > 0; i++)
+                            {
+                                min = Math.Min(min, ComputeMinLength(node.Child(i), maxDepth - 1));
+                            }
+                            return min;
+                        }
+
+                    case Concatenate:
+                        // The sum of all of the concatenation's children.
+                        {
+                            int sum = 0;
+                            int childCount = node.ChildCount();
+                            for (int i = 0; i < childCount; i++)
+                            {
+                                sum += ComputeMinLength(node.Child(i), maxDepth - 1);
+                            }
+                            return sum;
+                        }
+
+                    case Atomic:
+                    case Capture:
+                    case Group:
+                        // For groups, we just delegate to the sole child.
+                        Debug.Assert(node.ChildCount() == 1);
+                        return ComputeMinLength(node.Child(0), maxDepth - 1);
+
+                    case Empty:
+                    case Nothing:
+                    // Nothing to match.
+                    case Beginning:
+                    case Bol:
+                    case Boundary:
+                    case ECMABoundary:
+                    case End:
+                    case EndZ:
+                    case Eol:
+                    case Nonboundary:
+                    case NonECMABoundary:
+                    case Start:
+                    // Difficult to glean anything meaningful from boundaries or results only known at run time.
+                    case Prevent:
+                    case Require:
+                    // Lookaheads/behinds could potentially be included in the future, but that will require
+                    // a different structure, as they can't be added as part of a concatenation, since they overlap
+                    // with what comes after.
+                    case Ref:
+                    case Testgroup:
+                    case Testref:
+                        // Constructs requiring data at runtime from the matching pattern can't influence min length.
+                        return 0;
+
+                    default:
+                        Debug.Fail($"Unknown node: {node.Type}");
+                        return 0;
+                }
+            }
+        }
+
         public RegexNode MakeQuantifier(bool lazy, int min, int max)
         {
             if (min == 0 && max == 0)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -86,8 +86,9 @@ namespace System.Text.RegularExpressions
             parser.CountCaptures();
             parser.Reset(options);
             RegexNode root = parser.ScanRegex();
+            int minRequiredLength = root.ComputeMinLength();
             string[]? capnamelist = parser._capnamelist?.ToArray();
-            var tree = new RegexTree(root, parser._caps, parser._capnumlist!, parser._captop, parser._capnames!, capnamelist!, options);
+            var tree = new RegexTree(root, parser._caps, parser._capnumlist!, parser._captop, parser._capnames!, capnamelist!, options, minRequiredLength);
             parser.Dispose();
 
             return tree;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -19,8 +19,9 @@ namespace System.Text.RegularExpressions
         public readonly Hashtable CapNames;
         public readonly string[] CapsList;
         public readonly RegexOptions Options;
+        public readonly int MinRequiredLength;
 
-        internal RegexTree(RegexNode root, Hashtable caps, int[] capNumList, int capTop, Hashtable capNames, string[] capsList, RegexOptions options)
+        internal RegexTree(RegexNode root, Hashtable caps, int[] capNumList, int capTop, Hashtable capNames, string[] capsList, RegexOptions options, int minRequiredLength)
         {
             Root = root;
             Caps = caps;
@@ -29,6 +30,7 @@ namespace System.Text.RegularExpressions
             CapNames = capNames;
             CapsList = capsList;
             Options = options;
+            MinRequiredLength = minRequiredLength;
         }
 
 #if DEBUG

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -410,6 +410,29 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(expectedValue, match.Groups[0].Value);
         }
 
+        [Theory]
+        [InlineData(RegexOptions.None, 1)]
+        [InlineData(RegexOptions.None, 10)]
+        [InlineData(RegexOptions.None, 100)]
+        [InlineData(RegexOptions.Compiled, 1)]
+        [InlineData(RegexOptions.Compiled, 10)]
+        [InlineData(RegexOptions.Compiled, 100)]
+        public void Match_DeepNesting(RegexOptions options, int count)
+        {
+            const string Start = @"((?>abc|(?:def[ghi]", End = @")))";
+            const string Match = "defg";
+
+            string pattern = string.Concat(Enumerable.Repeat(Start, count)) + string.Concat(Enumerable.Repeat(End, count));
+            string input = string.Concat(Enumerable.Repeat(Match, count));
+
+            var r = new Regex(pattern, options);
+            Match m = r.Match(input);
+
+            Assert.True(m.Success);
+            Assert.Equal(input, m.Value);
+            Assert.Equal(count + 1, m.Groups.Count);
+        }
+
         [Fact]
         public void Match_Timeout()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -24,11 +24,13 @@ namespace System.Text.RegularExpressions.Tests
             const string S1 = "\u00D6\u200D";
             const string S2 = "\u004F\u0308";
 
+            // Validate the chosen strings to make sure they compare the way we want to test via Regex
             Assert.False(S1[0] == S2[0]);
             Assert.False(S1[1] == S2[1]);
             Assert.StartsWith(S1, S2, StringComparison.InvariantCulture);
-            Assert.True(S1.Equals(S1, StringComparison.InvariantCulture));
+            Assert.True(S1.Equals(S2, StringComparison.InvariantCulture));
 
+            // Test varying lengths of strings to validate codegen changes that kick in at longer lengths
             foreach (int multiple in new[] { 1, 10, 100 })
             {
                 string pattern = string.Concat(Enumerable.Repeat(S1, multiple));
@@ -40,7 +42,7 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.False(r.IsMatch(input));
                 Assert.True(r.IsMatch(pattern));
 
-                // Validate when it's not in the pattern, as it impacts "multi" matching.
+                // Validate when it's not at the beginning of the pattern, as it impacts "multi" matching.
                 r = new Regex("[abc]" + pattern, options);
                 Assert.False(r.IsMatch("a" + input));
                 Assert.True(r.IsMatch("a" + pattern));


### PR DESCRIPTION
We now do a cursory examination of the RegexNode tree in order to determine the smallest length string that could possibly match.  For example, the regex "(?:123|4567)8" has a minimum length of 4 (if the input were "1238"), and the regex "\d{1-2}-\d{1-2}-\d{2-4}" has a minimum length of 6 (e.g. "1-10-20"). If the input string is shorter than that minimum length, FindFirstChar will now immediately return false, as it can't possibly match, avoiding spending time evaluating a pattern that couldn't possibly match.

Contributes to https://github.com/dotnet/runtime/issues/1349
cc: @danmosemsft, @eerhardt, @ViktorHofer, @pgovind 

As a silly example:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    [Params(RegexOptions.None, RegexOptions.Compiled)]
    public RegexOptions Options { get; set; }

    private string _input = new string('x', 28);
    private Regex _regex;

    [GlobalSetup]
    public void Setup() => _regex = new Regex(@".*hello there how are you today", Options);

    [Benchmark] public bool Test() => _regex.IsMatch(_input);
}
```

| Method |           Toolchain |  Options |        Mean |      Error |     StdDev |      Median | Ratio |
|------- |-------------------- |--------- |------------:|-----------:|-----------:|------------:|------:|
|   Test | \master\corerun.exe |     None | 7,692.43 ns | 193.846 ns | 456.919 ns | 7,525.43 ns | 1.000 |
|   Test |     \pr\corerun.exe |     None |    24.13 ns |   0.104 ns |   0.098 ns |    24.13 ns | 0.003 |
|        |                     |          |             |            |            |             |       |
|   Test | \master\corerun.exe | Compiled | 2,141.20 ns |  12.438 ns |  11.026 ns | 2,141.36 ns |  1.00 |
|   Test |     \pr\corerun.exe | Compiled |    24.38 ns |   0.124 ns |   0.110 ns |    24.37 ns |  0.01 |