### PR TITLE
Make parsing of debug info lazy

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
@@ -84,7 +84,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         /// <param name="reader">R2R image reader<param>
         /// <param name="offset">Offset of the EH clause in the image</param>
-        public EHClause(R2RReader reader, int offset)
+        public EHClause(ReadyToRunReader reader, int offset)
         {
             Flags = (CorExceptionFlag)BitConverter.ToUInt32(reader.Image, offset + 0 * sizeof(uint));
             TryOffset = BitConverter.ToUInt32(reader.Image, offset + 1 * sizeof(uint));
@@ -175,7 +175,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="methodRva">Starting RVA of the runtime function</param>
         /// <param name="offset">File offset of the EH info</param>
         /// <param name="clauseCount">Number of EH info clauses</param>
-        public EHInfo(R2RReader reader, int ehInfoRva, int methodRva, int offset, int clauseCount)
+        public EHInfo(ReadyToRunReader reader, int ehInfoRva, int methodRva, int offset, int clauseCount)
         {
             EHInfoRVA = ehInfoRva;
             MethodRVA = methodRva;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCRefMap.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCRefMap.cs
@@ -57,12 +57,12 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// </summary>
     public class GCRefMapDecoder
     {
-        private readonly R2RReader _reader;
+        private readonly ReadyToRunReader _reader;
         private int _offset;
         private int _pendingByte;
         private int _pos;
 
-        public GCRefMapDecoder(R2RReader reader, int offset)
+        public GCRefMapDecoder(ReadyToRunReader reader, int offset)
         {
             _reader = reader;
             _offset = offset;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// <summary>
     /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_HEADER
     /// </summary>
-    public class R2RHeader
+    public class ReadyToRunHeader
     {
         /// <summary>
         /// The expected signature of a ReadyToRun header
@@ -51,9 +51,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// The ReadyToRun section RVAs and sizes
         /// </summary>
-        public IDictionary<R2RSection.SectionType, R2RSection> Sections { get; }
+        public IDictionary<ReadyToRunSection.SectionType, ReadyToRunSection> Sections { get; }
 
-        public R2RHeader() { }
+        public ReadyToRunHeader() { }
 
         /// <summary>
         /// Initializes the fields of the R2RHeader
@@ -62,7 +62,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="rva">Relative virtual address of the ReadyToRun header</param>
         /// <param name="curOffset">Index in the image byte array to the start of the ReadyToRun header</param>
         /// <exception cref="BadImageFormatException">The signature must be 0x00525452</exception>
-        public R2RHeader(byte[] image, int rva, int curOffset)
+        public ReadyToRunHeader(byte[] image, int rva, int curOffset)
         {
             RelativeVirtualAddress = rva;
             int startOffset = curOffset;
@@ -80,18 +80,18 @@ namespace ILCompiler.Reflection.ReadyToRun
             MinorVersion = NativeReader.ReadUInt16(image, ref curOffset);
             Flags = NativeReader.ReadUInt32(image, ref curOffset);
             int nSections = NativeReader.ReadInt32(image, ref curOffset);
-            Sections = new Dictionary<R2RSection.SectionType, R2RSection>();
+            Sections = new Dictionary<ReadyToRunSection.SectionType, ReadyToRunSection>();
 
             for (int i = 0; i < nSections; i++)
             {
                 int type = NativeReader.ReadInt32(image, ref curOffset);
-                var sectionType = (R2RSection.SectionType)type;
-                if (!Enum.IsDefined(typeof(R2RSection.SectionType), type))
+                var sectionType = (ReadyToRunSection.SectionType)type;
+                if (!Enum.IsDefined(typeof(ReadyToRunSection.SectionType), type))
                 {
                     // TODO (refactoring) - what should we do?
                     // R2RDump.WriteWarning("Invalid ReadyToRun section type");
                 }
-                Sections[sectionType] = new R2RSection(sectionType,
+                Sections[sectionType] = new ReadyToRunSection(sectionType,
                     NativeReader.ReadInt32(image, ref curOffset),
                     NativeReader.ReadInt32(image, ref curOffset));
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// <summary>
     /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_IMPORT_SECTION
     /// </summary>
-    public struct R2RImportSection
+    public struct ReadyToRunImportSection
     {
         public class ImportSectionEntry
         {
@@ -76,9 +76,9 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public int AuxiliaryDataSize { get; set; }
 
-        public R2RImportSection(
+        public ReadyToRunImportSection(
             int index,
-            R2RReader reader,
+            ReadyToRunReader reader,
             int rva,
             int size,
             CorCompileImportFlags flags,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
-    public struct R2RSection
+    public struct ReadyToRunSection
     {
         /// <summary>
         /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> ReadyToRunSectionType
@@ -46,7 +46,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public int Size { get; set; }
 
-        public R2RSection(SectionType type, int rva, int size)
+        public ReadyToRunSection(SectionType type, int rva, int size)
         {
             Type = type;
             RelativeVirtualAddress = rva;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             return formatter.EmitHandleName(handle, namespaceQualified, owningTypeOverride, signaturePrefix);
         }
 
-        public static string FormatSignature(IAssemblyResolver assemblyResolver, R2RReader r2rReader, int imageOffset)
+        public static string FormatSignature(IAssemblyResolver assemblyResolver, ReadyToRunReader r2rReader, int imageOffset)
         {
             SignatureDecoder decoder = new SignatureDecoder(assemblyResolver, r2rReader, imageOffset);
             string result = decoder.ReadR2RSignature();
@@ -353,7 +353,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// ECMA reader representing the top-level signature context.
         /// </summary>
-        private readonly R2RReader _contextReader;
+        private readonly ReadyToRunReader _contextReader;
 
         /// <summary>
         /// Dump options are used to specify details of signature formatting.
@@ -381,7 +381,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="options">Dump options and paths</param>
         /// <param name="r2rReader">R2RReader object representing the PE file containing the ECMA metadata</param>
         /// <param name="offset">Signature offset within the PE file byte array</param>
-        public SignatureDecoder(IAssemblyResolver options, R2RReader r2rReader, int offset)
+        public SignatureDecoder(IAssemblyResolver options, ReadyToRunReader r2rReader, int offset)
         {
             _metadataReader = r2rReader.MetadataReader;
             _options = options;
@@ -398,7 +398,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="signature">Signature to parse</param>
         /// <param name="offset">Signature offset within the signature byte array</param>
         /// <param name="contextReader">Top-level signature context reader</param>
-        private SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, byte[] signature, int offset, R2RReader contextReader)
+        private SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, byte[] signature, int offset, ReadyToRunReader contextReader)
         {
             _metadataReader = metadataReader;
             _options = options;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -12,9 +12,9 @@ namespace ILCompiler.Reflection.ReadyToRun
 {
     public abstract class TransitionBlock
     {
-        public R2RReader _reader;
+        public ReadyToRunReader _reader;
 
-        public static TransitionBlock FromReader(R2RReader reader)
+        public static TransitionBlock FromReader(ReadyToRunReader reader)
         {
             switch (reader.Architecture)
             {
@@ -22,7 +22,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     return X86TransitionBlock.Instance;
 
                 case Architecture.X64:
-                    return reader.OS == OperatingSystem.Windows ? X64WindowsTransitionBlock.Instance : X64UnixTransitionBlock.Instance;
+                    return reader.OperatingSystem == OperatingSystem.Windows ? X64WindowsTransitionBlock.Instance : X64UnixTransitionBlock.Instance;
 
                 case Architecture.Arm:
                     return ArmTransitionBlock.Instance;

--- a/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
@@ -89,7 +89,7 @@ namespace R2RDump
         /// <summary>
         /// R2R reader is used to access architecture info, the PE image data and symbol table.
         /// </summary>
-        private readonly R2RReader _reader;
+        private readonly ReadyToRunReader _reader;
 
         /// <summary>
         /// Dump options
@@ -105,7 +105,7 @@ namespace R2RDump
         /// Store the R2R reader and construct the disassembler for the appropriate architecture.
         /// </summary>
         /// <param name="reader"></param>
-        public Disassembler(R2RReader reader, DumpOptions options)
+        public Disassembler(ReadyToRunReader reader, DumpOptions options)
         {
             _reader = reader;
             _options = options;

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -92,7 +92,7 @@ namespace R2RDump
             }
         }
 
-        public static void WriteTo(this R2RImportSection.ImportSectionEntry theThis, TextWriter writer, DumpOptions options)
+        public static void WriteTo(this ReadyToRunImportSection.ImportSectionEntry theThis, TextWriter writer, DumpOptions options)
         {
             if (!options.Naked)
             {
@@ -110,9 +110,9 @@ namespace R2RDump
             }
         }
 
-        public static void WriteTo(this R2RSection theThis, TextWriter writer, DumpOptions options)
+        public static void WriteTo(this ReadyToRunSection theThis, TextWriter writer, DumpOptions options)
         {
-            writer.WriteLine($"Type:  {Enum.GetName(typeof(R2RSection.SectionType), theThis.Type)} ({theThis.Type:D})");
+            writer.WriteLine($"Type:  {Enum.GetName(typeof(ReadyToRunSection.SectionType), theThis.Type)} ({theThis.Type:D})");
             if (!options.Naked)
             {
                 writer.WriteLine($"RelativeVirtualAddress: 0x{theThis.RelativeVirtualAddress:X8}");
@@ -120,7 +120,7 @@ namespace R2RDump
             writer.WriteLine($"Size: {theThis.Size} bytes");
         }
 
-        public static void WriteTo(this R2RMethod theThis, TextWriter writer, DumpOptions options)
+        public static void WriteTo(this ReadyToRunMethod theThis, TextWriter writer, DumpOptions options)
         {
             writer.WriteLine(theThis.SignatureString);
 

--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -20,12 +20,12 @@ namespace R2RDump
         /// <summary>
         /// Left R2R image for the diff.
         /// </summary>
-        private readonly R2RReader _leftFile;
+        private readonly ReadyToRunReader _leftFile;
 
         /// <summary>
         /// Right R2R image for the diff.
         /// </summary>
-        private readonly R2RReader _rightFile;
+        private readonly ReadyToRunReader _rightFile;
 
         /// <summary>
         /// Text writer to receive diff output.
@@ -38,7 +38,7 @@ namespace R2RDump
         /// <param name="leftFile">Left R2R file</param>
         /// <param name="rightFile">Right R2R file</param>
         /// <param name="writer">Output writer to receive the diff</param>
-        public R2RDiff(R2RReader leftFile, R2RReader rightFile, TextWriter writer)
+        public R2RDiff(ReadyToRunReader leftFile, ReadyToRunReader rightFile, TextWriter writer)
         {
             _leftFile = leftFile;
             _rightFile = rightFile;
@@ -157,7 +157,7 @@ namespace R2RDump
         /// </summary>
         /// <param name="reader">R2R image to scan</param>
         /// <returns></returns>
-        private Dictionary<string, int> GetPESectionMap(R2RReader reader)
+        private Dictionary<string, int> GetPESectionMap(ReadyToRunReader reader)
         {
             Dictionary<string, int> sectionMap = new Dictionary<string, int>();
 
@@ -174,11 +174,11 @@ namespace R2RDump
         /// </summary>
         /// <param name="reader">R2R image to scan</param>
         /// <returns></returns>
-        private Dictionary<string, int> GetR2RSectionMap(R2RReader reader)
+        private Dictionary<string, int> GetR2RSectionMap(ReadyToRunReader reader)
         {
             Dictionary<string, int> sectionMap = new Dictionary<string, int>();
 
-            foreach (KeyValuePair<R2RSection.SectionType, R2RSection> typeAndSection in reader.R2RHeader.Sections)
+            foreach (KeyValuePair<ReadyToRunSection.SectionType, ReadyToRunSection> typeAndSection in reader.ReadyToRunHeader.Sections)
             {
                 string name = typeAndSection.Key.ToString();
                 sectionMap.Add(name, typeAndSection.Value.Size);
@@ -192,11 +192,11 @@ namespace R2RDump
         /// </summary>
         /// <param name="reader">R2R image to scan</param>
         /// <returns></returns>
-        private Dictionary<string, int> GetR2RMethodMap(R2RReader reader)
+        private Dictionary<string, int> GetR2RMethodMap(ReadyToRunReader reader)
         {
             Dictionary<string, int> methodMap = new Dictionary<string, int>();
 
-            foreach (R2RMethod method in reader.R2RMethods)
+            foreach (ReadyToRunMethod method in reader.R2RMethods)
             {
                 int size = method.RuntimeFunctions.Sum(rf => rf.Size);
                 methodMap.Add(method.SignatureString, size);

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -109,12 +109,12 @@ namespace R2RDump
 
     public abstract class Dumper
     {
-        protected readonly R2RReader _r2r;
+        protected readonly ReadyToRunReader _r2r;
         protected TextWriter _writer;
         protected readonly Disassembler _disassembler;
         protected readonly DumpOptions _options;
 
-        public Dumper(R2RReader r2r, TextWriter writer, Disassembler disassembler, DumpOptions options)
+        public Dumper(ReadyToRunReader r2r, TextWriter writer, Disassembler disassembler, DumpOptions options)
         {
             _r2r = r2r;
             _writer = writer;
@@ -122,9 +122,9 @@ namespace R2RDump
             _options = options;
         }
 
-        public IEnumerable<R2RSection> NormalizedSections()
+        public IEnumerable<ReadyToRunSection> NormalizedSections()
         {
-            IEnumerable<R2RSection> sections = _r2r.R2RHeader.Sections.Values;
+            IEnumerable<ReadyToRunSection> sections = _r2r.ReadyToRunHeader.Sections.Values;
             if (_options.Normalize)
             {
                 sections = sections.OrderBy((s) => s.Type);
@@ -132,9 +132,9 @@ namespace R2RDump
             return sections;
         }
 
-        public IEnumerable<R2RMethod> NormalizedMethods()
+        public IEnumerable<ReadyToRunMethod> NormalizedMethods()
         {
-            IEnumerable<R2RMethod> methods = _r2r.R2RMethods;
+            IEnumerable<ReadyToRunMethod> methods = _r2r.R2RMethods;
             if (_options.Normalize)
             {
                 methods = methods.OrderBy((m) => m.SignatureString);
@@ -155,14 +155,14 @@ namespace R2RDump
         abstract internal void WriteSubDivider();
         abstract internal void SkipLine();
         abstract internal void DumpHeader(bool dumpSections);
-        abstract internal void DumpSection(R2RSection section);
+        abstract internal void DumpSection(ReadyToRunSection section);
         abstract internal void DumpEntryPoints();
         abstract internal void DumpAllMethods();
-        abstract internal void DumpMethod(R2RMethod method);
+        abstract internal void DumpMethod(ReadyToRunMethod method);
         abstract internal void DumpRuntimeFunction(RuntimeFunction rtf);
         abstract internal void DumpDisasm(RuntimeFunction rtf, int imageOffset);
         abstract internal void DumpBytes(int rva, uint size, string name = "Raw", bool convertToOffset = true);
-        abstract internal void DumpSectionContents(R2RSection section);
+        abstract internal void DumpSectionContents(ReadyToRunSection section);
         abstract internal void DumpQueryCount(string q, string title, int count);
     }
 
@@ -170,7 +170,7 @@ namespace R2RDump
     {
         private readonly DumpOptions _options;
         private readonly TextWriter _writer;
-        private readonly Dictionary<R2RSection.SectionType, bool> _selectedSections = new Dictionary<R2RSection.SectionType, bool>();
+        private readonly Dictionary<ReadyToRunSection.SectionType, bool> _selectedSections = new Dictionary<ReadyToRunSection.SectionType, bool>();
         private Dumper _dumper;
 
         private R2RDump(DumpOptions options)
@@ -237,7 +237,7 @@ namespace R2RDump
         /// <param name="title">The title to print, "R2R Methods by Query" or "R2R Methods by Keyword"</param>
         /// <param name="queries">The keywords/ids to search for</param>
         /// <param name="exact">Specifies whether to look for methods with names/signatures/ids matching the method exactly or partially</param>
-        private void QueryMethod(R2RReader r2r, string title, IReadOnlyList<string> queries, bool exact)
+        private void QueryMethod(ReadyToRunReader r2r, string title, IReadOnlyList<string> queries, bool exact)
         {
             if (queries.Count > 0)
             {
@@ -245,9 +245,9 @@ namespace R2RDump
             }
             foreach (string q in queries)
             {
-                IList<R2RMethod> res = FindMethod(r2r, q, exact);
+                IList<ReadyToRunMethod> res = FindMethod(r2r, q, exact);
                 _dumper.DumpQueryCount(q, "Methods", res.Count);
-                foreach (R2RMethod method in res)
+                foreach (ReadyToRunMethod method in res)
                 {
                     _dumper.DumpMethod(method);
                 }
@@ -259,7 +259,7 @@ namespace R2RDump
         /// </summary>
         /// <param name="r2r">Contains all the extracted info about the ReadyToRun image</param>
         /// <param name="queries">The names/values to search for</param>
-        private void QuerySection(R2RReader r2r, IReadOnlyList<string> queries)
+        private void QuerySection(ReadyToRunReader r2r, IReadOnlyList<string> queries)
         {
             if (queries.Count > 0)
             {
@@ -267,9 +267,9 @@ namespace R2RDump
             }
             foreach (string q in queries)
             {
-                IList<R2RSection> res = FindSection(r2r, q);
+                IList<ReadyToRunSection> res = FindSection(r2r, q);
                 _dumper.DumpQueryCount(q, "Sections", res.Count);
-                foreach (R2RSection section in res)
+                foreach (ReadyToRunSection section in res)
                 {
                     _dumper.DumpSection(section);
                 }
@@ -282,7 +282,7 @@ namespace R2RDump
         /// </summary>
         /// <param name="r2r">Contains all the extracted info about the ReadyToRun image</param>
         /// <param name="queries">The ids to search for</param>
-        private void QueryRuntimeFunction(R2RReader r2r, IEnumerable<string> queries)
+        private void QueryRuntimeFunction(ReadyToRunReader r2r, IEnumerable<string> queries)
         {
             if (queries.Any())
             {
@@ -306,7 +306,7 @@ namespace R2RDump
         /// Outputs specified headers, sections, methods or runtime functions for one ReadyToRun image
         /// </summary>
         /// <param name="r2r">The structure containing the info of the ReadyToRun image</param>
-        public void Dump(R2RReader r2r)
+        public void Dump(ReadyToRunReader r2r)
         {
             _dumper.Begin();
 
@@ -363,7 +363,7 @@ namespace R2RDump
         /// </summary>
         /// <param name="exact">Specifies exact or partial match</param>
         /// <remarks>Case-insensitive and ignores whitespace</remarks>
-        private bool Match(R2RMethod method, string query, bool exact)
+        private bool Match(ReadyToRunMethod method, string query, bool exact)
         {
             int id;
             bool isNum = ArgStringToInt(query, out id);
@@ -394,11 +394,11 @@ namespace R2RDump
         /// Returns true if the name or value of the ReadyToRunSectionType of <param>section</param> matches <param>query</param>
         /// </summary>
         /// <remarks>Case-insensitive</remarks>
-        private bool Match(R2RSection section, string query)
+        private bool Match(ReadyToRunSection section, string query)
         {
             int queryInt;
             bool isNum = ArgStringToInt(query, out queryInt);
-            string typeName = Enum.GetName(typeof(R2RSection.SectionType), section.Type);
+            string typeName = Enum.GetName(typeof(ReadyToRunSection.SectionType), section.Type);
 
             return (isNum && (int)section.Type == queryInt) || typeName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
@@ -411,10 +411,10 @@ namespace R2RDump
         /// <param name="exact">Specifies exact or partial match</param>
         /// <out name="res">List of all matching methods</out>
         /// <remarks>Case-insensitive and ignores whitespace</remarks>
-        public IList<R2RMethod> FindMethod(R2RReader r2r, string query, bool exact)
+        public IList<ReadyToRunMethod> FindMethod(ReadyToRunReader r2r, string query, bool exact)
         {
-            List<R2RMethod> res = new List<R2RMethod>();
-            foreach (R2RMethod method in r2r.R2RMethods)
+            List<ReadyToRunMethod> res = new List<ReadyToRunMethod>();
+            foreach (ReadyToRunMethod method in r2r.R2RMethods)
             {
                 if (Match(method, query, exact))
                 {
@@ -431,10 +431,10 @@ namespace R2RDump
         /// <param name="query">The name or value to search for</param>
         /// <out name="res">List of all matching sections</out>
         /// <remarks>Case-insensitive</remarks>
-        public IList<R2RSection> FindSection(R2RReader r2r, string query)
+        public IList<ReadyToRunSection> FindSection(ReadyToRunReader r2r, string query)
         {
-            List<R2RSection> res = new List<R2RSection>();
-            foreach (R2RSection section in r2r.R2RHeader.Sections.Values)
+            List<ReadyToRunSection> res = new List<ReadyToRunSection>();
+            foreach (ReadyToRunSection section in r2r.ReadyToRunHeader.Sections.Values)
             {
                 if (Match(section, query))
                 {
@@ -449,9 +449,9 @@ namespace R2RDump
         /// </summary>
         /// <param name="r2r">Contains all extracted info about the ReadyToRun image</param>
         /// <param name="rtfQuery">The name or value to search for</param>
-        public RuntimeFunction FindRuntimeFunction(R2RReader r2r, int rtfQuery)
+        public RuntimeFunction FindRuntimeFunction(ReadyToRunReader r2r, int rtfQuery)
         {
-            foreach (R2RMethod m in r2r.R2RMethods)
+            foreach (ReadyToRunMethod m in r2r.R2RMethods)
             {
                 foreach (RuntimeFunction rtf in m.RuntimeFunctions)
                 {
@@ -481,12 +481,12 @@ namespace R2RDump
                     throw new ArgumentException("The option '--naked' is incompatible with '--raw'");
                 }
 
-                R2RReader previousReader = null;
+                ReadyToRunReader previousReader = null;
 
                 foreach (FileInfo filename in _options.In)
                 {
                     // parse the ReadyToRun image
-                    R2RReader r2r = new R2RReader(_options, filename.FullName);
+                    ReadyToRunReader r2r = new ReadyToRunReader(_options, filename.FullName);
 
                     if (_options.Disasm)
                     {

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -17,7 +17,7 @@ namespace R2RDump
 {
     class TextDumper : Dumper
     {
-        public TextDumper(R2RReader r2r, TextWriter writer, Disassembler disassembler, DumpOptions options)
+        public TextDumper(ReadyToRunReader r2r, TextWriter writer, Disassembler disassembler, DumpOptions options)
             : base(r2r, writer, disassembler, options)
         {
         }
@@ -27,7 +27,7 @@ namespace R2RDump
             if (!_options.Normalize)
             {
                 _writer.WriteLine($"Filename: {_r2r.Filename}");
-                _writer.WriteLine($"OS: {_r2r.OS}");
+                _writer.WriteLine($"OS: {_r2r.OperatingSystem}");
                 _writer.WriteLine($"Machine: {_r2r.Machine}");
                 _writer.WriteLine($"ImageBase: 0x{_r2r.ImageBase:X8}");
                 SkipLine();
@@ -63,20 +63,20 @@ namespace R2RDump
         /// </summary>
         internal override void DumpHeader(bool dumpSections)
         {
-            _writer.WriteLine(_r2r.R2RHeader.ToString());
+            _writer.WriteLine(_r2r.ReadyToRunHeader.ToString());
 
             if (_options.Raw)
             {
-                DumpBytes(_r2r.R2RHeader.RelativeVirtualAddress, (uint)_r2r.R2RHeader.Size);
+                DumpBytes(_r2r.ReadyToRunHeader.RelativeVirtualAddress, (uint)_r2r.ReadyToRunHeader.Size);
             }
             SkipLine();
             if (dumpSections)
             {
                 WriteDivider("R2R Sections");
-                _writer.WriteLine($"{_r2r.R2RHeader.Sections.Count} sections");
+                _writer.WriteLine($"{_r2r.ReadyToRunHeader.Sections.Count} sections");
                 SkipLine();
 
-                foreach (R2RSection section in NormalizedSections())
+                foreach (ReadyToRunSection section in NormalizedSections())
                 {
                     DumpSection(section);
                 }
@@ -87,7 +87,7 @@ namespace R2RDump
         /// <summary>
         /// Dumps one R2RSection
         /// </summary>
-        internal override void DumpSection(R2RSection section)
+        internal override void DumpSection(ReadyToRunSection section)
         {
             WriteSubDivider();
             section.WriteTo(_writer, _options);
@@ -107,7 +107,7 @@ namespace R2RDump
         internal override void DumpEntryPoints()
         {
             WriteDivider($@"R2R Entry Points");
-            foreach (R2RMethod method in NormalizedMethods())
+            foreach (ReadyToRunMethod method in NormalizedMethods())
             {
                 _writer.WriteLine(method.SignatureString);
             }
@@ -118,7 +118,7 @@ namespace R2RDump
             WriteDivider("R2R Methods");
             _writer.WriteLine($"{_r2r.R2RMethods.Count} methods");
             SkipLine();
-            foreach (R2RMethod method in NormalizedMethods())
+            foreach (ReadyToRunMethod method in NormalizedMethods())
             {
                 TextWriter temp = _writer;
                 _writer = new StringWriter();
@@ -131,7 +131,7 @@ namespace R2RDump
         /// <summary>
         /// Dumps one R2RMethod.
         /// </summary>
-        internal override void DumpMethod(R2RMethod method)
+        internal override void DumpMethod(ReadyToRunMethod method)
         {
             WriteSubDivider();
             method.WriteTo(_writer, _options);
@@ -267,11 +267,11 @@ namespace R2RDump
             SkipLine();
         }
 
-        internal override void DumpSectionContents(R2RSection section)
+        internal override void DumpSectionContents(ReadyToRunSection section)
         {
             switch (section.Type)
             {
-                case R2RSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES:
                     if (!_options.Naked)
                     {
                         uint availableTypesSectionOffset = (uint)_r2r.GetOffset(section.RelativeVirtualAddress);
@@ -285,14 +285,14 @@ namespace R2RDump
                         _writer.WriteLine(name);
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_METHODDEF_ENTRYPOINTS:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_METHODDEF_ENTRYPOINTS:
                     if (!_options.Naked)
                     {
                         NativeArray methodEntryPoints = new NativeArray(_r2r.Image, (uint)_r2r.GetOffset(section.RelativeVirtualAddress));
                         _writer.Write(methodEntryPoints.ToString());
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS:
                     if (!_options.Naked)
                     {
                         uint instanceSectionOffset = (uint)_r2r.GetOffset(section.RelativeVirtualAddress);
@@ -306,7 +306,7 @@ namespace R2RDump
                         _writer.WriteLine($@"0x{instanceMethod.Bucket:X2} -> {instanceMethod.Method.SignatureString}");
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS:
                     int rtfOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int rtfEndOffset = rtfOffset + section.Size;
                     int rtfIndex = 0;
@@ -327,17 +327,17 @@ namespace R2RDump
                         rtfIndex++;
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_COMPILER_IDENTIFIER:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_COMPILER_IDENTIFIER:
                     _writer.WriteLine(_r2r.CompilerIdentifier);
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_IMPORT_SECTIONS:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_IMPORT_SECTIONS:
                     if (_options.Naked)
                     {
                         DumpNakedImportSections();
                     }
                     else
                     {
-                        foreach (R2RImportSection importSection in _r2r.ImportSections)
+                        foreach (ReadyToRunImportSection importSection in _r2r.ImportSections)
                         {
                             importSection.WriteTo(_writer);
                             if (_options.Raw && importSection.Entries.Count != 0)
@@ -358,7 +358,7 @@ namespace R2RDump
                                     DumpBytes(importSection.AuxiliaryDataRVA, (uint)importSection.AuxiliaryDataSize);
                                 }
                             }
-                            foreach (R2RImportSection.ImportSectionEntry entry in importSection.Entries)
+                            foreach (ReadyToRunImportSection.ImportSectionEntry entry in importSection.Entries)
                             {
                                 entry.WriteTo(_writer, _options);
                                 _writer.WriteLine();
@@ -367,7 +367,7 @@ namespace R2RDump
                         }
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA:
                     int assemblyRefCount = _r2r.MetadataReader.GetTableRowCount(TableIndex.AssemblyRef);
                     _writer.WriteLine($"MSIL AssemblyRef's ({assemblyRefCount} entries):");
                     for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
@@ -385,7 +385,7 @@ namespace R2RDump
                         manifestAsmIndex++;
                     }
                     break;
-                case R2RSection.SectionType.READYTORUN_SECTION_ATTRIBUTEPRESENCE:
+                case ReadyToRunSection.SectionType.READYTORUN_SECTION_ATTRIBUTEPRESENCE:
                     int attributesStartOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int attributesEndOffset = attributesStartOffset + section.Size;
                     NativeCuckooFilter attributes = new NativeCuckooFilter(_r2r.Image, attributesStartOffset, attributesEndOffset);
@@ -397,13 +397,13 @@ namespace R2RDump
 
         private void DumpNakedImportSections()
         {
-            List<R2RImportSection.ImportSectionEntry> entries = new List<R2RImportSection.ImportSectionEntry>();
-            foreach (R2RImportSection importSection in _r2r.ImportSections)
+            List<ReadyToRunImportSection.ImportSectionEntry> entries = new List<ReadyToRunImportSection.ImportSectionEntry>();
+            foreach (ReadyToRunImportSection importSection in _r2r.ImportSections)
             {
                 entries.AddRange(importSection.Entries);
             }
             entries.Sort((e1, e2) => e1.Signature.CompareTo(e2.Signature));
-            foreach (R2RImportSection.ImportSectionEntry entry in entries)
+            foreach (ReadyToRunImportSection.ImportSectionEntry entry in entries)
             {
                 entry.WriteTo(_writer, _options);
                 _writer.WriteLine();


### PR DESCRIPTION
I am starting to make the parsing of the ready-to-run image lazy. 

The motivation for this change is to make the constructor of `ReadyToRunReader` fast.

The original code parses the whole file for everything we needed in the constructor path using the various `Parse*` methods. The updated one is changed so that:

1.) Before accessing the data through the property, the `Ensure*` methods are called.
2.) In the `Ensure*` methods, we perform the actual parsing only if the parsing was not done.

This is the essence of the change. Making everything lazy is still a work in progress but it will be the same pattern throughout.

The rest of the change is littered with `R2R` -> `ReadyToRun`. I believe the latter is a better API naming, and because the change is so invasive I wanted to do it earlier than later to avoid conflicts.
