### PR TITLE
Remove faulty assert from MethodDebugInformation

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
@@ -22,7 +22,6 @@ namespace System.Reflection.Metadata
         internal MethodDebugInformation(MetadataReader reader, MethodDebugInformationHandle handle)
         {
             Debug.Assert(reader != null);
-            Debug.Assert(!handle.IsNil);
 
             _reader = reader;
             _rowId = handle.RowId;

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -2661,6 +2661,21 @@ namespace System.Reflection.Metadata.Tests
         }
 
         [Fact]
+        public void GetMethodDebugInformation_InvalidHandle()
+        {
+            using (var provider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(PortablePdbs.DocumentsPdb)))
+            {
+                var reader = provider.GetMetadataReader();
+                var mdi = reader.GetMethodDebugInformation(default(MethodDebugInformationHandle));
+
+                AssertEx.Throws<BadImageFormatException>(() => mdi.SequencePointsBlob, _ => { });
+                AssertEx.Throws<BadImageFormatException>(() => mdi.Document, _ => { });
+                AssertEx.Throws<BadImageFormatException>(() => mdi.LocalSignature, _ => { });
+                AssertEx.Throws<BadImageFormatException>(() => mdi.GetSequencePoints(), _ => { });
+            }
+        }
+
+        [Fact]
         public void GetCustomDebugInformation()
         {
             using (var provider = MetadataReaderProvider.FromPortablePdbStream(new MemoryStream(PortablePdbs.DocumentsPdb)))

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -2668,10 +2668,10 @@ namespace System.Reflection.Metadata.Tests
                 var reader = provider.GetMetadataReader();
                 var mdi = reader.GetMethodDebugInformation(default(MethodDebugInformationHandle));
 
-                AssertEx.Throws<BadImageFormatException>(() => mdi.SequencePointsBlob, _ => { });
-                AssertEx.Throws<BadImageFormatException>(() => mdi.Document, _ => { });
-                AssertEx.Throws<BadImageFormatException>(() => mdi.LocalSignature, _ => { });
-                AssertEx.Throws<BadImageFormatException>(() => mdi.GetSequencePoints(), _ => { });
+                Assert.Throws<BadImageFormatException>(() => mdi.SequencePointsBlob);
+                Assert.Throws<BadImageFormatException>(() => mdi.Document);
+                Assert.Throws<BadImageFormatException>(() => mdi.LocalSignature);
+                Assert.Throws<BadImageFormatException>(() => mdi.GetSequencePoints());
             }
         }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/30261
I addressed the one that's causing problems for dynamic method reflection emit.  There are a bunch of other types with a similar assert that can be handled separately.  This one is just really annoying :)
cc: @jkotas, @tmat, @danmosemsft 