### PR TITLE
Fix crossgen2 handling of sequential layout with explicit size

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1274,7 +1274,7 @@ namespace Internal.JitInterface
                     result |= CorInfoFlag.CORINFO_FLG_CONTAINS_STACK_PTR;
 
                 // The CLR has more complicated rules around CUSTOMLAYOUT, but this will do.
-                if (metadataType.IsExplicitLayout || metadataType.IsWellKnownType(WellKnownType.TypedReference))
+                if (metadataType.IsExplicitLayout || (metadataType.IsSequentialLayout && metadataType.GetClassLayout().Size != 0) || metadataType.IsWellKnownType(WellKnownType.TypedReference))
                     result |= CorInfoFlag.CORINFO_FLG_CUSTOMLAYOUT;
 
                 // TODO


### PR DESCRIPTION
Crossgen2 is incorrectly not marking types with sequential layout and
explicit size as custom layout, which results in JIT generating incorrect
code for copying such structs. One example is the
Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize
test that has a struct with single int element, sequential layout and
explicitly set size to 16. The getClassAttribsInternal was not setting
CorInfoFlag.CORINFO_FLG_CUSTOMLAYOUT for this type and so JIT was
generating code that copied just the int element.

This change fixes it. Runtime uses similar check.