### PR TITLE
Globally disable Windows ARM32 runs to reduce noise in CoreCLR runs

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -223,21 +223,25 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm
-
-- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      osGroup: Windows_NT
-      archType: arm
-      platform: Windows_NT_arm
-      jobParameters:
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        managedTestBuildOsGroup: Windows_NT
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# Currently down as there's no suitable ARM32 pool at the moment, tracked under
+#   https://github.com/dotnet/runtime/issues/1097
+#   https://github.com/dotnet/runtime/issues/1663
+#   https://github.com/dotnet/core-eng/issues/8490
+#
+# - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       osGroup: Windows_NT
+#       archType: arm
+#       platform: Windows_NT_arm
+#       jobParameters:
+#         stagedBuild: ${{ parameters.stagedBuild }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         managedTestBuildOsGroup: Windows_NT
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm64
 

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -223,25 +223,20 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm
-# Currently down as there's no suitable ARM32 pool at the moment, tracked under
-#   https://github.com/dotnet/runtime/issues/1097
-#   https://github.com/dotnet/runtime/issues/1663
-#   https://github.com/dotnet/core-eng/issues/8490
-#
-# - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       osGroup: Windows_NT
-#       archType: arm
-#       platform: Windows_NT_arm
-#       jobParameters:
-#         stagedBuild: ${{ parameters.stagedBuild }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         managedTestBuildOsGroup: Windows_NT
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      osGroup: Windows_NT
+      archType: arm
+      platform: Windows_NT_arm
+      jobParameters:
+        stagedBuild: ${{ parameters.stagedBuild }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        managedTestBuildOsGroup: Windows_NT
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm64
 

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -115,10 +115,14 @@ jobs:
 
     # Windows_NT arm
     - ${{ if eq(parameters.platform, 'Windows_NT_arm') }}:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
-        - Windows.10.Arm64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.10.Arm64
+    # Currently down as there's no suitable ARM32 pool at the moment, tracked under
+    #   https://github.com/dotnet/runtime/issues/1097
+    #   https://github.com/dotnet/runtime/issues/1663
+    #   https://github.com/dotnet/core-eng/issues/8490
+    #  - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
+    #    - Windows.10.Arm64.Open
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - Windows.10.Arm64
 
     # Windows_NT arm64
     - ${{ if eq(parameters.platform, 'Windows_NT_arm64') }}:


### PR DESCRIPTION
As we still don't have a final resolution w.r.t. a new Windows
queue to run ARM32 tests on, I propose globally disable them before
the issue is resolved. We're tracking the underlying problem in:

https://github.com/dotnet/runtime/issues/1097
https://github.com/dotnet/runtime/issues/1663
https://github.com/dotnet/core-eng/issues/8490

Thanks

Tomas