### PR TITLE
Fix PEReader creation and caching

### DIFF
--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -5,6 +5,7 @@
 using ILCompiler.Reflection.ReadyToRun;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -90,20 +91,16 @@ namespace R2RDump
 
         private static unsafe MetadataReader Open(string filename)
         {
-            byte[] Image = File.ReadAllBytes(filename);
+            byte[] image = File.ReadAllBytes(filename);
 
-            fixed (byte* p = Image)
+            PEReader peReader = new PEReader(ImmutableArray.Create(image));
+
+            if (!peReader.HasMetadata)
             {
-                IntPtr ptr = (IntPtr)p;
-                PEReader peReader = new PEReader(p, Image.Length);
-
-                if (!peReader.HasMetadata)
-                {
-                    throw new Exception($"ECMA metadata not found in file '{filename}'");
-                }
-
-                return peReader.GetMetadataReader();
+                throw new Exception($"ECMA metadata not found in file '{filename}'");
             }
+
+            return peReader.GetMetadataReader();
         }
     }
 

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -2,19 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.Reflection.ReadyToRun;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using ILCompiler.Reflection.ReadyToRun;
 
 namespace R2RDump
 {
@@ -93,7 +93,7 @@ namespace R2RDump
         {
             byte[] image = File.ReadAllBytes(filename);
 
-            PEReader peReader = new PEReader(ImmutableArray.Create(image));
+            PEReader peReader = new PEReader(Unsafe.As<byte[], ImmutableArray<byte>>(ref image));
 
             if (!peReader.HasMetadata)
             {


### PR DESCRIPTION
Can't use a fixed stack-based pointer to initialize something on the heap and expect it to continue working :)

cc @dotnet/crossgen-contrib 