### PR TITLE
WIP: Smoke test re-enabling Windows ARM runs in CoreCLR PR

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -119,8 +119,8 @@ jobs:
     #   https://github.com/dotnet/runtime/issues/1097
     #   https://github.com/dotnet/runtime/issues/1663
     #   https://github.com/dotnet/core-eng/issues/8490
-    #  - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-    #    - Windows.10.Arm64.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
+        - Windows.10.Arm32.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64
 


### PR DESCRIPTION
Based on Ilya's suggestion, I'm smoke testing running CoreCLR PR
against the Hummingboard ARM32 pool to assess its usability for
runtime testing moving forward.

Thanks

Tomas