### PR TITLE
Enable upgrading loops before alternations to be atomic

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -720,8 +720,8 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Finds oneloop and setloop nodes in the concatenation that can be automatically upgraded
-        /// to oneloopatomic and setloopatomic nodes.  Such changes avoid potential useless backtracking.
+        /// Finds one/notone/setloop nodes in the concatenation that can be automatically upgraded
+        /// to one/notone/setloopatomic nodes.  Such changes avoid potential useless backtracking.
         /// This looks for cases like A*B, where A and B are known to not overlap: in such cases,
         /// we can effectively convert this to (?>A*)B.
         /// </summary>
@@ -745,107 +745,147 @@ namespace System.Text.RegularExpressions
                 }
                 Debug.Assert(node.Type != Group);
 
-                // Skip the successor down to the guaranteed next node.
-                while (subsequent.ChildCount() > 0)
-                {
-                    Debug.Assert(subsequent.Type != Group);
-                    switch (subsequent.Type)
-                    {
-                        case Capture:
-                        case Atomic:
-                        case Require:
-                        case Concatenate:
-                        case Loop when subsequent.M > 0:
-                        case Lazyloop when subsequent.M > 0:
-                            subsequent = subsequent.Child(0);
-                            continue;
-                    }
-
-                    break;
-                }
-
-                // If the two nodes don't agree on case-insensitivity, don't try to optimize.
-                // If they're both case sensitive or both case insensitive, then their tokens
-                // will be comparable.
-                if ((node.Options & RegexOptions.IgnoreCase) != (subsequent.Options & RegexOptions.IgnoreCase))
-                {
-                    continue;
-                }
-
-                // If this node is a one/notone/setloop, see if it overlaps with its successor in the concatenation.
-                // If it doesn't, then we can upgrade it to being a one/notone/setloopatomic.
-                // Doing so avoids unnecessary backtracking.
+                // If the node can be changed to atomic based on what comes after it, do so.
                 switch (node.Type)
                 {
-                    case Oneloop:
-                        switch (subsequent.Type)
-                        {
-                            case One when node.Ch != subsequent.Ch:
-                            case Onelazy when subsequent.M > 0 && node.Ch != subsequent.Ch:
-                            case Oneloop when subsequent.M > 0 && node.Ch != subsequent.Ch:
-                            case Oneloopatomic when subsequent.M > 0 && node.Ch != subsequent.Ch:
-                            case Notone when node.Ch == subsequent.Ch:
-                            case Notonelazy when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Notoneloop when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Notoneloopatomic when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Multi when node.Ch != subsequent.Str![0]:
-                            case Set when !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
-                            case Setlazy when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
-                            case Setloop when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
-                            case Setloopatomic when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
-                            case End:
-                            case EndZ when node.Ch != '\n':
-                            case Eol when node.Ch != '\n':
-                            case Boundary when RegexCharClass.IsWordChar(node.Ch):
-                            case Nonboundary when !RegexCharClass.IsWordChar(node.Ch):
-                            case ECMABoundary when RegexCharClass.IsECMAWordChar(node.Ch):
-                            case NonECMABoundary when !RegexCharClass.IsECMAWordChar(node.Ch):
-                                node.Type = Oneloopatomic;
-                                break;
-                        }
+                    case Oneloop when CanBeMadeAtomic(node, subsequent):
+                        node.Type = Oneloopatomic;
                         break;
+                    case Notoneloop when CanBeMadeAtomic(node, subsequent):
+                        node.Type = Notoneloopatomic;
+                        break;
+                    case Setloop when CanBeMadeAtomic(node, subsequent):
+                        node.Type = Setloopatomic;
+                        break;
+                }
 
-                    case Notoneloop:
-                        switch (subsequent.Type)
-                        {
-                            case One when node.Ch == subsequent.Ch:
-                            case Onelazy when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Oneloop when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Oneloopatomic when subsequent.M > 0 && node.Ch == subsequent.Ch:
-                            case Multi when node.Ch == subsequent.Str![0]:
-                            case End:
-                                node.Type = Notoneloopatomic;
-                                break;
-                        }
-                        break;
+                // Determines whether node can be switched to an atomic loop.  Subsequent is the node
+                // immediately after 'node'.
+                static bool CanBeMadeAtomic(RegexNode node, RegexNode subsequent, int maxDepth = 20)
+                {
+                    if (maxDepth <= 0)
+                    {
+                        // We hit our recursion limit.  Just don't apply the optimization.
+                        return false;
+                    }
 
-                    case Setloop:
+                    // Skip the successor down to the guaranteed next node.
+                    while (subsequent.ChildCount() > 0)
+                    {
+                        Debug.Assert(subsequent.Type != Group);
                         switch (subsequent.Type)
                         {
-                            case One when !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Onelazy when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Oneloop when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Oneloopatomic when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Notone when RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Notonelazy when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Notoneloop when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Notoneloopatomic when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
-                            case Multi when !RegexCharClass.CharInClass(subsequent.Str![0], node.Str!):
-                            case Set when !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
-                            case Setlazy when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
-                            case Setloop when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
-                            case Setloopatomic when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
-                            case End:
-                            case EndZ when !RegexCharClass.CharInClass('\n', node.Str!):
-                            case Eol when !RegexCharClass.CharInClass('\n', node.Str!):
-                            case Boundary when node.Str == RegexCharClass.WordClass || node.Str == RegexCharClass.DigitClass: // TODO: Expand these with a more inclusive overlap check that considers categories
-                            case Nonboundary when node.Str == RegexCharClass.NotWordClass || node.Str == RegexCharClass.NotDigitClass:
-                            case ECMABoundary when node.Str == RegexCharClass.ECMAWordClass || node.Str == RegexCharClass.ECMADigitClass:
-                            case NonECMABoundary when node.Str == RegexCharClass.NotECMAWordClass || node.Str == RegexCharClass.NotDigitClass:
-                                node.Type = Setloopatomic;
-                                break;
+                            case Concatenate:
+                            case Capture:
+                            case Atomic:
+                            case Require:
+                            case Loop when subsequent.M > 0:
+                            case Lazyloop when subsequent.M > 0:
+                                subsequent = subsequent.Child(0);
+                                continue;
                         }
+
                         break;
+                    }
+
+                    // If the two nodes don't agree on case-insensitivity, don't try to optimize.
+                    // If they're both case sensitive or both case insensitive, then their tokens
+                    // will be comparable.
+                    if ((node.Options & RegexOptions.IgnoreCase) != (subsequent.Options & RegexOptions.IgnoreCase))
+                    {
+                        return false;
+                    }
+
+                    // If the successor is an alternation, all of its children need to be evaluated, since any of them
+                    // could come after this node.  If any of them fail the optimization, then the whole node fails.
+                    if (subsequent.Type == Alternate)
+                    {
+                        int childCount = subsequent.ChildCount();
+                        for (int i = 0; i < childCount; i++)
+                        {
+                            if (!CanBeMadeAtomic(node, subsequent.Child(i), maxDepth - 1))
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                    // If this node is a one/notone/setloop, see if it overlaps with its successor in the concatenation.
+                    // If it doesn't, then we can upgrade it to being a one/notone/setloopatomic.
+                    // Doing so avoids unnecessary backtracking.
+                    switch (node.Type)
+                    {
+                        case Oneloop:
+                            switch (subsequent.Type)
+                            {
+                                case One when node.Ch != subsequent.Ch:
+                                case Onelazy when subsequent.M > 0 && node.Ch != subsequent.Ch:
+                                case Oneloop when subsequent.M > 0 && node.Ch != subsequent.Ch:
+                                case Oneloopatomic when subsequent.M > 0 && node.Ch != subsequent.Ch:
+                                case Notone when node.Ch == subsequent.Ch:
+                                case Notonelazy when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Notoneloop when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Notoneloopatomic when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Multi when node.Ch != subsequent.Str![0]:
+                                case Set when !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
+                                case Setlazy when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
+                                case Setloop when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
+                                case Setloopatomic when subsequent.M > 0 && !RegexCharClass.CharInClass(node.Ch, subsequent.Str!):
+                                case End:
+                                case EndZ when node.Ch != '\n':
+                                case Eol when node.Ch != '\n':
+                                case Boundary when RegexCharClass.IsWordChar(node.Ch):
+                                case Nonboundary when !RegexCharClass.IsWordChar(node.Ch):
+                                case ECMABoundary when RegexCharClass.IsECMAWordChar(node.Ch):
+                                case NonECMABoundary when !RegexCharClass.IsECMAWordChar(node.Ch):
+                                    return true;
+                            }
+                            break;
+
+                        case Notoneloop:
+                            switch (subsequent.Type)
+                            {
+                                case One when node.Ch == subsequent.Ch:
+                                case Onelazy when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Oneloop when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Oneloopatomic when subsequent.M > 0 && node.Ch == subsequent.Ch:
+                                case Multi when node.Ch == subsequent.Str![0]:
+                                case End:
+                                    return true;
+                            }
+                            break;
+
+                        case Setloop:
+                            switch (subsequent.Type)
+                            {
+                                case One when !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Onelazy when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Oneloop when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Oneloopatomic when subsequent.M > 0 && !RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Notone when RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Notonelazy when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Notoneloop when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Notoneloopatomic when subsequent.M > 0 && RegexCharClass.CharInClass(subsequent.Ch, node.Str!):
+                                case Multi when !RegexCharClass.CharInClass(subsequent.Str![0], node.Str!):
+                                case Set when !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
+                                case Setlazy when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
+                                case Setloop when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
+                                case Setloopatomic when subsequent.M > 0 && !RegexCharClass.MayOverlap(node.Str!, subsequent.Str!):
+                                case End:
+                                case EndZ when !RegexCharClass.CharInClass('\n', node.Str!):
+                                case Eol when !RegexCharClass.CharInClass('\n', node.Str!):
+                                case Boundary when node.Str == RegexCharClass.WordClass || node.Str == RegexCharClass.DigitClass: // TODO: Expand these with a more inclusive overlap check that considers categories
+                                case Nonboundary when node.Str == RegexCharClass.NotWordClass || node.Str == RegexCharClass.NotDigitClass:
+                                case ECMABoundary when node.Str == RegexCharClass.ECMAWordClass || node.Str == RegexCharClass.ECMADigitClass:
+                                case NonECMABoundary when node.Str == RegexCharClass.NotECMAWordClass || node.Str == RegexCharClass.NotDigitClass:
+                                    return true;
+                            }
+                            break;
+                    }
+
+                    return false;
                 }
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -661,6 +661,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"a*[bcd]+?", "aaab", RegexOptions.None, new string[] { "aaab" } };
             yield return new object[] { null, @"a*(?>[bcd]+)", "aaab", RegexOptions.None, new string[] { "aaab" } };
             yield return new object[] { null, @"a*[bcd]{1,3}", "aaab", RegexOptions.None, new string[] { "aaab" } };
+            yield return new object[] { null, @"a*([bcd]ab|[bef]cd){1,3}", "aaababecdcac", RegexOptions.ExplicitCapture, new string[] { "aaababecd" } };
+            yield return new object[] { null, @"a*([bcd]|[aef]){1,3}", "befb", RegexOptions.ExplicitCapture, new string[] { "bef" } }; // can't upgrade
             yield return new object[] { null, @"a*$", "aaa", RegexOptions.None, new string[] { "aaa" } };
             yield return new object[] { null, @"a*$", "aaa", RegexOptions.Multiline, new string[] { "aaa" } };
             yield return new object[] { null, @"a*\b", "aaa bbb", RegexOptions.None, new string[] { "aaa" } };


### PR DESCRIPTION
Changing loops to be atomic is beneficial because it avoids unnecessary backtracking (and if everything in the expression can be proven to avoid backtracking, we also can generate better code overall).  This change improves upon our detection to now consider the case where the subsequent node is an alternation, e.g. with the expression `\s+(something|anything)`, we can change that to the equivalent of `(?>\s+)(something|anything)` because we can see that for the alternation to succeed, it would never begin with a space, and therefore there's nothing the preceding loop could "give back" that would let the alternation succeed.

Example:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly Regex _regex = new Regex(@"a*(?:bc|de|fg|hi)", RegexOptions.Compiled);

    [Benchmark] public bool IsNotMatch() => _regex.IsMatch("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabd");
}
```

|     Method |           Toolchain |      Mean |     Error |    StdDev | Ratio |
|----------- |-------------------- |----------:|----------:|----------:|------:|
| IsNotMatch | \master\corerun.exe | 65.924 us | 0.0840 us | 0.0785 us |  1.00 |
| IsNotMatch |     \pr\corerun.exe |  4.561 us | 0.0314 us | 0.0263 us |  0.07 |

Best reviewed with whitespace disabled: https://github.com/dotnet/runtime/pull/1690/files?w=1

cc: @danmosemsft, @eerhardt, @pgovind, @ViktorHofer 