### PR TITLE
Fix linuxnonjit that got accidentally renamed to linuxonjit

### DIFF
--- a/src/coreclr/src/jit/linuxnonjit/CMakeLists.txt
+++ b/src/coreclr/src/jit/linuxnonjit/CMakeLists.txt
@@ -23,4 +23,4 @@ else()
     clr_unknown_arch()
 endif()
 
-add_jit(linuxonjit)
+add_jit(linuxnonjit)


### PR DESCRIPTION
The PR #1292 has accidentally renamed the linuxnonjit to linuxonjit.
This change fixes it.