### PR TITLE
Remove codebase argument from AssemblyNative::Load

### DIFF
--- a/src/coreclr/src/vm/assemblynative.cpp
+++ b/src/coreclr/src/vm/assemblynative.cpp
@@ -31,8 +31,7 @@
 #include "../binder/inc/bindertracing.h"
 #include "../binder/inc/clrprivbindercoreclr.h"
 
-FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAFE,
-        StringObject* codeBaseUNSAFE,
+FCIMPL5(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAFE,
         AssemblyBaseObject* requestingAssemblyUNSAFE,
         StackCrawlMark* stackMark,
         CLR_BOOL fThrowOnFileNotFound,
@@ -43,14 +42,12 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     struct _gc
     {
         ASSEMBLYNAMEREF        assemblyName;
-        STRINGREF              codeBase;
         ASSEMBLYREF            requestingAssembly;
         ASSEMBLYREF            rv;
         ASSEMBLYLOADCONTEXTREF assemblyLoadContext;
     } gc;
 
     gc.assemblyName        = (ASSEMBLYNAMEREF)        assemblyNameUNSAFE;
-    gc.codeBase            = (STRINGREF)              codeBaseUNSAFE;
     gc.requestingAssembly  = (ASSEMBLYREF)            requestingAssemblyUNSAFE;
     gc.rv                  = NULL;
     gc.assemblyLoadContext = (ASSEMBLYLOADCONTEXTREF) assemblyLoadContextUNSAFE;
@@ -69,8 +66,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
 
     if(gc.assemblyName->GetSimpleName() == NULL)
     {
-        if (gc.codeBase == NULL)
-            COMPlusThrow(kArgumentException, W("Format_StringZeroLength"));
+        COMPlusThrow(kArgumentException, W("Format_StringZeroLength"));
     }
     else
     {
@@ -100,9 +96,6 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     {   // Insuficient assembly name for binding (e.g. ContentType=WindowsRuntime cannot bind by assembly name)
         EEFileLoadException::Throw(&spec, COR_E_NOTSUPPORTED);
     }
-
-    if (gc.codeBase != NULL)
-        spec.SetCodeBase(pStackingAllocator, &gc.codeBase);
 
     if (pParentAssembly != NULL)
         spec.SetParentAssembly(pParentAssembly);

--- a/src/coreclr/src/vm/assemblynative.hpp
+++ b/src/coreclr/src/vm/assemblynative.hpp
@@ -32,8 +32,7 @@ public:
     static
     void QCALLTYPE GetExecutingAssembly(QCall::StackCrawlMarkHandle stackMark, QCall::ObjectHandleOnStack retAssembly);
 
-    static FCDECL6(Object*,         Load,                       AssemblyNameBaseObject* assemblyNameUNSAFE,
-                                                                StringObject* codeBaseUNSAFE,
+    static FCDECL5(Object*,         Load,                       AssemblyNameBaseObject* assemblyNameUNSAFE,
                                                                 AssemblyBaseObject* requestingAssemblyUNSAFE,
                                                                 StackCrawlMark* stackMark,
                                                                 CLR_BOOL fThrowOnFileNotFound,

--- a/src/coreclr/src/vm/assemblyspec.cpp
+++ b/src/coreclr/src/vm/assemblyspec.cpp
@@ -624,32 +624,6 @@ void AssemblySpec::AssemblyNameInit(ASSEMBLYNAMEREF* pAsmName, PEImage* pImageIn
     GCPROTECT_END();
 }
 
-// This uses thread storage to allocate space. Please use Checkpoint and release it.
-void AssemblySpec::SetCodeBase(StackingAllocator* alloc, STRINGREF *pCodeBase)
-{
-    CONTRACTL
-    {
-        INSTANCE_CHECK;
-        THROWS;
-        GC_TRIGGERS;
-        MODE_COOPERATIVE;
-        PRECONDITION(CheckPointer(pCodeBase));
-        INJECT_FAULT(COMPlusThrowOM(););
-    }
-    CONTRACTL_END;
-
-    // Codebase
-    if (pCodeBase != NULL && *pCodeBase != NULL) {
-        WCHAR* pString;
-        int    iString;
-        (*pCodeBase)->RefInterpretGetStringValuesDangerousForGC(&pString, &iString);
-
-        DWORD dwCodeBase = (DWORD) iString+1;
-        m_wszCodeBase = new (alloc) WCHAR[dwCodeBase];
-        memcpy((void*)m_wszCodeBase, pString, dwCodeBase * sizeof(WCHAR));
-    }
-}
-
 #endif // CROSSGEN_COMPILE
 
 // Check if the supplied assembly's public key matches up with the one in the Spec, if any

--- a/src/coreclr/src/vm/assemblyspec.hpp
+++ b/src/coreclr/src/vm/assemblyspec.hpp
@@ -123,7 +123,6 @@ class AssemblySpec  : public BaseAssemblySpec
         WRAPPER_NO_CONTRACT;
         BaseAssemblySpec::SetCodeBase(szCodeBase);
     }
-    void SetCodeBase(StackingAllocator* alloc, STRINGREF *pCodeBase);
 
     void SetParentAssembly(DomainAssembly *pAssembly)
     {


### PR DESCRIPTION
Calls into `AssemblyNative::Load` would have always had null for the code base.