### PR TITLE
Delete duplicated R2R version definition and sync to reality

### DIFF
--- a/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 4;
-        public const ushort CurrentMinorVersion = 0;
+        public const ushort CurrentMinorVersion = 1;
     }
 
 #pragma warning disable 0169

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
@@ -11,14 +11,6 @@ using Internal.ReadyToRunConstants;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
-    internal struct ReadyToRunHeaderConstants
-    {
-        public const uint Signature = 0x00525452; // 'RTR'
-
-        public const ushort CurrentMajorVersion = 3;
-        public const ushort CurrentMinorVersion = 0;
-    }
-
     public abstract class HeaderTableNode : ObjectNode, ISymbolDefinitionNode
     {
         public TargetDetails Target { get; private set; }


### PR DESCRIPTION
We're not generating R2R version 3.0: we started generating 4.1 when nop padding/jump stamps were removed. (Seems like R2R 4.0 was actually skipped entirely but we ended up with the 4.0 version in one of the copies of the struct because only major version was bumped for jump stamps; minor was untouched - minor went up with cuckoo metadata before that and that didn't involve crossgen2 at that point)

Didn't dig into history to find out why it's duplicated in the first place, but it doesn't look like a good place to be in.

@dotnet/crossgen-contrib PTAL