### PR TITLE
Flush GC log on shutdown

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -680,7 +680,7 @@ void GCHeap::ShutDownLogging()
         fwrite(gc_log_buffer, gc_log_buffer_offset, 1, gc_log);
         fflush(gc_log);
         fclose(gc_log);
-        gc_config_log_buffer_offset = 0;
+        gc_log_buffer_offset = 0;
     }
 #endif
 }

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -672,6 +672,19 @@ void GCLogConfig (const char *fmt, ... )
 }
 #endif // GC_CONFIG_DRIVEN && !DACCESS_COMPILE
 
+void GCHeap::ShutDownLogging()
+{
+#if defined(TRACE_GC) && !defined(DACCESS_COMPILE)
+    if (gc_log_on && (gc_log != NULL))
+    {
+        fwrite(gc_log_buffer, gc_log_buffer_offset, 1, gc_log);
+        fflush(gc_log);
+        fclose(gc_log);
+        gc_config_log_buffer_offset = 0;
+    }
+#endif
+}
+
 #ifdef SYNCHRONIZATION_STATS
 
 // Number of GCs have we done since we last logged.

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -672,7 +672,7 @@ void GCLogConfig (const char *fmt, ... )
 }
 #endif // GC_CONFIG_DRIVEN && !DACCESS_COMPILE
 
-void GCHeap::ShutDownLogging()
+void GCHeap::Shutdown()
 {
 #if defined(TRACE_GC) && !defined(DACCESS_COMPILE)
     if (gc_log_on && (gc_log != NULL))
@@ -36413,7 +36413,7 @@ void DestructObject (CObjectHeader* hdr)
     hdr->~CObjectHeader();
 }
 
-HRESULT GCHeap::Shutdown ()
+HRESULT GCHeap::StaticShutdown ()
 {
     deleteGCShadow();
 

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -70,7 +70,7 @@ public:
     ~GCHeap(){};
 
     /* BaseGCHeap Methods*/
-    PER_HEAP_ISOLATED   HRESULT Shutdown ();
+    PER_HEAP_ISOLATED   HRESULT StaticShutdown ();
 
     size_t  GetTotalBytesInUse ();
     // Gets the amount of bytes objects currently occupy on the GC heap.
@@ -312,7 +312,7 @@ public:
 
     size_t GetLastGCGenerationSize(int gen);
 
-    virtual void ShutDownLogging();
+    virtual void Shutdown();
 };
 
 #endif  // GCIMPL_H_

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -311,6 +311,8 @@ public:
     int GetLastGCPercentTimeInGC();
 
     size_t GetLastGCGenerationSize(int gen);
+
+    virtual void ShutDownLogging();
 };
 
 #endif  // GCIMPL_H_

--- a/src/coreclr/src/gc/gcinterface.h
+++ b/src/coreclr/src/gc/gcinterface.h
@@ -734,6 +734,9 @@ public:
     // Tells the GC how many YieldProcessor calls are equal to one scaled yield processor call.
     virtual void SetYieldProcessorScalingFactor(float yieldProcessorScalingFactor) = 0;
 
+    // Flush the log and close the file if GCLog is turned on.
+    virtual void ShutDownLogging() = 0;
+
     /*
     ============================================================================
     Add/RemoveMemoryPressure support routines. These are on the interface

--- a/src/coreclr/src/gc/gcinterface.h
+++ b/src/coreclr/src/gc/gcinterface.h
@@ -735,7 +735,7 @@ public:
     virtual void SetYieldProcessorScalingFactor(float yieldProcessorScalingFactor) = 0;
 
     // Flush the log and close the file if GCLog is turned on.
-    virtual void ShutDownLogging() = 0;
+    virtual void Shutdown() = 0;
 
     /*
     ============================================================================

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -1647,6 +1647,7 @@ part2:
 #ifdef LOGGING
                 ShutdownLogging();
 #endif
+                GCHeapUtilities::GetGCHeap()->ShutDownLogging();
             }
         }
 

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -1647,7 +1647,7 @@ part2:
 #ifdef LOGGING
                 ShutdownLogging();
 #endif
-                GCHeapUtilities::GetGCHeap()->ShutDownLogging();
+                GCHeapUtilities::GetGCHeap()->Shutdown();
             }
         }
 


### PR DESCRIPTION
This change fixed the 'bug' that the remaining data in the `gc_log_buffer` is not flushed to the file.
