### PR TITLE
Fix invocation of runtest.py

### DIFF
--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -185,7 +185,7 @@ if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python "%~dp0runtest.py" %__RuntestPyArgs%
+set NEXTCMD=python "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
 echo !NEXTCMD!
 !NEXTCMD!
 


### PR DESCRIPTION
If you pass arguments to runtest.cmd, the argument parsing "shift"
commands will lose the `%0` argument, so using `%~dp0` to find
the script location no longer works.

Use the cached script location to invoke runtest.py.