### PR TITLE
Move Assembly.GetEntryAssembly method to shared version of Assembly

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -104,14 +104,8 @@ namespace System.Reflection
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void GetEntryAssemblyNative(ObjectHandleOnStack retAssembly);
 
-        // internal test hook
-        private static bool s_forceNullEntryPoint = false;
-
-        public static Assembly? GetEntryAssembly()
+        private static Assembly? GetEntryAssemblyInternal()
         {
-            if (s_forceNullEntryPoint)
-                return null;
-
             RuntimeAssembly? entryAssembly = null;
             GetEntryAssemblyNative(ObjectHandleOnStack.Create(ref entryAssembly));
             return entryAssembly;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs
@@ -190,6 +190,17 @@ namespace System.Reflection
                 return m.Assembly;
         }
 
+        // internal test hook
+        private static bool s_forceNullEntryPoint = false;
+
+        public static Assembly? GetEntryAssembly()
+        {
+            if (s_forceNullEntryPoint)
+                return null;
+
+            return GetEntryAssemblyInternal();
+        }
+
         public static Assembly Load(byte[] rawAssembly) => Load(rawAssembly, rawSymbolStore: null);
 
         // Loads the assembly with a COFF based IMAGE containing


### PR DESCRIPTION
There is `System.Diagnostics.TraceSourceTests.DefaultTraceListenerClassTests.EntryAssemblyName_Null_NotIncludedInTrace` which Mono runs as part of common netcore test suit but the logic under the test is still located in Assembly.CoreCRL version so the test fails.
This PR moves common part to shared version of Assembly.
Please also see https://github.com/mono/mono/pull/18403
