### PR TITLE
Spanify and cleanup System.Security.Principal.Windows

### DIFF
--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
@@ -18,7 +18,7 @@ namespace System.Security.Principal
         // Container enumerated by this collection
         //
 
-        private readonly List<IdentityReference> _Identities;
+        private readonly List<IdentityReference> _identities;
 
         #endregion
 
@@ -39,7 +39,7 @@ namespace System.Security.Principal
 
         public IdentityReferenceCollection(int capacity)
         {
-            _Identities = new List<IdentityReference>(capacity);
+            _identities = new List<IdentityReference>(capacity);
         }
 
         #endregion
@@ -48,14 +48,14 @@ namespace System.Security.Principal
 
         public void CopyTo(IdentityReference[] array, int offset)
         {
-            _Identities.CopyTo(0, array, offset, Count);
+            _identities.CopyTo(0, array, offset, Count);
         }
 
         public int Count
         {
             get
             {
-                return _Identities.Count;
+                return _identities.Count;
             }
         }
 
@@ -74,7 +74,7 @@ namespace System.Security.Principal
                 throw new ArgumentNullException(nameof(identity));
             }
 
-            _Identities.Add(identity);
+            _identities.Add(identity);
         }
 
         public bool Remove(IdentityReference identity)
@@ -86,7 +86,7 @@ namespace System.Security.Principal
 
             if (Contains(identity))
             {
-                return _Identities.Remove(identity);
+                return _identities.Remove(identity);
             }
 
             return false;
@@ -94,7 +94,7 @@ namespace System.Security.Principal
 
         public void Clear()
         {
-            _Identities.Clear();
+            _identities.Clear();
         }
 
         public bool Contains(IdentityReference identity)
@@ -104,7 +104,7 @@ namespace System.Security.Principal
                 throw new ArgumentNullException(nameof(identity));
             }
 
-            return _Identities.Contains(identity);
+            return _identities.Contains(identity);
         }
 
         #endregion
@@ -129,17 +129,12 @@ namespace System.Security.Principal
         {
             get
             {
-                return _Identities[index];
+                return _identities[index];
             }
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _Identities[index] = value;
+                _identities[index] = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 
@@ -147,7 +142,7 @@ namespace System.Security.Principal
         {
             get
             {
-                return _Identities;
+                return _identities;
             }
         }
 
@@ -398,12 +393,7 @@ namespace System.Security.Principal
 
         internal IdentityReferenceEnumerator(IdentityReferenceCollection collection)
         {
-            if (collection == null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
-
-            _collection = collection;
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
             _current = -1;
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
@@ -134,7 +134,11 @@ namespace System.Security.Principal
 
             set
             {
-                _identities[index] = value ?? throw new ArgumentNullException(nameof(value));
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+                _identities[index] = value;
             }
         }
 
@@ -393,7 +397,11 @@ namespace System.Security.Principal
 
         internal IdentityReferenceEnumerator(IdentityReferenceCollection collection)
         {
-            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+            _collection = collection;
             _current = -1;
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IdentityReference.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/IdentityReference.cs
@@ -17,11 +17,11 @@ namespace System.Security.Principal
 
         public abstract IdentityReference Translate(Type targetType);
 
-        public override abstract bool Equals(object o);
+        public abstract override bool Equals(object o);
 
-        public override abstract int GetHashCode();
+        public abstract override int GetHashCode();
 
-        public override abstract string ToString();
+        public abstract override string ToString();
 
         public static bool operator ==(IdentityReference left, IdentityReference right)
         {

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
@@ -154,16 +154,13 @@ namespace System.Security.Principal
 
         internal static IdentityReferenceCollection Translate(IdentityReferenceCollection sourceAccounts, Type targetType, bool forceSuccess)
         {
-            bool SomeFailed = false;
-            IdentityReferenceCollection Result;
+            IdentityReferenceCollection result = Translate(sourceAccounts, targetType, out bool someFailed);
 
-            Result = Translate(sourceAccounts, targetType, out SomeFailed);
-
-            if (forceSuccess && SomeFailed)
+            if (forceSuccess && someFailed)
             {
                 IdentityReferenceCollection UnmappedIdentities = new IdentityReferenceCollection();
 
-                foreach (IdentityReference id in Result)
+                foreach (IdentityReference id in result)
                 {
                     if (id.GetType() != targetType)
                     {
@@ -174,7 +171,7 @@ namespace System.Security.Principal
                 throw new IdentityNotMappedException(SR.IdentityReference_IdentityNotMapped, UnmappedIdentities);
             }
 
-            return Result;
+            return result;
         }
 
         internal static IdentityReferenceCollection Translate(IdentityReferenceCollection sourceAccounts, Type targetType, out bool someFailed)
@@ -348,7 +345,7 @@ namespace System.Security.Principal
                             case SidNameUse.Alias:
                             case SidNameUse.Computer:
                             case SidNameUse.WellKnownGroup:
-                                Result.Add(new SecurityIdentifier(Lts.Sid, true));
+                                Result.Add(new SecurityIdentifier(Lts.Sid));
                                 break;
 
                             default:

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -347,7 +347,7 @@ namespace System.Security.Principal
 
             _identifierAuthority = identifierAuthority;
 #if NETCOREAPP2_0
-            _subAuthorities = = (int[])subAuthorities.Clone();
+            _subAuthorities = (int[])subAuthorities.Clone();
 #else
             _subAuthorities = subAuthorities.ToArray();
 #endif

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -347,8 +347,7 @@ namespace System.Security.Principal
 
             _identifierAuthority = identifierAuthority;
 #if NETCOREAPP2_0
-            _subAuthorities = new int[subAuthorities.Length];
-            Array.Copy(subAuthorities, _subAuthorities, subAuthorities.Length);
+            _subAuthorities = = (int[])subAuthorities.Clone();
 #else
             _subAuthorities = subAuthorities.ToArray();
 #endif
@@ -364,14 +363,14 @@ namespace System.Security.Principal
             // } SID, *PISID;
             //
 
-            _binaryForm = new byte[1 + 1 + 6 + 4 * subAuthorities.Length];
+            _binaryForm = new byte[1 + 1 + 6 + 4 * _subAuthorities.Length];
 
             //
             // First two bytes contain revision and subauthority count
             //
 
             _binaryForm[0] = Revision;
-            _binaryForm[1] = (byte)subAuthorities.Length;
+            _binaryForm[1] = (byte)_subAuthorities.Length;
 
             //
             // Identifier authority takes up 6 bytes
@@ -386,7 +385,7 @@ namespace System.Security.Principal
             // Subauthorities go last, preserving big-endian representation
             //
 
-            for (int i = 0; i < subAuthorities.Length; i++)
+            for (int i = 0; i < _subAuthorities.Length; i++)
             {
                 for (byte shift = 0; shift < 4; shift += 1)
                 {

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
@@ -40,10 +40,9 @@ namespace System.Security.Principal
             string systemName,
             PolicyRights rights)
         {
-            SafeLsaPolicyHandle policyHandle;
 
             Interop.OBJECT_ATTRIBUTES attributes = default;
-            uint error = Interop.Advapi32.LsaOpenPolicy(systemName, ref attributes, (int)rights, out policyHandle);
+            uint error = Interop.Advapi32.LsaOpenPolicy(systemName, ref attributes, (int)rights, out SafeLsaPolicyHandle policyHandle);
             if (error == 0)
             {
                 return policyHandle;
@@ -172,7 +171,7 @@ namespace System.Security.Principal
             uint length = (uint)SecurityIdentifier.MaxBinaryLength;
             resultSid = new byte[length];
 
-            if (FALSE != Interop.Advapi32.CreateWellKnownSid((int)sidType, domainSid == null ? null : domainSid.BinaryForm, resultSid, ref length))
+            if (FALSE != Interop.Advapi32.CreateWellKnownSid((int)sidType, domainSid?.BinaryForm, resultSid, ref length))
             {
                 return Interop.Errors.ERROR_SUCCESS;
             }
@@ -197,15 +196,13 @@ namespace System.Security.Principal
             }
             else
             {
-                bool result;
-
                 byte[] BinaryForm1 = new byte[sid1.BinaryLength];
                 sid1.GetBinaryForm(BinaryForm1, 0);
 
                 byte[] BinaryForm2 = new byte[sid2.BinaryLength];
                 sid2.GetBinaryForm(BinaryForm2, 0);
 
-                return (Interop.Advapi32.IsEqualDomainSid(BinaryForm1, BinaryForm2, out result) == FALSE ? false : result);
+                return (Interop.Advapi32.IsEqualDomainSid(BinaryForm1, BinaryForm2, out bool result) == FALSE ? false : result);
             }
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -439,8 +439,8 @@ namespace System.Security.Principal
                 {
                     // This approach will not work correctly for domain guests (will return false
                     // instead of true). This is a corner-case that is not very interesting.
-                    _isAuthenticated = CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                                    new int[] { Interop.SecurityIdentifier.SECURITY_AUTHENTICATED_USER_RID })) ? 1 : 0;
+                    ReadOnlySpan<int> subAuthorities = stackalloc int[1] { Interop.SecurityIdentifier.SECURITY_AUTHENTICATED_USER_RID };
+                    _isAuthenticated = CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities)) ? 1 : 0;
                 }
                 return _isAuthenticated == 1;
             }
@@ -503,8 +503,8 @@ namespace System.Security.Principal
                 if (_safeTokenHandle.IsInvalid)
                     return false;
 
-                return CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                new int[] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, (int)WindowsBuiltInRole.Guest }));
+                ReadOnlySpan<int> subAuthorities = stackalloc int[2] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, (int)WindowsBuiltInRole.Guest };
+                return CheckNtTokenForSid(new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities));
             }
         }
 
@@ -515,8 +515,10 @@ namespace System.Security.Principal
                 // special case the anonymous identity.
                 if (_safeTokenHandle.IsInvalid)
                     return false;
-                SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                                new int[] { Interop.SecurityIdentifier.SECURITY_LOCAL_SYSTEM_RID });
+
+                ReadOnlySpan<int> subAuthorities = stackalloc int[1] { Interop.SecurityIdentifier.SECURITY_LOCAL_SYSTEM_RID };
+                SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities);
+
                 return (this.User == sid);
             }
         }
@@ -528,8 +530,9 @@ namespace System.Security.Principal
                 // special case the anonymous identity.
                 if (_safeTokenHandle.IsInvalid)
                     return true;
-                SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                                new int[] { Interop.SecurityIdentifier.SECURITY_ANONYMOUS_LOGON_RID });
+
+                ReadOnlySpan<int> subAuthorities = stackalloc int[1] { Interop.SecurityIdentifier.SECURITY_ANONYMOUS_LOGON_RID };
+                SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities);
                 return (this.User == sid);
             }
         }

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -126,7 +126,12 @@ namespace System.Security.Principal
             return IsInRole(
                 new SecurityIdentifier(
                     IdentifierAuthority.NTAuthority,
-                    stackalloc int[] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid }
+#if NETCOREAPP2_0
+                    new
+#else
+                    stackalloc
+#endif
+                    int[] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid }
                 )
             );
         }

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -41,18 +41,11 @@ namespace System.Security.Principal
         //
         // Properties.
         //
-        public override IIdentity Identity
-        {
-            get
-            {
-                return _identity;
-            }
-        }
+        public override IIdentity Identity => _identity;
 
         //
         // Public methods.
         //
-
 
         public override bool IsInRole(string role)
         {
@@ -130,9 +123,12 @@ namespace System.Security.Principal
 
         public virtual bool IsInRole(int rid)
         {
-            ReadOnlySpan<int> subAuthorities = stackalloc int[2] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid  };
-            SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities);
-            return IsInRole(sid);
+            return IsInRole(
+                new SecurityIdentifier(
+                    IdentifierAuthority.NTAuthority,
+                    stackalloc int[] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid }
+                )
+            );
         }
 
         // This method (with a SID parameter) is more general than the 2 overloads that accept a WindowsBuiltInRole or

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -135,9 +135,8 @@ namespace System.Security.Principal
 
         public virtual bool IsInRole(int rid)
         {
-            SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority,
-                                                            new int[] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid });
-
+            ReadOnlySpan<int> subAuthorities = stackalloc int[2] { Interop.SecurityIdentifier.SECURITY_BUILTIN_DOMAIN_RID, rid  };
+            SecurityIdentifier sid = new SecurityIdentifier(IdentifierAuthority.NTAuthority, subAuthorities);
             return IsInRole(sid);
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -35,10 +35,7 @@ namespace System.Security.Principal
         public WindowsPrincipal(WindowsIdentity ntIdentity)
             : base(ntIdentity)
         {
-            if (ntIdentity == null)
-                throw new ArgumentNullException(nameof(ntIdentity));
-
-            _identity = ntIdentity;
+            _identity = ntIdentity ?? throw new ArgumentNullException(nameof(ntIdentity));
         }
 
         //
@@ -91,8 +88,7 @@ namespace System.Security.Principal
             {
                 foreach (ClaimsIdentity identity in Identities)
                 {
-                    WindowsIdentity wi = identity as WindowsIdentity;
-                    if (wi != null)
+                    if (identity is WindowsIdentity wi)
                     {
                         foreach (Claim claim in wi.UserClaims)
                         {
@@ -113,8 +109,7 @@ namespace System.Security.Principal
             {
                 foreach (ClaimsIdentity identity in Identities)
                 {
-                    WindowsIdentity wi = identity as WindowsIdentity;
-                    if (wi != null)
+                    if (identity is WindowsIdentity wi)
                     {
                         foreach (Claim claim in wi.DeviceClaims)
                         {

--- a/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -13,37 +13,37 @@ public class SecurityIdentifierTests
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnNull()
     {
-        Assert.Throws<ArgumentNullException>("binaryForm", () => new SecurityIdentifier(null, 0));
+        AssertExtensions.Throws<ArgumentNullException>("binaryForm", () => new SecurityIdentifier(null, 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnEmpty()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(Array.Empty<byte>(), 0));
+        AssertExtensions.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(Array.Empty<byte>(), 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnNegativeOffset()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("offset", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, -1));
+        AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, -1));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnExcessiveOffset()
     {
-        Assert.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 9));
+        AssertExtensions.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 9));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnInvalidRevision()
     {
-        Assert.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 2, 1, 0, 0, 0, 0, 0, 0 }, 0));
+        AssertExtensions.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 2, 1, 0, 0, 0, 0, 0, 0 }, 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnTooManySubAuthorities()
     {
-        Assert.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 100, 0, 0, 0, 0, 0, 0 }, 0));
+        AssertExtensions.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 100, 0, 0, 0, 0, 0, 0 }, 0));
     }
 
     [Fact]

--- a/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -13,37 +13,37 @@ public class SecurityIdentifierTests
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnNull()
     {
-        Assert.Throws<ArgumentNullException>(() => new SecurityIdentifier(null, 0));
+        Assert.Throws<ArgumentNullException>("binaryForm", () => new SecurityIdentifier(null, 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnEmpty()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(Array.Empty<byte>(), 0));
+        Assert.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(Array.Empty<byte>(), 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnNegativeOffset()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, -1));
+        Assert.Throws<ArgumentOutOfRangeException>("offset", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, -1));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnExcessiveOffset()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 9));
+        Assert.Throws<ArgumentOutOfRangeException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 9));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnInvalidRevision()
     {
-        Assert.Throws<ArgumentException>(() => new SecurityIdentifier(new byte[] { 2, 1, 0, 0, 0, 0, 0, 0 }, 0));
+        Assert.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 2, 1, 0, 0, 0, 0, 0, 0 }, 0));
     }
 
     [Fact]
     public void SecurityIdentifierBinaryCtorThrowsOnTooManySubAuthorities()
     {
-        Assert.Throws<ArgumentException>(() => new SecurityIdentifier(new byte[] { 1, 100, 0, 0, 0, 0, 0, 0 }, 0));
+        Assert.Throws<ArgumentException>("binaryForm", () => new SecurityIdentifier(new byte[] { 1, 100, 0, 0, 0, 0, 0, 0 }, 0));
     }
 
     [Fact]

--- a/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/SecurityIdentifierTests.cs
@@ -9,6 +9,43 @@ using Xunit;
 
 public class SecurityIdentifierTests
 {
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SecurityIdentifier(null, 0));
+    }
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnEmpty()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(Array.Empty<byte>(), 0));
+    }
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnNegativeOffset()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, -1));
+    }
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnExcessiveOffset()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SecurityIdentifier(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 9));
+    }
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnInvalidRevision()
+    {
+        Assert.Throws<ArgumentException>(() => new SecurityIdentifier(new byte[] { 2, 1, 0, 0, 0, 0, 0, 0 }, 0));
+    }
+
+    [Fact]
+    public void SecurityIdentifierBinaryCtorThrowsOnTooManySubAuthorities()
+    {
+        Assert.Throws<ArgumentException>(() => new SecurityIdentifier(new byte[] { 1, 100, 0, 0, 0, 0, 0, 0 }, 0));
+    }
+
     [Fact]
     public void ValidateGetCurrentUser()
     {


### PR DESCRIPTION
The code for and around `SecurityIdentifier` has a number of places where arrays are created only to be passed to a function which will copy their contents. A temporary array of known and small max length is also used when creating one. These can all be made cheaper using stackalloc and spans. This work is in the first commit.

The second commit is a general cleanup and formatting of some code which looks like it's quite old. There are no functional changes just renames and reformat to be within current guidelines and auto code fix applications.