### PR TITLE
Cleanup remaining rhel/centos 6 conditions

### DIFF
--- a/src/coreclr/init-distro-rid.sh
+++ b/src/coreclr/init-distro-rid.sh
@@ -26,11 +26,10 @@
 #
 #   |    OS     |           Expected RID            |
 #   -------------------------------------------------
-#   |  alpine*  |        linux-musl-(arch)          |
 #   |  freeBSD  |        freebsd.(version)-x64      |
 #
 # It is important to note that the function does not return anything, but it
-# will set __DistroRid if there is a non-portable distro rid to be used.
+# exports __DistroRid, if there is a non-portable distro rid to be used.
 #
 initNonPortableDistroRid()
 {
@@ -82,7 +81,6 @@ initNonPortableDistroRid()
     fi
 }
 
-
 # initDistroRidGlobal
 #
 # Input:
@@ -96,10 +94,12 @@ initNonPortableDistroRid()
 #
 # Notes:
 #
-# The following out parameters are returned
+# It is important to note that the function does not return anything, but it
+# exports the following variables on success:
 #
 #   __DistroRid
 #   __PortableBuild
+#   __RuntimeId
 #
 initDistroRidGlobal()
 {

--- a/src/coreclr/init-distro-rid.sh
+++ b/src/coreclr/init-distro-rid.sh
@@ -37,25 +37,24 @@ initNonPortableDistroRid()
     # Make sure out parameter is cleared.
     __DistroRid=
 
-    local buildOs=$1
-    local buildArch=$2
-    local isPortable=$3
-    local rootfsDir=$4
+    local buildOs="$1"
+    local buildArch="$2"
+    local isPortable="$3"
+    local rootfsDir="$4"
 
     if [ "$buildOs" = "Linux" ]; then
-        # RHEL 6 is the only distro we will check redHat release for.
         if [ -e "${rootfsDir}/etc/os-release" ]; then
             source "${rootfsDir}/etc/os-release"
 
             # We have forced __PortableBuild=0. This is because -portablebuld
             # has been passed as false.
-            if (( ${isPortable} == 0 )); then
-                if [ "${ID}" == "rhel" ]; then
+            if (( isPortable == 0 )); then
+                if [ "${ID}" = "rhel" ]; then
                     # remove the last version digit
-                    VERSION_ID=${VERSION_ID%.*}
+                    VERSION_ID="${VERSION_ID%.*}"
                 fi
 
-                if [ -z ${VERSION_ID+x} ]; then
+                if [ -z "${VERSION_ID+x}" ]; then
                         # Rolling release distros do not set VERSION_ID, so omit
                         # it here to be consistent with everything else.
                         nonPortableBuildID="${ID}-${buildArch}"
@@ -64,25 +63,19 @@ initNonPortableDistroRid()
                 fi
             fi
 
-        elif [ -e "${rootfsDir}/etc/redhat-release" ]; then
-            local redhatRelease=$(<${rootfsDir}/etc/redhat-release)
-
-            if [[ "${redhatRelease}" == "CentOS release 6."* || "$redhatRelease" == "Red Hat Enterprise Linux Server release 6."* ]]; then
-                nonPortableBuildID="rhel.6-${buildArch}"
-            fi
         elif [ -e "${rootfsDir}/android_platform" ]; then
-            source $rootfsDir/android_platform
+            source "$rootfsDir"/android_platform
             nonPortableBuildID="$RID"
         fi
     fi
 
     if [ "$buildOs" = "FreeBSD" ]; then
-        __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
-        nonPortableBuildID="freebsd.$__freebsd_version-${buildArch}"
+        __freebsd_major_version=$(freebsd-version | { read v; echo "${v%%.*}"; })
+        nonPortableBuildID="freebsd.$__freebsd_major_version-${buildArch}"
     fi
 
-    if [ "${nonPortableBuildID}" != "" ]; then
-        export __DistroRid=${nonPortableBuildID}
+    if [ -n "${nonPortableBuildID}" ]; then
+        export __DistroRid="${nonPortableBuildID}"
 
         # We are using a non-portable build rid. Force __PortableBuild to false.
         export __PortableBuild=0
@@ -117,22 +110,14 @@ initDistroRidGlobal()
     # deprecated. Now only __DistroRid is supported. It will be used for both
     # portable and non-portable rids and will be used in build-packages.sh
 
-    local buildOs=$1
-    local buildArch=$2
-    local isPortable=$3
-    local rootfsDir=$4
+    local buildOs="$1"
+    local buildArch="$2"
+    local isPortable="$3"
+    local rootfsDir="$4"
 
-    # Setup whether this is a crossbuild. We can find this out if rootfsDir
-    # is set.
-    local isCrossBuild=0
-
-    if [ -z "${rootfsDir}" ]; then
-        isCrossBuild=0
-    else
+    if [ -n "${rootfsDir}" ]; then
         # We may have a cross build. Check for the existance of the rootfsDir
-        if [ -e ${rootfsDir} ]; then
-            isCrossBuild=1
-        else
+        if [ ! -e "${rootfsDir}" ]; then
             echo "Error rootfsDir has been passed, but the location is not valid."
             exit 1
         fi
@@ -144,7 +129,7 @@ initDistroRidGlobal()
         isPortable=0
     fi
 
-    initNonPortableDistroRid ${buildOs} ${buildArch} ${isPortable} ${rootfsDir}
+    initNonPortableDistroRid "${buildOs}" "${buildArch}" "${isPortable}" "${rootfsDir}"
 
     if [ -z "${__DistroRid}" ]; then
         # The non-portable build rid was not set. Set the portable rid.
@@ -157,7 +142,7 @@ initDistroRidGlobal()
             distroRid="linux-musl-${buildArch}"
         fi
 
-        if [ "${distroRid}" == "" ]; then
+        if [ -z "${distroRid}" ]; then
             if [ "$buildOs" = "Linux" ]; then
                 distroRid="linux-$buildArch"
             elif [ "$buildOs" = "OSX" ]; then
@@ -167,7 +152,7 @@ initDistroRidGlobal()
             fi
         fi
 
-        export __DistroRid=${distroRid}
+        export __DistroRid="${distroRid}"
     fi
 
     if [ -z "$__DistroRid" ]; then
@@ -178,6 +163,6 @@ initDistroRidGlobal()
         echo "__DistroRid: ${__DistroRid}"
         echo "__RuntimeId: ${__DistroRid}"
 
-        export __RuntimeId=${__DistroRid}
+        export __RuntimeId="${__DistroRid}"
     fi
 }

--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -29,11 +29,6 @@ init_rid_plat()
             if [[ "$ID" == "alpine" ]]; then
                 __rid_plat="linux-musl"
             fi
-        elif [ -e /etc/redhat-release ]; then
-            local redhatRelease=$(</etc/redhat-release)
-            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
-               __rid_plat="rhel.6"
-            fi
         fi
     fi
 

--- a/src/installer/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/installer/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -137,22 +137,6 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                     }
                 }
             }
-            else if (File.Exists("/etc/redhat-release"))
-            {
-                var lines = File.ReadAllLines("/etc/redhat-release");
-
-                if (lines.Length >= 1)
-                {
-                    string line = lines[0];
-                    if (line.StartsWith("Red Hat Enterprise Linux Server release 6.") ||
-                        line.StartsWith("CentOS release 6."))
-                    {
-                        result = new DistroInfo();
-                        result.Id = "rhel";
-                        result.VersionId = "6";
-                    }
-                }
-            }
 
             if (result != null)
             {

--- a/src/libraries/Native/build-native.sh
+++ b/src/libraries/Native/build-native.sh
@@ -40,11 +40,6 @@ initHostDistroRid()
                 VERSION_ID=${VERSION_ID%.*}
             fi
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
-        elif [ -e /etc/redhat-release ]; then
-            local redhatRelease=$(</etc/redhat-release)
-            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
-               __HostDistroRid="rhel.6-$__HostArch"
-            fi
         fi
     elif  [ "$__HostOS" == "OSX" ]; then
         _osx_version=`sw_vers -productVersion | cut -f1-2 -d'.'`


### PR DESCRIPTION
Also fixes some warnings reported by `shellcheck` in `init-distro-rid.sh`.

cc @jkotas