### PR TITLE
Fix test property evaluation on netfx vertical

### DIFF
--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -64,7 +64,7 @@
             CopyToOutputDirectory="PreserveNewest"
             Visible="false" />
 
-      <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true'" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
+      <_xunitConsoleNetCoreExclude Condition="'$(GenerateDependencyFile)' != 'true' and '$(XunitConsoleNetCore21AppPath)' != ''" Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\xunit.console.deps.json" />
       <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsoleNetCore21AppPath)'))\*"
             Exclude="@(_xunitConsoleNetCoreExclude)"
             Condition="'$(TargetsNetCoreApp)' == 'true' and '$(XunitConsoleNetCore21AppPath)' != ''"


### PR DESCRIPTION
When running on netfx vertical there's a chance that the `XunitConsoleNetCore21AppPath` property which is defined in https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.XUnitConsoleRunner/src/build/Microsoft.DotNet.XUnitConsoleRunner.props#L4 isn't available because the packages isn't restored / imported. Guarding against that by checking if the property is set.

cc @MarcoRossignoli 