### PR TITLE
Fix builds of about 30 framework assemblies without large bubble

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -130,12 +130,20 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 methodSpec.DecodeSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
                 token = new ModuleToken(token.Module, methodSpec.Method);
             }
+
             if (token.TokenType == CorTokenType.mdtMemberRef)
             {
                 MemberReference memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
                 EntityHandle owningTypeHandle = memberRef.Parent;
                 AddModuleTokenForType(method.OwningType, new ModuleToken(token.Module, owningTypeHandle));
                 memberRef.DecodeMethodSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
+            }
+            else if (token.TokenType == CorTokenType.mdtMethodDef)
+            {
+                MethodDefinition methodDef = token.MetadataReader.GetMethodDefinition((MethodDefinitionHandle)token.Handle);
+                TypeDefinitionHandle owningTypeHandle = methodDef.GetDeclaringType();
+                AddModuleTokenForType(method.OwningType, new ModuleToken(token.Module, owningTypeHandle));
+                methodDef.DecodeSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -311,10 +311,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TypeFlags.Nullable:
                 case TypeFlags.Enum:
                     {
-                        ModuleToken token = context.GetModuleTokenForType((EcmaType)typeDesc);
-                        EmitModuleOverride(token.Module, context);
-                        EmitElementType(CorElementType.ELEMENT_TYPE_VALUETYPE);
-                        EmitToken(token.Token);
+                        if (typeDesc == typeDesc.Context.GetWellKnownType(WellKnownType.TypedReference))
+                        {
+                            EmitElementType(CorElementType.ELEMENT_TYPE_TYPEDBYREF);
+                        }
+                        else
+                        {
+                            ModuleToken token = context.GetModuleTokenForType((EcmaType)typeDesc);
+                            EmitModuleOverride(token.Module, context);
+                            EmitElementType(CorElementType.ELEMENT_TYPE_VALUETYPE);
+                            EmitToken(token.Token);
+                        }
                         return;
                     }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -53,7 +53,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public EcmaModule GetTargetModule(TypeDesc type)
         {
-            if (type.IsPrimitive || type.IsString || type.IsObject)
+            if (type.IsPrimitive || type.IsString || type.IsObject || type == type.Context.GetWellKnownType(WellKnownType.TypedReference))
             {
                 return LocalContext;
             }


### PR DESCRIPTION
I haven't yet nailed down the cause of compilation failure in
S.P.CoreLib, however in the process I found out that about 30 more
framework assemblies are broken w.r.t. Crossgen2 compilation
when large version bubble is not specified. This had basically
two causes:

1) Missing ModuleTokenResolver logic for harvesting typerefs from
MethodDef tokens;

2) Incomplete support for TypedReference.

Thanks

Tomas