### PR TITLE
[Do not merge, regression testing] Fix deadlock in AsyncOperation when TryCancel() called from TryComplete()

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -115,7 +115,8 @@ namespace System.Net.Sockets
                 Waiting = 0,
                 Running = 1,
                 Complete = 2,
-                Cancelled = 3
+                Cancelled = 3,
+                Aborted = 4
             }
 
             private int _state; // Actually AsyncOperation.State.
@@ -167,32 +168,25 @@ namespace System.Net.Sockets
             public bool TrySetRunning()
             {
                 State oldState = (State)Interlocked.CompareExchange(ref _state, (int)State.Running, (int)State.Waiting);
-                if (oldState == State.Cancelled)
-                {
-                    // This operation has already been cancelled, and had its completion processed.
-                    // Simply return false to indicate no further processing is needed.
-                    return false;
-                }
-
-                Debug.Assert(oldState == (int)State.Waiting);
-                return true;
+                Debug.Assert(oldState == State.Waiting || oldState == State.Cancelled || oldState == State.Aborted);
+                return oldState == State.Waiting;
             }
 
-            public void SetComplete()
+            public bool TrySetComplete()
             {
-                Debug.Assert(Volatile.Read(ref _state) == (int)State.Running);
-
-                Volatile.Write(ref _state, (int)State.Complete);
+                State oldState = (State)Interlocked.CompareExchange(ref _state, (int)State.Complete, (int)State.Running);
+                Debug.Assert(oldState == State.Running || oldState == State.Aborted);
+                return oldState == State.Running;
             }
 
-            public void SetWaiting()
+            public bool TrySetWaiting()
             {
-                Debug.Assert(Volatile.Read(ref _state) == (int)State.Running);
-
-                Volatile.Write(ref _state, (int)State.Waiting);
+                State oldState = (State)Interlocked.CompareExchange(ref _state, (int)State.Waiting, (int)State.Running);
+                Debug.Assert(oldState == State.Running || oldState == State.Aborted);
+                return oldState == State.Running;
             }
 
-            public bool TryCancel()
+            public bool TryCancel(bool aborting)
             {
                 Trace("Enter");
 
@@ -201,42 +195,43 @@ namespace System.Net.Sockets
                 // important we clean it up, regardless.
                 CancellationRegistration.Dispose();
 
-                // Try to transition from Waiting to Cancelled
-                SpinWait spinWait = default;
-                bool keepWaiting = true;
-                while (keepWaiting)
+                State oldState;
+                if (aborting)
                 {
-                    int state = Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
-                    switch ((State)state)
+                    oldState = (State)Interlocked.Exchange(ref _state, (int)State.Aborted);
+                }
+                else
+                {
+                    // Cancel operation when it is not completed.
+                    SpinWait spinWait = default;
+                    do
                     {
-                        case State.Running:
+                        oldState = (State)Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
+
+                        if (oldState == State.Running)
+                        {
                             // A completion attempt is in progress. Keep busy-waiting.
                             Trace("Busy wait");
                             spinWait.SpinOnce();
-                            break;
-
-                        case State.Complete:
-                            // A completion attempt succeeded. Consider this operation as having completed within the timeout.
-                            Trace("Exit, previously completed");
-                            return false;
-
-                        case State.Waiting:
-                            // This operation was successfully cancelled.
-                            // Break out of the loop to handle the cancellation
-                            keepWaiting = false;
-                            break;
-
-                        case State.Cancelled:
-                            // Someone else cancelled the operation.
-                            // The previous canceller will have fired the completion, etc.
-                            Trace("Exit, previously cancelled");
-                            return false;
-                    }
+                        }
+                    } while (oldState == State.Running);
                 }
 
-                Trace("Cancelled, processing completion");
+                // Exit if the operation had already completed.
+                switch (oldState)
+                {
+                    case State.Complete:
+                        Trace("Exit, previously completed");
+                        return false;
+                    case State.Cancelled:
+                    case State.Aborted:
+                        Trace("Exit, previously cancelled/aborted");
+                        return false;
+                }
 
-                // The operation successfully cancelled.
+                Trace($"{(aborting?"Aborted":"Cancelled")}, processing completion");
+
+                // The operation successfully cancelled/aborted.
                 // It's our responsibility to set the error code and queue the completion.
                 DoAbort();
 
@@ -250,7 +245,7 @@ namespace System.Net.Sockets
 #if DEBUG
                     Debug.Assert(Interlocked.CompareExchange(ref _callbackQueued, 1, 0) == 0, $"Unexpected _callbackQueued: {_callbackQueued}");
 #endif
-                    // We've marked the operation as canceled, and so should invoke the callback, but
+                    // We've marked the operation as canceled/aborted, and so should invoke the callback, but
                     // we can't pool the object, as ProcessQueue may still have a reference to it, due to
                     // using a pattern whereby it takes the lock to grab an item, but then releases the lock
                     // to do further processing on the item that's still in the list.
@@ -260,7 +255,7 @@ namespace System.Net.Sockets
                 Trace("Exit");
 
                 // Note, we leave the operation in the OperationQueue.
-                // When we get around to processing it, we'll see it's cancelled and skip it.
+                // When we get around to processing it, we'll see it's cancelled/aborted and skip it.
                 return true;
             }
 
@@ -793,7 +788,7 @@ namespace System.Net.Sockets
                                 // call TryCancel, so we do this after the op is fully enqueued.
                                 if (cancellationToken.CanBeCanceled)
                                 {
-                                    operation.CancellationRegistration = cancellationToken.UnsafeRegister(s => ((TOperation)s).TryCancel(), operation);
+                                    operation.CancellationRegistration = cancellationToken.UnsafeRegister(s => ((TOperation)s).TryCancel(aborting: false), operation);
                                 }
 
                                 return true;
@@ -924,7 +919,7 @@ namespace System.Net.Sockets
                 while (true)
                 {
                     // Try to change the op state to Running.
-                    // If this fails, it means the operation was previously cancelled,
+                    // If this fails, it means the operation was previously cancelled/aborted,
                     // and we should just remove it from the queue without further processing.
                     if (!op.TrySetRunning())
                     {
@@ -934,12 +929,17 @@ namespace System.Net.Sockets
                     // Try to perform the IO
                     if (op.TryComplete(context))
                     {
-                        op.SetComplete();
-                        wasCompleted = true;
+                        if (op.TrySetComplete())
+                        {
+                            wasCompleted = true;
+                        }
                         break;
                     }
 
-                    op.SetWaiting();
+                    if (!op.TrySetWaiting())
+                    {
+                        break;
+                    }
 
                     // Check for retry and reset queue state.
 
@@ -1106,7 +1106,7 @@ namespace System.Net.Sockets
                         AsyncOperation op = _tail;
                         do
                         {
-                            aborted |= op.TryCancel();
+                            aborted |= op.TryCancel(aborting: true);
                             op = op.Next;
                         } while (op != _tail);
                     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -935,6 +935,44 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Fact]
+        public async Task ReceiveAsync_ConcurrentShutdownWithTimeoutAndClose_SucceedsOrThrowsAppropriateException()
+        {
+            if (UsesSync) return;
+
+            for (int i = 0; i < 10000; i++) // run multiple times to attempt to force various interleavings
+            {
+                (Socket client, Socket server) = CreateConnectedSocketPair();
+                using (var b = new Barrier(2))
+                {
+                    Task dispose = Task.Factory.StartNew(() =>
+                    {
+                        b.SignalAndWait();
+                        client.Shutdown(SocketShutdown.Both);
+                        client.Close(15);
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+                    Task send = Task.Factory.StartNew(() =>
+                    {
+                        SendAsync(server, new ArraySegment<byte>(new byte[1])).GetAwaiter().GetResult();
+                        b.SignalAndWait();
+                        ReceiveAsync(client, new ArraySegment<byte>(new byte[1])).GetAwaiter().GetResult();
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+                    await dispose;
+                    Exception error = await Record.ExceptionAsync(() => send);
+                    if (error != null)
+                    {
+                        Assert.True(
+                            error is ObjectDisposedException ||
+                            error is SocketException ||
+                            (error is SEHException && PlatformDetection.IsInAppContainer),
+                            error.ToString());
+                    }
+                }
+            }
+        }
+
         protected static (Socket, Socket) CreateConnectedSocketPair()
         {
             using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))


### PR DESCRIPTION
I've opened this PR to verify if the regression test (0bc0349) added to: https://github.com/dotnet/runtime/pull/381 intermittently hangs on CI on macOS after reverting the fix.

Please do not merge.