### PR TITLE
Fix System.Net.Quic.csproj configurations

### DIFF
--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>System.Net.Quic</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>$(NetCoreAppCurrent)-Unix-Debug;$(NetCoreAppCurrent)-Unix-Release;$(NetCoreAppCurrent)-Windows_NT-Debug;$(NetCoreAppCurrent)-Windows_NT-Release</Configurations>
+    <Configurations>$(NetCoreAppCurrent)-Linux-Debug;$(NetCoreAppCurrent)-Linux-Release;$(NetCoreAppCurrent)-OSX-Debug;$(NetCoreAppCurrent)-OSX-Release;$(NetCoreAppCurrent)-Windows_NT-Debug;$(NetCoreAppCurrent)-Windows_NT-Release</Configurations>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The Configurations.props file was modified to have $(NetCoreAppCurrent)-Linux and
$(NetCoreAppCurrent)-OSX instead of $(NetCoreAppCurrent)-Unix in a recent PR #427,
but the Configurations in the System.Net.Quic.csproj were not updated accordingly.
This leads to the following local compilation failure:
`/home/janvorli/.nuget/packages/microsoft.dotnet.build.tasks.packaging/5.0.0-beta.20057.5/build/Packaging.targets(1098,5): error : Files /home/janvorli/git/runtime2/artifacts/bin/System.Net.Quic/netcoreapp5.0-Linux-Release/System.Net.Quic.dll and /home/janvorli/git/runtime2/artifacts/bin/System.Net.Quic/netcoreapp5.0-Unix-Release/System.Net.Quic.dll have the same TargetPath runtime.linux-x64.Microsoft.Private.CoreFx.NETCoreApp/runtimes/linux-x64/lib/netcoreapp5.0/System.Net.Quic.dll. [/home/janvorli/git/runtime2/src/libraries/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj]/`

This change fixes it.