### PR TITLE
Remove unnecessary DynamicMethod from in-memory compiled regex

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
@@ -8,19 +8,18 @@ namespace System.Text.RegularExpressions
     {
         private readonly Action<RegexRunner> _goMethod;
         private readonly Func<RegexRunner, bool> _findFirstCharMethod;
-        private readonly Action<RegexRunner> _initTrackCountMethod;
 
-        public CompiledRegexRunner(Action<RegexRunner> go, Func<RegexRunner, bool> firstChar, Action<RegexRunner> trackCount)
+        public CompiledRegexRunner(Action<RegexRunner> go, Func<RegexRunner, bool> findFirstChar, int trackCount)
         {
             _goMethod = go;
-            _findFirstCharMethod = firstChar;
-            _initTrackCountMethod = trackCount;
+            _findFirstCharMethod = findFirstChar;
+            runtrackcount = trackCount;
         }
 
         protected override void Go() => _goMethod(this);
 
         protected override bool FindFirstChar() => _findFirstCharMethod(this);
 
-        protected override void InitTrackCount() => _initTrackCountMethod(this);
+        protected override void InitTrackCount() { }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
@@ -10,24 +10,23 @@ namespace System.Text.RegularExpressions
     {
         private readonly DynamicMethod _goMethod;
         private readonly DynamicMethod _findFirstCharMethod;
-        private readonly DynamicMethod _initTrackCountMethod;
+        private readonly int _trackcount;
 
         // Delegates are lazily created to avoid forcing JIT'ing until the regex is actually executed.
         private Action<RegexRunner>? _go;
         private Func<RegexRunner, bool>? _findFirstChar;
-        private Action<RegexRunner>? _initTrackCount;
 
-        public CompiledRegexRunnerFactory(DynamicMethod goMethod, DynamicMethod findFirstCharMethod, DynamicMethod initTrackCountMethod)
+        public CompiledRegexRunnerFactory(DynamicMethod goMethod, DynamicMethod findFirstCharMethod, int trackcount)
         {
             _goMethod = goMethod;
             _findFirstCharMethod = findFirstCharMethod;
-            _initTrackCountMethod = initTrackCountMethod;
+            _trackcount = trackcount;
         }
 
         protected internal override RegexRunner CreateInstance() =>
             new CompiledRegexRunner(
                 _go ??= (Action<RegexRunner>)_goMethod.CreateDelegate(typeof(Action<RegexRunner>)),
                 _findFirstChar ??= (Func<RegexRunner, bool>)_findFirstCharMethod.CreateDelegate(typeof(Func<RegexRunner, bool>)),
-                _initTrackCount ??= (Action<RegexRunner>)_initTrackCountMethod.CreateDelegate(typeof(Action<RegexRunner>)));
+                _trackcount);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1415,15 +1415,6 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /// <summary>Generates a very simple method that sets the _trackcount field.</summary>
-        protected void GenerateInitTrackCount()
-        {
-            Ldthis();
-            Ldc(_trackcount);
-            Stfld(s_runtrackcountField);
-            Ret();
-        }
-
         private bool TryGenerateNonBacktrackingGo(RegexNode node)
         {
             Debug.Assert(node.Type == RegexNode.Capture && node.ChildCount() == 1,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -35,10 +35,7 @@ namespace System.Text.RegularExpressions
             DynamicMethod findFirstCharMethod = DefineDynamicMethod("FindFirstChar" + regexnumString, typeof(bool), typeof(CompiledRegexRunner));
             GenerateFindFirstChar();
 
-            DynamicMethod initTrackCountMethod = DefineDynamicMethod("InitTrackCount" + regexnumString, null, typeof(CompiledRegexRunner));
-            GenerateInitTrackCount();
-
-            return new CompiledRegexRunnerFactory(goMethod, findFirstCharMethod, initTrackCountMethod);
+            return new CompiledRegexRunnerFactory(goMethod, findFirstCharMethod, _trackcount);
         }
 
         /// <summary>Begins the definition of a new method (no args) with a specified return value.</summary>


### PR DESCRIPTION
We're generating a dynamic method just to store a value into a base field, and we can more easily just due that directly without any code gen.

cc: @danmosemsft, @eerhardt, @pgovind, @ViktorHofer 