### PR TITLE
Add basic Capture support to non-backtracking RegexCompiler

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -21,7 +21,7 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public partial class Regex : ISerializable
     {
-        private const int MaxOptionShift = 10;
+        internal const int MaxOptionShift = 10;
 
         protected internal string? pattern;                   // The string pattern provided
         protected internal RegexOptions roptions;             // the top-level options from the options string

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -15,12 +15,14 @@ namespace System.Text.RegularExpressions
         Singleline              = 0x0010, // "s"
         IgnorePatternWhitespace = 0x0020, // "x"
         RightToLeft             = 0x0040, // "r"
-
 #if DEBUG
         Debug                   = 0x0080, // "d"
 #endif
-
         ECMAScript              = 0x0100, // "e"
         CultureInvariant        = 0x0200,
+
+        // RegexCompiler internally uses 0x80000000 for its own internal purposes.
+        // If such a value ever needs to be added publicly, RegexCompiler will need
+        // to be changed to avoid it.
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -56,9 +56,15 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(RegexOptions.Compiled)]
         public void CtorDebugInvoke(RegexOptions options)
         {
-            var r = new Regex("[abc]def(ghi|jkl)", options | (RegexOptions)0x80 /*RegexOptions.Debug*/);
+            Regex r;
+
+            r = new Regex("[abc]def(ghi|jkl)", options | (RegexOptions)0x80 /*RegexOptions.Debug*/);
             Assert.False(r.Match("a").Success);
             Assert.True(r.Match("adefghi").Success);
+
+            r = new Regex("(ghi|jkl)*ghi", options | (RegexOptions)0x80 /*RegexOptions.Debug*/);
+            Assert.False(r.Match("jkl").Success);
+            Assert.True(r.Match("ghi").Success);
         }
 
         [Fact]


### PR DESCRIPTION
Lots of regexes end up using captures, either by design or accidentally because parens are a natural grouping mechanism.  Support for them means many more regexes can now use the non-backtracking compiler that produces much better code gen.

We now also auto-atomicify more loops by ensuring we traverse concatenations as part of the checks.  This means that an expression like `"(a|b)*c"` now becomes the equivalent of `"(?>([ab])*)c"`.

And we remove unnecessary Atomic nodes at the root, e.g. "(?>foo)" becomes just "foo".

(Also a few tweaks to improve code coverage and to fix some debug-spew issues.)

Example:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly Regex _regex = new Regex(@"123(abc|def)", RegexOptions.Compiled);

    [Benchmark] public bool Match() =>   _regex.IsMatch("123ab123ab123de123def");
    [Benchmark] public bool NoMatch() => _regex.IsMatch("123ab123ab123de123deg");
}
```

|  Method |           Toolchain |      Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |-------------------- |----------:|---------:|---------:|------:|------:|------:|------:|----------:|
|   Match | \master\corerun.exe | 128.93 ns | 0.664 ns | 0.621 ns |  1.00 |     - |     - |     - |         - |
|   Match |     \pr\corerun.exe |  92.29 ns | 0.335 ns | 0.314 ns |  0.72 |     - |     - |     - |         - |
|         |                     |           |          |          |       |       |       |       |           |
| NoMatch | \master\corerun.exe | 126.81 ns | 0.437 ns | 0.409 ns |  1.00 |     - |     - |     - |         - |
| NoMatch |     \pr\corerun.exe |  81.83 ns | 0.383 ns | 0.358 ns |  0.65 |     - |     - |     - |         - |

Contributes to https://github.com/dotnet/runtime/issues/1349
cc: @danmosemsft, @eerhardt, @ViktorHofer, @pgovind 