### PR TITLE
Don't reload a lclVar if it's RegOptional

### DIFF
--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -5414,25 +5414,28 @@ void LinearScan::allocateRegisters()
 
             if (refType == RefTypeParamDef || refType == RefTypeZeroInit)
             {
-                // For a ParamDef with a weighted refCount less than unity, don't enregister it at entry.
-                // TODO-CQ: Consider doing this only for stack parameters, since otherwise we may be needlessly
-                // inserting a store.
-                LclVarDsc* varDsc = currentInterval->getLocalVar(compiler);
-                assert(varDsc != nullptr);
-                if (refType == RefTypeParamDef && varDsc->lvRefCntWtd() <= BB_UNITY_WEIGHT)
+                if (nextRefPosition == nullptr)
                 {
-                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_ENTRY_REG_ALLOCATED, currentInterval));
-                    didDump  = true;
-                    allocate = false;
-                    setIntervalAsSpilled(currentInterval);
-                }
-                // If it has no actual references, mark it as "lastUse"; since they're not actually part
-                // of any flow they won't have been marked during dataflow.  Otherwise, if we allocate a
-                // register we won't unassign it.
-                else if (nextRefPosition == nullptr)
-                {
+                    // If it has no actual references, mark it as "lastUse"; since they're not actually part
+                    // of any flow they won't have been marked during dataflow.  Otherwise, if we allocate a
+                    // register we won't unassign it.
                     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_ZERO_REF, currentInterval));
                     currentRefPosition->lastUse = true;
+                }
+                if (refType == RefTypeParamDef)
+                {
+                    LclVarDsc* varDsc = currentInterval->getLocalVar(compiler);
+                    assert(varDsc != nullptr);
+                    if (varDsc->lvRefCntWtd() <= BB_UNITY_WEIGHT)
+                    {
+                        // For a ParamDef with a weighted refCount less than unity, don't enregister it at entry.
+                        // TODO-CQ: Consider doing this only for stack parameters, since otherwise we may be needlessly
+                        // inserting a store.
+                        allocate = false;
+                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_ENTRY_REG_ALLOCATED, currentInterval));
+                        didDump = true;
+                        setIntervalAsSpilled(currentInterval);
+                    }
                 }
             }
 #ifdef FEATURE_SIMD
@@ -6171,6 +6174,16 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPositi
         else
         {
             treeNode->gtFlags &= ~GTF_VAR_DEATH;
+        }
+
+        if ((currentRefPosition->registerAssignment != RBM_NONE) && (interval->physReg == REG_NA) &&
+            currentRefPosition->RegOptional() && currentRefPosition->lastUse)
+        {
+            // This can happen if the incoming location for the block was changed from a register to the stack
+            // during resolution. In this case we're better off making it contained.
+            assert(inVarToRegMaps[curBBNum][varDsc->lvVarIndex] == REG_STK);
+            currentRefPosition->registerAssignment = RBM_NONE;
+            treeNode->SetRegNum(REG_NA);
         }
     }
 


### PR DESCRIPTION
I encountered this while working on enregistering SIMD8. If a RegOptional reference has a register during allocation, but is spilled during resolution, it is beneficial to make it contained instead of loading it.