### PR TITLE
Process "multi" strings in compiled regexes 4 or 2 chars at a time when possible

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -72,5 +72,6 @@
     <Reference Include="System.Reflection.Emit.ILGeneration" />
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -72,6 +72,5 @@
     <Reference Include="System.Reflection.Emit.ILGeneration" />
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -47,25 +47,28 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_dumpStateM = RegexRunnerMethod("DumpState");
 #endif
 
-        private static readonly MethodInfo s_charToLowerMethod = typeof(char).GetMethod("ToLower", new Type[] { typeof(char), typeof(CultureInfo) })!;
-        private static readonly MethodInfo s_charToLowerInvariantMethod = typeof(char).GetMethod("ToLowerInvariant", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_charIsDigitMethod = typeof(char).GetMethod("IsDigit", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_charIsWhiteSpaceMethod = typeof(char).GetMethod("IsWhiteSpace", new Type[] { typeof(char) })!;
-        private static readonly MethodInfo s_stringGetCharsMethod = typeof(string).GetMethod("get_Chars", new Type[] { typeof(int) })!;
-        private static readonly MethodInfo s_stringAsSpanMethod = typeof(MemoryExtensions).GetMethod("AsSpan", new Type[] { typeof(string), typeof(int), typeof(int) })!;
-        private static readonly MethodInfo s_stringIndexOf = typeof(string).GetMethod("IndexOf", new Type[] { typeof(char), typeof(int), typeof(int) })!;
-        private static readonly MethodInfo s_spanIndexOf = typeof(MemoryExtensions).GetMethod("IndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
-        private static readonly MethodInfo s_spanIndexOfAnyCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
-        private static readonly MethodInfo s_spanIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
-        private static readonly MethodInfo s_spanGetItemMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Item", new Type[] { typeof(int) })!;
-        private static readonly MethodInfo s_spanGetLengthMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Length")!;
-        private static readonly MethodInfo s_spanSliceIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int) })!;
-        private static readonly MethodInfo s_spanSliceIntIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int), typeof(int) })!;
+        private static readonly MethodInfo s_charToLowerMethod = typeof(char).GetMethod("ToLower", new Type[] { typeof(char), typeof(CultureInfo) })!;
+        private static readonly MethodInfo s_charToLowerInvariantMethod = typeof(char).GetMethod("ToLowerInvariant", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_cultureInfoGetCurrentCultureMethod = typeof(CultureInfo).GetMethod("get_CurrentCulture")!;
-        private static readonly MethodInfo s_memoryMarshalGetReference = typeof(MemoryMarshal).GetMethod("GetReference", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
 #if DEBUG
         private static readonly MethodInfo s_debugWriteLine = typeof(Debug).GetMethod("WriteLine", new Type[] { typeof(string) })!;
 #endif
+        private static readonly MethodInfo s_spanGetItemMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Item", new Type[] { typeof(int) })!;
+        private static readonly MethodInfo s_spanGetLengthMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Length")!;
+        private static readonly MethodInfo s_memoryMarshalGetReference = typeof(MemoryMarshal).GetMethod("GetReference", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOf = typeof(MemoryExtensions).GetMethod("IndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanSliceIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int) })!;
+        private static readonly MethodInfo s_spanSliceIntIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int), typeof(int) })!;
+        private static readonly MethodInfo s_spanStartsWith = typeof(MemoryExtensions).GetMethod("StartsWith", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanStartsWithComparison = typeof(MemoryExtensions).GetMethod("StartsWith", new Type[] { typeof(ReadOnlySpan<char>), typeof(ReadOnlySpan<char>), typeof(StringComparison) })!;
+        private static readonly MethodInfo s_stringAsSpanMethod = typeof(MemoryExtensions).GetMethod("AsSpan", new Type[] { typeof(string) })!;
+        private static readonly MethodInfo s_stringAsSpanIntIntMethod = typeof(MemoryExtensions).GetMethod("AsSpan", new Type[] { typeof(string), typeof(int), typeof(int) })!;
+        private static readonly MethodInfo s_stringGetCharsMethod = typeof(string).GetMethod("get_Chars", new Type[] { typeof(int) })!;
+        private static readonly MethodInfo s_stringIndexOf = typeof(string).GetMethod("IndexOf", new Type[] { typeof(char), typeof(int), typeof(int) })!;
 
         protected ILGenerator? _ilg;
 
@@ -1322,7 +1325,7 @@ namespace System.Text.RegularExpressions
                             Ldloc(_runtextendLocal);
                             Ldloc(_runtextposLocal);
                             Sub();
-                            Call(s_stringAsSpanMethod);
+                            Call(s_stringAsSpanIntIntMethod);
                             Ldc(setChars[0]);
                             Ldc(setChars[1]);
                             if (setCharsCount == 3)
@@ -1376,7 +1379,7 @@ namespace System.Text.RegularExpressions
                     Ldloc(_runtextendLocal);
                     Ldloc(_runtextposLocal);
                     Sub();
-                    Call(s_stringAsSpanMethod);
+                    Call(s_stringAsSpanIntIntMethod);
                     Stloc(textSpanLocal);
 
                     // for (int i = 0;
@@ -1660,7 +1663,7 @@ namespace System.Text.RegularExpressions
                 Ldthisfld(s_runtextendField);
                 Ldloc(runtextposLocal);
                 Sub();
-                Call(s_stringAsSpanMethod);
+                Call(s_stringAsSpanIntIntMethod);
                 Stloc(textSpanLocal);
             }
 
@@ -2161,17 +2164,51 @@ namespace System.Text.RegularExpressions
             // Emits the code to handle a multiple-character match.
             void EmitMultiChar(RegexNode node)
             {
-                ReadOnlySpan<char> s = node.Str;
+                bool caseInsensitive = IsCaseInsensitive(node);
+
+                // If the multi string's length exceeds the maximum length we want to unroll, instead generate a call to StartsWith.
+                // Each character that we unroll results in code generation that increases the size of both the IL and the resulting asm,
+                // and with a large enough string, that can cause significant overhead as well as even risk stack overflow due to
+                // having an obscenely long method.  Such long string lengths in a pattern are generally quite rare.  However, we also
+                // want to unroll for shorter strings, because the overhead of invoking StartsWith instead of doing a few simple
+                // inline comparisons is very measurable, especially if we're doing a culture-sensitive comparison and StartsWith
+                // accesses CultureInfo.CurrentCulture on each call.  We need to be cognizant not only of the cost if the whole
+                // string matches, but also the cost when the comparison fails early on, and thus we pay for the call overhead
+                // but don't reap the benefits of all the vectorization StartsWith can do.
+                const int MaxUnrollLength = 64;
+                if (node.Str!.Length > MaxUnrollLength)
+                {
+                    // if (!textSpan.Slice(textSpanPos).StartsWith("..."[, StringComparison.XxIgnoreCase])) goto doneLabel;
+                    Ldloca(textSpanLocal);
+                    Ldc(textSpanPos);
+                    Call(s_spanSliceIntMethod);
+                    Ldstr(node.Str);
+                    Call(s_stringAsSpanMethod);
+                    if (!caseInsensitive)
+                    {
+                        Call(s_spanStartsWith);
+                    }
+                    else
+                    {
+                        Ldc((int)(UseToLowerInvariant ? StringComparison.InvariantCultureIgnoreCase : StringComparison.CurrentCultureIgnoreCase));
+                        Call(s_spanStartsWithComparison);
+                    }
+                    BrfalseFar(doneLabel);
+                    textSpanPos += node.Str.Length;
+
+                    return;
+                }
 
                 // Emit the length check for the whole string.  If the generated code gets past this point,
                 // we know the span is at least textSpanPos + s.Length long.
+                ReadOnlySpan<char> s = node.Str;
                 EmitSpanLengthCheck(s.Length);
 
                 // If we're doing a case-insensitive comparison, we need to lower case each character,
                 // so we just go character-by-character.  But if we're not, we try to process multiple
                 // characters at a time; this is helpful not only for throughput but also in reducing
                 // the amount of IL and asm that results from this unrolling.
-                if (!IsCaseInsensitive(node))
+                if (!caseInsensitive)
                 {
                     // TODO https://github.com/dotnet/corefx/issues/39227:
                     // If/when we implement CompileToAssembly, this code will either need to be special-cased
@@ -2219,7 +2256,7 @@ namespace System.Text.RegularExpressions
                     EmitTextSpanOffset();
                     textSpanPos++;
                     LdindU2();
-                    if (IsCaseInsensitive(node)) CallToLower();
+                    if (caseInsensitive) CallToLower();
                     Ldc(s[i]);
                     BneFar(doneLabel);
                 }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -380,17 +380,14 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Match_VaryingLengthStrings()
         {
-            for (int length = 2; length < 32; length++)
+            foreach (int length in new[] { 2, 3, 4, 5, 6, 7, 8, 9, 31, 32, 33, 63, 64, 65, 100_000 })
             {
-                for (int prechars = 0; prechars < 4; prechars++)
+                string text = string.Concat(Enumerable.Range(0, length).Select(i => (char)('A' + (i % 26))));
+                string pattern = "[123]" + text;
+                string input = "2" + text;
+                foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled, RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant })
                 {
-                    var r = new Random(42);
-                    string pattern = string.Concat(Enumerable.Range(0, length).Select(i => (char)r.Next(0, 1 + char.MaxValue)));
-                    string input = new string('#', prechars) + pattern;
-                    foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled })
-                    {
-                        Match(pattern, input, options, prechars, length, expectedSuccess: true, expectedValue: pattern);
-                    }
+                    Match(pattern, input, options, 0, input.Length, expectedSuccess: true, expectedValue: input);
                 }
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -377,18 +377,25 @@ namespace System.Text.RegularExpressions.Tests
             VerifyMatch(new Regex(pattern, options).Match(input, beginning, length), expectedSuccess, expectedValue);
         }
 
-        [Fact]
-        public void Match_VaryingLengthStrings()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
+        [InlineData(RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+        [InlineData(RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        public void Match_VaryingLengthStrings(RegexOptions options)
         {
-            foreach (int length in new[] { 2, 3, 4, 5, 6, 7, 8, 9, 31, 32, 33, 63, 64, 65, 100_000 })
+            var lengths = new List<int>() { 2, 3, 4, 5, 6, 7, 8, 9, 31, 32, 33, 63, 64, 65 };
+            if ((options & RegexOptions.IgnoreCase) == 0)
+            {
+                lengths.Add(100_000); // currently produces too large a compiled method for case-insensitive
+            }
+
+            foreach (int length in lengths)
             {
                 string text = string.Concat(Enumerable.Range(0, length).Select(i => (char)('A' + (i % 26))));
                 string pattern = "[123]" + text;
                 string input = "2" + text;
-                foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled, RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant })
-                {
-                    Match(pattern, input, options, 0, input.Length, expectedSuccess: true, expectedValue: input);
-                }
+                Match(pattern, input, options, 0, input.Length, expectedSuccess: true, expectedValue: input);
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -377,6 +377,24 @@ namespace System.Text.RegularExpressions.Tests
             VerifyMatch(new Regex(pattern, options).Match(input, beginning, length), expectedSuccess, expectedValue);
         }
 
+        [Fact]
+        public void Match_VaryingLengthStrings()
+        {
+            for (int length = 2; length < 32; length++)
+            {
+                for (int prechars = 0; prechars < 4; prechars++)
+                {
+                    var r = new Random(42);
+                    string pattern = string.Concat(Enumerable.Range(0, length).Select(i => (char)r.Next(0, 1 + char.MaxValue)));
+                    string input = new string('#', prechars) + pattern;
+                    foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled })
+                    {
+                        Match(pattern, input, options, prechars, length, expectedSuccess: true, expectedValue: pattern);
+                    }
+                }
+            }
+        }
+
         private static void VerifyMatch(Match match, bool expectedSuccess, string expectedValue)
         {
             Assert.Equal(expectedSuccess, match.Success);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -390,11 +390,11 @@ namespace System.Text.RegularExpressions.Tests
                 lengths.Add(100_000); // currently produces too large a compiled method for case-insensitive
             }
 
+            bool caseInsensitive = (options & RegexOptions.IgnoreCase) != 0;
             foreach (int length in lengths)
             {
-                string text = string.Concat(Enumerable.Range(0, length).Select(i => (char)('A' + (i % 26))));
-                string pattern = "[123]" + text;
-                string input = "2" + text;
+                string pattern = "[123]" + string.Concat(Enumerable.Range(0, length).Select(i => (char)('A' + (i % 26))));
+                string input = "2" + string.Concat(Enumerable.Range(0, length).Select(i => (char)((caseInsensitive ? 'a' : 'A') + (i % 26))));
                 Match(pattern, input, options, 0, input.Length, expectedSuccess: true, expectedValue: input);
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Linq;
 using System.Tests;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -14,11 +14,13 @@ namespace System.Text.RegularExpressions.Tests
         /// <summary>
         /// See https://en.wikipedia.org/wiki/Dotted_and_dotless_I
         /// </summary>
-        [Fact]
-        public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture()
+        [Theory]
+        [InlineData(2)]
+        [InlineData(256)]
+        public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length)
         {
             var turkish = new CultureInfo("tr-TR");
-            string input = "I\u0131\u0130i";
+            string input = string.Concat(Enumerable.Repeat("I\u0131\u0130i", length / 2));
 
             Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             Regex[] turkishRegex = Create(input, turkish, RegexOptions.IgnoreCase);


### PR DESCRIPTION
When we encounter a series of characters in a regex pattern, we emit a comparison check per character.  This updates that codegen to compare 2 or 4 characters at a time, when possible.  In general these sequences are not long, but they can easily be a handful of characters, and comparing with ints and longs instead of chars slightly improves both throughput and the size of the IL and JIT'd asm.

@jkotas, any concerns with the change (philosophically due to the Unsafe usage, or otherwise)?  Note that I first used StartsWith, but the overhead from that was very pronounced, with the cross-over point not being until around 40 or so characters.

Trivial microbenchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly Regex _regex = new Regex(@"Oh what a beautiful morning.  Oh what a beautiful day.  I've got a beautiful feeling everything's going my way.", RegexOptions.Compiled);

    [Benchmark] public bool Match() =>   _regex.IsMatch("Oh what a beautiful morning.  Oh what a beautiful day.  I've got a beautiful feeling everything's going my way.");
}
```

| Method |           Toolchain |     Mean |    Error |   StdDev | Ratio |
|------- |-------------------- |---------:|---------:|---------:|------:|
|  Match | \master\corerun.exe | 74.27 ns | 0.155 ns | 0.130 ns |  1.00 |
|  Match |     \pr\corerun.exe | 61.73 ns | 0.195 ns | 0.182 ns |  0.83 |

Contributes to https://github.com/dotnet/runtime/issues/1349