### PR TITLE
Tiny cleanup - make host_startup_info return void

### DIFF
--- a/src/installer/corehost/cli/host_startup_info.cpp
+++ b/src/installer/corehost/cli/host_startup_info.cpp
@@ -30,7 +30,7 @@ bool get_path_from_argv(pal::string_t *path)
     return false;
 }
 
-int host_startup_info_t::parse(
+void host_startup_info_t::parse(
     int argc,
     const pal::char_t* argv[])
 {
@@ -49,7 +49,6 @@ int host_startup_info_t::parse(
     trace::info(_X("Host path: [%s]"), host_path.c_str());
     trace::info(_X("Dotnet path: [%s]"), dotnet_root.c_str());
     trace::info(_X("App path: [%s]"), app_path.c_str());
-    return 0;
 }
 
 bool host_startup_info_t::is_valid(host_mode_t mode) const

--- a/src/installer/corehost/cli/host_startup_info.h
+++ b/src/installer/corehost/cli/host_startup_info.h
@@ -16,7 +16,7 @@ struct host_startup_info_t
         const pal::char_t* dotnet_root_value,
         const pal::char_t* app_path_value);
 
-    int parse(
+    void parse(
         int argc,
         const pal::char_t* argv[]);
 


### PR DESCRIPTION
The original return value was always 0 and never actually checked.