### PR TITLE
Stop buffering traces by default

### DIFF
--- a/src/installer/corehost/common/trace.cpp
+++ b/src/installer/corehost/common/trace.cpp
@@ -57,6 +57,7 @@ bool trace::enable()
         if (pal::getenv(_X("COREHOST_TRACEFILE"), &tracefile_str))
         {
             FILE *tracefile = pal::file_open(tracefile_str, _X("a"));
+            setvbuf(tracefile, nullptr, _IONBF, 0);
 
             if (tracefile)
             {

--- a/src/installer/corehost/common/trace.cpp
+++ b/src/installer/corehost/common/trace.cpp
@@ -57,10 +57,10 @@ bool trace::enable()
         if (pal::getenv(_X("COREHOST_TRACEFILE"), &tracefile_str))
         {
             FILE *tracefile = pal::file_open(tracefile_str, _X("a"));
-            setvbuf(tracefile, nullptr, _IONBF, 0);
 
             if (tracefile)
             {
+                setvbuf(tracefile, nullptr, _IONBF, 0);
                 g_trace_file = tracefile;
             }
             else

--- a/src/installer/test/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/test/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -241,6 +241,21 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
+        public void TracingNotBufferedByDefault()
+        {
+            CommandResult result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} false nullptr x")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable("COREHOST_TRACEFILE", "Tracing.out")
+                .MultilevelLookup(true)
+                .DotNetRoot(null)
+                .Execute();
+
+            result.Should().Fail()
+                .And.FileExists("Tracing.out")
+                .And.FileContains("Tracing.out", "Tracing enabled");
+        }
+
+        [Fact]
         public void TestOnlyDisabledByDefault()
         {
             // Intentionally not enabling test-only behavior. This test validates that even if the test-only env. variable is set


### PR DESCRIPTION
Solves #1465. The only scenarios in which we'll keep buffering the traces are when `COREHOST_TRACE=0` or when a custom error writer is set.