### PR TITLE
JIT: some jitstress fixes

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -1724,6 +1724,12 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     assert(pAlloc);
     compArenaAllocator = pAlloc;
 
+#if defined(DEBUG) || defined(LATE_DISASM)
+    info.compMethodName = nullptr;
+    info.compClassName  = nullptr;
+    info.compFullName   = nullptr;
+#endif // defined(DEBUG) || defined(LATE_DISASM)
+
     // Inlinee Compile object will only be allocated when needed for the 1st time.
     InlineeCompiler = nullptr;
 
@@ -3347,6 +3353,12 @@ bool Compiler::compStressCompile(compStressArea stressArea, unsigned weight)
 {
     unsigned hash;
     DWORD    stressLevel;
+
+    // This can be called early, before info is fully set up.
+    if (info.compMethodName == nullptr)
+    {
+        return false;
+    }
 
     if (!bRangeAllowStress)
     {


### PR DESCRIPTION
Jitstress' `STRESS_LCL_FLD` mode was not handling `LCL_VAR_ADDR` nodes, leading
to bad "stress only" codegen. Handle these node types properly.

Fixes #1704.

Also initialize `compMethodName` early, so we can check for nullptr later on
when considering the jit stress range and avoid an AV.

Fixes #1684.