### PR TITLE
Change all ActiveIssues to use Uris instead of numbers

### DIFF
--- a/src/libraries/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
+++ b/src/libraries/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
@@ -192,7 +192,7 @@ namespace System.Net.WebSockets.Tests
             }
         }
 
-        [ActiveIssue(36016)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36016")]
         [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServersAndBoolean))]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -274,7 +274,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         [Fact]
 #if TESTING_CNG_IMPLEMENTATION
-        [ActiveIssue(18882, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/18882", TargetFrameworkMonikers.NetFramework)]
 #endif
         public static void ImportNoDP()
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -1340,7 +1340,7 @@ zM=
         }
 
         [Fact]
-        [ActiveIssue(37595, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37595", TestPlatforms.OSX)]
         public static void FromNonsenseXml()
         {
             // This is DiminishedDPParameters XML, but with a P that is way too long.

--- a/src/libraries/Microsoft.CSharp/tests/AccessTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/AccessTests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void AccessNestedPrivateProtectedAssembly()
         {
             dynamic d = Container.PrivateProtectedValueTypeArray();
@@ -272,7 +272,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void InaccessibleFields()
         {
             dynamic d = new TypeWithFields();

--- a/src/libraries/Microsoft.CSharp/tests/ArrayHandling.cs
+++ b/src/libraries/Microsoft.CSharp/tests/ArrayHandling.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
     public class ArrayHandling
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void SingleRankNonSZArray()
         {
             dynamic d = Array.CreateInstance(typeof(int), new[] { 8 }, new[] { -2 });
@@ -23,7 +23,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ArrayTypeNames()
         {
             dynamic d;
@@ -42,7 +42,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void MultiDimArrayTypeNames()
         {
             dynamic d = new int[3, 2, 1];
@@ -58,7 +58,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void IncorrectNumberOfIndices()
         {
             dynamic d = new int[2, 2, 2];
@@ -116,7 +116,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void NonSZ1RArrayLenght()
         {
             dynamic d = Array.CreateInstance(typeof(int), new[] {23}, new[] {-2});

--- a/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
+++ b/src/libraries/Microsoft.CSharp/tests/BindingErrors.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void TryInvokeOrAccessNestedClassAsMember()
         {
             dynamic dFirst = new Outer.Inner();
@@ -456,7 +456,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void TryInvokeTypeParameterAsMember()
         {
             dynamic d = new List<int>();
@@ -485,7 +485,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void AccessMethodHiddenByNested()
         {
             dynamic dFirst = new DerivedOuterHidingMethod.Inner();

--- a/src/libraries/Microsoft.CSharp/tests/EnumArithmeticTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/EnumArithmeticTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(ByteEnumAdditions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void LiftedEnumAdditionByte(ByteEnum? enumVal, byte? integralVal, ByteEnum expected)
         {
             dynamic d = enumVal;
@@ -259,7 +259,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(SByteEnumAdditions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void LiftedEnumAdditionSByte(SByteEnum? enumVal, sbyte? integralVal, SByteEnum expected)
         {
             dynamic d = enumVal;
@@ -428,7 +428,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(UInt32EnumSubtractions))]
         [MemberData(nameof(Int64EnumSubtractions))]
         [MemberData(nameof(UInt64EnumSubtractions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void EnumSubtraction(dynamic enumVal, dynamic integralVal, object enMinusIn, object inMinusEn)
         {
             object result = unchecked(enumVal - integralVal);
@@ -440,7 +440,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(ByteEnumSubtractions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void LiftedEnumSubtraction(ByteEnum? enumVal, byte? integralVal, ByteEnum? enMinusIn, ByteEnum? inMinusEn)
         {
             dynamic d = enumVal;
@@ -460,7 +460,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(SByteEnumSubtractions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void LiftedEnumSubtractionSByte(SByteEnum? enumVal, sbyte? integralVal, SByteEnum? enMinusIn, SByteEnum? inMinusEn)
         {
             dynamic d = enumVal;
@@ -594,7 +594,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(ByteEnumSelfSubtraction))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void EnumSubtractionByte(ByteEnum? x, ByteEnum? y, byte expected, bool overflows)
         {
             dynamic d = x;
@@ -614,7 +614,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(SByteEnumSelfSubtraction))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void EnumSubtractionSByte(SByteEnum? x, SByteEnum? y, sbyte expected, bool overflows)
         {
             dynamic d = x;
@@ -756,7 +756,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(UInt32EnumValueArguments))]
         [MemberData(nameof(Int64EnumValueArguments))]
         [MemberData(nameof(UInt64EnumValueArguments))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void WithLiteralNull(dynamic value)
         {
             object result = value + null;
@@ -788,7 +788,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(ByteEnumValueArguments))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void WithTypedNullNullableByte(dynamic value)
         {
             object result = value + (byte?)null;
@@ -802,7 +802,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Theory, MemberData(nameof(SByteEnumValueArguments))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void WithTypedNullNullableSByte(dynamic value)
         {
             object result = value + (sbyte?)null;

--- a/src/libraries/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/EnumUnaryOperationTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(Int32Enums))]
         [MemberData(nameof(UInt32Enums))]
         [MemberData(nameof(Int64Enums))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ConstantEnumOnesComplement(object operand, object result)
         {
             CallSite<Func<CallSite, object, object>> cs = CallSite<Func<CallSite, object, object>>.Create(
@@ -131,7 +131,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(Int32Enums))]
         [MemberData(nameof(UInt32Enums))]
         [MemberData(nameof(Int64Enums))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ConstantCheckedEnumOnesComplement(object operand, object result)
         {
             CallSite<Func<CallSite, object, object>> cs = CallSite<Func<CallSite, object, object>>.Create(

--- a/src/libraries/Microsoft.CSharp/tests/ExplicitConversionTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/ExplicitConversionTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ClassInterfaceExplicitConversion()
         {
             AssertExplicitConvert(new SealedClass(), default(IInterface), ExpectedConversionResult.CompileError);
@@ -110,7 +110,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ClassInterfaceArrayElementExplicitConversions()
         {
             AssertExplicitConvert(new SealedClass[0], default(IInterface[]), ExpectedConversionResult.CompileError);
@@ -131,7 +131,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ClassInterfaceArrayIListElementExplicitConversions()
         {
             AssertExplicitConvert(new SealedClass[0], default(IList<IInterface>), ExpectedConversionResult.CompileError);

--- a/src/libraries/Microsoft.CSharp/tests/ImplicitConversionTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/ImplicitConversionTests.cs
@@ -340,7 +340,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ArraysToInterfaces()
         {
             int[] intArray = {1, 2, 3};

--- a/src/libraries/Microsoft.CSharp/tests/IndexingTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/IndexingTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CustomIndexerName()
         {
             dynamic d = new AllTheIntegers();
@@ -53,7 +53,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CustomIndexerNameDynamicArgument()
         {
             AllTheIntegers all = new AllTheIntegers();
@@ -72,7 +72,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void DeepInheritingIndexingInterface()
         {
             IC ifaceTyped = new Implementation();
@@ -128,7 +128,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void GetIndexWithNonRepeatingArgumentInfos()
         {
             CallSiteBinder binder = Binder.GetIndex(CSharpBinderFlags.None, GetType(), new ArgumentEnumerable(2));
@@ -140,7 +140,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void SetIndexWithNonRepeatingArgumentInfos()
         {
             CallSiteBinder binder = Binder.SetIndex(CSharpBinderFlags.None, GetType(), new ArgumentEnumerable(3));

--- a/src/libraries/Microsoft.CSharp/tests/IntegerBinaryOperationTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/IntegerBinaryOperationTests.cs
@@ -498,7 +498,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(UInt64TestMultiplications))]
         [MemberData(nameof(UInt64TestNotEquals))]
         [MemberData(nameof(UInt64TestSubtractions))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ConstantExpressions(object x, object y, ExpressionType type, object result, bool shouldSucceedChecked)
         {
             var callsite = GetBinaryOperationCallSite(type, false, true, true);
@@ -533,7 +533,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(UInt32DivisionByZero))]
         [MemberData(nameof(Int64DivisionByZero))]
         [MemberData(nameof(UInt64DivisionByZero))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ConstantDivideByZero(ExpressionType type, object x)
         {
             var callsite = GetBinaryOperationCallSite(type, false, true, true);
@@ -609,7 +609,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void NullDMO()
         {
             BinaryOperationBinder binder = Binder.BinaryOperation(

--- a/src/libraries/Microsoft.CSharp/tests/IntegerUnaryOperationTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/IntegerUnaryOperationTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         [MemberData(nameof(Int64TestOnesComplements))]
         [MemberData(nameof(UInt64TestUnaryPluses))]
         [MemberData(nameof(UInt64TestOnesComplements))]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void ConstantExpressions(object x, ExpressionType type, object result, bool shouldSucceedChecked)
         {
             var callsite = GetUnaryOperationCallSite(type, false, true);

--- a/src/libraries/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void InstanceArgumentInsteadOfTypeForStaticCall()
         {
             CallSite<Func<CallSite, object, object, object, object>> site =
@@ -62,7 +62,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void InstanceArgumentInsteadOfTypeForStaticCallNamedArgument()
         {
             CallSite<Func<CallSite, object, object, object, object>> site =
@@ -80,7 +80,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void NullArgumentInsteadOfTypeForStaticCallNamedArgument()
         {
             CallSite<Func<CallSite, object, object, object, object>> site =
@@ -98,7 +98,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void NonTypeToCtor()
         {
             CallSite<Func<CallSite, object, object>> site = CallSite<Func<CallSite, object, object>>.Create(

--- a/src/libraries/Microsoft.CSharp/tests/RuntimeBinderTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/RuntimeBinderTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.CSharp.RuntimeBinder.Tests
 {
-    [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
     public class RuntimeBinderTests
     {
         [Fact]

--- a/src/libraries/Microsoft.CSharp/tests/VarArgsTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/VarArgsTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void FailBindOnlyVarargsAvailable()
         {
             dynamic d = new HasVarargs();
@@ -74,7 +74,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CorrectNullaryOverload()
         {
             dynamic d = new HasVarargs();
@@ -82,7 +82,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CorrectUnaryOverload()
         {
             dynamic d = new HasVarargs();
@@ -97,7 +97,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CorrectBinaryOverload()
         {
             dynamic d = new HasVarargs();
@@ -106,7 +106,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
         }
 
         [Fact]
-        [ActiveIssue(31032, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31032", TargetFrameworkMonikers.NetFramework)]
         public void CorrectCtor()
         {
             dynamic d = 19;

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualBasic.Tests
             }
         }
 
-        [ActiveIssue(39888, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39888", TargetFrameworkMonikers.NetFramework)]
         [Theory]
         [InlineData(0, 0)]
         [InlineData(33, 33)]

--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Win32.SystemEventsTests
             Assert.Throws<ArgumentException>(() => SystemEvents.CreateTimer(int.MinValue));
         }
 
-        [ActiveIssue(29166)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/29166")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void TimerElapsedSignaled()
         {

--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Win32.SystemEventsTests
 {
     public class InvokeOnEventsThreadTests : SystemEventsTest
     {
-        [ActiveIssue(38661, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/38661", TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void InvokeOnEventsThreadRunsAsynchronously()
         {

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/PhoneAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/PhoneAttributeTests.cs
@@ -44,7 +44,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             // Certain invalid phone numbers are reported as valid with .NET core.
             // The full .NET framework considers them invalid. This is likely a bug
             // in .NET core. Seee https://github.com/dotnet/corefx/issues/17873.
-            // [ActiveIssue(17873)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/17873")]
             if (PlatformDetection.IsFullFramework)
             {
                 yield return new TestCase(new PhoneAttribute(), "+4+2+5+-+5+5+5+-+1+2++1+2++");

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AdvancedValueComposition.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AdvancedValueComposition.cs
@@ -69,7 +69,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void FunctionsFieldsAndProperties2_WithCatalog()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -97,7 +97,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void FunctionsFieldsAndProperties2_StronglyTypedMetadata()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -122,7 +122,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void InAdditionToCatalogTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -163,7 +163,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void CollectionMetadataPropertyTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -178,7 +178,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportExportSansNameTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -189,7 +189,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void MultipleInstantiationOfStaticCatalogItem()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -208,7 +208,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void MultipleInstantiationOfNonStaticCatalogItem()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -224,7 +224,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ImportIntoUntypedExportTest()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AllowNonPublicCompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AllowNonPublicCompositionTests.cs
@@ -91,7 +91,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestPublicImportsExpectingPublicExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -100,7 +100,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestInternalImportsExpectingPublicExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -109,7 +109,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestPublicImportsExpectingInternalExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -118,7 +118,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestInternalImportsExpectingInternalExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -127,7 +127,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestPublicImportsExpectingProtectedExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -136,7 +136,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestInternalImportsExpectingProtectedExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -145,7 +145,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestPublicImportsExpectingProtectedInternalExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -154,7 +154,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestInternalImportsExpectingProtectedInternalExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -163,7 +163,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestPublicImportsExpectingPrivateExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -172,7 +172,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void TestInternalImportsExpectingPrivateExportsFromCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelCompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelCompositionTests.cs
@@ -257,7 +257,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void MemberExports()
         {
             var exporter = PartFactory.CreateAttributed(new ObjectWithMemberExports());
@@ -297,7 +297,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(739354)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/739354")]
         public void TestExportedValueCachesNullValue()
         {
             var container = ContainerFactory.Create();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelDiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/AttributedModelDiscoveryTests.cs
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Composition.AttributedModel
             public override int MyProp { get; set; }
         }
 
-        [ActiveIssue(551341)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/551341")]
         [Fact]
         public void ShowIssueWithVirtualPropertiesInReflectionAPI()
         {
@@ -232,7 +232,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void IsDiscoverable()
         {
             var expectations = new ExpectationCollection<Type, bool>();
@@ -257,7 +257,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void CreatePartDefinition_EnsureIsDiscoverable()
         {
             var expectations = new ExpectationCollection<Type, bool>();
@@ -331,7 +331,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(710352)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/710352")]
         public void MixedDuplicateExports_ShouldOnlyCollapseInheritedExport()
         {
             var def = AttributedModelServices.CreatePartDefinition(typeof(DuplicateMixedExporter1), null);

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/INotifyImportTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/AttributedModel/INotifyImportTests.cs
@@ -94,7 +94,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(700940)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/700940")]
         public void ImportCompletedUsingSatisfyImportsOnce()
         {
             var container = ContainerFactory.Create();
@@ -137,7 +137,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(654513)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/654513")]
         public void ImportCompletedCalledAfterAllImportsAreFullyComposed()
         {
             int importSatisfationCount = 0;
@@ -190,7 +190,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCompletedChildNeedsParentContainer()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -233,7 +233,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCompletedChildDoesnotNeedParentContainer()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -271,7 +271,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCompletedBindChildIndirectlyThroughParentContainerBind()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -305,7 +305,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCompletedGetExportedValueLazy()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -326,7 +326,7 @@ namespace System.ComponentModel.Composition.AttributedModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCompletedGetExportedValueEager()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ComponentServicesTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ComponentServicesTests.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.Composition
     public class ComponentServicesTests
     {
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void GetValuesByType()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerExtensibilityTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerExtensibilityTests.cs
@@ -45,7 +45,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void CanBeCollectedAfterDispose()
         {
             AggregateExportProvider exportProvider = new AggregateExportProvider();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerImportTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerImportTests.cs
@@ -184,7 +184,7 @@ namespace System.ComponentModel.Composition
 
         [ConditionalFact(Helpers.ComImportAvailable)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ImportValueComComponent()
         {
             CTaskScheduler scheduler = new CTaskScheduler();
@@ -210,7 +210,7 @@ namespace System.ComponentModel.Composition
 
         [ConditionalFact(Helpers.ComImportAvailable)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void DelayImportValueComComponent()
         {
             CTaskScheduler scheduler = new CTaskScheduler();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionContainerTests.cs
@@ -144,7 +144,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(579990)]  // NullReferenceException
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/579990")]  // NullReferenceException
         public void ExportsChanged_Add_WhenDisposed_ShouldThrowObjectDisposed()
         {
             var container = CreateCompositionContainer();
@@ -157,7 +157,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(579990)] // NullReferenceException
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/579990")] // NullReferenceException
         public void ExportsChanged_Remove_WhenDisposed_ShouldThrowObjectDisposed()
         {
             var container = CreateCompositionContainer();
@@ -2418,7 +2418,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException)
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException)
         public void TryGetValueWithCatalogVerifyExecptionDuringGet()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -2458,7 +2458,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void ContainerXGetXTest()
         {
             CompositionContainer container = CreateCompositionContainer();
@@ -2469,7 +2469,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void ContainerXGetXByComponentCatalogTest()
         {
             CompositionContainer container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -2984,7 +2984,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void ComposeExportedValueOfT_ValidContractName_ExportedValue_ExportContainsEmptyMetadata()
         {
             string expectedContractName = "ContractName";

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionResultTest.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/CompositionResultTest.cs
@@ -159,7 +159,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void MergeResult_ResultWithNullErrorsAsResultArgument_ShouldReturnResultWithSameErrors()
         {
             var emptyResult = CreateCompositionResult((IEnumerable<CompositionError>)null);
@@ -177,7 +177,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void MergeResult_ResultWithEmptyErrorsAsResultArgument_ShouldReturnResultWithSameErrors()
         {
             var emptyResult = CreateCompositionResult(Enumerable.Empty<CompositionError>());

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportCollectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportCollectionTests.cs
@@ -162,7 +162,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCollectionsFromCatalogOnly()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();
@@ -178,7 +178,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ImportCollectionsFormContainerAndCatalog()
         {
             var cat = CatalogFactory.CreateDefaultAttributed();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportFactoryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ExportFactoryTests.cs
@@ -392,7 +392,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ExportFactory_SimpleDispose()
         {
             var catalog = new AssemblyCatalog(Assembly.GetExecutingAssembly());

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/GenerationServicesTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/GenerationServicesTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Internal
         }
 
         [Fact]
-        [ActiveIssue(507696)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/507696")]
         public void EnumTypeEnumerable()
         {
             TestEnum[] enumerable = new TestEnum[] { TestEnum.First, TestEnum.Second };

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AggregateCatalogTest.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AggregateCatalogTest.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void Constructor1_ShouldSetPartsPropertyToEmpty()
         {
             var catalog = new AggregateCatalog();
@@ -55,7 +55,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void Constructor3_NullAsCatalogsArgument_ShouldSetPartsPropertyToEmpty()
         {
             var catalog = new AggregateCatalog((IEnumerable<ComposablePartCatalog>)null);
@@ -64,7 +64,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void Constructor3_EmptyIEnumerableAsCatalogsArgument_ShouldSetPartsPropertyToEmpty()
         {
             var catalog = new AggregateCatalog(Enumerable.Empty<ComposablePartCatalog>());
@@ -73,7 +73,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor3_ArrayWithNullAsCatalogsArgument_ShouldThrowArgument()
         {
             var catalogs = new ComposablePartCatalog[] { null };
@@ -122,7 +122,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void GetExports_NullAsConstraintArgument_ShouldThrowArgumentNull()
         {
             var catalog = CreateAggregateCatalog();
@@ -394,7 +394,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(514749)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/514749")]
         public void MutableMultithreadedEnumerations()
         {
             var catalog = new AggregateCatalog();
@@ -498,7 +498,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void AggregatingCatalogAddAndRemoveChildren()
         {
             int changedCount = 0;
@@ -568,7 +568,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void AggregatingCatalogAddAndRemoveNestedChildren()
         {
             int changedCount = 0;
@@ -623,7 +623,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void AggregatingDisposedAndNotifications()
         {
             int changedCount = 0;
@@ -751,7 +751,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void CatalogEvents_AggregateAddRemove()
         {
             var catalog = new AggregateCatalog();
@@ -759,7 +759,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void CatalogEvents_DeepAggregateAddRemove()
         {
             var deepCatalog = new AggregateCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AssemblyCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AssemblyCatalogDebuggerProxyTests.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel.Composition.Hosting
     public class AssemblyCatalogDebuggerProxyTests
     {
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor_NullAsCatalogArgument_ShouldThrowArgumentNull()
         {
             AssertExtensions.Throws<ArgumentNullException>("catalog", () =>
@@ -21,7 +21,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Constructor_ValueAsCatalogArgument_ShouldSetPartsProperty()
         {
             var expectations = Expectations.GetAssemblies();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AssemblyCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/AssemblyCatalogTests.cs
@@ -169,7 +169,7 @@ namespace System.ComponentModel.Composition
         //  Test cases for AssemblyCatalog(string codebase) constructor
         //=========================================================================================================================================
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor1_ValueAsCodebaseArgument_ShouldSetAssemblyProperty()
         {
             AssemblyCatalogConstructorTests.Constructor_ValueAsCodebaseArgument_ShouldSetAssemblyProperty((s) =>
@@ -216,7 +216,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)] // Also see https://github.com/dotnet/corefx/issues/27269
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")] // Also see https://github.com/dotnet/corefx/issues/27269
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Constructor1_InvalidFileNameAsCodeBaseArgument_ShouldThrowIO_Core()
         {
@@ -227,7 +227,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor1_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad()
         {
             AssemblyCatalogConstructorTests.Constructor_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad((s) =>
@@ -237,7 +237,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor1_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong()
         {
             AssemblyCatalogConstructorTests.Constructor_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong((s) =>
@@ -247,7 +247,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
         public void Constructor1_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat()
         {
             AssemblyCatalogConstructorTests.Constructor_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat((s) =>
@@ -266,7 +266,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor1_ShouldSetOriginToNull()
         {
             var catalog = (ICompositionElement)new AssemblyCatalog(GetAttributedAssemblyCodeBase());
@@ -279,7 +279,7 @@ namespace System.ComponentModel.Composition
         //=========================================================================================================================================
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor2_ValueAsCodebaseArgument_ShouldSetAssemblyProperty()
         {
             AssemblyCatalogConstructorTests.Constructor_ValueAsCodebaseArgument_ShouldSetAssemblyProperty((s) =>
@@ -326,7 +326,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)] // Also see https://github.com/dotnet/corefx/issues/27269
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")] // Also see https://github.com/dotnet/corefx/issues/27269
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Constructor2_InvalidFileNameAsCodeBaseArgument_ShouldThrowArgument()
         {
@@ -337,7 +337,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor2_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad()
         {
             AssemblyCatalogConstructorTests.Constructor_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad((s) =>
@@ -347,7 +347,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor2_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong()
         {
             AssemblyCatalogConstructorTests.Constructor_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong((s) =>
@@ -357,7 +357,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
         public void Constructor2_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat()
         {
             AssemblyCatalogConstructorTests.Constructor_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat((s) =>
@@ -388,7 +388,7 @@ namespace System.ComponentModel.Composition
         //  Test cases for AssemblyCatalog(string codebase, ICompositionElement definitonOrigin) constructor
         //=========================================================================================================================================
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor3_ValueAsCodebaseArgument_ShouldSetAssemblyProperty()
         {
             AssemblyCatalogConstructorTests.Constructor_ValueAsCodebaseArgument_ShouldSetAssemblyProperty((s) =>
@@ -435,7 +435,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)] // // Also see https://github.com/dotnet/corefx/issues/27269
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")] // // Also see https://github.com/dotnet/corefx/issues/27269
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Constructor3_InvalidFileNameAsCodeBaseArgument_ShouldThrowIO_Core()
         {
@@ -446,7 +446,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor3_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad()
         {
             AssemblyCatalogConstructorTests.Constructor_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad((s) =>
@@ -456,7 +456,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor3_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong()
         {
             AssemblyCatalogConstructorTests.Constructor_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong((s) =>
@@ -466,7 +466,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
         public void Constructor3_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat()
         {
             AssemblyCatalogConstructorTests.Constructor_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat((s) =>
@@ -543,7 +543,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)] // Also see https://github.com/dotnet/corefx/issues/27269
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")] // Also see https://github.com/dotnet/corefx/issues/27269
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Constructor4_InvalidFileNameAsCodeBaseArgument_ShouldThrowIO_Core()
         {
@@ -554,7 +554,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor4_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad()
         {
             AssemblyCatalogConstructorTests.Constructor_DirectoryAsCodeBaseArgument_ShouldThrowFileLoad((s) =>
@@ -564,7 +564,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor4_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong()
         {
             AssemblyCatalogConstructorTests.Constructor_TooLongFileNameAsCodeBaseArgument_ShouldThrowPathTooLong((s) =>
@@ -574,7 +574,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // fault segmentation - AnyUnix
         public void Constructor4_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat()
         {
             AssemblyCatalogConstructorTests.Constructor_NonAssemblyFileNameAsCodeBaseArgument_ShouldThrowBadImageFormat((s) =>
@@ -613,7 +613,7 @@ namespace System.ComponentModel.Composition
         //  Test cases for AssemblyCatalog(string codebase, ICompositionElement definitonOrigin) constructor
         //=========================================================================================================================================
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor7_ValueAsAssemblyArgument_ShouldSetAssemblyProperty()
         {
             AssemblyCatalogConstructorTests.Constructor_ValueAsCodebaseArgument_ShouldSetAssemblyProperty((a) =>
@@ -647,7 +647,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor6_NullReflectionContextArgument_ShouldThrowArgumentNull()
         {
             AssemblyCatalogConstructorTests.Constructor_NullReflectionContextArgument_ShouldThrowArgumentNull((rc) =>
@@ -657,7 +657,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor7_NullDefinitionOriginArgument_ShouldThrowArgumentNull()
         {
             AssemblyCatalogConstructorTests.Constructor_NullDefinitionOriginArgument_ShouldThrowArgumentNull((dO) =>
@@ -709,7 +709,7 @@ namespace System.ComponentModel.Composition
         //=========================================================================================================================================
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void DiscoverCatalogUsingReflectionContextCatalogDiscoveryAttribute()
         {
             var catalog = new AssemblyCatalog(typeof(TestAssemblyOne).Assembly);
@@ -722,7 +722,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void DiscoverCatalogUsingDerivedReflectionContextCatalogDiscoveryAttribute()
         {
             var catalog = new AssemblyCatalog(typeof(TestAssemblyTwo).Assembly);
@@ -735,7 +735,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void DiscoverCatalogUsingNoDefaultConstructorReflectionContextCatalogDiscoveryAttribute_ShouldThrowArgumentException()
         {
             AssertExtensions.Throws<MissingMethodException>(() =>
@@ -746,7 +746,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void DiscoverCatalogUsingDerivedReflectionContextCatalogDiscoveryAttribute_ShouldThrowArgumentException()
         {
 
@@ -819,7 +819,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void GetExports_NullAsConstraintArgument_ShouldThrowArgumentNull()
         {
             var catalog = CreateAssemblyCatalog();
@@ -845,7 +845,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Parts()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -854,7 +854,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Parts_ShouldSetDefinitionOriginToCatalogItself()
         {
             var catalog = CreateAssemblyCatalog();
@@ -867,7 +867,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void AddAssemblyUsingFile()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly.Location);
@@ -877,7 +877,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TwoTypesWithSameSimpleName()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -895,7 +895,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void GettingFunctionExports()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -906,7 +906,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void AnExportOfAnInstanceThatFailsToCompose()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -922,7 +922,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void SharedPartCreation()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -940,7 +940,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void NonSharedPartCreation()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -958,7 +958,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void RecursiveNonSharedPartCreation()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -996,7 +996,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // typeof(System.Reflection.ReflectionTypeLoadException)
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // typeof(System.Reflection.ReflectionTypeLoadException)
         public void RecursiveNonSharedPartCreationDisableSilentRejection()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);
@@ -1034,7 +1034,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TryToDiscoverExportWithGenericParameter()
         {
             var catalog = new AssemblyCatalog(typeof(AssemblyCatalogTests).Assembly);

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CatalogExportProviderTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/CatalogExportProviderTests.cs
@@ -117,7 +117,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(743740)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/743740")]
         public void GetExports_AfterResurrectedDefinitionHasBeenRemovedAndReaddedToCatalog_ShouldNotBeTreatedAsRejected()
         {
             var definition1 = PartDefinitionFactory.Create(PartFactory.CreateImporterExporter("Export", "Import"));
@@ -153,7 +153,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void BasicTest()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -176,7 +176,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void BasicTestWithRequiredMetadata_NoTypeConstraint()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -194,7 +194,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void BasicTestWithRequiredMetadata_TypeConstraint()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -212,7 +212,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void BasicTestWithRequiredMetadata_WrongTypeConstraint()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -230,7 +230,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ComponentCatalogResolverGetStaticExport()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -244,7 +244,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ComponentCatalogResolverComponentCatalogExportReference()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -263,7 +263,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ValueTypeFromCatalog()
         {
             var catalog = CatalogFactory.CreateDefaultAttributed();
@@ -330,7 +330,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void CreationPolicyNonShared_MultipleCallsReturnsDifferentInstances()
         {
             var catalog = CatalogFactory.CreateAttributed(typeof(CreationPolicyNonShared));
@@ -352,7 +352,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(684514)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/684514")]
         public void GetExports_NoSourceProvider_ShouldThrowInvalidOperation()
         {
             var catalog = CatalogFactory.CreateAttributed();
@@ -364,7 +364,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(561310)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/561310")]
         public void Recomposition_PartDefWithRecomposableImportIsRemoved_ExportsMatchingImportChanged_ShouldNotBeRecomposed()
         {
             string dependencyContractName = "dependency";
@@ -392,7 +392,7 @@ namespace System.ComponentModel.Composition
 
         [Fact]
         [Trait("Type", "Integration")]
-        [ActiveIssue(561310)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/561310")]
         public void Recomposition_PartDefWithNonRecomposableImportIsRemoved_ExportsMatchingImportChanged_ShouldNotBeRejected()
         {
             string dependencyContractName = "dependency";
@@ -419,7 +419,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void CanBeCollectedAfterDispose()
         {
             AggregateExportProvider sourceExportProvider = new AggregateExportProvider();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
@@ -39,7 +39,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor_ValueAsCatalogArgument_ShouldSetAssemblyProperty()
         {
             string directoryPath = GetTemporaryDirectory();
@@ -68,7 +68,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Constuctor_ValueAsCatalogArgument_ShouldSetSearchPatternProperty()
         {
             string directoryPath = GetTemporaryDirectory();
@@ -90,7 +90,7 @@ namespace System.ComponentModel.Composition.Primitives
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void FullPath_ValidPath_ShouldBeFine()
         {
             string directoryPath = GetTemporaryDirectory();
@@ -116,7 +116,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void LoadedFiles_EmptyDirectory_ShouldBeFine()
         {
             string directoryPath = GetTemporaryDirectory();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
@@ -91,7 +91,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
         public void ICompositionElementDisplayName_ShouldIncludeCatalogTypeNameAndDirectoryPath()
         {
             var paths = GetPathExpectations();
@@ -107,7 +107,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
         public void ICompositionElementDisplayName_ShouldIncludeDerivedCatalogTypeNameAndAssemblyFullName()
         {
             var paths = GetPathExpectations();
@@ -123,7 +123,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.IO.DirectoryNotFoundException : Could not find a part of the path '/HOME/HELIXBOT/DOTNETBUILD/WORK/E77C2FB6-5244-4437-8E27-6DD709101152/WORK/D9EBA0EA-A511-4F42-AC8B-AC8054AAF606/UNZIP/'.
         public void ToString_ShouldReturnICompositionElementDisplayName()
         {
             var paths = GetPathExpectations();
@@ -243,7 +243,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void AddAssembly1_TooLongPathNameArgument_ShouldThrowPathTooLongException()
         {
             Assert.Throws<PathTooLongException>(() =>
@@ -253,7 +253,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Parts()
         {
                 var catalog = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
@@ -262,7 +262,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Parts_ShouldSetDefinitionOriginToCatalogItself()
         {
                 var catalog = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
@@ -275,7 +275,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Path_ValidPath_ShouldBeFine()
         {
                 var expectations = new ExpectationCollection<string, string>();
@@ -294,7 +294,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void FullPath_ValidPath_ShouldBeFine()
         {
                 var expectations = new ExpectationCollection<string, string>();
@@ -375,7 +375,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Constructor_PassExistingFileName_ShouldThrow()
         {
                 using (File.CreateText(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.txt"))) { }
@@ -391,7 +391,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Refresh_AssemblyAdded_ShouldFireOnChanged()
         {
                 bool changedFired = false;
@@ -421,7 +421,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Refresh_AssemblyRemoved_ShouldFireOnChanged()
         {
                 string file = Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.dll");
@@ -453,7 +453,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void Refresh_DirectoryRemoved_ShouldThrowDirectoryNotFound()
         {
             DirectoryCatalog cat;
@@ -494,7 +494,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void AddAndRemoveDirectory()
         {
                 var cat = new AggregateCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/TypeCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/TypeCatalogTests.cs
@@ -259,7 +259,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Parts()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -280,7 +280,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ICompositionElementDisplayName_SingleTypeAsTypesArgument_ShouldIncludeCatalogTypeNameAndTypeFullName()
         {
             var expectations = Expectations.GetAttributedTypes();
@@ -326,7 +326,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ICompositionElementDisplayName_ShouldIncludeDerivedCatalogTypeNameAndTypeFullNames()
         {
             var expectations = Expectations.GetAttributedTypes();
@@ -342,7 +342,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ToString_ShouldReturnICompositionElementDisplayName()
         {
             var expectations = Expectations.GetAttributedTypes();
@@ -356,7 +356,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void GetExports()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -372,7 +372,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TwoTypesWithSameSimpleName()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -392,7 +392,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void GettingFunctionExports()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -403,7 +403,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void AnExportOfAnInstanceThatFailsToCompose()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -419,7 +419,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void SharedPartCreation()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -437,7 +437,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void NonSharedPartCreation()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -455,7 +455,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void RecursiveNonSharedPartCreation()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());
@@ -493,7 +493,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TryToDiscoverExportWithGenericParameter()
         {
             var catalog = new TypeCatalog(Assembly.GetExecutingAssembly().GetTypes());

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportDefinitionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportDefinitionTests.cs
@@ -159,7 +159,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ToString_ValueAsConstraintArgument_ShouldReturnConstraintProperty()
         {
             var expectations = new ExpectationCollection<Expression<Func<ExportDefinition, bool>>, string>();
@@ -177,7 +177,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ToString_DerivedImportDefinition_ShouldReturnOverriddenConstraintProperty()
         {
             var expectations = new ExpectationCollection<Expression<Func<ExportDefinition, bool>>, string>();
@@ -195,7 +195,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(738535)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/738535")]
         public void ContractName_ShouldBeIncludedInConstraintAutomatically()
         {
             string testContractName = "TestContractName";

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/MetadataTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/MetadataTests.cs
@@ -169,7 +169,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ValidMetadataDiscoveredByComponentCatalogTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -361,7 +361,7 @@ namespace System.ComponentModel.Composition
         #region Tests for weakly supported metadata as part of contract
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void FailureImportForNoRequiredMetadatForExportCollection()
         {
             CompositionContainer container = ContainerFactory.Create();
@@ -381,7 +381,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(472538)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/472538")]
         public void FailureImportForNoRequiredMetadataThroughComponentCatalogTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -403,7 +403,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void SelectiveImportBasedOnMetadataForExport()
         {
             CompositionContainer container = ContainerFactory.Create();
@@ -424,7 +424,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void SelectiveImportBasedOnMetadataForExportCollection()
         {
             CompositionContainer container = ContainerFactory.Create();
@@ -447,7 +447,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(472538)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/472538")]
         public void SelectiveImportBasedOnMetadataThruoughComponentCatalogTest()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -529,7 +529,7 @@ namespace System.ComponentModel.Composition
         #region Tests for strongly typed metadata as part of contract
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void SelectiveImportBySTM_Export()
         {
             CompositionContainer container = ContainerFactory.Create();
@@ -551,7 +551,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void SelectiveImportBySTM_ExportCollection()
         {
             CompositionContainer container = ContainerFactory.Create();
@@ -574,7 +574,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void SelectiveImportBySTMThroughComponentCatalog1()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -588,7 +588,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(468388)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/468388")]
         public void SelectiveImportBySTMThroughComponentCatalog2()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -611,7 +611,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TestMultipleStronglyTypedAttributes()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -622,7 +622,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TestMultipleStronglyTypedAttributesAsIEnumerable()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -633,7 +633,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TestMultipleStronglyTypedAttributesAsArray()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();
@@ -644,7 +644,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void TestMultipleStronglyTypedAttributesWithInvalidType()
         {
             var container = ContainerFactory.CreateWithDefaultAttributedCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Primitives/ComposablePartCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Primitives/ComposablePartCatalogDebuggerProxyTests.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Constructor_ValueAsCatalogArgument_ShouldSetPartsProperty()
         {
             var expectations = Expectations.GetCatalogs();
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void Parts_ShouldNotCacheUnderlyingParts()
         {
             var catalog = CatalogFactory.CreateAggregateCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinitionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinitionTests.cs
@@ -235,7 +235,7 @@ IEnumerable<ImportDefinition> imports;
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ICompositionElementDisplayName_ShouldReturnTypeDisplayName()
         {
             var expectations = Expectations.GetAttributedTypes();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartTests.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
     public class ReflectionComposablePartTests
     {
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types.Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types.Retrieve the LoaderExceptions property for more information.
         public void Constructor1_DefinitionAsDefinitionArgument_ShouldSetOriginProperty()
         {
             var expectations = Expectations.GetAttributedDefinitions();
@@ -383,7 +383,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue(484204)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/484204")]
         public void GetExportedValue_MissingPostImports_ShouldThrowComposition()
         {
             var part = CreatePart(typeof(MySharedPartExport));
@@ -515,7 +515,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types.Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types.Retrieve the LoaderExceptions property for more information.
         public void ICompositionElementDisplayName_ShouldReturnTypeDisplayName()
         {
             var expectations = Expectations.GetAttributedTypes();
@@ -528,7 +528,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void ToString_ShouldReturnICompositionElementDisplayName()
         {
             var expectations = Expectations.GetAttributedTypes();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CatalogFilteringTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CatalogFilteringTests.cs
@@ -51,7 +51,7 @@ namespace System.ComponentModel.Composition
         }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void FilteredCatalog_EventsFired()
         {
             var aggCatalog = CatalogFactory.CreateAggregateCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CompositionContainerAttributedModelCycleTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/CompositionContainerAttributedModelCycleTests.cs
@@ -44,7 +44,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void APrerequisiteDependsOnBNone_ShouldNotThrow()
         {
             AssertNotCycle(typeof(APrerequisiteDependsOnBNone),
@@ -59,7 +59,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void APostDependsOnBPost_ShouldNotThrow()
         {
             AssertNotCycle(typeof(APostDependsOnBPost),
@@ -67,7 +67,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void APostDependsOnBNone_ShouldNotThrow()
         {
             AssertNotCycle(typeof(APostDependsOnBNone),
@@ -75,7 +75,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void BPrerequisiteDependsOnANone_ShouldNotThrow()
         {
             AssertNotCycle(typeof(ANone),
@@ -83,7 +83,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void BPostDependsOnANone_ShouldNotThrow()
         {
             AssertNotCycle(typeof(ANone),
@@ -91,7 +91,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ANoneWithBNone_ShouldNotThrow()
         {
             AssertNotCycle(typeof(ANone),
@@ -99,7 +99,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void PartWithHasPrerequisteImportThatIsInAPostCycle_ShouldNotThrow()
         {
             AssertNotCycle(typeof(PartWithHasPrerequisteImportThatIsInAPostCycle)

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ConstructorInjectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ConstructorInjectionTests.cs
@@ -47,7 +47,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void OptionalConstructorArgument()
         {
             var container = GetContainerWithCatalog();
@@ -72,7 +72,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void RebindingShouldNotHappenForConstructorArguments()
         {
             var container = GetContainerWithCatalog();
@@ -124,7 +124,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void MissingConstructorArgsWithTypeFromCatalogMissingArg()
         {
             var container = GetContainerWithCatalog();
@@ -139,7 +139,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498, TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498", TestPlatforms.AnyUnix)] // Actual:   typeof(System.Reflection.ReflectionTypeLoadException): Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void MissingConstructorArgsWithWithTypeFromCatalogWithArg()
         {
             var container = GetContainerWithCatalog();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
@@ -820,7 +820,7 @@ namespace Tests.Integration
         public class FooWithInterfaceWithMultipleFoos : IFoo3 { }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void InheritedExport_InterfaceHiearchy()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(FooWithInterfaceWithMultipleFoos));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ExportProviderEventTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/ExportProviderEventTests.cs
@@ -111,7 +111,7 @@ namespace System.ComponentModel.Composition
         public class SampleCatalogExport2 { }
 
         [Fact]
-        [ActiveIssue(812029)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/812029")]
         public void CatalogMultipleAdds_ShouldFireEvents()
         {
             var catalog = new TypeCatalog(typeof(SampleCatalogExport));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/LifetimeTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/LifetimeTests.cs
@@ -905,7 +905,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void NonSharedPart_Simple_ShouldBeCollected()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartSimple));
@@ -922,7 +922,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ContainerDispose_SharedPart_ShouldCollectWholeObjectChain()
         {
             // Test only works properly with while using the real ConditionalWeakTable
@@ -951,7 +951,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void AddRemovePart_SharedPart_ShouldCollectOnlyRoot()
         {
             var container = GetContainer();
@@ -988,7 +988,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void AddRemovePart_NonSharedPart_ShouldCollectWholeObjectChain()
         {
             var container = GetContainer();
@@ -1023,7 +1023,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ContainerDispose_NonSharedPart_ShouldCollectWholeObjectChain()
         {
             // Test only works properly with while using the real ConditionalWeakTable
@@ -1052,7 +1052,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void NonSharedImporter_ReleaseReference_ShouldCollectWholeChain()
         {
             var container = GetContainer();
@@ -1082,7 +1082,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ChildContainerDispose_NonSharedPart_ShouldOnlyCleanupChildAndSimpleNonShared()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -1111,7 +1111,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ChildContainerGetReleaseExport_NonSharedPart_ShouldCollectWholeObjectChain()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -1139,7 +1139,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void NonSharedPart_RecomposableImport_NoReference_ShouldBeCollected()
         {
             var catalog = new TypeCatalog(typeof(NonSharedPartRecomposable));
@@ -1169,7 +1169,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void ChildContainerAddRemovePart_NonSharedPart_ShouldCollectWholeObjectChain()
         {
             var child = CreateParentChildContainerWithNonSharedImporter();
@@ -1204,7 +1204,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void GetReleaseExport_SharedPart_ShouldCollectOnlyRoot()
         {
             var container = GetContainer();
@@ -1234,7 +1234,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(25498)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25498")]
         public void GetReleaseExport_NonSharedPart_ShouldCollectWholeObjectChain()
         {
             var container = GetContainer();

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RecompositionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RecompositionTests.cs
@@ -414,7 +414,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(733533)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/733533")]
         public void RemoveCatalogWithNonSharedPartWithRequiredImport()
         {
             var typeCatalog = new TypeCatalog(typeof(NonSharedImporter), typeof(SimpleImport));
@@ -435,7 +435,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(734123)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/734123")]
         public void GetExportResultShouldBePromise()
         {
             var typeCatalog = new TypeCatalog(typeof(RootImporter), typeof(SimpleImport));
@@ -512,7 +512,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(762215)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/762215")]
         public void TestPartCreatorResurrection()
         {
             var container = new CompositionContainer(new TypeCatalog(typeof(NonDisposableImportsDisposable), typeof(PartImporter<NonDisposableImportsDisposable>)));

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RejectionTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/RejectionTests.cs
@@ -463,7 +463,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(684510)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/684510")]
         public void PartAOptionalDependsOnPartB_PartBGetAddedLater()
         {
             var container = new CompositionContainer(new TypeCatalog(typeof(PartC), typeof(PartA)));
@@ -489,7 +489,7 @@ namespace Tests.Integration
         }
 
         [Fact]
-        [ActiveIssue(684510)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/684510")]
         public void PartAOptionalDependsOnPartBAndPartC_PartCGetRecurrected()
         {
             var container = new CompositionContainer(new TypeCatalog(typeof(PartA2), typeof(PartB)));

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionHostTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionHostTests.cs
@@ -11,7 +11,7 @@ namespace System.Composition.Hosting.Core.Tests
     public class CompositionHostTests
     {
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_CompositionContextContract_ReturnsExpected()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -22,7 +22,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_MultipleDependencies_ReturnsExpected()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new MultipleDependency()))
@@ -57,7 +57,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Theory]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         [InlineData(typeof(int), new Type[] { typeof(int) })]
         [InlineData(typeof(IList<>), new Type[] { typeof(IList<>) })]
         [InlineData(typeof(ICollection<>), new Type[] { typeof(ICollection<>) })]
@@ -87,7 +87,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Theory]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         [InlineData(typeof(string[]), new Type[] { typeof(string[]), typeof(string) })]
         [InlineData(typeof(IList<string>), new Type[] { typeof(IList<string>), typeof(string) })]
         [InlineData(typeof(ICollection<string>), new Type[] { typeof(ICollection<string>), typeof(string) })]
@@ -106,7 +106,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Theory]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         [InlineData(typeof(ExportFactory<int>), null, new Type[] { typeof(int), typeof(ExportFactory<int>) })]
         [InlineData(typeof(ExportFactory<int>), new string[] { "1", "2", "3" }, new Type[] { typeof(int), typeof(ExportFactory<int>) })]
         [InlineData(typeof(ExportFactory<int, ParameterlessConstructor>), null, new Type[] { typeof(int), typeof(ExportFactory<int, ParameterlessConstructor>) })]
@@ -135,7 +135,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Theory]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         [InlineData(typeof(Lazy<int, int>))]
         [InlineData(typeof(Lazy<int, IDictionary<string, string>>))]
         [InlineData(typeof(Lazy<int, PrivateConstructor>))]
@@ -149,7 +149,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_AbstractMetadata_ThrowsInvalidOperationException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -159,7 +159,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_NullProviderInProviders_ThrowsNullReferenceException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[] { null }))
@@ -178,7 +178,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_MultipleReturns_ThrowsCompositionFailedException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new MultiplePromises()))
@@ -201,7 +201,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_FailedDependency_ThrowsCompositionFailedException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new FailedDependency()))

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionOperationTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionOperationTests.cs
@@ -10,7 +10,7 @@ namespace System.Composition.Hosting.Core.Tests
     public class CompositionOperationTests
     {
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void Run_ValidContextAndAction_ReturnsExpected()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -50,7 +50,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void Run_NullActivator_ThrowsArgumentNullException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -63,7 +63,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AddNonPrequisiteAction_NullAction_ThrowsArgumentNullException()
         {
             object Activator(LifetimeContext context, CompositionOperation operation)
@@ -82,7 +82,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AddPostCompositionAction_NullAction_ThrowsArgumentNullException()
         {
             object Activator(LifetimeContext context, CompositionOperation operation)

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/LifetimeContextTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/LifetimeContextTests.cs
@@ -15,7 +15,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AddBoundInstance_NonNullInstance_DisposesInstanceOnDisposal()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -36,7 +36,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AddBoundInstance_NullInstance_ThrowsNullReferenceExceptionOnDisposal()
         {
             CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]);
@@ -48,7 +48,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AddBoundInstance_Disposed_ThrowsObjectDisposedException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -62,7 +62,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetOrCreate_ValidActivatorDuringInitialization_Success()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -91,7 +91,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetOrCreate_ValidActivatorAfterInitialization_Success()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -121,7 +121,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetOrCreate_NullActivator_ThrowsNullReferenceException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -140,7 +140,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetOrCreate_NullOperation_ThrowsNullReferenceException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -153,7 +153,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void FindContextWithin_NullSharingBoundary_ReturnsRoot()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -166,7 +166,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void FindContextWithin_UnknownSharingBoundary_ThrowsCompositionFailedException()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))
@@ -179,7 +179,7 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ToString_NoParent_ReturnsExpected()
         {
             using (CompositionHost host = CompositionHost.CreateCompositionHost(new ExportDescriptorProvider[0]))

--- a/src/libraries/System.Composition.TypedParts/tests/ContainerConfigurationTests.cs
+++ b/src/libraries/System.Composition.TypedParts/tests/ContainerConfigurationTests.cs
@@ -16,7 +16,7 @@ namespace System.Composition.Hosting.Tests
     public class ContainerConfigurationTests
     {
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithProvider_ValidProvider_RegistersProvider()
         {
             var configuration = new ContainerConfiguration();
@@ -63,7 +63,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithDefaultConventions_PartWithNoMatchingConvention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -78,7 +78,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithDefaultConventions_IEnumerablePartsWithNoMatchingConvention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -93,7 +93,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithDefaultConventions_PartsArrayWithNoMatchingConvention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -108,7 +108,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithDefaultConventions_PartTNoMatchingConvention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -144,7 +144,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithPartT_Convention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -158,7 +158,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithPart_Convention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -180,7 +180,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WithParts_Convention_Success()
         {
             var conventions = new ConventionBuilder();
@@ -263,7 +263,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_ExportedSubClass_Success()
         {
             CompositionHost container = new ContainerConfiguration()
@@ -284,7 +284,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_OpenGenericTypes_Success()
         {
             var conventions = new ConventionBuilder();
@@ -314,7 +314,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_ImportConventionsWithInheritedProperties_Success()
         {
             var conventions = new ConventionBuilder();
@@ -342,7 +342,7 @@ namespace System.Composition.Hosting.Tests
         public class DerivedFromBaseWithImport : BaseWithImport { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_ExportConventionsWithInheritedProperties_Success()
         {
             var conventions = new ConventionBuilder();
@@ -364,7 +364,7 @@ namespace System.Composition.Hosting.Tests
         public class DerivedFromBaseWithExport : BaseWithExport { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_ExportsToInheritedProperties_DontInterfereWithBase()
         {
             var conventions = new ConventionBuilder();
@@ -388,7 +388,7 @@ namespace System.Composition.Hosting.Tests
         public class DerivedFromBaseWithExport2 : BaseWithExport { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_HasConventions_ClassExportsAreNotInherited()
         {
             CompositionHost container = new ContainerConfiguration()
@@ -398,7 +398,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_HasConventions_PropertyExportsAreNotInherited()
         {
             CompositionHost container = new ContainerConfiguration()
@@ -421,7 +421,7 @@ namespace System.Composition.Hosting.Tests
         public class CustomExport : ExportAttribute { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_HasConventions_CustomAttributesAreNotInherited()
         {
             CompositionHost container = new ContainerConfiguration()
@@ -436,7 +436,7 @@ namespace System.Composition.Hosting.Tests
         public class DerivedFromBaseWithCustomExport : BaseWithCustomExport { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_OpenGenericTypePart_Success()
         {
             ContainerConfiguration configuration = new ContainerConfiguration().WithParts(typeof(GenericExportedType<>));
@@ -490,7 +490,7 @@ namespace System.Composition.Hosting.Tests
         public class ContractExportedType { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_AbstractOrStructType_Success()
         {
             ContainerConfiguration configuration = new ContainerConfiguration().WithParts(typeof(AbstractClass), typeof(StructType));
@@ -504,7 +504,7 @@ namespace System.Composition.Hosting.Tests
         public struct StructType { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_MetadataProperty_Success()
         {
             ContainerConfiguration configuration = new ContainerConfiguration().WithPart(typeof(MetadataProperty));
@@ -542,7 +542,7 @@ namespace System.Composition.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreateContainer_MetadataClass_Success()
         {
             ContainerConfiguration configuration = new ContainerConfiguration().WithPart(typeof(MetadataClass));

--- a/src/libraries/System.Composition.TypedParts/tests/ReflectionTests.cs
+++ b/src/libraries/System.Composition.TypedParts/tests/ReflectionTests.cs
@@ -27,7 +27,7 @@ namespace System.Composition.TypedParts.Tests
         /// revert to a default value during GetExport.
         /// </remarks>
         [ConditionalFact(nameof(HasMultiplerProcessors))]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultiThreadedGetExportsWorkWithImportingConstuctor()
         {
             var errors = new ConcurrentBag<Exception>();

--- a/src/libraries/System.Composition/tests/ActivationEventOrderingTests.cs
+++ b/src/libraries/System.Composition/tests/ActivationEventOrderingTests.cs
@@ -32,7 +32,7 @@ namespace System.Composition.UnitTests
     public class ActivationEventOrderingTests : ContainerTests
     {
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void OnImportsSatisfiedIsCalledAfterPropertyInjection()
         {
             var cc = CreateContainer(typeof(TracksImportSatisfaction), typeof(Imported));

--- a/src/libraries/System.Composition/tests/CardinalityTests.cs
+++ b/src/libraries/System.Composition/tests/CardinalityTests.cs
@@ -32,7 +32,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void RequestingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB));
@@ -43,7 +43,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB), typeof(UsesLog));

--- a/src/libraries/System.Composition/tests/CircularityTests.cs
+++ b/src/libraries/System.Composition/tests/CircularityTests.cs
@@ -117,7 +117,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanHandleDefinitionCircularity()
         {
             var cc = CreateContainer(typeof(ACircular), typeof(BLazy));
@@ -127,7 +127,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanHandleDefinitionCircularity2()
         {
             var cc = CreateContainer(typeof(ACircular), typeof(BLazy));
@@ -136,7 +136,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesPropertyPropertyCircularity()
         {
             var cc = CreateContainer(typeof(PropertyPropertyA), typeof(PropertyPropertyB));
@@ -145,7 +145,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesPropertyPropertyCircularityReversed()
         {
             var cc = CreateContainer(typeof(PropertyPropertyA), typeof(PropertyPropertyB));
@@ -154,7 +154,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesConstructorPropertyCircularity()
         {
             var cc = CreateContainer(typeof(ConstructorPropertyA), typeof(ConstructorPropertyB));
@@ -163,7 +163,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesConstructorPropertyCircularityReversed()
         {
             var cc = CreateContainer(typeof(ConstructorPropertyA), typeof(ConstructorPropertyB));
@@ -172,7 +172,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesMetadataCircularity()
         {
             var cc = CreateContainer(typeof(MetadataCircularityA), typeof(MetadataCircularityB));
@@ -183,7 +183,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SharedPartCanHaveNonPrereqDependencyOnSelf()
         {
             var cc = CreateContainer(typeof(NonPrereqSelfDependency));
@@ -192,7 +192,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void PrerequisiteCircularitiesAreDetected()
         {
             var cc = CreateContainer(typeof(PrDepA), typeof(PrDepB));

--- a/src/libraries/System.Composition/tests/CompositionContextExtensionsTests.cs
+++ b/src/libraries/System.Composition/tests/CompositionContextExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace System.Composition.UnitTests
         public interface IUnregistered { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GettingAnOptionalExportThatDoesntExistReturnsNull()
         {
             var c = CreateContainer();

--- a/src/libraries/System.Composition/tests/ConcurrencyTests.cs
+++ b/src/libraries/System.Composition/tests/ConcurrencyTests.cs
@@ -29,7 +29,7 @@ namespace System.Composition.UnitTests
         // This does not test the desired behaviour deterministically,
         // but is close enough to be repeatable at least on my machine :)
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SharedInstancesAreNotVisibleUntilActivationCompletes()
         {
             var c = CreateContainer(typeof(PausesDuringActivation));

--- a/src/libraries/System.Composition/tests/ConstraintTests.cs
+++ b/src/libraries/System.Composition/tests/ConstraintTests.cs
@@ -42,7 +42,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GenericPartDiscoveryIgnoresAPartAndDoesntThrowAnExceptionWhenItsConstraintOnTypeParameterIsNotAssignableFromTheExportTarget()
         {
             var container = CreateContainer(typeof(ThingHandler<>), typeof(BookHandler<>));
@@ -54,7 +54,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GenericPartDiscoveryIncludesAPartWhenItsConstraintOnTypeParameterIsAssignableFromTheExportTarget()
         {
             var container = CreateContainer(typeof(ThingHandler<>), typeof(BookHandler<>));
@@ -67,7 +67,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_ComplexConstraint_ExportSuccessful()
         {
             CompositionContext container = CreateContainer(typeof(UnrelatedThings<,>));
@@ -79,8 +79,8 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(23607)]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23607")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExport_WhereClause_ExportSuccessful()
         {
             CompositionContext container = CreateContainer(typeof(InheritedThings<,>));

--- a/src/libraries/System.Composition/tests/CustomerReportedMetadataBug.cs
+++ b/src/libraries/System.Composition/tests/CustomerReportedMetadataBug.cs
@@ -38,7 +38,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SampleServicesCorrectlyImported()
         {
             var container = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/DictionaryImportTests.cs
+++ b/src/libraries/System.Composition/tests/DictionaryImportTests.cs
@@ -69,7 +69,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DictionaryImportsKeyedByMetadata()
         {
             var container = CreateContainer(new[] { typeof(ValueA), typeof(ValueB), typeof(Consumer) });
@@ -82,7 +82,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DictionaryImportsReceiveMetadataFromNestedAdapters()
         {
             var container = CreateContainer(new[] { typeof(ValueA), typeof(ValueB), typeof(LazyConsumer) });
@@ -94,7 +94,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WhenAMetadataKeyIsDuplicatedAnInformativeExceptionIsThrown()
         {
             var container = CreateContainer(typeof(ValueA), typeof(ValueA), typeof(Consumer));
@@ -103,7 +103,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WhenAMetadataKeyIsMissingAnInformativeExceptionIsThrown()
         {
             var container = CreateContainer(typeof(ValueA), typeof(ValueMissing), typeof(Consumer));
@@ -112,7 +112,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WhenAMetadataValueIsOfTheWrongTypeAnInformativeExceptionIsThrown()
         {
             var container = CreateContainer(typeof(ValueA), typeof(NonStringValue), typeof(Consumer));
@@ -121,7 +121,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DictionaryImportsCompatibleWithConventionBuilder()
         {
             var rb = new ConventionBuilder();

--- a/src/libraries/System.Composition/tests/DiscoveryTests.cs
+++ b/src/libraries/System.Composition/tests/DiscoveryTests.cs
@@ -41,7 +41,7 @@ namespace System.Composition.UnitTests
         public class NotDiscoverable { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversCustomExportAttributes()
         {
             var container = CreateContainer(typeof(UnfairRule));
@@ -50,7 +50,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversCustomExportAttributesUnderConventions()
         {
             var container = CreateContainer(new ConventionBuilder(), typeof(UnfairRule));
@@ -59,7 +59,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void InstanceExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRule)));
@@ -67,7 +67,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void PropertyExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRuleProperty)));
@@ -75,7 +75,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ANonDiscoverablePartIsIgnored()
         {
             var container = CreateContainer(typeof(NotDiscoverable));
@@ -91,7 +91,7 @@ namespace System.Composition.UnitTests
         public class SpecialCloudBus : CloudBus { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DoesNotDiscoverExportAttributesFromBase()
         {
             var container = CreateContainer(typeof(SpecialCloudBus));
@@ -112,7 +112,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SatisfiesImportsAppliedToBase()
         {
             var container = CreateContainer(typeof(HomeController), typeof(CloudBus));
@@ -130,7 +130,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultipleImportAttributesAreDetected()
         {
             var c = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
+++ b/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
@@ -64,7 +64,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MissingTopLevelExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -73,7 +73,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MissingTopLevelNamedExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -82,7 +82,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MissingDependencyMessageIsInformative()
         {
             var cc = CreateContainer(typeof(UserOfUnregistered));
@@ -93,7 +93,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CycleMessageIsInformative()
         {
             var cc = CreateContainer(typeof(CycleA), typeof(CycleB), typeof(CycleC));
@@ -107,7 +107,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CardinalityViolationMessageIsInformative()
         {
             var cc = CreateContainer(typeof(ShouldBeOne), typeof(ButThereIsAnother), typeof(RequiresOnlyOne));

--- a/src/libraries/System.Composition/tests/ExportDescriptorProviderTests.cs
+++ b/src/libraries/System.Composition/tests/ExportDescriptorProviderTests.cs
@@ -41,7 +41,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ProvidersCanLocateImplementationsOfAContractItSupports()
         {
             var container = new ContainerConfiguration()
@@ -54,7 +54,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ProvidersCanDetectAbsenceOfAContractItSupports()
         {
             var container = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/ExportFactoryTests.cs
+++ b/src/libraries/System.Composition/tests/ExportFactoryTests.cs
@@ -106,7 +106,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SharedPartsAreSharedBetweenAllScopes()
         {
             var cc = CreateContainer(typeof(SharedUnbounded), typeof(DataConsistencyBoundaryProvider));
@@ -117,7 +117,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void TheSameSharedInstanceIsReusedWithinItsSharingBoundary()
         {
             var cc = CreateContainer(typeof(SharedBoundedByDC), typeof(SharedPartConsumer), typeof(DataConsistencyBoundaryProvider));
@@ -131,7 +131,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void NonSharedInstancesCreatedByAnExportFactoryAreControlledByTheirExportLifetimeContext()
         {
             var cc = CreateContainer(typeof(A), typeof(UseExportFactory));
@@ -144,7 +144,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DependenciesOfSharedPartsAreResolvedInTheGlobalScope()
         {
             var cc = new ContainerConfiguration()
@@ -160,7 +160,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WhenABoundaryIsPresentBoundedPartsCannotBeCreatedOutsideIt()
         {
             var container = CreateContainer(typeof(DataConsistencyBoundaryProvider), typeof(SharedBoundedByDC));
@@ -168,7 +168,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void TheProductOfAnExportFactoryCanBeDisposedDuringDisposalOfTheParent()
         {
             var container = new ContainerConfiguration()
@@ -200,7 +200,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ExportFactoryCanBeComposedWithImportManyAndNames()
         {
             var cc = CreateContainer(typeof(AConsumer), typeof(A1), typeof(A2));
@@ -234,7 +234,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void WhenReleasingAnExportFromAnExportFactoryItsNonSharedDependenciesAreDisposed()
         {
             var cc = CreateContainer(typeof(Disposable), typeof(HasDisposableDependency), typeof(HasFactory));

--- a/src/libraries/System.Composition/tests/ExportMetadataDiscoveryTests.cs
+++ b/src/libraries/System.Composition/tests/ExportMetadataDiscoveryTests.cs
@@ -52,7 +52,7 @@ namespace System.Composition.UnitTests
         public class MultipleNames { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversMetadataSpecifiedUsingMetadataAttributeOnExportAttribute()
         {
             var cc = CreateContainer(typeof(SingleNamedExport));
@@ -61,7 +61,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void IfMetadataIsSpecifiedOnAnExportAttributeOtherExportsDoNotHaveIt()
         {
             var cc = CreateContainer(typeof(MultipleExportsOneNamedAndBothPrioritized));
@@ -71,7 +71,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversStandaloneExportMetadata()
         {
             var cc = CreateContainer(typeof(NamedAndPrioritized));
@@ -80,7 +80,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversStandaloneExportMetadataUsingMetadataAttributes()
         {
             var cc = CreateContainer(typeof(NamedWithCustomMetadata));
@@ -89,7 +89,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void StandaloneExportMetadataAppliesToAllExportsOnAMember()
         {
             var cc = CreateContainer(typeof(MultipleExportsOneNamedAndBothPrioritized));
@@ -99,7 +99,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultiplePiecesOfMetadataAreCombinedIntoAnArray()
         {
             var cc = CreateContainer(typeof(MultipleNames));
@@ -120,7 +120,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultipleExportsCanBeRetrievedWhenANonDefaultConstructorExists()
         {
             var c = CreateContainer(typeof(ConstructorImported), typeof(MultipleExportsNonDefaultConstructor));

--- a/src/libraries/System.Composition/tests/ImportManyTests.cs
+++ b/src/libraries/System.Composition/tests/ImportManyTests.cs
@@ -42,7 +42,7 @@ namespace System.Composition.UnitTests
             }
         }
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportsMany()
         {
             var cc = CreateContainer(typeof(A), typeof(A2), typeof(ImportManyIA));
@@ -51,7 +51,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportsManyProperties()
         {
             var cc = CreateContainer(typeof(A), typeof(A2), typeof(ImportManyPropsOfA));

--- a/src/libraries/System.Composition/tests/ImportOrderingTests.cs
+++ b/src/libraries/System.Composition/tests/ImportOrderingTests.cs
@@ -49,7 +49,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CollectionsImportedWithAnOrderingAttributeComeInOrder()
         {
             var container = CreateExtendedContainer(typeof(HasImportedItems), typeof(Item1), typeof(Item4), typeof(Item2), typeof(Item3));
@@ -63,7 +63,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void IfAnItemIsMissingMetadataAnInformativeExceptionIsThrown()
         {
             var container = CreateExtendedContainer(typeof(HasImportedItems), typeof(Item1), typeof(ItemWithoutOrder));

--- a/src/libraries/System.Composition/tests/InheritanceTests.cs
+++ b/src/libraries/System.Composition/tests/InheritanceTests.cs
@@ -26,7 +26,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class Derived : Base { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ClassExportsAreNotInherited()
         {
             var cc = CreateContainer(typeof(Derived));
@@ -35,7 +35,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void PropertyExportsAreNotInherited()
         {
             var cc = CreateContainer(typeof(Derived));
@@ -47,7 +47,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class ExportingDerived : Base { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ExportsAtTheClassLevelAreAppliedIgnoringBaseExports()
         {
             var cc = CreateContainer(typeof(ExportingDerived));
@@ -88,7 +88,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class NonOverridingImporter : BaseImporter { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportsOnOverriddenPropertiesOverrideImportsOnTheBase()
         {
             var c = CreateContainer(typeof(Exporter), typeof(OverridingImporter), typeof(NonOverridingImporter));
@@ -99,7 +99,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void LooseImportsOnDerivedPropertiesOverrideImportsOnTheBase()
         {
             var c = CreateContainer(typeof(Exporter));
@@ -112,7 +112,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportsOnBaseAreInherited()
         {
             var c = CreateContainer(typeof(Exporter), typeof(NonOverridingImporter));
@@ -122,7 +122,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void LooseImportsOnBaseAreInherited()
         {
             var c = CreateContainer(typeof(Exporter));
@@ -138,7 +138,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class DiscoverableDerived : NotDiscoverableBase { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void PartNotDiscoverableAttributeIsNotInherited()
         {
             var c = CreateContainer(typeof(DiscoverableDerived));
@@ -153,7 +153,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class SharedDerived : SharedBase { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void PartMetadataIsNotInherited()
         {
             var c = CreateContainer(typeof(SharedDerived));
@@ -174,7 +174,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class InheritsImportsSatisfied : HasImportsSatisfied { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void OnImportsSatisfiedAttributeIsInherited()
         {
             var c = CreateContainer(typeof(InheritsImportsSatisfied));
@@ -193,7 +193,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class ABHandler : AHandler { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MetadataIsOnlyDrawnFromTheTypeToWhichItIsApplied()
         {
             var c = CreateContainer(typeof(ABHandler));
@@ -215,7 +215,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ExportsOnOverridePropertiesOverrideExportsOnTheBase()
         {
             var c = CreateContainer(typeof(DerivedOverrideExporter));

--- a/src/libraries/System.Composition/tests/LazyTests.cs
+++ b/src/libraries/System.Composition/tests/LazyTests.cs
@@ -36,7 +36,7 @@ namespace System.Composition.UnitTests
         public class Named { public string Name { get; set; } }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ComposesLazily()
         {
             var cc = CreateContainer(typeof(A), typeof(BLazy));
@@ -45,7 +45,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SupportsExportMetadata()
         {
             var cc = CreateContainer(typeof(NamedFred));
@@ -54,7 +54,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ReturnsExportMetadataAsADictionary()
         {
             var cc = CreateContainer(typeof(NamedFred));
@@ -76,7 +76,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void LazyCanBeComposedWithImportManyAndNames()
         {
             var cc = CreateContainer(typeof(AConsumer), typeof(A1), typeof(A2));

--- a/src/libraries/System.Composition/tests/LightContainerTests.cs
+++ b/src/libraries/System.Composition/tests/LightContainerTests.cs
@@ -54,7 +54,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CreatesInstanceWithNoDependencies()
         {
             var cc = CreateContainer(typeof(A));
@@ -63,7 +63,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DefaultLifetimeIsNonShared()
         {
             var cc = CreateContainer(typeof(A));
@@ -73,7 +73,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void Composes()
         {
             var cc = CreateContainer(typeof(A), typeof(B));
@@ -82,7 +82,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanSpecifyExportsWithConventionBuilder()
         {
             var rb = new ConventionBuilder();
@@ -93,7 +93,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanSpecifyLifetimeWithConventionBuilder()
         {
             var rb = new ConventionBuilder();
@@ -105,7 +105,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void InjectsPropertyImports()
         {
             var rb = new ConventionBuilder();
@@ -116,7 +116,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void VerifyAssemblyNameCanBeUsedWithContainer()
         {
             var test = new ContainerConfiguration()
@@ -128,7 +128,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void VerifyAssemblyWithTwoBaseTypeWithOnlyOneExportedWorks()
         {
             var test = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/LooseImportsTests.cs
+++ b/src/libraries/System.Composition/tests/LooseImportsTests.cs
@@ -24,7 +24,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SatisfyImportsSetsLooseImportsOnAttributedPart()
         {
             var container = CreateContainer(typeof(Transaction));

--- a/src/libraries/System.Composition/tests/MetadataConstraintTests.cs
+++ b/src/libraries/System.Composition/tests/MetadataConstraintTests.cs
@@ -32,7 +32,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AnImportMetadataConstraintMatchesMetadataOnTheExport()
         {
             var cc = CreateContainer(typeof(SomeSetting), typeof(SomeSettingUser));
@@ -41,7 +41,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AnImportMetadataConstraintMatchesMetadataOnTheExportEvenIfDiscoveryHasCompletedForTheExport()
         {
             var cc = CreateContainer(typeof(SomeSetting), typeof(SomeSettingUser));
@@ -51,7 +51,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ImportMetadataConstraintsComposeWithOtherRelationshipTypes()
         {
             var cc = CreateContainer(typeof(SomeSetting), typeof(ManySettingUser));
@@ -63,7 +63,7 @@ namespace System.Composition.UnitTests
         public class SomeSetting<T> { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ConstraintsCanBeAppliedToGenerics()
         {
             var contract = new CompositionContract(typeof(SomeSetting<string>), null, new Dictionary<string, object>
@@ -87,7 +87,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ItemEqualityIsUsedWhenMatchingMetadataValuesThatAreArrays()
         {
             var c = CreateContainer(typeof(Presenter), typeof(Controller));

--- a/src/libraries/System.Composition/tests/MetadataTests.cs
+++ b/src/libraries/System.Composition/tests/MetadataTests.cs
@@ -32,7 +32,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void HandlesMetadataCircularity()
         {
             var cc = CreateContainer(typeof(MetadataCircularityA), typeof(MetadataCircularityB));
@@ -91,7 +91,7 @@ namespace System.Composition.UnitTests
         public class Prioritized {[DefaultValue(0)] public int Priority { get; set; } }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultipleMetadataAttributesWithAPropertyThatReturnsNull()
         {
             var cc = CreateContainer(typeof(NameNullTwiceExport));
@@ -100,7 +100,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversMetadataSpecifiedUsingMetadataAttributeOnExportAttribute()
         {
             var cc = CreateContainer(typeof(SingleNamedExport));
@@ -109,7 +109,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void IfMetadataIsSpecifiedOnAnExportAttributeOtherExportsDoNotHaveIt()
         {
             var cc = CreateContainer(typeof(MultipleExportsOneNamedAndBothPrioritized));
@@ -119,7 +119,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversStandaloneExportMetadata()
         {
             var cc = CreateContainer(typeof(NamedAndPrioritized));
@@ -128,7 +128,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void DiscoversStandaloneExportMetadataUsingMetadataAttributes()
         {
             var cc = CreateContainer(typeof(NamedWithCustomMetadata));
@@ -137,7 +137,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void StandaloneExportMetadataAppliesToAllExportsOnAMember()
         {
             var cc = CreateContainer(typeof(MultipleExportsOneNamedAndBothPrioritized));
@@ -147,7 +147,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultiplePiecesOfMetadataAreCombinedIntoAnArray()
         {
             var cc = CreateContainer(typeof(MultipleNames));
@@ -161,7 +161,7 @@ namespace System.Composition.UnitTests
         public class NamedFred { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SupportsExportMetadata()
         {
             var cc = CreateContainer(typeof(NamedFred));

--- a/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
+++ b/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
@@ -22,7 +22,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class Named { public string Name { get; set; } }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AConcreteTypeWithWritablePropertiesIsAMetadataView()
         {
             var cc = new ContainerConfiguration()
@@ -40,7 +40,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class OptionallyNamed {[DefaultValue("B")] public string Name { get; set; } }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MetadataViewsCanCarryDefaultValues()
         {
             var cc = new ContainerConfiguration()
@@ -63,7 +63,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AConcreteTypeWithDictionaryConstructorIsAMetadataView()
         {
             var cc = new ContainerConfiguration()
@@ -81,7 +81,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void AConcreteTypeWithUnsupportedConstructorsCannotBeUsedAsAMetadataView()
         {
             var cc = new ContainerConfiguration()
@@ -106,7 +106,7 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void UnsupportedMetadataViewMessageIsInformative()
         {
             var cc = new ContainerConfiguration().WithParts(typeof(ImportsWithMetadataInterface), typeof(ExportsWithMetadata)).CreateContainer();
@@ -124,7 +124,7 @@ namespace System.Composition.Lightweight.UnitTests
         public class HasOrder { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ReadOnlyPropertiesOnMetadataViewsAreIgnored()
         {
             var c = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/OpenGenericsTests.cs
+++ b/src/libraries/System.Composition/tests/OpenGenericsTests.cs
@@ -65,7 +65,7 @@ namespace System.Composition.UnitTests
         private class ExportsBase<T> : SomeGenericType<T> { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanExportBasicOpenGeneric()
         {
             var cc = CreateContainer(typeof(BasicRepository<>));
@@ -74,7 +74,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void OpenGenericProvidesMultipleInstantiations()
         {
             var cc = CreateContainer(typeof(BasicRepository<>));
@@ -84,7 +84,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanExportOpenGenericProperty()
         {
             var cc = CreateContainer(typeof(RepositoryProperty<>));
@@ -93,7 +93,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ASharedOpenGenericWithTwoExportsIsProvidedByASingleInstance()
         {
             var cc = CreateContainer(typeof(TwoGenericExports<>));
@@ -105,7 +105,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void APartWithMultipleGenericExportsIsOnlyDiscoveredOnce()
         {
             var cc = CreateContainer(typeof(BasicRepository<>), typeof(TwoGenericExports<>));
@@ -119,7 +119,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultipleGenericExportsCanBeSpecifiedAtTheClassLevel()
         {
             var cc = CreateContainer(typeof(FirstAndSecond<>));
@@ -130,7 +130,7 @@ namespace System.Composition.UnitTests
         // In future, the set of allowable generic type mappings will be expanded (see
         // ignored tests above).
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void TypesWithMismatchedGenericParameterListsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithKey<,>)));
@@ -138,7 +138,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void TypesWithNonGenericExportsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithNonGenericExport<>)));
@@ -146,7 +146,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void OpenGenericsCanExportSelf()
         {
             var cc = CreateContainer(typeof(ExportSelf<>));
@@ -155,7 +155,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void OpenGenericsCanExportBase()
         {
             var cc = CreateContainer(typeof(ExportsBase<>));

--- a/src/libraries/System.Composition/tests/OptionalImportTests.cs
+++ b/src/libraries/System.Composition/tests/OptionalImportTests.cs
@@ -55,7 +55,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MissingOptionalConstructorParametersAreSuppliedTheirDefaultValue()
         {
             var cc = CreateContainer(typeof(Supplied), typeof(HasOptionalConstructorParameter));
@@ -65,7 +65,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MissingOptionalPropertyImportsAreIgnored()
         {
             var cc = CreateContainer(typeof(Supplied), typeof(HasOptionalProperty));

--- a/src/libraries/System.Composition/tests/PropertyExportTests.cs
+++ b/src/libraries/System.Composition/tests/PropertyExportTests.cs
@@ -20,7 +20,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CanExportProperty()
         {
             var cc = CreateContainer(typeof(Messenger));
@@ -45,7 +45,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ExportedPropertiesShareTheSameSharedPartInstance()
         {
             var cc = CreateContainer(typeof(SelfObsessed), typeof(Selfless));

--- a/src/libraries/System.Composition/tests/SharingTests.cs
+++ b/src/libraries/System.Composition/tests/SharingTests.cs
@@ -319,7 +319,7 @@ namespace System.Composition.UnitTests
         /// we fail only when we create instance of B.. is that correct.
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void BoundaryExposedBoundaryButNoneImported()
         {
             try
@@ -339,7 +339,7 @@ namespace System.Composition.UnitTests
         /// Needs to be fixed so that specifying boundary would automatically create the shared
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void BoundarySharingTest()
         {
             var cc = CreateContainer(typeof(A), typeof(B), typeof(C), typeof(D));
@@ -361,7 +361,7 @@ namespace System.Composition.UnitTests
         /// CirA root of the composition has to be shared explicitly.
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void CircularBoundarySharingTest()
         {
             var cc = CreateContainer(typeof(CirA), typeof(CirB), typeof(CirC));
@@ -378,7 +378,7 @@ namespace System.Composition.UnitTests
         /// Something is badly busted here.. I am getting a null ref exception
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void MultipleBoundarySpecified()
         {
             var cc = CreateContainer(typeof(ProjA), typeof(ProjB), typeof(SolA), typeof(DocA), typeof(DocB), typeof(ColA), typeof(ColB));
@@ -388,7 +388,7 @@ namespace System.Composition.UnitTests
 
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void SharedPartExportingMultipleContractsSharesAnInstance()
         {
             var cc = CreateContainer(typeof(XY));
@@ -398,7 +398,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExportsCreatesInstancedObjectByDefault()
         {
             var cc = CreateContainer(typeof(NonSharedClass));
@@ -408,7 +408,7 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetExportsCreatesSharedObjectsWhenSpecified()
         {
             var cc = CreateContainer(typeof(SharedClass));
@@ -423,7 +423,7 @@ namespace System.Composition.UnitTests
         /// verify that On Method call different instances are returned.
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ExportFactoryCreatesNewInstances()
         {
             var cc = CreateContainer(typeof(ClassWithExportFactoryShared), typeof(NonSharedClass));
@@ -439,7 +439,7 @@ namespace System.Composition.UnitTests
         /// ExportFactory should be importable as a property
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ClassWithExportFactoryAsAProperty()
         {
             var cc = CreateContainer(typeof(ClassWithExportFactoryAsAProperty), typeof(NonSharedClass));
@@ -456,7 +456,7 @@ namespace System.Composition.UnitTests
         /// is creating a part which is shared, it will return back the same instance of the part.
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ClassWithExportFactoryAndSharedExport()
         {
             var cc = CreateContainer(typeof(ClassWithExportFactoryShared), typeof(SharedClass));
@@ -473,7 +473,7 @@ namespace System.Composition.UnitTests
         /// Two instances of the root class are created , the part created using export factory should not be shared
         /// </summary>
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ClassWithNonSharedExportFactoryCreatesSharedInstances()
         {
             var cc = CreateContainer(typeof(ClassWithExportFactoryNonShared), typeof(SharedClass));
@@ -489,7 +489,7 @@ namespace System.Composition.UnitTests
         public class ASharedPart { }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void ConsistentResultsAreReturneWhenResolvingLargeNumbersOfSharedParts()
         {
             var config = new ContainerConfiguration();

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/ConfigurationManagerTest.cs
@@ -67,7 +67,7 @@ namespace MonoTests.System.Configuration
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29752
-        [ActiveIssue(15065, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15065", TestPlatforms.AnyUnix)]
         public void OpenExeConfiguration1_UserLevel_PerUserRoamingAndLocal()
         {
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
@@ -156,7 +156,7 @@ namespace MonoTests.System.Configuration
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/corefx/issues/29752
-        [ActiveIssue(15066, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15066", TestPlatforms.AnyUnix)]
         public void exePath_UserLevelPerRoamingAndLocal()
         {
             SysConfig config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
@@ -15,7 +15,7 @@ namespace System.ConfigurationTests
             ["SettingsKey"] = "SettingsKeyFoo"
         };
 
-        [ActiveIssue(37364)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37364")]
         [Fact]
         public void GetPropertyValues_NotStoredProperty_ValueEqualsNull()
         {
@@ -31,7 +31,7 @@ namespace System.ConfigurationTests
             Assert.Null(propertyValues["PropertyName"].PropertyValue);
         }
 
-        [ActiveIssue(37364)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37364")]
         [Fact]
         public void GetPropertyValues_NotStoredConnectionStringProperty_ValueEqualsEmptyString()
         {

--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -13,7 +13,7 @@ using Xunit;
 public partial class CancelKeyPressTests
 {
     [Fact]
-    [ActiveIssue(39172)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/39172")]
     [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes
     public void HandlerInvokedForSigInt()
     {
@@ -21,7 +21,7 @@ public partial class CancelKeyPressTests
     }
 
     [Fact]
-    [ActiveIssue(39172)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/39172")]
     [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.OSX)] // Jenkins blocks SIGQUIT on OS X, causing the test to fail in CI
     public void HandlerInvokedForSigQuit()
     {
@@ -29,7 +29,7 @@ public partial class CancelKeyPressTests
     }
 
     [Fact]
-    [ActiveIssue(39172)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/39172")]
     [PlatformSpecific(TestPlatforms.AnyUnix)]  // events are triggered by Unix signals (SIGINT, SIGQUIT, SIGCHLD).
     public void ExitDetectionNotBlockedByHandler()
     {

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -666,7 +666,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        [ActiveIssue(39229)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39229")]
         public void SerializeDataSet3()
         {
             string xml = @"<?xml version=""1.0"" encoding=""utf-16""?><DataSet><xs:schema id=""Example"" xmlns="""" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata""><xs:element name=""Example"" msdata:IsDataSet=""true""><xs:complexType><xs:choice maxOccurs=""unbounded"" minOccurs=""0""><xs:element name=""Packages""><xs:complexType><xs:attribute name=""ID"" type=""xs:int"" use=""required"" /><xs:attribute name=""ShipDate"" type=""xs:dateTime"" /><xs:attribute name=""Message"" type=""xs:string"" /><xs:attribute name=""Handlers"" type=""xs:int"" /></xs:complexType></xs:element></xs:choice></xs:complexType></xs:element></xs:schema><diffgr:diffgram xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"" xmlns:diffgr=""urn:schemas-microsoft-com:xml-diffgram-v1""><Example><Packages diffgr:id=""Packages1"" msdata:rowOrder=""0"" ID=""0"" ShipDate=""2004-10-11T17:46:18.6962302-05:00"" Message=""Received with no breakage!"" Handlers=""3"" /><Packages diffgr:id=""Packages2"" msdata:rowOrder=""1"" ID=""1"" /></Example></diffgr:diffgram></DataSet>";
@@ -1710,7 +1710,7 @@ namespace System.Data.Tests
 
         #region DataSet.GetChanges Tests
         [Fact]
-        [ActiveIssue(39171)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39171")]
         public void GetChanges_Relations_DifferentRowStatesTest()
         {
             DataSet ds = new DataSet("ds");

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringSortingTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringSortingTest.cs
@@ -37,7 +37,7 @@ namespace System.Data.SqlTypes.Tests
 
         private static readonly UnicodeEncoding s_unicodeEncoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
 
-        [ActiveIssue(12518, TestPlatforms.AnyUnix)] // TODO: Add this to the theory below when the issue is addressed on Unix
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/12518", TestPlatforms.AnyUnix)] // TODO: Add this to the theory below when the issue is addressed on Unix
         [Theory]
         [InlineData("ja-JP", 0x0411)] // Japanese - Japan
         public static void SqlStringValidComparisonTest_Windows(string cultureName, int localeId) => SqlStringValidComparisonTest(cultureName, localeId);

--- a/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
+++ b/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
@@ -135,7 +135,7 @@ namespace System.Data.OleDb.Tests
         {
             if (PlatformDetection.IsWindows7)
             {
-                return; // [ActiveIssue(37438)]
+                return; // [ActiveIssue("https://github.com/dotnet/corefx/issues/37438")]
             }
 
             DataTable t1 = connection.GetSchema();
@@ -159,7 +159,7 @@ namespace System.Data.OleDb.Tests
         {
             if (PlatformDetection.IsWindows7)
             {
-                return; // [ActiveIssue(37438)]
+                return; // [ActiveIssue("https://github.com/dotnet/corefx/issues/37438")]
             }
 
             DataTable schema = connection.GetSchema(tableName);

--- a/src/libraries/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
+++ b/src/libraries/System.Data.SqlClient/tests/FunctionalTests/DiagnosticTest.cs
@@ -445,7 +445,7 @@ namespace System.Data.SqlClient.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,  "Feature not available on Framework")]
         public void ConnectionOpenErrorTest()
         {
@@ -477,7 +477,7 @@ namespace System.Data.SqlClient.Tests
             }).Dispose();
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework,  "Feature not available on Framework")]
         public void ConnectionOpenAsyncErrorTest()
         {

--- a/src/libraries/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/libraries/System.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -43,7 +43,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         // data value and server consts
         private string _connStr;
 
-        [ActiveIssue(27858, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/27858", TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public void TestMain()
         {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -501,7 +501,7 @@ namespace System.Diagnostics.Tests
         /// Stresses the AllListeners by having many threads be adding and removing.
         /// </summary>
         [OuterLoop]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35539)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35539")]
         [InlineData(100, 100)] // run multiple times to stress it further
         [InlineData(100, 101)]
         [InlineData(100, 102)]

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -113,7 +113,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(40224, TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40224", TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(TraceEventType.Information, EventLogEntryType.Information, ushort.MaxValue + 1, ushort.MaxValue)]
         [InlineData(TraceEventType.Error, EventLogEntryType.Error, ushort.MinValue - 1, ushort.MinValue)]
@@ -195,7 +195,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { null, new object[] { "thanks, 00", "i like it...", 111 } };
         }
 
-        [ActiveIssue(40224, TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40224", TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [MemberData(nameof(GetTraceEventFormat_MemberData))]
         public void TraceEventFormatAndParams(string format, object[] parameters)

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -28,7 +28,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(34547)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/34547")]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData("System")]

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -144,7 +144,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(38180)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/38180")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounter_NextValue_ProcessorCounter()
         {
@@ -222,7 +222,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(25349)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25349")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounter_IncrementBy_IncrementByReadOnly()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -350,7 +350,7 @@ namespace System.Diagnostics.Tests
             }, workingDirectory, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
 
-        [ActiveIssue(12696)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/12696")]
         [Fact, PlatformSpecific(TestPlatforms.Windows), OuterLoop] // Uses P/Invokes, Requires admin privileges
         public void TestUserCredentialsPropertiesOnWindows()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -549,7 +549,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue(35933, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/35933", TestPlatforms.AnyUnix)]
         public unsafe void TestCheckChildProcessUserAndGroupIds()
         {
             string userName = GetCurrentRealUserName();
@@ -578,7 +578,7 @@ namespace System.Diagnostics.Tests
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue(38833, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/38833", TestPlatforms.AnyUnix)]
         public unsafe void TestCheckChildProcessUserAndGroupIdsElevated(bool useRootGroups)
         {
             Func<string, string, int> runsAsRoot = (string username, string useRootGroupsArg) =>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1845,7 +1845,7 @@ namespace System.Diagnostics.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ActiveIssue(37054, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37054", TestPlatforms.OSX)]
         [Fact]
         public void LongProcessNamesAreSupported()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -215,7 +215,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue(15844, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15844", TestPlatforms.AnyUnix)]
         public void WaitChain()
         {
             Process root = CreateProcess(() =>

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalContextTests.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalContextTests.cs
@@ -101,7 +101,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
             }
         }
 
-        [ActiveIssue(23800)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23800")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop("Takes too long on domain joined machines")]
         [InlineData(ContextType.Machine, null, "userName", "password")]
@@ -127,7 +127,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
             }
         }
 
-        [ActiveIssue(23800)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23800")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop("Takes too long on domain joined machines")]
         [InlineData(ContextType.Machine, null, null, "userName", "password")]
@@ -298,7 +298,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
             Assert.Equal(expected, context.ValidateCredentials(userName, password, ContextOptions.Negotiate));
         }
 
-        [ActiveIssue(23800)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23800")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop("Takes too long on domain joined machines")]
         public void ValidateCredentials_InvalidUserName_ThrowsException()
@@ -307,7 +307,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
             Assert.Throws<Exception>(() => context.ValidateCredentials("\0", "password"));
         }
 
-        [ActiveIssue(23800)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23800")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [OuterLoop("Takes too long on domain joined machines")]
         public void ValidateCredentials_IncorrectUserNamePassword_ThrowsException()

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -71,7 +71,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_NullFilePath_ThrowsArgumentNullException()
         {
@@ -79,7 +79,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentNullException>("path", () => new Bitmap((string)null, false));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData("", "path")]
         [InlineData("\0", "path")]
@@ -109,7 +109,7 @@ namespace System.Drawing.Tests
             Assert.Throws<NullReferenceException>(() => new Bitmap(null, "name"));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(typeof(Bitmap), null)]
         [InlineData(typeof(Bitmap), "")]
@@ -159,7 +159,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Bitmap((Stream)null, false));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_InvalidBytesInStream_ThrowsArgumentException()
         {
@@ -185,7 +185,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(10, 10, PixelFormat.Format1bppIndexed)]
         [InlineData(10, 10, PixelFormat.Format8bppIndexed)]
@@ -220,7 +220,7 @@ namespace System.Drawing.Tests
             yield return new object[] { 1, 1, 1, PixelFormat.Format1bppIndexed, IntPtr.Zero };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Width_Height_Stride_PixelFormat_Scan0_TestData))]
         public void Ctor_Width_Height_Stride_PixelFormat_Scan0(int width, int height, int stride, PixelFormat pixelFormat, IntPtr scan0)
@@ -234,7 +234,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -250,7 +250,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(width, 1, 0, PixelFormat.Format16bppArgb1555, IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -266,7 +266,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(1, height, 0, PixelFormat.Format16bppArgb1555, IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Undefined - 1)]
         [InlineData(PixelFormat.Undefined)]
@@ -284,7 +284,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(1, 1, 0, format, IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_InvalidScan0_ThrowsArgumentException()
         {
@@ -306,7 +306,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(Helpers.GetTestBitmapPath("16x16_nonindexed_24bit.png")), 32, 48 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Image_TestData))]
         public void Ctor_Width_Height_Graphics(Bitmap image, int width, int height)
@@ -346,7 +346,7 @@ namespace System.Drawing.Tests
             Assert.Throws<NullReferenceException>(() => new Bitmap((Image)null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Image_TestData))]
         public void Ctor_Image_Width_Height(Image image, int width, int height)
@@ -360,7 +360,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Image_TestData))]
         public void Ctor_Size(Image image, int width, int height)
@@ -400,7 +400,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(3, 3, PixelFormat.Format64bppPArgb), new Rectangle(1, 1, 1, 1), PixelFormat.Format16bppRgb565 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Clone_TestData))]
         public void Clone_Rectangle_ReturnsExpected(Bitmap bitmap, Rectangle rectangle, PixelFormat targetFormat)
@@ -439,7 +439,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Clone_TestData))]
         public void Clone_RectangleF_ReturnsExpected(Bitmap bitmap, Rectangle rectangle, PixelFormat format)
@@ -461,7 +461,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 1)]
         [InlineData(1, 0)]
@@ -474,7 +474,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0, 4, 1)]
         [InlineData(0, 0, 1, 4)]
@@ -491,7 +491,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Max)]
         [InlineData(PixelFormat.Indexed)]
@@ -510,7 +510,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_GrayscaleFormat_ThrowsOutOfMemoryException()
         {
@@ -544,7 +544,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetFrameCount_NewBitmap_ReturnsZero()
         {
@@ -566,7 +566,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetFrameCount(FrameDimension.Page));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -614,7 +614,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(1)]
@@ -626,7 +626,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(1)]
@@ -638,7 +638,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetPixel_GrayScalePixelFormat_ThrowsArgumentException()
         {
@@ -664,7 +664,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(512, 512, PixelFormat.Format16bppRgb555), 512, 512 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(GetHbitmap_TestData))]
         public void GetHbitmap_FromHbitmap_ReturnsExpected(Bitmap bitmap, int width, int height)
@@ -706,7 +706,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(1, 1)]
         [InlineData(short.MaxValue, 1)]
@@ -728,7 +728,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetHbitmap());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHbitmap_InvalidHandle_ThrowsExternalException()
         {
@@ -772,7 +772,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(512, 512, PixelFormat.Format16bppRgb555).GetHicon(), 512, 512 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHicon_TestData))]
         public Bitmap GetHicon_FromHicon_ReturnsExpected(IntPtr handle, int width, int height)
@@ -790,7 +790,7 @@ namespace System.Drawing.Tests
             return result;
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHicon_Grayscale_ThrowsArgumentException()
         {
@@ -809,7 +809,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetHicon());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHicon_InvalidHandle_ThrowsArgumentException()
         {
@@ -817,7 +817,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Bitmap.FromHicon((IntPtr)10));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHicon_1bppIcon_ThrowsArgumentException()
         {
@@ -827,7 +827,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromResource_InvalidHandle_ThrowsArgumentException()
         {
@@ -835,7 +835,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Bitmap.FromResource((IntPtr)10, "Name"));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromResource_InvalidBitmapName_ThrowsArgumentException()
         {
@@ -843,7 +843,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Bitmap.FromResource((IntPtr)10, "Name"));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeTransparent_NoColorWithMatches_SetsMatchingPixelsToTransparent()
         {
@@ -882,7 +882,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeTransparent_CustomColorExists_SetsMatchingPixelsToTransparent()
         {
@@ -955,9 +955,9 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent(Color.Red));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ActiveIssue(21886, TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue(29858, TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/21886", TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/29858", TestPlatforms.Windows)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeTransparent_GrayscalePixelFormat_ThrowsArgumentException()
         {
@@ -968,7 +968,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeTransparent_Icon_ThrowsInvalidOperationException()
         {
@@ -1004,7 +1004,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(1)]
@@ -1016,7 +1016,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(1)]
@@ -1028,7 +1028,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetPixel_GrayScalePixelFormat_ThrowsArgumentException()
         {
@@ -1072,7 +1072,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -1149,15 +1149,15 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(184, 184, PixelFormat.Format1bppIndexed), new Rectangle(0, 0, 184, 184), ImageLockMode.WriteOnly, PixelFormat.Format1bppIndexed, 24, 2 };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
-        [ActiveIssue(40224, TestPlatforms.Windows)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40224", TestPlatforms.Windows)]
         [MemberData(nameof(LockBits_TestData))]
         public void LockBits_Invoke_Success(Bitmap bitmap, Rectangle rectangle, ImageLockMode lockMode, PixelFormat pixelFormat, int expectedStride, int expectedReserved)
         {
             Do_LockBits_Invoke_Success(bitmap, rectangle, lockMode, pixelFormat, expectedStride, expectedReserved);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(LockBits_NotUnix_TestData))]
         public void LockBits_Invoke_Success_NotUnix(Bitmap bitmap, Rectangle rectangle, ImageLockMode lockMode, PixelFormat pixelFormat, int expectedStride, int expectedReserved)
@@ -1207,7 +1207,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1, 0, 1, 1)]
         [InlineData(2, 0, 1, 1)]
@@ -1232,7 +1232,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.DontCare)]
         [InlineData(PixelFormat.Max)]
@@ -1257,7 +1257,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void LockBits_ReadOnlyGrayscale_ThrowsArgumentException()
         {
@@ -1274,7 +1274,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData((ImageLockMode)(-1))]
         [InlineData(ImageLockMode.UserInputBuffer + 1)]
@@ -1318,7 +1318,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, -1)]
         [InlineData(0, 2)]
@@ -1347,7 +1347,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Indexed)]
         [InlineData(PixelFormat.Gdi)]
@@ -1371,7 +1371,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void UnlockBits_NotLocked_ThrowsExternalException()
         {
@@ -1381,7 +1381,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void UnlockBits_AlreadyUnlocked_ThrowsExternalException()
         {
@@ -1414,7 +1414,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Size);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Format16bppArgb1555)]
         [InlineData(PixelFormat.Format16bppRgb555)]
@@ -1583,7 +1583,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Palette_SetNull_ThrowsNullReferenceException()
         {
@@ -1605,7 +1605,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Size);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBits_Marshalling_Success()
         {
             Color red = Color.FromArgb(Color.Red.ToArgb());

--- a/src/libraries/System.Drawing.Common/tests/BrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BrushTests.cs
@@ -20,7 +20,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(39232)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39232")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_NoSuchEntryPoint_SilentyCatchesException()
         {

--- a/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -18,7 +18,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_ValidTargetGraphics_Success()
         {
@@ -61,7 +61,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_ValidTargetHdc_Success()
         {
@@ -134,7 +134,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Fact]
         public void Allocate_InvalidHdc_ThrowsArgumentException()
         {
@@ -144,7 +144,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_NullGraphicsZeroSize_Success()
         {
@@ -155,7 +155,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_NullGraphicsNonZeroSize_ThrowsArgumentNullException()
         {
@@ -166,7 +166,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_DisposedGraphics_ThrowsArgumentException()
         {
@@ -182,7 +182,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Allocate_BusyGraphics_ThrowsInvalidOperationException()
         {
@@ -264,7 +264,7 @@ namespace System.Drawing.Tests
             GC.WaitForPendingFinalizers();
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_BusyAndValidated_ThrowsInvalidOperationException()
         {
@@ -279,7 +279,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_BusyAndInvalidated_ThrowsInvalidOperationException()
         {

--- a/src/libraries/System.Drawing.Common/tests/BufferedGraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BufferedGraphicsTests.cs
@@ -42,7 +42,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Render_ParameterlessWithTargetGraphics_Success()
         {
@@ -69,7 +69,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Render_ParameterlessWithNullTargetGraphics_Success()
         {
@@ -97,7 +97,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Render_TargetGraphics_Success()
         {
@@ -138,7 +138,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Render_InvalidTargetDC_Nop()
         {

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
@@ -128,7 +128,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void BaseCap_ReturnsTriangle()
         {

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
@@ -41,7 +41,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { fillPath, null, LineCap.Flat, 0f, LineCap.Flat };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Path_Path_LineCap_Float_TestData))]
         public void Ctor_Path_Path_LineCap_Float(GraphicsPath fillPath, GraphicsPath strokePath, LineCap baseCap, float baseInset, LineCap expectedCap)
@@ -57,7 +57,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         // These values are outside the valid range of the LineCap enum.
         [InlineData(LineCap.Flat - 1)]
@@ -72,7 +72,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_FillPath_Incomplete_ThrowsArgumentException()
         {
@@ -83,7 +83,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_FillPath_DoesNotCrossYAxis_ThrowsNotImplementedException()
         {
@@ -114,7 +114,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(LineCap.SquareAnchor, LineCap.SquareAnchor)]
         [InlineData(LineCap.Custom, LineCap.Custom)]
@@ -177,7 +177,7 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(LineCap.Custom)]
         [InlineData(LineCap.Flat - 1)]
         [InlineData(LineCap.Custom + 1)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void BaseCap_Set_InvalidLineCap_ThrowsArgumentException(LineCap baseCap)
         {
             using (GraphicsPath strokePath = new GraphicsPath())

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
@@ -63,7 +63,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void NextSubpath_PathFigureNotClosed_ReturnsExpeced()
         {
@@ -87,7 +87,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void NextSubpath_NullPath_ReturnsExpected()
         {
@@ -98,7 +98,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void NextSubpath_FigureNotClosed_ReturnsExpeced()
         {
@@ -239,7 +239,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Rewind_Success()
         {

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -142,7 +142,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(FillMode.Alternate - 1)]
         [InlineData(FillMode.Winding + 1)]
@@ -375,7 +375,7 @@ namespace System.Drawing.Drawing2D.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new GraphicsPath().AddLines(new PointF[0]));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddArc_Values_Success()
         {
@@ -398,7 +398,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddArc_Rectangle_Success()
         {
@@ -419,7 +419,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0)]
         [InlineData(1, 0)]
@@ -529,7 +529,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddCurve_TwoPoints_Success()
         {
@@ -548,7 +548,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddCurve_TwoPointsWithTension_Success()
         {
@@ -725,7 +725,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddClosedCurve_Points_Success()
         {
@@ -765,7 +765,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddClosedCurve_Tension_Success()
         {
@@ -1000,7 +1000,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddPie_Rectangle_Success()
         {
@@ -1013,7 +1013,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddPie_Values_Success()
         {
@@ -1028,7 +1028,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0)]
         [InlineData(2, 0)]
@@ -1043,7 +1043,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddPolygon_Points_Success()
         {
@@ -1059,7 +1059,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddPolygon_SamePoints_Success()
         {
@@ -1165,7 +1165,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_Point_Success()
         {
@@ -1180,7 +1180,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_Rectangle_Success()
         {
@@ -1195,7 +1195,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_NegativeSize_Success()
         {
@@ -1218,7 +1218,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_StringFormat_Success()
         {
@@ -1237,7 +1237,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_EmptyString_Success()
         {
@@ -1252,7 +1252,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddString_StringNull_ThrowsNullReferenceException()
         {
@@ -1550,7 +1550,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Warp_RectangleEmpty_Success()
         {
@@ -1918,7 +1918,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void StartClose_AddString()
         {
@@ -1937,7 +1937,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Widen_Pen_Success()
         {
@@ -1986,7 +1986,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Widen_MatrixNull_Success()
         {
@@ -2000,7 +2000,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Widen_MatrixEmpty_Success()
         {
@@ -2024,7 +2024,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Rectangle(1, 1, 2, 2), 1.1f, new RectangleF(0.45f, 0.45f, 3.10f, 3.10f) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Widen_PenSmallWidth_TestData))]
         public void Widen_Pen_SmallWidth_Succes(
@@ -2120,14 +2120,14 @@ namespace System.Drawing.Drawing2D.Tests
             AssertIsOutlineVisibleRectangle(null);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsVisible_RectangleWithoutGraphics_ReturnsExpected()
         {
             AssertIsVisibleRectangle(null);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsVisible_RectangleWithGraphics_ReturnsExpected()
         {
@@ -2293,7 +2293,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Reverse_Pie_Succes()
         {
@@ -2331,7 +2331,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Reverse_String_Succes()
         {

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -24,7 +24,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Point(4, 6), new Point(1, 2), Color.Black, Color.Wheat, new RectangleF(1, 2, 3, 4) };
         }
 
-        [ActiveIssue(32706, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/32706", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Point_TestData))]
         public void Ctor_PointF_PointF_Color_Color(Point point1, Point point2, Color color1, Color color2, RectangleF expectedRectangle)
@@ -44,7 +44,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_PointF_PointF_Color_Color_FloatRanges()
         {
@@ -57,7 +57,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(32706, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/32706", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Point_TestData))]
         public void Ctor_Point_Point_Color_Color(Point point1, Point point2, Color color1, Color color2, RectangleF expectedRectangle)
@@ -77,7 +77,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
@@ -282,7 +282,7 @@ namespace System.Drawing.Drawing2D.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_GetWithInterpolationColorsSet_ReturnsNull()
         {
@@ -299,7 +299,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(new float[] { 1 }, new float[] { 1 })]
         [InlineData(new float[] { 0 }, new float[] { 0 })]
@@ -567,7 +567,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetBlend_ThrowsArgumentException()
         {
@@ -631,7 +631,7 @@ namespace System.Drawing.Drawing2D.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => brush.LinearColors = new Color[] { Color.Red, Color.Wheat });
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Rectangle_GetDisposed_ThrowsArgumentException()
         {
@@ -748,7 +748,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(MatrixOrder.Prepend)]
         [InlineData(MatrixOrder.Append)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -52,7 +52,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(float.NaN)]
         [InlineData(float.NegativeInfinity)]
@@ -254,7 +254,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(float.NaN)]
         [InlineData(float.PositiveInfinity)]
@@ -322,7 +322,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue), MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Multiply_TestData))]
         public void Multiply_Matrix_Success(Matrix matrix, Matrix multiple, MatrixOrder order, float[] expected)
@@ -465,7 +465,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.NegativeInfinity, PointF.Empty, MatrixOrder.Append, new float[] { float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN }, null, false };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Rotate_TestData))]
         public void Rotate_Matrix_Success(Matrix matrix, float angle, PointF point, MatrixOrder order, float[] expectedElements, float[] expectedElementsRotateAt, bool isIdentity)
@@ -578,7 +578,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Scale_TestData))]
         public void Scale_Matrix_Succss(Matrix matrix, float scaleX, float scaleY, MatrixOrder order, float[] expectedElements)
@@ -655,7 +655,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Shear_TestData))]
         public void Shear_Matrix_Succss(Matrix matrix, float shearX, float shearY, MatrixOrder order, float[] expectedElements)
@@ -724,7 +724,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { 1, 2, 3, 4, float.MaxValue, float.MaxValue } };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Translate_TestData))]
         public void Translate_Matrix_Success(Matrix matrix, float offsetX, float offsetY, MatrixOrder order, float[] expectedElements)

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -36,7 +36,7 @@ namespace System.Drawing.Drawing2D.Tests
         private readonly PointF[] _defaultFloatPoints = new PointF[2] { new PointF(1, 2), new PointF(20, 30) };
         private readonly RectangleF _defaultRectangle = new RectangleF(1, 2, 19, 28);
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_Points_ReturnsExpected()
         {
@@ -59,7 +59,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { WrapMode.TileFlipY };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(WrapMode_TestData))]
         public void Ctor_PointsWrapMode_ReturnsExpected(WrapMode wrapMode)
@@ -102,7 +102,7 @@ namespace System.Drawing.Drawing2D.Tests
                 new PathGradientBrush(_defaultFloatPoints, (WrapMode)int.MaxValue));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_Path_ReturnsExpected()
         {
@@ -131,7 +131,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_ReturnsExpected()
         {
@@ -175,7 +175,7 @@ namespace System.Drawing.Drawing2D.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => brush.CenterColor = Color.Blue);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SurroundColors_ReturnsExpected()
         {
@@ -280,7 +280,7 @@ namespace System.Drawing.Drawing2D.Tests
             yield return new object[] { new float[1] { 1 }, new float[3] { 0, 3, 1 } };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Blend_FactorsPositions_TestData))]
         public void Blend_ReturnsExpected(float[] factors, float[] positions)
@@ -603,7 +603,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_CannotChange()
         {

--- a/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -9,7 +9,7 @@ namespace System.Drawing.Tests
 {
     public class FontFamilyTests
     {
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(GenericFontFamilies.Serif - 1, "Courier New")] // Value is outside the enum range.
         [InlineData(GenericFontFamilies.Monospace + 1, "Courier New")] // Value is outside the enum range.
@@ -24,7 +24,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData("Courier New", "Courier New")]
         [InlineData("Microsoft Sans Serif", "Microsoft Sans Serif")]
@@ -38,7 +38,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_Name_FontCollection()
         {
@@ -53,7 +53,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(null)]
         [InlineData("NoSuchFont")]
@@ -84,7 +84,7 @@ namespace System.Drawing.Tests
             yield return new object[] { FontFamily.GenericSansSerif, null, false };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Equals_TestData))]
         public void Equals_Object_ReturnsExpected(FontFamily fontFamily, object other, bool expected)
@@ -130,7 +130,7 @@ namespace System.Drawing.Tests
 #pragma warning restore 0618
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GenericMonospace_Get_ReturnsExpected()
         {
@@ -144,7 +144,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GenericSansSerif_Get_ReturnsExpected()
         {
@@ -158,7 +158,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GenericSerif_Get_ReturnsExpected()
         {
@@ -180,7 +180,7 @@ namespace System.Drawing.Tests
 #pragma warning restore 0618
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHashCode_Invoke_ReturnsNameHashCode()
         {
@@ -201,7 +201,7 @@ namespace System.Drawing.Tests
             yield return new object[] { FontStyle.Strikeout + 1 };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FontStyle_TestData))]
         public void FontFamilyProperties_CustomFont_ReturnsExpected(FontStyle style)
@@ -221,7 +221,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsStyleAvailable_Disposed_ThrowsArgumentException()
         {
@@ -231,7 +231,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.IsStyleAvailable(FontStyle.Italic));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetEmHeight_Disposed_ThrowsArgumentException()
         {
@@ -243,7 +243,7 @@ namespace System.Drawing.Tests
 
         private const int FrenchLCID = 1036;
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1, "Code New Roman")]
         [InlineData(0, "Code New Roman")]
@@ -263,7 +263,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetName_Disposed_ThrowsArgumentException()
         {
@@ -273,7 +273,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetName(0));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetCellAscent_Disposed_ThrowsArgumentException()
         {
@@ -283,7 +283,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellAscent(FontStyle.Italic));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetCellDescent_Disposed_ThrowsArgumentException()
         {
@@ -293,7 +293,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellDescent(FontStyle.Italic));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetLineSpacing_Disposed_ThrowsArgumentException()
         {
@@ -303,7 +303,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetLineSpacing(FontStyle.Italic));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_MultipleTimes_Nop()
         {

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -323,7 +323,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_FamilyNamePrefixedWithAtSign_StripsSign()
         {
@@ -341,7 +341,7 @@ namespace System.Drawing.Tests
             Assert.Throws<NullReferenceException>(() => new Font(null, FontStyle.Regular));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_DisposedFont_Success()
         {
@@ -383,7 +383,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10, gdiVerticalFont: true));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]
@@ -409,7 +409,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(GraphicsUnit.Display)]
         [InlineData(GraphicsUnit.World - 1)]
@@ -429,7 +429,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Invoke_ReturnsExpected()
         {
@@ -448,7 +448,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_DisposedFont_ThrowsArgumentException()
         {
@@ -467,7 +467,7 @@ namespace System.Drawing.Tests
             var font = new Font(family, 10, FontStyle.Bold, GraphicsUnit.Inch, 10, gdiVerticalFont: true);
 
             yield return new object[] { font, font, true };
-            // [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
             if (PlatformDetection.IsWindows)
             {
                 yield return new object[] { font.Clone(), new Font(family, 10, FontStyle.Bold, GraphicsUnit.Inch, 10, gdiVerticalFont: true), false };
@@ -506,14 +506,14 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdc_ZeroHdc_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => Font.FromHdc(IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdc_GraphicsHdc_ThrowsArgumentException()
         {
@@ -532,14 +532,14 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHfont_Zero_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => Font.FromHfont(IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHeight_Parameterless_ReturnsExpected()
         {
@@ -553,7 +553,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHeight_Graphics_ReturnsExpected()
         {
@@ -566,7 +566,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0)]
         [InlineData(-1, -0.1571995)]
@@ -594,7 +594,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(22571)] // PR issue, This causes an AccessViolation in GDI+.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22571")] // PR issue, This causes an AccessViolation in GDI+.
         public void GetHeight_DisposedGraphics_ThrowsArgumentException()
         {
             using (FontFamily family = FontFamily.GenericMonospace)
@@ -624,7 +624,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(FontStyle.Bold, int.MinValue, 0)]
         [InlineData(FontStyle.Bold, -2147483099, 0)]
@@ -662,7 +662,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromLogFont_NullLogFont_ThrowsArgumentNullException()
         {
@@ -690,7 +690,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromLogFont_InvalidLogFont_ThrowsArgumentException()
         {
@@ -711,7 +711,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromLogFont_UnblittableStruct()
         {
@@ -785,7 +785,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(FontStyle.Strikeout | FontStyle.Bold | FontStyle.Italic, 255, true, "@", 700)]
         [InlineData(FontStyle.Regular, 0, false, "", 400)]
@@ -815,7 +815,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(TextRenderingHint.SystemDefault)]
         [InlineData(TextRenderingHint.AntiAlias)]
@@ -852,7 +852,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "AV Exception is wrapped in a TargetInvocationException in the .NET Framework.")]
         public void ToLogFont_NullLogFont_ThrowsArgumentNullException()
@@ -867,7 +867,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToLogFont_NullGraphics_ThrowsArgumentNullException()
         {
@@ -912,7 +912,7 @@ namespace System.Drawing.Tests
             public string lfFaceName;
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToHfont_SimpleFont_Roundtrips()
         {
@@ -928,7 +928,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToHfont_ComplicatedFont_DoesNotRoundtrip()
         {
@@ -944,7 +944,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToHfont_Disposed_ThrowsArgumentException()
         {
@@ -959,7 +959,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToString_Invoke_ReturnsExpected()
         {

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -12,7 +12,7 @@ namespace System.Drawing.Tests
 {
     public class GraphicsTests
     {
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdc_FromHdc_Roundtrips()
         {
@@ -36,7 +36,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdc_SameImage_ReturnsSame()
         {
@@ -56,7 +56,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdc_NotReleased_ThrowsInvalidOperationException()
         {
@@ -75,7 +75,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdc_Disposed_ThrowsObjectDisposedException()
         {
@@ -97,7 +97,7 @@ namespace System.Drawing.Tests
             yield return new object[] { Helpers.GetDC(foregroundWindow) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdc_ReturnsExpected(IntPtr hdc)
@@ -109,7 +109,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdcWithContext_ReturnsExpected(IntPtr hdc)
@@ -121,7 +121,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdcInternal_GetDC_ReturnsExpected(IntPtr hdc)
@@ -133,28 +133,28 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdc_ZeroHdc_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("hdc", () => Graphics.FromHdc(IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdcInternal_ZeroHdc_ThrowsOutOfMemoryException()
         {
             Assert.Throws<OutOfMemoryException>(() => Graphics.FromHdcInternal(IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdc_ZeroHdc_ThrowsOutOfMemoryException()
         {
             Assert.Throws<OutOfMemoryException>(() => Graphics.FromHdc(IntPtr.Zero, (IntPtr)10));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHdc_InvalidHdc_ThrowsOutOfMemoryException()
         {
@@ -162,7 +162,7 @@ namespace System.Drawing.Tests
             Assert.Throws<OutOfMemoryException>(() => Graphics.FromHwndInternal((IntPtr)10));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ReleaseHdc_ValidHdc_ResetsHdc()
         {
@@ -186,7 +186,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ReleaseHdc_NoSuchHdc_ResetsHdc()
         {
@@ -203,7 +203,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ReleaseHdc_OtherGraphicsHdc_Success()
         {
@@ -236,7 +236,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ReleaseHdc_Disposed_ThrowsObjectDisposedException()
         {
@@ -257,7 +257,7 @@ namespace System.Drawing.Tests
             yield return new object[] { Helpers.GetForegroundWindow() };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwnd_ValidHwnd_ReturnsExpected(IntPtr hWnd)
@@ -269,7 +269,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwndInternal_ValidHwnd_ReturnsExpected(IntPtr hWnd)
@@ -281,7 +281,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromHwnd_InvalidHwnd_ThrowsOutOfMemoryException()
         {
@@ -289,7 +289,7 @@ namespace System.Drawing.Tests
             Assert.Throws<OutOfMemoryException>(() => Graphics.FromHdcInternal((IntPtr)10));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Format16bppRgb555)]
         [InlineData(PixelFormat.Format16bppRgb565)]
@@ -309,7 +309,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void FromImage_NullImage_ThrowsArgumentNullException()
         {
@@ -348,7 +348,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(PixelFormat.Format16bppArgb1555)]
         [InlineData(PixelFormat.Format16bppGrayScale)]
@@ -366,7 +366,7 @@ namespace System.Drawing.Tests
             yield return new object[] { CompositingMode.SourceOver, Color.FromArgb(220, 185, 185, 185) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(CompositingMode_TestData))]
         public void CompositingMode_Set_GetReturnsExpected(CompositingMode mode, Color expectedOverlap)
@@ -409,7 +409,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void CompositingMode_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -468,7 +468,7 @@ namespace System.Drawing.Tests
             yield return new object[] { CompositingQuality.HighQuality, gammaCorrectedColors };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(CompositingQuality_TestData))]
         public void CompositingQuality_Set_GetReturnsExpected(CompositingQuality quality, Color[][] expectedIntersectionColor)
@@ -503,7 +503,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void CompositingQuality_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -566,7 +566,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DpiX_GetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -597,7 +597,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DpiY_GetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -649,7 +649,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Flush_Busy_ThrowsInvalidOperationException()
         {
@@ -723,7 +723,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationMode_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -785,7 +785,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void PageScale_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -857,7 +857,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void PageUnit_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -928,7 +928,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void PixelOffsetMode_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -999,7 +999,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Point(3, 3), allEmpty };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(RenderingOrigin_TestData))]
         public void RenderingOrigin_SetToCustom_RendersExpected(Point renderingOrigin, Color[][] expectedRendering)
@@ -1019,7 +1019,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void RenderingOrigin_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -1090,7 +1090,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SmoothingMode_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -1149,7 +1149,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TextContrast_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -1211,7 +1211,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TextRenderingHint_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -1244,7 +1244,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Transform_SetValid_GetReturnsExpected()
         {
@@ -1307,7 +1307,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Transform_GetSetWhenBusy_ThrowsInvalidOperationException()
         {
@@ -1357,7 +1357,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ResetTransform_Busy_ThrowsInvalidOperationException()
         {
@@ -1475,7 +1475,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MultiplyTransform_Busy_ThrowsInvalidOperationException()
         {
@@ -1563,7 +1563,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TranslateTransform_Busy_ThrowsInvalidOperationException()
         {
@@ -1657,7 +1657,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ScaleTransform_Busy_ThrowsInvalidOperationException()
         {
@@ -1744,7 +1744,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void RotateTransform_Busy_ThrowsInvalidOperationException()
         {
@@ -1788,8 +1788,8 @@ namespace System.Drawing.Tests
             yield return new object[] { 0, 0, 0, 0, new Size(-1, -1) };
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(CopyFromScreen_TestData))]
         public void CopyFromScreen_OutOfRange_DoesNotAffectGraphics(int sourceX, int sourceY, int destinationX, int destinationY, Size size)
@@ -1806,8 +1806,8 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, 0, 0, 0, 10, 10)]
         [InlineData(0, 0, 0, 0, int.MaxValue, int.MaxValue)]
@@ -1866,8 +1866,8 @@ namespace System.Drawing.Tests
             yield return new object[] { CopyPixelOperation.CaptureBlt };
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(CopyPixelOperation_TestData))]
         public void CopyFromScreen_IntsAndValidCopyPixelOperation_Success(CopyPixelOperation copyPixelOperation)
@@ -1881,8 +1881,8 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(CopyPixelOperation_TestData))]
         public void CopyFromScreen_PointsAndValidCopyPixelOperation_Success(CopyPixelOperation copyPixelOperation)
@@ -1896,8 +1896,8 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(CopyPixelOperation.NoMirrorBitmap + 1)]
         [InlineData(CopyPixelOperation.Blackness - 1)]
@@ -1926,8 +1926,8 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void CopyFromScreen_Busy_ThrowsInvalidOperationException()
         {
@@ -1949,8 +1949,8 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(23650)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23650")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void CopyFromScreen_Disposed_ThrowsArgumentException()
         {
@@ -2017,7 +2017,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(TransformPoints_TestData))]
         public void TransformPoints_Points_Success(CoordinateSpace destSpace, CoordinateSpace srcSpace, Point[] points, Point[] expected)
@@ -2085,7 +2085,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(TransformPointFs_TestData))]
         public void TransformPoints_PointFs_Success(CoordinateSpace destSpace, CoordinateSpace srcSpace, PointF[] points, PointF[] expected)
@@ -2102,7 +2102,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(CoordinateSpace.Device)]
         [InlineData(CoordinateSpace.World)]
@@ -2121,7 +2121,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(CoordinateSpace.Device)]
         [InlineData(CoordinateSpace.World)]
@@ -2140,7 +2140,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(CoordinateSpace.World - 1)]
         [InlineData(CoordinateSpace.Device + 1)]
@@ -2154,7 +2154,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(CoordinateSpace.World - 1)]
         [InlineData(CoordinateSpace.Device + 1)]
@@ -2179,7 +2179,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints_EmptyPoints_ThrowsArgumentException()
         {
@@ -2191,7 +2191,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints_Busy_ThrowsInvalidOperationException()
         {
@@ -2211,7 +2211,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints_Disposed_ThrowsArgumentException()
         {
@@ -2231,7 +2231,7 @@ namespace System.Drawing.Tests
             yield return new object[] { PixelFormat.Format16bppRgb555, Color.Red, Color.FromArgb(255, 248, 0, 0) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(GetNearestColor_TestData))]
         public void GetNearestColor_Color_ReturnsExpected(PixelFormat pixelFormat, Color color, Color expected)
@@ -2243,7 +2243,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetNearestColor_Busy_ThrowsInvalidOperationException()
         {
@@ -2262,7 +2262,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetNearestColor_Disposed_ThrowsArgumentException()
         {
@@ -2275,7 +2275,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_NullPen_ThrowsArgumentNullException()
         {
@@ -2289,7 +2289,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_DisposedPen_ThrowsArgumentException()
         {
@@ -2306,7 +2306,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_ZeroWidth_ThrowsArgumentException()
         {
@@ -2321,7 +2321,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_ZeroHeight_ThrowsArgumentException()
         {
@@ -2336,7 +2336,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_Busy_ThrowsInvalidOperationException()
         {
@@ -2359,7 +2359,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawArc_Disposed_ThrowsArgumentException()
         {
@@ -2404,7 +2404,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawRectangle_Busy_ThrowsInvalidOperationException()
         {
@@ -2490,7 +2490,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawRectangles_Busy_ThrowsInvalidOperationException()
         {
@@ -2555,7 +2555,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawEllipse_Busy_ThrowsInvalidOperationException()
         {
@@ -2623,7 +2623,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawPie_ZeroWidth_ThrowsArgumentException()
         {
@@ -2638,7 +2638,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawPie_ZeroHeight_ThrowsArgumentException()
         {
@@ -2653,7 +2653,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawPie_Busy_ThrowsInvalidOperationException()
         {
@@ -2743,7 +2743,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawPolygon_Busy_ThrowsInvalidOperationException()
         {
@@ -2828,7 +2828,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawPath_Busy_ThrowsInvalidOperationException()
         {
@@ -2934,7 +2934,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(4, -1, 4)]
         [InlineData(4, 0, -1)]
@@ -2953,7 +2953,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawCurve_Busy_ThrowsInvalidOperationException()
         {
@@ -3058,7 +3058,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawClosedCurve_Busy_ThrowsInvalidOperationException()
         {
@@ -3117,7 +3117,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clear_Busy_ThrowsInvalidOperationException()
         {
@@ -3150,7 +3150,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawString_DefaultFont_Succeeds()
         {
@@ -3162,7 +3162,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawString_CompositingModeSourceCopy_ThrowsArgumentException()
         {

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
@@ -22,7 +22,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(30683, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30683", TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBezier_Points()
         {
@@ -44,7 +44,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(30683, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30683", TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBezier_PointFs()
         {
@@ -93,7 +93,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBezier_Busy_ThrowsInvalidOperationException()
         {
@@ -115,7 +115,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBezier_Disposed_ThrowsArgumentException()
         {
@@ -143,7 +143,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBeziers_DisposedPen_ThrowsArgumentException()
         {
@@ -170,7 +170,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBeziers_EmptyPoints_ThrowsArgumentException()
         {
@@ -183,7 +183,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBeziers_Busy_ThrowsInvalidOperationException()
         {
@@ -204,7 +204,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawBeziers_Disposed_ThrowsArgumentException()
         {

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -7,7 +7,7 @@ namespace System.Drawing.Tests
 {
     public class Graphics_DrawLineTests : DrawingTest
     {
-        [ActiveIssue(30683, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30683", TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawLines_Points()
         {
@@ -23,7 +23,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(30683, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30683", TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawLines_PointFs()
         {
@@ -68,7 +68,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawLine_Busy_ThrowsInvalidOperationException()
         {
@@ -158,7 +158,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DrawLines_Busy_ThrowsInvalidOperationException()
         {

--- a/src/libraries/System.Drawing.Common/tests/IconTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/IconTests.cs
@@ -76,7 +76,7 @@ namespace System.Drawing.Tests
             yield return new object[] { "256x256_one_entry_32bit.ico", new Size(int.MaxValue, int.MaxValue), new Size(256, 256) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_FilePath_Width_Height(string fileName, Size size, Size expectedSize)
@@ -89,7 +89,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_FilePath_Size(string fileName, Size size, Size expectedSize)
@@ -122,7 +122,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Width_Height(string fileName, Size size, Size expectedSize)
@@ -136,7 +136,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Stream_Size(string fileName, Size size, Size expectedSize)
@@ -215,7 +215,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new byte[] { 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, typeof(Win32Exception) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_InvalidBytesInStream_TestData))]
         public void Ctor_InvalidBytesInStream_ThrowsException(byte[] bytes, Type exceptionType)
@@ -229,7 +229,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Icon_Width_Height(string fileName, Size size, Size expectedSize)
@@ -244,7 +244,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Size_TestData))]
         public void Ctor_Icon_Size(string fileName, Size size, Size expectedSize)
@@ -349,7 +349,7 @@ namespace System.Drawing.Tests
             Assert.Throws<ObjectDisposedException>(() => icon.Handle);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_OwnsHandle_DestroysHandle()
         {
@@ -434,7 +434,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_NonFilePath_ThrowsFileNotFound()
         {
@@ -514,7 +514,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_NullOutputStreamNoIconData_ThrowsArgumentNullException()
         {
@@ -527,7 +527,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_ClosedOutputStreamIconData_ThrowsException()
         {
@@ -540,7 +540,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_ClosedOutputStreamNoIconData_DoesNothing()
         {
@@ -554,7 +554,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_NoIconDataOwnsHandleAndDisposed_ThrowsObjectDisposedException()
         {
@@ -614,7 +614,7 @@ namespace System.Drawing.Tests
 
         private const string DontSupportPngFramesInIcons = "Switch.System.Drawing.DontSupportPngFramesInIcons";
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToBitmap_PngIconSupportedInSwitches_Success()
         {
@@ -651,7 +651,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToBitmap_PngIconNotSupportedInSwitches_ThrowsArgumentOutOfRangeException()
         {

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -22,7 +22,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(InvalidBytes_TestData))]
         public void FromFile_InvalidBytes_ThrowsOutOfMemoryException(byte[] bytes)
@@ -77,7 +77,7 @@ namespace System.Drawing.Tests
             Assert.Throws<FileNotFoundException>(() => Image.FromFile("NoSuchFile", useEmbeddedColorManagement: true));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(InvalidBytes_TestData))]
         public void FromStream_InvalidBytes_ThrowsArgumentException(byte[] bytes)
@@ -159,7 +159,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(GetEncoderParameterList_ReturnsExpected_TestData))]
         public void GetEncoderParameterList_ReturnsExpected(ImageFormat format, Guid[] expectedParameters)

--- a/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -67,7 +67,7 @@ namespace System.Drawing.Imaging.Tests
             imageAttr.Dispose();
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)] // Causes a crash on libgdiplus.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)] // Causes a crash on libgdiplus.
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Success()
         {
@@ -520,7 +520,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetThreshold_Threshold_Success()
         {
@@ -535,7 +535,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetThreshold_ThresholdType_Success(ColorAdjustType type)
@@ -552,7 +552,7 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [MemberData(nameof(ColorAdjustTypeI_TestData))]
         public void SetThreshold_ThresholdTypeI_Success(ColorAdjustType type)
         {
@@ -567,7 +567,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetThreshold_Disposed_ThrowsArgumentException()
         {
@@ -577,7 +577,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetThreshold(0.5f));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetThreshold_InvalidType_ThrowsArgumentException(ColorAdjustType type)
@@ -588,7 +588,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearThreshold_Success()
         {
@@ -604,7 +604,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearThreshold_ThresholdTypeI_Success(ColorAdjustType type)
@@ -621,7 +621,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearThreshold_Disposed_ThrowsArgumentException()
         {
@@ -631,7 +631,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearThreshold(ColorAdjustType.Default));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearThreshold_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -642,7 +642,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetGamma_Gamma_Success()
         {
@@ -657,7 +657,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetGamma_GammaType_Success(ColorAdjustType type)
@@ -673,7 +673,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustTypeI_TestData))]
         public void SetGamma_GammaTypeI_Success(ColorAdjustType type)
@@ -745,7 +745,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetNoOp_Success()
         {
@@ -762,7 +762,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void SetNoOp_Type_Success(ColorAdjustType type)
@@ -819,7 +819,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void ClearNoOp_Type_Success(ColorAdjustType type)
@@ -858,7 +858,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearNoOp_Disposed_ThrowsArgumentException()
         {
@@ -879,7 +879,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22309)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22309")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetColorKey_Success()
         {
@@ -895,7 +895,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22309)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22309")]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetColorKey_Type_Success(ColorAdjustType type)
@@ -1011,7 +1011,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, Color.FromArgb(255, 100, 100, 100), Color.FromArgb(255, 207, 207, 207) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlag_TestData))]
         public void SetOutputChannel_Flag_Success(ColorChannelFlag flag, Color actualColor, Color expectedColor)
@@ -1040,7 +1040,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, ColorAdjustType.Bitmap, Color.FromArgb(255, 100, 100, 100), Color.FromArgb(255, 207, 207, 207) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlagType_TestData))]
         public void SetOutputChannel_FlagType_Success(ColorChannelFlag flag, ColorAdjustType type, Color actualColor, Color expectedColor)
@@ -1073,7 +1073,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { ColorChannelFlag.ColorChannelY, ColorAdjustType.Text, Color.FromArgb(255, 100, 100, 100) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(SetOutputChannel_ColorChannelFlagTypeI_TestData))]
         public void SetOutputChannel_FlagTypeI_Success(ColorChannelFlag flag, ColorAdjustType type, Color color)
@@ -1090,7 +1090,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannel_Disposed_ThrowsArgumentException()
         {
@@ -1101,7 +1101,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetOutputChannel_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1121,7 +1121,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { (ColorChannelFlag)int.MaxValue };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(SetOutputChannel_InvalidColorChannelFlags_TestData))]
         public void SetOutputChannel_InvalidFlags_ThrowsArgumentException(ColorChannelFlag flag)
@@ -1133,7 +1133,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearOutputChannel_Success()
         {
@@ -1150,7 +1150,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearOutputChannel_Type_Success(ColorAdjustType type)
@@ -1168,7 +1168,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearOutputChannel_Disposed_ThrowsArgumentException()
         {
@@ -1179,7 +1179,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearOutputChannel_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1190,7 +1190,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannelColorProfile_Name_Success()
         {
@@ -1206,7 +1206,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannelColorProfile_Disposed_ThrowsArgumentException()
         {
@@ -1229,7 +1229,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(22309)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22309")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannelColorProfile_InvalidPath_ThrowsArgumentException()
         {
@@ -1240,7 +1240,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannelColorProfile_InvalidPath_ThrowsOutOfMemoryException()
         {
@@ -1251,7 +1251,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetOutputChannelColorProfile_InvalidPath_ThrowsPathTooLongException()
         {
@@ -1263,7 +1263,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void SetOutputChannelColorProfile_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1274,7 +1274,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearOutputChannelColorProfile_Success()
         {
@@ -1292,7 +1292,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearOutputChannelColorProfile_Type_Success(ColorAdjustType type)
@@ -1311,7 +1311,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearOutputChannelColorProfile_Disposed_ThrowsArgumentException()
         {
@@ -1322,7 +1322,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void ClearOutputChannelColorProfile_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
@@ -1415,7 +1415,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetRemapTable_EmptyMap_ThrowsArgumentException()
         {
@@ -1425,7 +1425,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ClearRemapTable_Success()
         {
@@ -1441,7 +1441,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_AllTypesAllowed_TestData))]
         public void ClearRemapTable_Type_Success(ColorAdjustType type)
@@ -1489,7 +1489,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetAdjustedPalette_Disposed_ThrowsArgumentException()
         {
@@ -1511,7 +1511,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
         public void GetAdjustedPalette_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)

--- a/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -43,7 +43,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Metafile(IntPtr.Zero, false));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_IntPtrToWmf_ThrowsExternalException()
         {
@@ -111,7 +111,7 @@ namespace System.Drawing.Imaging.Tests
             AssertExtensions.Throws<ArgumentNullException, ArgumentException>("stream", null, () => new Metafile((Stream)null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_EmptyStream_ThrowsExternalException()
         {
@@ -190,7 +190,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(InvalidPath_TestData))]
         public void Ctor_ZeroPointerEmfTypeInvalidString_ThrowsArgumentException(string description)
@@ -955,7 +955,7 @@ namespace System.Drawing.Imaging.Tests
             Assert.Throws<NullReferenceException>(() => Metafile.GetMetafileHeader((Stream)null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Static_GetMetafileHeader_EmptyStream_ArgumentException()
         {
@@ -995,7 +995,7 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHenhmetafile_Disposed_ThrowsArgumentException()
         {

--- a/src/libraries/System.Drawing.Common/tests/Imaging/PropertyItemTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/PropertyItemTests.cs
@@ -39,7 +39,7 @@ namespace System.Drawing.Imaging.Tests
             yield return new object[] { 0, 0, 0, new byte[0] };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Properties_TestData))]
         public void Properties_SetValues_ReturnsExpected(int id, int len, short type, byte[] value)

--- a/src/libraries/System.Drawing.Common/tests/Printing/PageSettingsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PageSettingsTests.cs
@@ -34,7 +34,7 @@ namespace System.Drawing.Printing.Tests
 
     public class PageSettingsTests
     {
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void Clone_Success()
         {

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -37,7 +37,7 @@ namespace System.Drawing.Printing.Tests
             }
         };
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void Ctor_Default_Success()
         {
@@ -49,7 +49,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void DefaultPageSettings_SetValue_ReturnsExpected()
         {
@@ -64,8 +64,8 @@ namespace System.Drawing.Printing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(39381)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39381")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         public void DefaultPageSettings_Null_ReturnsExpected()
         {
             using (var document = new PrintDocument())
@@ -87,7 +87,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void DocumentName_Null_ReturnsExpected()
         {
@@ -110,7 +110,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void PrintController_SetValue_ReturnsExpected()
         {
@@ -125,7 +125,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void PrinterSettings_SetValue_ReturnsExpected()
         {
@@ -149,7 +149,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void BeginPrint_SetValue_ReturnsExpected()
         {
@@ -170,8 +170,8 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ActiveIssue(30223)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30223")]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void EndPrint_SetValue_ReturnsExpected()
         {
@@ -192,8 +192,8 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
-        [ActiveIssue(30223)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/30223")]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void PrintPage_SetValue_ReturnsExpected()
         {
@@ -214,7 +214,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void QueryPageSettings_SetValue_ReturnsExpected()
         {

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -43,7 +43,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotNull(printerSettings.DefaultPageSettings);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void CanDuplex_ReturnsExpected()
         {
@@ -119,7 +119,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Equal(duplex, printerSettings.Duplex);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(Duplex.Default - 1)]
         [InlineData(Duplex.Horizontal + 1)]
@@ -182,7 +182,7 @@ namespace System.Drawing.Printing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         public void IsValid_ReturnsExpected()
         {
             var printerSettings = new PrinterSettings()
@@ -279,7 +279,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Equal(printFileName, printerSettings.PrintFileName);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Fact]
         public void PrintFileName_Null_ThrowsArgumentNullException()
         {
@@ -287,7 +287,7 @@ namespace System.Drawing.Printing.Tests
             AssertExtensions.Throws<ArgumentNullException>(null, () => printerSettings.PrintFileName = null);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Fact]
         public void PrintFileName_Empty_ThrowsArgumentNullException()
         {
@@ -295,7 +295,7 @@ namespace System.Drawing.Printing.Tests
             AssertExtensions.Throws<ArgumentNullException>(string.Empty, () => printerSettings.PrintFileName = string.Empty);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void PaperSizes_ReturnsExpected()
         {
@@ -303,7 +303,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotNull(printerSettings.PaperSizes);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void PaperSources_ReturnsExpected()
         {
@@ -311,7 +311,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotNull(printerSettings.PaperSources);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Theory]
         [InlineData(PrintRange.AllPages)]
         [InlineData(PrintRange.CurrentPage)]
@@ -350,7 +350,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Equal(printToFile, printerSettings.PrintToFile);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Theory]
         [InlineData("")]
         [InlineData("My printer")]
@@ -364,7 +364,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Equal(printerName, printerSettings.PrinterName);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void PrinterName_Null_ReturnsExpected()
         {
@@ -376,7 +376,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotNull(printerSettings.PrinterName);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void PrinterResolutions_ReturnsExpected()
         {
@@ -390,7 +390,7 @@ namespace System.Drawing.Printing.Tests
             yield return new object[] { ImageFormat.Png };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         [MemberData(nameof(IsDirectPrintingSupported_ImageFormatSupported_TestData))]
         public void IsDirectPrintingSupported_ImageFormatSupported_ReturnsExpected(ImageFormat imageFormat)
@@ -411,7 +411,7 @@ namespace System.Drawing.Printing.Tests
             yield return new object[] { ImageFormat.Bmp };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(IsDirectPrintingSupported_ImageFormatNotSupported_TestData))]
         public void IsDirectPrintingSupported_ImageFormatNotSupported_ReturnsExpected(ImageFormat imageFormat)
@@ -420,7 +420,7 @@ namespace System.Drawing.Printing.Tests
             Assert.False(printerSettings.IsDirectPrintingSupported(imageFormat));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsDirectPrintingSupported_ImageNotSupported_ReturnsExpected()
         {
@@ -431,7 +431,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported)]
         public void SupportsColor_ReturnsExpected()
         {
@@ -469,7 +469,7 @@ namespace System.Drawing.Printing.Tests
             Assert.False(ReferenceEquals(clone, printerSettings));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void CreateMeasurementGraphics_Default_ReturnsExpected()
         {
@@ -484,7 +484,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void CreateMeasurementGraphics_Bool_ReturnsExpected()
         {
@@ -497,7 +497,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void CreateMeasurementGraphics_PageSettings_ReturnsExpected()
         {
@@ -513,7 +513,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void CreateMeasurementGraphics_PageSettingsBool_ReturnsExpected()
         {
@@ -527,7 +527,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/corefx/issues/29858
         public void CreateMeasurementGraphics_Null_ThrowsNullReferenceException()
         {
@@ -536,7 +536,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Throws<NullReferenceException>(() => printerSettings.CreateMeasurementGraphics(null, true));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdevmode_ReturnsExpected()
         {
@@ -547,7 +547,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotEqual(IntPtr.Zero, handle);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdevmode_PageSettings_ReturnsExpected()
         {
@@ -559,7 +559,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotEqual(IntPtr.Zero, handle);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdevmode_Null_ThrowsNullReferenceException()
         {
@@ -567,7 +567,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Throws<NullReferenceException>(() => printerSettings.GetHdevmode(null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdevnames_ReturnsExpected()
         {
@@ -578,7 +578,7 @@ namespace System.Drawing.Printing.Tests
             Assert.NotEqual(IntPtr.Zero, handle);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(typeof(PrinterSettingsTests), nameof(CanTestSetHdevmode_IntPtr_Success))]
         public void SetHdevmode_IntPtr_Success()
         {
@@ -615,7 +615,7 @@ namespace System.Drawing.Printing.Tests
             "Microsoft XPS Document Writer", // Backup for older Windows
         };
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdevmode_Zero_ThrowsArgumentException()
         {
@@ -623,7 +623,7 @@ namespace System.Drawing.Printing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => printerSettings.SetHdevmode(IntPtr.Zero));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SetHdevnames_IntPtr_Success()
         {
@@ -634,7 +634,7 @@ namespace System.Drawing.Printing.Tests
             Assert.Equal(newPrinterSettings.PrinterName, printerSettings.PrinterName);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToString_ReturnsExpected()
         {

--- a/src/libraries/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/RegionTests.cs
@@ -51,7 +51,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1, -2, -3, -4, true)]
         [InlineData(0, 0, 0, 0, true)]
@@ -68,7 +68,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(1, 2, 3, float.NegativeInfinity, true)]
         [InlineData(-1, -2, -3, -4, true)]
@@ -139,7 +139,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentNullException>("rgnData", () => new Region((RegionData)null));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0)]
         [InlineData(1)]
@@ -155,7 +155,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_EmptyGraphicsPath_ThrowsExternalException()
         {
@@ -178,7 +178,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_GraphicsPath()
         {
@@ -242,7 +242,7 @@ namespace System.Drawing.Tests
             yield return new object[] { path6, true };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_InfiniteGraphicsPath_TestData))]
         public void Ctor_InfiniteGraphicsPath_IsInfinite(GraphicsPath path, bool isInfinite)
@@ -454,7 +454,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Region().Complement(CreateDisposedRegion()));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_SameRegion_ThrowsInvalidOperationException()
         {
@@ -522,7 +522,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(24525, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24525", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_GraphicsPathWithMultipleRectangles_Success()
         {
@@ -636,7 +636,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Region(graphics1), new Region(graphics6), false };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Equals_TestData))]
         public void Equals_Valid_ReturnsExpected(Region region, Region other, bool expected)
@@ -898,7 +898,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Region().Exclude(CreateDisposedRegion()));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Exclude_SameRegion_ThrowsInvalidOperationException()
         {
@@ -908,7 +908,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Exclude_TestData))]
         public void Exclude_Rectangle_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -927,7 +927,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Exclude_TestData))]
         public void Exclude_RectangleF_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -946,7 +946,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Exclude_TestData))]
         public void Exclude_GraphicsPath_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -1059,7 +1059,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHrgn_NullGraphics_ThrowsArgumentNullException()
         {
@@ -1117,7 +1117,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetRegionData());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetRegionScans_CustomMatrix_TransformsRegionScans()
         {
@@ -1151,7 +1151,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetRegionScans_DisposedMatrix_ThrowsArgumentException()
         {
@@ -1237,7 +1237,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Intersect_TestData))]
         public void Intersect_Region_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -1287,7 +1287,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Region().Intersect(CreateDisposedRegion()));
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Intersect_SameRegion_ThrowsInvalidOperationException()
         {
@@ -1361,7 +1361,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Intersect_TestData))]
         public void Intersect_GraphicsPath_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -1836,7 +1836,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Union_TestData))]
         public void Union_Region_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -1858,7 +1858,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Union_InfiniteRegion_Success()
         {
@@ -1890,7 +1890,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Union_SameRegion_ThrowsInvalidOperationException()
         {
@@ -2158,7 +2158,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(float.MaxValue)]
         [InlineData(float.MinValue)]
@@ -2244,7 +2244,7 @@ namespace System.Drawing.Tests
             };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Xor_TestData))]
         public void Xor_Region_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -2303,7 +2303,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Xor_SameRegion_ThrowsInvalidOperationException()
         {
@@ -2313,7 +2313,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Xor_TestData))]
         public void Xor_Rectangle_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -2332,7 +2332,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Xor_TestData))]
         public void Xor_RectangleF_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)
@@ -2351,7 +2351,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Xor_TestData))]
         public void Xor_GraphicsPath_Success(Region region, RectangleF[] rectangles, RectangleF[] expectedScans)

--- a/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
@@ -14,7 +14,7 @@ namespace System.Drawing.Tests
             yield return new object[] { Color.PapayaWhip, Color.PapayaWhip };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Colors_TestData))]
         public void Ctor_Color(Color color, Color expectedColor)
@@ -60,7 +60,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Color_EmptyAndGetDisposed_ThrowsArgumentException()
         {

--- a/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
@@ -136,7 +136,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => format.Clone());
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0, StringDigitSubstitute.None, 0)]
         [InlineData(EnglishLanguageCode, StringDigitSubstitute.Traditional, EnglishLanguageCode)]

--- a/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -77,7 +77,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddFontFile_SameNameMultipleTimes_FamiliesContainsFirstFontOnly()
         {
@@ -101,7 +101,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddFontFile_NullFileName_ThrowsArgumentNullException()
         {
@@ -158,7 +158,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddFontFile_Disposed_ThrowsArgumentException()
         {
@@ -200,7 +200,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(0)]
         [InlineData(-1)]
@@ -229,7 +229,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void AddMemoryFont_Disposed_ThrowsArgumentException()
         {

--- a/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -17,7 +17,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Metafile(Helpers.GetTestBitmapPath("telescope_01.wmf")), PixelFormat.Format32bppArgb, new Size(490, 654) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Bitmap_TestData))]
         public void Ctor_Bitmap(Image bitmap, PixelFormat expectedPixelFormat, Size expectedSize)
@@ -41,7 +41,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_BitmapFromIconHandle_Success()
         {
@@ -64,7 +64,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_WrapMode_TestData))]
         public void Ctor_Image_WrapMode(Image image, WrapMode wrapMode, PixelFormat expectedPixelFormat, Size expectedSize)
@@ -94,7 +94,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(10, 10), new Rectangle(5, 5, 5, 5) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_Rectangle_TestData))]
         public void Ctor_Image_Rectangle(Image image, Rectangle rectangle)
@@ -118,7 +118,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_Rectangle_TestData))]
         public void Ctor_Image_RectangleF(Image image, Rectangle rectangle)
@@ -154,7 +154,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_WrapMode_Rectangle_TestData))]
         public void Ctor_Image_WrapMode_Rectangle(Image image, WrapMode wrapMode, Rectangle rectangle)
@@ -178,7 +178,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_WrapMode_Rectangle_TestData))]
         public void Ctor_Image_WrapMode_RectangleF(Image image, WrapMode wrapMode, Rectangle rectangle)
@@ -215,7 +215,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_Rectangle_ImageAttributes_TestData))]
         public void Ctor_Image_Rectangle_ImageAttributes(Image image, Rectangle rectangle, ImageAttributes attributes, WrapMode expectedWrapMode)
@@ -240,7 +240,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Image_Rectangle_ImageAttributes_TestData))]
         public void Ctor_Image_RectangleF_ImageAttributes(Image image, Rectangle rectangle, ImageAttributes attributes, WrapMode expectedWrapMode)
@@ -449,7 +449,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(MatrixOrder.Prepend - 1)]
         [InlineData(MatrixOrder.Append + 1)]
@@ -841,7 +841,7 @@ namespace System.Drawing.Tests
             });
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void WrapMode_TileFlipX_ReturnsExpected()
         {
@@ -858,7 +858,7 @@ namespace System.Drawing.Tests
             });
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void WrapMode_TileFlipY_ReturnsExpected()
         {
@@ -875,7 +875,7 @@ namespace System.Drawing.Tests
             });
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void WrapMode_TileFlipXY_ReturnsExpected()
         {

--- a/src/libraries/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -43,7 +43,7 @@ namespace System.Drawing.Tests
             yield return new object[] { Helpers.GetTestBitmapPath("invalid.ico"), new Size(0, 0) };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_FileName_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
@@ -64,7 +64,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(null, -1, -1)]
         [InlineData(typeof(ClassWithNoNamespace), -1, -1)]
@@ -86,7 +86,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(null, null, -1, -1)]
         [InlineData(null, "invalid.ico", -1, -1)]
@@ -133,7 +133,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetImage_NullComponent_ReturnsNull()
         {
@@ -158,7 +158,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetImage_Default_ReturnsExpected()
         {
@@ -175,7 +175,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Logical name with no extension is not supported in desktop framework")]
         [InlineData(typeof(Icon_toolboxBitmapAttributeTest), 256, 256)]
@@ -204,7 +204,7 @@ namespace System.Drawing.Tests
             yield return new object[] { ToolboxBitmapAttribute.Default, null, false };
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Equals_TestData))]
         public void Equals_Other_ReturnsExpected(ToolboxBitmapAttribute attribute, object other, bool expected)

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/BmpCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/BmpCodecTests.cs
@@ -249,7 +249,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap24bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/GifCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/GifCodecTests.cs
@@ -109,7 +109,7 @@ namespace MonoTests.System.Drawing.Imaging
             Bitmap8bitsPixels(Helpers.GetTestBitmapPath("nature24bits87.gif"));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap8bitsData()
         {
             string sInFile = Helpers.GetTestBitmapPath("nature24bits.gif");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
@@ -186,7 +186,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap16Data()
         {
             string sInFile = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");
@@ -421,7 +421,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap32Data()
         {
             string sInFile = Helpers.GetTestBitmapPath("VisualPng.ico");
@@ -663,7 +663,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap48Data()
         {
             string sInFile = Helpers.GetTestBitmapPath("48x48_one_entry_1bit.ico");
@@ -889,7 +889,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap64Data()
         {
             string sInFile = Helpers.GetTestBitmapPath("64x64_one_entry_8bit.ico");
@@ -1686,7 +1686,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap96Data()
         {
             string sInFile = Helpers.GetTestBitmapPath("96x96_one_entry_8bit.ico");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/JpegCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/JpegCodecTests.cs
@@ -112,7 +112,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotWindows7), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotWindows7), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap8bbpIndexedGreyscaleData()
         {
             string sInFile = Helpers.GetTestBitmapPath("nature-greyscale.jpg");
@@ -233,7 +233,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap24bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("almogaver24bits.bmp");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTesst.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTesst.cs
@@ -37,7 +37,7 @@ using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging
 {
-    [ActiveIssue(24354, TestPlatforms.AnyUnix)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/24354", TestPlatforms.AnyUnix)]
     public class PngCodecTest
     {
         private bool IsArm64Process()

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TiffCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TiffCodecTests.cs
@@ -65,7 +65,7 @@ namespace MonoTests.System.Drawing.Imaging
 
         /* Checks bitmap features on a known 32bbp bitmap */
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         public void Bitmap32bitsPixelFormat()
         {
             string sInFile = Helpers.GetTestBitmapPath("almogaver32bits.tif");
@@ -122,7 +122,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void Bitmap32bitsData()
         {
             string sInFile = Helpers.GetTestBitmapPath("almogaver32bits.tif");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -65,7 +65,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void LockBits_IndexedWrite_NonIndexed()
         {
             using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format8bppIndexed))
@@ -76,7 +76,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void LockBits_NonIndexedWrite_ToIndexed()
         {
             using (Bitmap bmp = new Bitmap(100, 100, PixelFormat.Format32bppRgb))
@@ -90,7 +90,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBits_ImageLockMode_Invalid()
         {
             using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format24bppRgb))
@@ -298,7 +298,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void Format32bppRgb()
         {
             FormatTest(PixelFormat.Format32bppRgb);
@@ -507,7 +507,7 @@ namespace MonoTests.System.Drawing
 
         // Rotate 1- and 4-bit bitmaps in different ways and check the
         // resulting pixels using MD5
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         [InlineData("1bit.png", RotateFlipType.Rotate180FlipNone, "64AE60858A02228F7B1B18C7812FB6")]
         [InlineData("1bit.png", RotateFlipType.Rotate180FlipX, "353E937CFF31B1BF6C3DD0A031ACB5")]
         [InlineData("1bit.png", RotateFlipType.Rotate180FlipXY, "A4DAF507C92BDE10626BC7B34FEFE5")]
@@ -630,7 +630,7 @@ namespace MonoTests.System.Drawing
         private static byte[] DefaultBitmapHash = new byte[] { 0xD8, 0xD3, 0x68, 0x9C, 0x86, 0x7F, 0xB6, 0xA0, 0x76, 0xD6, 0x00, 0xEF, 0xFF, 0xE5, 0x8E, 0x1B };
         private static byte[] FinalWholeBitmapHash = new byte[] { 0x5F, 0x52, 0x98, 0x37, 0xE3, 0x94, 0xE1, 0xA6, 0x06, 0x6C, 0x5B, 0xF1, 0xA9, 0xC2, 0xA9, 0x43 };
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format32bppArgb_ReadWrite_Whole()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -643,7 +643,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format32bppPArgb_ReadWrite_Whole()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -657,7 +657,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void LockBitmap_Format32bppArgb_Format32bppRgb_ReadWrite_Whole()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -670,7 +670,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format24bppRgb_ReadWrite_Whole()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -685,7 +685,7 @@ namespace MonoTests.System.Drawing
 
         private static byte[] FinalPartialBitmapHash = new byte[] { 0xED, 0xD8, 0xDC, 0x9B, 0x44, 0x00, 0x22, 0x9B, 0x07, 0x06, 0x4A, 0x21, 0x70, 0xA7, 0x31, 0x1D };
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format32bppArgb_ReadWrite_Partial()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -698,7 +698,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format32bppPArgb_ReadWrite_Partial()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -712,7 +712,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20884)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884")]
         public void LockBitmap_Format32bppArgb_Format32bppRgb_ReadWrite_Partial()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -725,7 +725,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockBitmap_Format32bppArgb_Format24bppRgb_ReadWrite_Partial()
         {
             using (Bitmap bmp = CreateBitmap(100, 100, PixelFormat.Format32bppArgb))
@@ -740,7 +740,7 @@ namespace MonoTests.System.Drawing
 
         // Tests the LockBitmap and UnlockBitmap functions, specifically the copying
         // of bitmap data in the directions indicated by the ImageLockMode.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35744)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/35744")]
         public void LockUnlockBitmap()
         {
             BitmapData data;
@@ -901,7 +901,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void Serialize_Icon()
         {
             // this cause a problem with resgen, see http://bugzilla.ximian.com/show_bug.cgi?id=80565

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1892,7 +1892,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void MeasureString_MultlineString_Width()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -2810,21 +2810,21 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844, TestPlatforms.Any)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844", TestPlatforms.Any)]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Document()
         {
             Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Document));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Inch()
         {
             Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Inch));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844, TestPlatforms.Any)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844", TestPlatforms.Any)]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Millimeter()
         {
             Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Millimeter));
@@ -2838,7 +2838,7 @@ namespace MonoTests.System.Drawing
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844, TestPlatforms.Any)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844", TestPlatforms.Any)]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Point()
         {
             Assert.Throws<NotImplementedException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Point));
@@ -3208,7 +3208,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20884", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints()
         {

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -372,21 +372,21 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void CreateFilename_SingleGraphics_EmfOnly()
         {
             CreateFilename(EmfType.EmfOnly, true);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void CreateFilename_SingleGraphics_EmfPlusDual()
         {
             CreateFilename(EmfType.EmfPlusDual, true);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue(20844)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20844")]
         public void CreateFilename_SingleGraphics_EmfPlusOnly()
         {
             CreateFilename(EmfType.EmfPlusOnly, true);

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -66,7 +66,7 @@ namespace System.IO.Compression.Tests
         /// This test ensures that a zipfile with path names that are invalid to this OS will throw errors
         /// when an attempt is made to extract them.
         /// </summary>
-        [ActiveIssue(25665)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25665")]
         [Theory]
         [InlineData("NullCharFileName_FromWindows")]
         [InlineData("NullCharFileName_FromUnix")]
@@ -96,7 +96,7 @@ namespace System.IO.Compression.Tests
         /// when an attempt is made to extract them.
         /// </summary>
         [Theory]
-        [ActiveIssue(27269)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/27269")]
         [InlineData("WindowsInvalid_FromUnix", null)]
         [InlineData("WindowsInvalid_FromWindows", null)]
         [InlineData("NullCharFileName_FromWindows", "path")]

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/DirectoryObjectSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/DirectoryObjectSecurityTests.cs
@@ -68,7 +68,7 @@ namespace System.Security.AccessControl
         }
 
         [Fact]
-        [ActiveIssue(24903, TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24903", TargetFrameworkMonikers.NetFramework)]
         public void GetAccessRules_InvalidTargetType()
         {
             var activeDirectorySecurity = new ActiveDirectorySecurity();

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -31,7 +31,7 @@ namespace System.IO.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        [ActiveIssue(42507, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/42507", TestPlatforms.OSX)]
         public void Directory_Move_Multiple_From_Watched_To_Unwatched_Mac(int filesCount)
         {
             // On Mac, the FSStream aggregate old events caused by the test setup.

--- a/src/libraries/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
@@ -13,7 +13,7 @@ namespace System.IO.Tests
         protected abstract void InvokeCreate(T item);
 
         [Fact]
-        [ActiveIssue(39108)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39108")]
         public void DoesntExistThenCreate_ReturnsDefaultValues()
         {
             T item = GetMissingItem();

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -508,7 +508,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(1221)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
         [PlatformSpecific(TestPlatforms.Windows)] // testing drive labels
         public void NotReadyDriveAsPath_ThrowsDirectoryNotFoundException()
         {   // Behavior is suspect, should really have thrown IOException similar to the SubDirectory case
@@ -527,7 +527,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // testing drive labels
-        [ActiveIssue(1221)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
         public void SubdirectoryOnNotReadyDriveAsPath_ThrowsIOException()
         {
             var drive = IOServices.GetNotReadyDrive();

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -254,7 +254,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(24242)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/24242")]
         [PlatformSpecific(TestPlatforms.Windows)]
         [OuterLoop("This test is very slow.")]
         public void RecursiveDelete_DeepNesting()

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete_MountVolume.cs
@@ -22,7 +22,7 @@ public class Directory_Delete_MountVolume
     private static bool s_pass = true;
 
     [Fact]
-    [ActiveIssue(1221)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
     [PlatformSpecific(TestPlatforms.Windows)] // testing volumes / mounts / drive letters
     public static void RunTest()
     {

--- a/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Tests
     public class EnumerableTests : FileSystemTest
     {
         [Fact]
-        [ActiveIssue(25613, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25613", TestPlatforms.AnyUnix)]
         public void FileEnumeratorIsThreadSafe()
         {
             string directory = Directory.CreateDirectory(GetTestFilePath()).FullName;

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -329,7 +329,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(1221)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
         [PlatformSpecific(TestPlatforms.Windows)] // drive labels
         public void NotReadyDriveAsPath_ReturnsFalse()
         {
@@ -346,7 +346,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(1221)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
         [PlatformSpecific(TestPlatforms.Windows)] // drive labels
         public void SubdirectoryOnNotReadyDriveAsPath_ReturnsFalse()
         {

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -218,7 +218,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20779, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20779", TestPlatforms.AnyUnix)]
         [Theory,
             // Question marks collapse (right) to periods
             InlineData(
@@ -243,8 +243,8 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20779, TestPlatforms.AnyUnix)]
-        [ActiveIssue(20780, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20779", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20780", TestPlatforms.AnyUnix)]
         [Theory,
             // Periods are optional if left of ? and end of match
             InlineData(
@@ -284,7 +284,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20780, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20780", TestPlatforms.AnyUnix)]
         [Theory,
             // Periods are optional if left of * and end of match
             InlineData(
@@ -304,7 +304,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20780, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20780", TestPlatforms.AnyUnix)]
         // Can't do these without extended path support on Windows, UsingNewNormalization filters appropriately
         [ConditionalTheory(nameof(UsingNewNormalization)),
             // Periods are optional if left of * or ? and end of match
@@ -349,7 +349,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20781, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20781", TestPlatforms.AnyUnix)]
         [Theory,
             InlineData(
                 "foo*.",
@@ -363,7 +363,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20781, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20781", TestPlatforms.AnyUnix)]
         // Can't do these without extended path support on Windows, UsingNewNormalization filters appropriately
         [ConditionalTheory(nameof(UsingNewNormalization)),
             InlineData(
@@ -409,7 +409,7 @@ namespace System.IO.Tests
             ValidatePatternMatch(expected, GetEntries(testDir, pattern));
         }
 
-        [ActiveIssue(20781, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20781", TestPlatforms.AnyUnix)]
         [OuterLoop("These are pretty corner, don't need to run all the time.")]
         [Theory,
             // "foo*." actually becomes "foo<" when passed to NT. It matches all characters up to, and including, the final period.

--- a/src/libraries/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/ReparsePoints_MountVolume.cs
@@ -19,7 +19,7 @@ public class Directory_ReparsePoints_MountVolume
     private static bool s_pass = true;
 
     [Fact]
-    [ActiveIssue(1221)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/1221")]
     [PlatformSpecific(TestPlatforms.Windows)] // testing mounting volumes and reparse points
     public static void runTest()
     {

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -42,7 +42,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(39230)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39230")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes
         public async Task FifoReadWriteViaFileStream()
         {

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -3752,7 +3752,7 @@ namespace System.IO.Packaging.Tests
             }
         }
 
-        [ActiveIssue(39075)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39075")]
         [Fact]
         [OuterLoop]
         public void VeryLargePart()

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
@@ -28,7 +28,7 @@ namespace System.IO.Pipes.Tests
         {
             if (PlatformDetection.IsFedora)
             {
-                // [ActiveIssue(38834)]
+                // [ActiveIssue("https://github.com/dotnet/corefx/issues/38834")]
                 throw new SkipTestException("Failing on Fedora by not throwing expected exception");
             }
 

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.RunAsClient.Unix.cs
@@ -27,7 +27,7 @@ namespace System.IO.Pipes.Tests
 
         [ConditionalFact(nameof(IsSuperUser))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Uses P/Invokes
-        [ActiveIssue(0)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/0")]
         public void RunAsClient_Unix()
         {
             string pipeName = Path.GetRandomFileName();

--- a/src/libraries/System.IO.Ports/tests/SerialPort/ReadTimeout.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/ReadTimeout.cs
@@ -33,7 +33,7 @@ namespace System.IO.Ports.Tests
 
         #region Test Cases
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Default_Read_byte_int_int()
         {
@@ -41,7 +41,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(Read_byte_int_int, false);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Default_Read_char_int_int()
         {
@@ -49,7 +49,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(Read_char_int_int, false);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Default_ReadByte()
         {
@@ -57,7 +57,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadByte, false);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Default_ReadLine()
         {
@@ -65,7 +65,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadLine, false);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Default_ReadTo()
         {
@@ -73,7 +73,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadTo, false);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Infinite_Read_byte_int_int()
         {
@@ -81,7 +81,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(Read_byte_int_int, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Infinite_Read_char_int_int()
         {
@@ -89,7 +89,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(Read_char_int_int, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Infinite_ReadByte()
         {
@@ -97,7 +97,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadByte, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Infinite_ReadLine()
         {
@@ -105,7 +105,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadLine, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
         public void ReadTimeout_Infinite_ReadTo()
         {
@@ -113,7 +113,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(ReadTo, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_Read_byte_int_int_BeforeOpen()
         {
@@ -121,7 +121,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutBeforeOpen(Read_byte_int_int);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_Read_char_int_int_BeforeOpen()
         {
@@ -129,7 +129,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutBeforeOpen(Read_char_int_int);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadByte_BeforeOpen()
         {
@@ -137,7 +137,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutBeforeOpen(ReadByte);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadLine_BeforeOpen()
         {
@@ -145,7 +145,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutBeforeOpen(ReadLine);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadTo_BeforeOpen()
         {
@@ -153,7 +153,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutBeforeOpen(ReadTo);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_Read_byte_int_int_AfterOpen()
         {
@@ -161,7 +161,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutAfterOpen(Read_byte_int_int);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_Read_char_int_int_AfterOpen()
         {
@@ -169,7 +169,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutAfterOpen(Read_char_int_int);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadByte_AfterOpen()
         {
@@ -177,7 +177,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutAfterOpen(ReadByte);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadLine_AfterOpen()
         {
@@ -185,7 +185,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutAfterOpen(ReadLine);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_0_ReadTo_AfterOpen()
         {
@@ -193,7 +193,7 @@ namespace System.IO.Ports.Tests
             VerifyZeroTimeoutAfterOpen(ReadTo);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_Int32MinValue()
         {
@@ -202,7 +202,7 @@ namespace System.IO.Ports.Tests
             VerifyException(int.MinValue, ThrowAt.Set, typeof(ArgumentOutOfRangeException));
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort))]
         public void ReadTimeout_NEG2()
         {

--- a/src/libraries/System.IO.Ports/tests/SerialPort/WriteTimeout.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/WriteTimeout.cs
@@ -73,7 +73,7 @@ namespace System.IO.Ports.Tests
             VerifyInfiniteTimeout(Write_byte_int_int, true);
         }
 
-        [ActiveIssue(15961)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/15961")]
         [ConditionalFact(nameof(HasOneSerialPort), nameof(HasHardwareFlowControl))]
         public void WriteTimeout_Infinite_Write_char_int_int()
         {

--- a/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        [ActiveIssue(13007)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13007")]
         public static void Left_ValueTypeContainsChildTryExpression(bool useInterpreter)
         {
             Expression tryExpression = Expression.TryFinally(
@@ -305,7 +305,7 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
-        [ActiveIssue(13007)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13007")]
         public static void ValueTypeIndexAssign(bool useInterpreter)
         {
             Expression index = Expression.Property(Expression.Constant(new StructWithPropertiesAndFields()), typeof(StructWithPropertiesAndFields).GetProperty("Item"), new Expression[] { Expression.Constant(1) });

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -975,7 +975,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, func());
         }
 
-        [Fact, ActiveIssue(15719)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/15719")]
         public void TryFinallyWithinFilterCompiled()
         {
             TryFinallyWithinFilter(false);
@@ -1036,7 +1036,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, func());
         }
 
-        [Fact, ActiveIssue(15719)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/15719")]
         public void TryCatchWithinFilterCompiled()
         {
             TryCatchWithinFilter(false);
@@ -1066,7 +1066,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(2, func());
         }
 
-        [Fact, ActiveIssue(15719)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/15719")]
         public void TryCatchThrowingWithinFilterCompiled()
         {
             TryCatchThrowingWithinFilter(false);

--- a/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(16, x);
         }
 
-        [Fact, ActiveIssue(13458)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/13458")]
         public void CreateByRefAliasingInterpreted()
         {
             CreateByRefAliasing(useInterpreter: true);

--- a/src/libraries/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/Combinatorial/CancellationParallelQueryCombinationTests.cs
@@ -605,7 +605,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [ActiveIssue(21876, TestPlatforms.Linux)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/21876", TestPlatforms.Linux)]
         [MemberData(nameof(UnaryCancelingOperators))]
         [MemberData(nameof(BinaryCancelingOperators))]
         [MemberData(nameof(OrderCancelingOperators))]

--- a/src/libraries/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -128,7 +128,7 @@ namespace System.SpanTests
         // the residual chunk of size (bufferSize % 4GB). The inputs sizes to this method, 4GB and 4GB+256B,
         // test the two size selection paths in CoptyTo method - memory size that is multiple of 4GB or,
         // a multiple of 4GB + some more size.
-        [ActiveIssue(25254)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25254")]
         [Theory]
         [OuterLoop]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]

--- a/src/libraries/System.Memory/tests/Span/CopyTo.cs
+++ b/src/libraries/System.Memory/tests/Span/CopyTo.cs
@@ -197,7 +197,7 @@ namespace System.SpanTests
         // the residual chunk of size (bufferSize % 4GB). The inputs sizes to this method, 4GB and 4GB+256B,
         // test the two size selection paths in CoptyTo method - memory size that is multiple of 4GB or,
         // a multiple of 4GB + some more size.
-        [ActiveIssue(25254)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25254")]
         [Theory]
         [OuterLoop]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -98,7 +98,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
-        [ActiveIssue(17234)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17234")]
         [OuterLoop] // TODO: Issue #11345
         [Fact]
         [OuterLoop]

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.Enterprise.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [ActiveIssue(416)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/416")]
         [Fact]
         public async Task HttpClient_InvalidAuthentication_Failure()
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -130,7 +130,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop("Uses external server")]
-        [ActiveIssue(10041)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/10041")]
         [ConditionalTheory(nameof(DomainJoinedTestsEnabled))]
         [InlineData(false)]
         [InlineData(true)]
@@ -152,7 +152,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop("Uses external server")]
-        [ActiveIssue(10041)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/10041")]
         [ConditionalFact(nameof(DomainProxyTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithNoCredentials_ProxyAuthenticationRequired()
         {
@@ -167,7 +167,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop("Uses external server")]
-        [ActiveIssue(10041)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/10041")]
         [ConditionalFact(nameof(DomainProxyTestsEnabled))]
         public async Task Proxy_UseAuthenticatedProxyWithDefaultCredentials_OK()
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -175,7 +175,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseHttp2.ToString()).Dispose();
         }
 
-        [ActiveIssue(23771, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23771", TestPlatforms.AnyUnix)]
         [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]
@@ -270,7 +270,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseHttp2.ToString()).Dispose();
         }
 
-        [ActiveIssue(23209)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23209")]
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledLogging()
@@ -1046,7 +1046,7 @@ namespace System.Net.Http.Functional.Tests
             }, switchValue.ToString()).Dispose();
         }
 
-        [ActiveIssue(23209)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23209")]
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledActivityLogging()

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -122,7 +122,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [ActiveIssue(28805)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/28805")]
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -179,7 +179,7 @@ namespace System.Net.Http.Functional.Tests
             }, options);
         }
 
-        [ActiveIssue(37336)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37336")]
         [Theory]
         [InlineData(ClientCertificateOption.Manual)]
         [InlineData(ClientCertificateOption.Automatic)]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -76,7 +76,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ActiveIssue(42323)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/42323")]
         [OuterLoop("Uses external server")]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
         [Theory]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -209,7 +209,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(35466)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/35466")]
         [ConditionalTheory(nameof(SupportsAlpn))]
         [InlineData(SettingId.MaxFrameSize, 16383, ProtocolErrors.PROTOCOL_ERROR)]
         [InlineData(SettingId.MaxFrameSize, 162777216, ProtocolErrors.PROTOCOL_ERROR)]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
@@ -47,7 +47,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.False(proxy.Disposed);
         }
 
-        [ActiveIssue(32809)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/32809")]
         [OuterLoop("Uses external server")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(AuthenticationSchemes.Ntlm, true, false)]
@@ -125,7 +125,7 @@ namespace System.Net.Http.Functional.Tests
             }, UseHttp2.ToString()).Dispose();
         }
 
-        [ActiveIssue(32809)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/32809")]
         [OuterLoop("Uses external server")]
         [Theory]
         [MemberData(nameof(CredentialsForProxy))]
@@ -216,7 +216,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public async Task Proxy_SslProxyUnsupported_Throws()
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -150,7 +150,7 @@ namespace System.Net.Http.Functional.Tests
 
         // We have tests that validate with SslStream, but that's limited by what the current OS supports.
         // This tests provides additional validation against an external server.
-        [ActiveIssue(26186)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/26186")]
         [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
         [Theory]
         [MemberData(nameof(SupportedSSLVersionServers))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2187,7 +2187,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue(31104, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31104", TestPlatforms.AnyUnix)]
         public async Task PostAsync_ReuseRequestContent_Success(Configuration.Http.RemoteServer remoteServer)
         {
             const string ContentString = "This is the content string.";
@@ -2371,7 +2371,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [Fact]
-        [ActiveIssue(339)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
         public async Task SendAsync_RequestVersionNotSpecified_ServerReceivesVersion11Request()
         {
             // The default value for HttpRequestMessage.Version is Version(1,1).
@@ -2508,7 +2508,7 @@ namespace System.Net.Http.Functional.Tests
         }
 #endregion
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public async Task GetAsync_InvalidUrl_ExpectedExceptionThrown()
         {
             string invalidUri = $"http://{Configuration.Sockets.InvalidHost}";

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/IdnaProtocolTests.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ActiveIssue(26355)] // We aren't doing IDNA encoding properly
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/26355")] // We aren't doing IDNA encoding properly
         [Theory]
         [MemberData(nameof(InternationalHostNames))]
         public async Task InternationalRequestHeaderValues_UsesIdnaEncoding_Success(string hostname)
@@ -83,7 +83,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ActiveIssue(26355)] // We aren't doing IDNA decoding properly
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/26355")] // We aren't doing IDNA decoding properly
         [Theory]
         [MemberData(nameof(InternationalHostNames))]
         public async Task InternationalResponseHeaderValues_UsesIdnaDecoding_Success(string hostname)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace System.Net.Http.Functional.Tests
 {
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public class PlatformHandler_HttpClientHandler : HttpClientHandlerTestBase
     {
         public PlatformHandler_HttpClientHandler(ITestOutputHelper output) : base(output) { }
@@ -60,42 +60,42 @@ namespace System.Net.Http.Functional.Tests
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_Asynchrony_Test : HttpClientHandler_Asynchrony_Test
     {
         public PlatformHandler_HttpClientHandler_Asynchrony_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpProtocolTests : HttpProtocolTests
     {
         public PlatformHandler_HttpProtocolTests(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpProtocolTests_Dribble : HttpProtocolTests_Dribble
     {
         public PlatformHandler_HttpProtocolTests_Dribble(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_DiagnosticsTest : DiagnosticsTest
     {
         public PlatformHandler_DiagnosticsTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClient_SelectedSites_Test : HttpClient_SelectedSites_Test
     {
         public PlatformHandler_HttpClient_SelectedSites_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientEKUTest : HttpClientEKUTest
     {
         public PlatformHandler_HttpClientEKUTest(ITestOutputHelper output) : base(output) { }
@@ -103,14 +103,14 @@ namespace System.Net.Http.Functional.Tests
 
 #if NETCOREAPP
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_Decompression_Tests : HttpClientHandler_Decompression_Test
     {
         public PlatformHandler_HttpClientHandler_Decompression_Tests(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test
     {
         public PlatformHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test(ITestOutputHelper output) : base(output) { }
@@ -118,91 +118,91 @@ namespace System.Net.Http.Functional.Tests
 #endif
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_ClientCertificates_Test : HttpClientHandler_ClientCertificates_Test
     {
         public PlatformHandler_HttpClientHandler_ClientCertificates_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_DefaultProxyCredentials_Test : HttpClientHandler_DefaultProxyCredentials_Test
     {
         public PlatformHandler_HttpClientHandler_DefaultProxyCredentials_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test
     {
         public PlatformHandler_HttpClientHandler_MaxConnectionsPerServer_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_ServerCertificates_Test : HttpClientHandler_ServerCertificates_Test
     {
         public PlatformHandler_HttpClientHandler_ServerCertificates_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_PostScenarioTest : PostScenarioTest
     {
         public PlatformHandler_PostScenarioTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_ResponseStreamTest : ResponseStreamTest
     {
         public PlatformHandler_ResponseStreamTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_SslProtocols_Test : HttpClientHandler_SslProtocols_Test
     {
         public PlatformHandler_HttpClientHandler_SslProtocols_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_Proxy_Test : HttpClientHandler_Proxy_Test
     {
         public PlatformHandler_HttpClientHandler_Proxy_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_SchSendAuxRecordHttpTest : SchSendAuxRecordHttpTest
     {
         public PlatformHandler_SchSendAuxRecordHttpTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandlerTest : HttpClientHandlerTest
     {
         public PlatformHandler_HttpClientHandlerTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandlerTest_AutoRedirect : HttpClientHandlerTest_AutoRedirect
     {
         public PlatformHandlerTest_AutoRedirect(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_DefaultCredentialsTest : DefaultCredentialsTest
     {
         public PlatformHandler_DefaultCredentialsTest(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_IdnaProtocolTests : IdnaProtocolTests
     {
         public PlatformHandler_IdnaProtocolTests(ITestOutputHelper output) : base(output) { }
@@ -211,42 +211,42 @@ namespace System.Net.Http.Functional.Tests
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpRetryProtocolTests : HttpRetryProtocolTests
     {
         public PlatformHandler_HttpRetryProtocolTests(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandlerTest_Cookies : HttpClientHandlerTest_Cookies
     {
         public PlatformHandlerTest_Cookies(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandlerTest_Cookies_Http11 : HttpClientHandlerTest_Cookies_Http11
     {
         public PlatformHandlerTest_Cookies_Http11(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_MaxResponseHeadersLength_Test : HttpClientHandler_MaxResponseHeadersLength_Test
     {
         public PlatformHandler_HttpClientHandler_MaxResponseHeadersLength_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_Cancellation_Test : HttpClientHandler_Cancellation_Test
     {
         public PlatformHandler_HttpClientHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
     }
 
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandler_HttpClientHandler_Authentication_Test : HttpClientHandler_Authentication_Test
     {
         public PlatformHandler_HttpClientHandler_Authentication_Test(ITestOutputHelper output) : base(output) { }
@@ -255,13 +255,13 @@ namespace System.Net.Http.Functional.Tests
     // Enable this to run HTTP2 tests on platform handler
 #if PLATFORM_HANDLER_HTTP2_TESTS
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     public sealed class PlatformHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
     }
     
     // Test only WinHttpHandler since the CurlHandler was removed
-    [ActiveIssue(339)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/339")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SchSendAuxRecordHttpTest.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
-    [ActiveIssue(26539)]    // Flaky test
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/26539")]    // Flaky test
     public abstract class SchSendAuxRecordHttpTest : HttpClientHandlerTestBase
     {
         public SchSendAuxRecordHttpTest(ITestOutputHelper output) : base(output) { }

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -32,7 +32,7 @@ namespace System.Net.Tests
 
         public void Dispose() => _factory.Dispose();
 
-        // [ActiveIssue(20840, TestPlatforms.Unix)] // Managed implementation connects successfully.
+        // [ActiveIssue("https://github.com/dotnet/corefx/issues/20840", TestPlatforms.Unix)] // Managed implementation connects successfully.
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
         [InlineData("Basic")]
         [InlineData("NTLM")]
@@ -49,7 +49,7 @@ namespace System.Net.Tests
             }
         }
 
-        // [ActiveIssue(20840, TestPlatforms.Unix)] Managed implementation connects successfully.
+        // [ActiveIssue("https://github.com/dotnet/corefx/issues/20840", TestPlatforms.Unix)] Managed implementation connects successfully.
         [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))]
         [InlineData("Basic")]
         [InlineData("NTLM")]
@@ -106,7 +106,7 @@ namespace System.Net.Tests
             yield return new object[] { "abc", HttpStatusCode.InternalServerError };
         }
 
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20098, TestPlatforms.Unix)]
+        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20098", TestPlatforms.Unix)]
         [InlineData("ExampleRealm")]
         [InlineData("  ExampleRealm  ")]
         [InlineData("")]

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -144,7 +144,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(20294, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20294", TargetFrameworkMonikers.Netcoreapp)]
         public async Task ContentLength_ManuallyRemovedFromHeaders_DoesNotAffect()
         {
             HttpListenerRequest request = await GetRequest("POST", null, new string[] { "Content-Length: 1" }, content: "\r\n");

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -35,7 +35,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22057", TargetFrameworkMonikers.Netcoreapp)]
         public async Task AddHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -78,7 +78,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22057", TargetFrameworkMonikers.Netcoreapp)]
         public async Task AppendHeader_LongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -838,7 +838,7 @@ namespace System.Net.Tests
 
         [Theory]
         [InlineData("Transfer-Encoding")]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22057", TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRestricted_ThrowsArgumentException(string name)
         {
             HttpListenerResponse response = await GetResponse();
@@ -859,7 +859,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22057", TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetLongName_ThrowsArgumentOutOfRangeException()
         {
             HttpListenerResponse response = await GetResponse();
@@ -871,7 +871,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(22057, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22057", TargetFrameworkMonikers.Netcoreapp)]
         public async Task Headers_SetRequestHeader_ThrowsInvalidOperationException()
         {
             HttpListenerResponse response = await GetResponse();

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -155,7 +155,7 @@ namespace System.Net.Tests
         }
 
         // The managed implementation should also dispose the OutputStream after calling Abort.
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(19975, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/19975", TestPlatforms.AnyUnix)]
         public async Task Abort_Invoke_ForciblyTerminatesConnection()
         {
             Client.Send(Factory.GetContent("1.1", "POST", null, "Give me a context, please", null, headerOnly: false));
@@ -266,7 +266,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20201", TestPlatforms.AnyUnix)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_AllContentLengthAlreadySent_DoesNotSendEntity(bool willBlock)
@@ -360,7 +360,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20201", TestPlatforms.AnyUnix)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CloseResponseEntity_SendMoreThanContentLength_ThrowsInvalidOperationException(bool willBlock)

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -76,7 +76,7 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentException>("messageType", () => context.WebSocket.SendAsync(new ArraySegment<byte>(), messageType, false, new CancellationToken()));
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20395", TestPlatforms.AnyUnix)]
         public async Task SendAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -153,7 +153,7 @@ namespace System.Net.Tests
             await AssertExtensions.ThrowsAsync<ArgumentNullException>("buffer.Array", () => context.WebSocket.ReceiveAsync(new ArraySegment<byte>(), new CancellationToken()));
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20395, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20395", TestPlatforms.AnyUnix)]
         public async Task ReceiveAsync_Disposed_ThrowsObjectDisposedException()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -169,11 +169,11 @@ namespace System.Net.Tests
             yield return new object[] { WebSocketCloseStatus.MandatoryExtension, "StatusDescription", WebSocketCloseStatus.MandatoryExtension };
         }
 
-        [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20396, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20396", TestPlatforms.AnyUnix)]
         [MemberData(nameof(CloseStatus_Valid_TestData))]
         public async Task CloseOutputAsync_HandshakeStartedFromClient_Success(WebSocketCloseStatus status, string statusDescription, WebSocketCloseStatus expectedCloseStatus)
         {
-            // [ActiveIssue(20392, TargetFrameworkMonikers.Netcoreapp)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/20392", TargetFrameworkMonikers.Netcoreapp)]
             string expectedStatusDescription = statusDescription;
             if (statusDescription == null)
             {
@@ -232,11 +232,11 @@ namespace System.Net.Tests
             await context.WebSocket.CloseOutputAsync(WebSocketCloseStatus.Empty, null, new CancellationToken());
         }
 
-        [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20396, TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20396", TestPlatforms.AnyUnix)]
         [MemberData(nameof(CloseStatus_Valid_TestData))]
         public async Task CloseAsync_HandshakeStartedFromClient_Success(WebSocketCloseStatus status, string statusDescription, WebSocketCloseStatus expectedCloseStatus)
         {
-            // [ActiveIssue(20392, TargetFrameworkMonikers.Netcoreapp)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/20392", TargetFrameworkMonikers.Netcoreapp)]
             string expectedStatusDescription = statusDescription;
             if (statusDescription == null)
             {
@@ -315,7 +315,7 @@ namespace System.Net.Tests
             await Assert.ThrowsAsync<ArgumentException>(paramName, () => context.WebSocket.CloseOutputAsync(status, statusDescription, new CancellationToken()));
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20394, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20394", TestPlatforms.AnyUnix)]
         public async Task CloseAsync_AfterDisposed_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -325,7 +325,7 @@ namespace System.Net.Tests
             await context.WebSocket.CloseAsync(WebSocketCloseStatus.Empty, null, new CancellationToken());
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20394, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20394", TestPlatforms.AnyUnix)]
         public async Task CloseAsync_AfterAborted_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();
@@ -335,7 +335,7 @@ namespace System.Net.Tests
             await context.WebSocket.CloseAsync(WebSocketCloseStatus.Empty, null, new CancellationToken());
         }
 
-        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue(20397, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20397", TestPlatforms.AnyUnix)]
         public async Task Dispose_CallAfterDisposed_Nop()
         {
             HttpListenerWebSocketContext context = await GetWebSocketContext();

--- a/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -297,7 +297,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20201", TestPlatforms.AnyUnix)]
         public async Task Write_TooMuch_ThrowsProtocolViolationException()
         {
             using (HttpClient client = new HttpClient())
@@ -325,7 +325,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20201", TestPlatforms.AnyUnix)]
         public async Task Write_TooLittleAsynchronouslyAndClose_ThrowsInvalidOperationException()
         {
             using (HttpClient client = new HttpClient())
@@ -351,7 +351,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue(20201, TestPlatforms.AnyUnix)]
+        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/20201", TestPlatforms.AnyUnix)]
         public async Task Write_TooLittleSynchronouslyAndClose_ThrowsInvalidOperationException()
         {
             using (HttpClient client = new HttpClient())
@@ -377,8 +377,8 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
-        [ActiveIssue(19534, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20246")] // CI hanging frequently
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19534", TestPlatforms.OSX)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -416,8 +416,8 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(20246)] // CI hanging frequently
-        [ActiveIssue(19534, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20246")] // CI hanging frequently
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19534", TestPlatforms.OSX)]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -456,11 +456,11 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(19534, TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19534", TestPlatforms.OSX)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/18188", platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
         public async Task Write_ContentToClosedConnectionAsynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";
@@ -496,11 +496,11 @@ namespace System.Net.Tests
             }
         }
 
-        [ActiveIssue(19534, TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19534", TestPlatforms.OSX)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue(18188, platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/18188", platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
         public async Task Write_ContentToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";

--- a/src/libraries/System.Net.HttpListener/tests/SimpleHttpTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/SimpleHttpTests.cs
@@ -168,7 +168,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(39552)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39552")]
         public void ListenerRestart_BeginGetContext_Success()
         {
             using (HttpListenerFactory factory = new HttpListenerFactory())
@@ -182,7 +182,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact]
-        [ActiveIssue(39552)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39552")]
         public async Task ListenerRestart_GetContext_Success()
         {
             const string Content = "ListenerRestart_GetContext_Success";

--- a/src/libraries/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
+++ b/src/libraries/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
@@ -4,6 +4,6 @@
 
 using Xunit;
 
-// [ActiveIssue(20103)]: Disabling parallel execution of HttpListener tests
+// [ActiveIssue("https://github.com/dotnet/corefx/issues/20103")]: Disabling parallel execution of HttpListener tests
 // until all of the hangs can be addressed
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,7 +309,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue(40711)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40711")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and may not time out for low values")]
         [PlatformSpecific(~TestPlatforms.OSX)] // on OSX, not all synchronous operations (e.g. connect) can be aborted by closing the socket.
         public void TestZeroTimeout()

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -102,8 +102,8 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(IPAddress.IPv6Loopback, entry.AddressList[0]);
         }
 
-        [ActiveIssue(37362, TestPlatforms.OSX)]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37362", TestPlatforms.OSX)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/32797")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
             IPHostEntry entry = Dns.GetHostByName("");
@@ -112,8 +112,8 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(Dns.GetHostName(), entry.HostName, StringComparison.OrdinalIgnoreCase);
         }
 
-        [ActiveIssue(37362, TestPlatforms.OSX)]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37362", TestPlatforms.OSX)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/32797")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,8 +20,8 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
-        [ActiveIssue(37362, TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37362", TestPlatforms.OSX)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/32797")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntry_HostString_Ok(string hostName)
@@ -69,8 +69,8 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ActiveIssue(37362, TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37362", TestPlatforms.OSX)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/32797")]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName) =>

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.NetworkInformation.Tests
             _log = output;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_AccessAllMethods_NoErrors()
         {
@@ -52,7 +52,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotNull(gp.GetUdpIPv6Statistics());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [MemberData(nameof(Loopbacks))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
@@ -78,7 +78,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [MemberData(nameof(Loopbacks))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)
@@ -109,7 +109,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_TcpActiveConnections_NotListening()
         {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -13,7 +13,7 @@ namespace System.Net.NetworkInformation.Tests
         private readonly NetworkAddressChangedEventHandler _addressHandler = delegate { };
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAddressChanged_AddRemove_Success()
         {
             NetworkChange.NetworkAddressChanged += _addressHandler;
@@ -21,7 +21,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAddressChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAddressChanged -= _addressHandler;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
@@ -13,7 +13,7 @@ namespace System.Net.NetworkInformation.Tests
         private readonly NetworkAvailabilityChangedEventHandler _availabilityHandler = delegate { };
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAvailabilityChanged_AddRemove_Success()
         {
             NetworkChange.NetworkAvailabilityChanged += _availabilityHandler;
@@ -21,14 +21,14 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAvailabilityChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAvailabilityChanged -= _availabilityHandler;
         }
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAddressChanged_Add_DoesNotBlock()
         {
             // Register without unregistering.
@@ -42,7 +42,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAddressChanged_AddAndRemove_NetworkAvailabilityChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAddressChanged += _addressHandler;
@@ -55,7 +55,7 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
-        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33530", TestPlatforms.FreeBSD)]
         public void NetworkAvailabilityChanged_NetworkAddressChanged_AddAndRemove_Success(bool addAddressFirst, bool removeAddressFirst)
         {
             if (addAddressFirst)

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -85,7 +85,7 @@ namespace System.Net.NetworkInformation.Tests
             }
         }
 
-        [ActiveIssue(1332)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1332")]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -499,7 +499,7 @@ namespace System.Net.Tests
             Assert.Equal(int.MaxValue, request.Timeout);
         }
 
-        [ActiveIssue(22627)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/22627")]
         [Fact]
         public async Task Timeout_SetTenMillisecondsOnLoopback_ThrowsWebException()
         {
@@ -1450,7 +1450,7 @@ namespace System.Net.Tests
             Assert.NotNull(request.Proxy);
         }
 
-        [ActiveIssue(42323)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/42323")]
         [OuterLoop("Uses external server")]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
         [Fact]
@@ -1715,7 +1715,7 @@ namespace System.Net.Tests
             });
         }
 
-        [ActiveIssue(19083)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19083")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "dotnet/corefx #19083")]
         [Fact]
         public async Task Abort_BeginGetRequestStreamThenAbort_EndGetRequestStreamThrowsWebException()
@@ -1757,7 +1757,7 @@ namespace System.Net.Tests
             });
         }
 
-        [ActiveIssue(18800)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/18800")]
         [Fact]
         public async Task Abort_BeginGetResponseThenAbort_EndGetResponseThrowsWebException()
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -44,7 +44,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
-        [ActiveIssue(37899)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37899")]
         public async Task ServerAsyncAuthenticate_MismatchProtocols_Fails(
             SslProtocols serverProtocol,
             SslProtocols clientProtocol,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlertsTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Security.Tests
         private const uint SEC_E_CERT_UNKNOWN = 0x80090327;
 
         [Fact]
-        [ActiveIssue(12319, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/12319", TestPlatforms.AnyUnix)]
         public async Task SslStream_StreamToStream_HandshakeAlert_Ok()
         {
             VirtualNetwork network = new VirtualNetwork();

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -144,7 +144,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        [ActiveIssue(17209, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17209", TestPlatforms.AnyUnix)]
         public async Task Accept_WithTargetSocket_Success()
         {
             if (!SupportsAcceptIntoExistingSocket)
@@ -166,7 +166,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(17209, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17209", TestPlatforms.AnyUnix)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(false)]
@@ -221,7 +221,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        [ActiveIssue(17209, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17209", TestPlatforms.AnyUnix)]
         public void Accept_WithAlreadyBoundTargetSocket_Fails()
         {
             if (!SupportsAcceptIntoExistingSocket)
@@ -242,7 +242,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [Fact]
-        [ActiveIssue(17209, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17209", TestPlatforms.AnyUnix)]
         public async Task Accept_WithInUseTargetSocket_Fails()
         {
             if (!SupportsAcceptIntoExistingSocket)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -595,7 +595,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalTheory(nameof(LocalhostIsBothIPv4AndIPv6))]
-        [ActiveIssue(20893)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20893")]
         [MemberData(nameof(DualMode_Connect_IPAddress_DualMode_Data))]
         public void DualModeConnectAsync_Static_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
@@ -336,7 +336,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [InlineData(false, 0)]
         [InlineData(true, 0)]
         [InlineData(false, 1)]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -80,7 +80,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void IOControl_SIOCATMARK_Unix_Success()
         {
             using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
@@ -178,7 +178,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [PlatformSpecific(~TestPlatforms.OSX)] // typical OSX install has very low max open file descriptors value
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void Select_Error_OneReadyAtATime()
         {
             const int Errors = 90; // value larger than the internal value in SocketPal.Unix that swaps between stack and heap allocation

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -288,7 +288,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Theory]
-        [ActiveIssue(27269)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/27269")]
         [InlineData(SocketImplementationType.APM)]
         [InlineData(SocketImplementationType.Async)]
         [PlatformSpecific(TestPlatforms.Windows)] // valid filename chars on Unix

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -44,7 +44,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(16945)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/16945")]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
@@ -1212,7 +1212,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void SendIovMaxUdp_SuccessOrMessageSize()
         {
             // sending more than IOV_MAX segments causes EMSGSIZE on some platforms.
@@ -1253,7 +1253,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public async Task ReceiveIovMaxUdp_SuccessOrMessageSize()
         {
             // receiving more than IOV_MAX segments causes EMSGSIZE on some platforms.
@@ -1325,7 +1325,7 @@ namespace System.Net.Sockets.Tests
             await receiveTask;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [PlatformSpecific(~TestPlatforms.Windows)] // All data is sent, even when very large (100M).
         public void SocketSendWouldBlock_ReturnsBytesSent()
         {
@@ -1354,7 +1354,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public async Task Socket_ReceiveFlags_Success()
         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -381,7 +381,7 @@ namespace System.Net.Sockets.Tests
             ReuseAddress(exclusiveAddressUse, firstSocketReuseAddress, secondSocketReuseAddress, expectFailure);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Windows defaults are different
         public void ExclusiveAddress_Default_Unix()
         {
@@ -393,7 +393,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [InlineData(1)]
         [InlineData(0)]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // Unix does not have separate options for ExclusiveAddressUse and ReuseAddress.
@@ -417,7 +417,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void ExclusiveAddressUseTcp()
         {
             using (Socket a = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -258,7 +258,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet_True()
         {
             using (TcpClient client = new TcpClient())
@@ -268,7 +268,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void Roundtrip_ExclusiveAddressUse_GetEqualsSet_False()
         {
             using (TcpClient client = new TcpClient())

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Sockets.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("port", () => TcpListener.Create(66000));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -283,7 +283,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void EnableBroadcast_Roundtrips()
         {
             using (var udpClient = new UdpClient())

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -179,7 +179,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(29742, TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/29742", TestPlatforms.Windows)]
         [ConditionalTheory(nameof(PlatformSupportsUnixDomainSockets))]
         [InlineData(5000, 1, 1)]
         [InlineData(500, 18, 21)]
@@ -243,7 +243,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalTheory(nameof(PlatformSupportsUnixDomainSockets))]
-        [ActiveIssue(29742, TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/29742", TestPlatforms.Windows)]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ConcurrentSendReceive(bool forceNonBlocking)

--- a/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/ManualPerformanceTests/SocketPerformanceAsyncTests.cs
@@ -28,7 +28,7 @@ namespace System.Net.Sockets.Performance.Tests
             }
         }
 
-        [ActiveIssue(13349, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13349", TestPlatforms.OSX)]
         [OuterLoop]
         [Fact]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -176,7 +176,7 @@ namespace System.Net.Tests
             yield return new object[] { new Uri($"http://{IPAddress.None}"), false };
         }
 
-        [ActiveIssue(23766, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/23766", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(BypassOnLocal_MemberData))]
         public static void WebProxy_BypassOnLocal_MatchesExpected(Uri destination, bool isLocal)

--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -47,7 +47,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue(13302)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13302")]
         public async Task ReceiveAsync_Cancel_Success(Uri server)
         {
             await TestCancellation(async (cws) =>

--- a/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.cs
@@ -62,7 +62,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(28027)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/28027")]
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task Proxy_ConnectThruProxy_Success(Uri server)
@@ -162,7 +162,7 @@ namespace System.Net.WebSockets.Client.Tests
         {
             if (PlatformDetection.IsWindows7)
             {
-                return; // [ActiveIssue(27846)]
+                return; // [ActiveIssue("https://github.com/dotnet/corefx/issues/27846")]
             }
 
             bool callbackInvoked = false;
@@ -198,7 +198,7 @@ namespace System.Net.WebSockets.Client.Tests
         {
             if (PlatformDetection.IsWindows7)
             {
-                return; // [ActiveIssue(27846)]
+                return; // [ActiveIssue("https://github.com/dotnet/corefx/issues/27846")]
             }
 
             using (X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate())
@@ -234,7 +234,7 @@ namespace System.Net.WebSockets.Client.Tests
         {
             if (PlatformDetection.IsWindows7)
             {
-                return; // [ActiveIssue(27846)]
+                return; // [ActiveIssue("https://github.com/dotnet/corefx/issues/27846")]
             }
 
             bool connectionAccepted = false;

--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -17,7 +17,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CloseTest(ITestOutputHelper output) : base(output) { }
 
-        [ActiveIssue(36016)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36016")]
         [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServersAndBoolean))]
         public async Task CloseAsync_ServerInitiatedClose_Success(Uri server, bool useCloseOutputAsync)
@@ -197,7 +197,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(36016)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36016")]
         [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ServerInitiated_CanSend(Uri server)
@@ -260,7 +260,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(20362, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/20362", TargetFrameworkMonikers.Netcoreapp)]
         [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -87,7 +87,7 @@ namespace System.Xml.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public static void InitializationWithUriOnNonAsyncReaderTrows()
         {
             Assert.Throws<System.Net.Http.HttpRequestException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
@@ -205,7 +205,7 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [ActiveIssue(39106)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39106")]
         //[Variation(Desc = "v5.2- Test Default value of ProhibitDTD for Add(TextReader) for schema with DTD", Priority = 1, Params = new object[] { "bug356711_a.xsd", 0 })]
         [InlineData("bug356711_a.xsd", 0)]
         //[Variation(Desc = "v5.1- Test Default value of ProhibitDTD for Add(TextReader) with an xs:import for schema with DTD", Priority = 1, Params = new object[] { "bug356711.xsd", 0 })]
@@ -233,7 +233,7 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [ActiveIssue(39106)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39106")]
         //[Variation(Desc = "v6.2- Test Default value of ProhibitDTD for Add(XmlTextReader) for schema with DTD", Priority = 1, Params = new object[] { "bug356711_a.xsd" })]
         [InlineData("bug356711_a.xsd")]
         //[Variation(Desc = "v6.1- Test Default value of ProhibitDTD for Add(XmlTextReader) with an xs:import for schema with DTD", Priority = 1, Params = new object[] { "bug356711.xsd" })]

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -2629,7 +2629,7 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(39105)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/39105")]
     public static void Xml_TypeWithReadOnlyMyCollectionProperty()
     {
         var value = new TypeWithReadOnlyMyCollectionProperty();

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1671,7 +1671,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal(value, actual);
     }
 
-    [ActiveIssue(28321)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/28321")]
     [Fact]
     public static void SerializeWithDefaultValueSetToNaNTest()
     {

--- a/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderSetParent.cs
+++ b/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderSetParent.cs
@@ -40,7 +40,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        [ActiveIssue(13977)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13977")]
         public void SetParent_This_LoopsForever()
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -99,7 +99,7 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(type.AsType().GetNestedTypes(AllFlags), createdType.GetNestedTypes(AllFlags));
                 Assert.Equal(type.AsType().GetNestedType(name, AllFlags), createdType.GetNestedType(name, AllFlags));
 
-                // [ActiveIssue(10989, TestPlatforms.AnyUnix)]
+                // [ActiveIssue("https://github.com/dotnet/corefx/issues/10989", TestPlatforms.AnyUnix)]
                 // Assert.Equal(createdType, module.GetType(name, true, true));
                 // Assert.Equal(createdType, module.GetType(name.ToLowerInvariant(), true, true));
                 // Assert.Equal(createdType, module.GetType(name.ToUpperInvariant(), true, true));

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/MethodBodyStreamEncoderTests.cs
@@ -374,7 +374,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
             }
         }
 
-        [Fact, ActiveIssue(26910)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/26910")]
         public unsafe void LocAlloc()
         {
             var streamBuilder = new BlobBuilder();
@@ -419,7 +419,7 @@ namespace System.Reflection.Metadata.Ecma335.Tests
             }, bodyBytes);
         }
 
-        [Fact, ActiveIssue(26910)]
+        [Fact, ActiveIssue("https://github.com/dotnet/corefx/issues/26910")]
         public unsafe void LocAlloc_WithInstructionEncoder()
         {
             var streamBuilder = new BlobBuilder();

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderProviderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderProviderTests.cs
@@ -124,7 +124,7 @@ namespace System.Reflection.Metadata.Tests
         }
 
         [Fact]
-        [ActiveIssue(7996)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/7996")]
         public void FromMetadataStream_NonZeroStart()
         {
             var stream = new MemoryStream();

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -87,7 +87,7 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Fact(Skip = "https://github.com/dotnet/corefx/issues/7996")]
-        [ActiveIssue(7996)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/7996")]
         public void SubStream()
         {
             var stream = new MemoryStream();

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -535,7 +535,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue(33249)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/33249")]
         public static void Constructor_String_LoadVersionTest()
         {
             string assemblyNamePrefix = "System.Reflection.Tests.Assembly_";

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
@@ -199,7 +199,7 @@ namespace MonoTests.System.Runtime.Caching
 
 
         [Fact]
-        [ActiveIssue(25168)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25168")]
         private static void Constructor_Calls_StartMonitoring_Handler()
         {
             Tuple<string, string, string, IList<string>> setup = null;
@@ -220,7 +220,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        [ActiveIssue(25168)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25168")]
         private static void Dispose_Calls_StopMonitoring_Handler()
         {
             Tuple<string, string, string, IList<string>> setup = null;
@@ -242,7 +242,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        [ActiveIssue(25168)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25168")]
         private static void Dispose_NullState_NoStopMonitoring_Handler()
         {
             Tuple<string, string, string, IList<string>> setup = null;

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -247,7 +247,7 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        [ActiveIssue(37989)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/37989")]
         public void Contains()
         {
             var mc = new PokerMemoryCache("MyCache");

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/ObjectCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/ObjectCacheTest.cs
@@ -40,7 +40,7 @@ namespace MonoTests.System.Runtime.Caching
     public class ObjectCacheTest
     {
         [Fact]
-        [ActiveIssue(25168)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/25168")]
         private static void Host_SetToProvider()
         {
             var tns1 = new TestNotificationSystem();

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -86,7 +86,7 @@ namespace System.Tests
             }).Dispose();
         }
 
-        [ActiveIssue(12716)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/12716")]
         [PlatformSpecific(~TestPlatforms.OSX)] // Unhandled exception on a separate process causes xunit to crash on osx
         [Fact]
         public void UnhandledException_Called()

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -221,7 +221,7 @@ namespace System.Tests
         {
             bool lookForSetValue = (target == EnvironmentVariableTarget.Process) || PlatformDetection.IsWindowsAndElevated;
             
-            // [ActiveIssue(40226)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/40226")]
             if (PlatformDetection.IsWindowsNanoServer && target == EnvironmentVariableTarget.User)
             {
                 lookForSetValue = false;

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -17,7 +17,7 @@ namespace System.Tests
 
         internal static bool IsSupportedTarget(EnvironmentVariableTarget target)
         {
-            // [ActiveIssue(40226)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/40226")]
             if (target == EnvironmentVariableTarget.User && PlatformDetection.IsWindowsNanoServer)
             {
                 return false;

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
@@ -42,7 +42,7 @@ namespace System.IO.Tests
             Assert.Equal(expected, Path.GetFileName(path));
         }
 
-        [ActiveIssue(27552)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/27552")]
         [Theory,
             MemberData(nameof(TestData_GetPathRoot_Windows)),
             MemberData(nameof(TestData_GetPathRoot_Unc)),

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -183,7 +183,7 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [MemberData(nameof(GetNativeVariantForObject_NonRoundtrippingPrimitives_TestData))]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(31077)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31077")]
         public void GetNativeVariantForObject_ValidObject_Success(object primitive, VarEnum expectedVarType, IntPtr expectedValue, object expectedRoundtripValue)
         {
             var v = new Variant();

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
@@ -672,7 +672,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue(31480, TargetFrameworkMonikers.Netcoreapp)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/31480", TargetFrameworkMonikers.Netcoreapp)]
         public void GetObjectForNativeVariant_Record_ReturnsExpected()
         {
             int record = 10;

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4058,7 +4058,7 @@ public static partial class DataContractSerializerTests
         Assert.NotNull(actual);
     }
 
-    [ActiveIssue(33317, TestPlatforms.OSX)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/33317", TestPlatforms.OSX)]
     [Fact]
     public static void DCS_DeeplyLinkedData()
     {

--- a/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/Foundation/PointTests.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/Foundation/PointTests.cs
@@ -100,7 +100,7 @@ namespace Windows.Foundation.Tests
         }
 
         [Theory]
-        [ActiveIssue(41849)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41849")]
         [MemberData(nameof(ToString_TestData))]
         public void ToString_Invoke_ReturnsExpected(Point point, string format, IFormatProvider formatProvider, string expected)
         {

--- a/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/Foundation/RectTests.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/Foundation/RectTests.cs
@@ -308,7 +308,7 @@ namespace Windows.Foundation.Tests
         }
 
         [Theory]
-        [ActiveIssue(41849)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41849")]
         [MemberData(nameof(ToString_TestData))]
         public void ToString_Invoke_ReturnsExpected(Rect rect, string format, IFormatProvider formatProvider, string expected)
         {

--- a/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/UI/ColorTests.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime/tests/Windows/UI/ColorTests.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Tests
         }
 
         [Theory]
-        [ActiveIssue(41849)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41849")]
         [MemberData(nameof(ToString_TestData))]
         public void ToString_Invoke_ReturnsExpected(Color color, string format, IFormatProvider formatProvider, string expected)
         {

--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -780,7 +780,7 @@ namespace System.Tests
             Assert.True((end - start) < 5 * size, $"Allocated too much: start: {start} end: {end} size: {size}");
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))] // [ActiveIssue(37378)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/37378")]
         public static void GetGCMemoryInfo()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2154,7 +2154,7 @@ namespace System.Tests
             }
         }
 
-        [ActiveIssue(14797, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/14797", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(SystemTimeZonesTestData))]
         public static void ToSerializedString_FromSerializedString_RoundTrips(TimeZoneInfo timeZone)

--- a/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -536,7 +536,7 @@ namespace System.Tests
 
             Uri invalidPunicodeUri = new Uri("http://xn--\u1234pck.com");
             yield return new object[] { invalidPunicodeUri, UriComponents.Host, "xn--\u1234pck.com" };
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // TODO: [ActiveIssue(8242, TestPlatforms.AnyUnix)]
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // TODO: [ActiveIssue("https://github.com/dotnet/corefx/issues/8242", TestPlatforms.AnyUnix)]
             {
                 yield return new object[] { invalidPunicodeUri, UriComponents.NormalizedHost, "xn--\u1234pck.com" };
             }

--- a/src/libraries/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_GetBinaryForm.cs
+++ b/src/libraries/System.Security.AccessControl/tests/CommonSecurityDescriptor/CommonSecurityDescriptor_GetBinaryForm.cs
@@ -84,7 +84,7 @@ namespace System.Security.AccessControl.Tests
 
         [Theory]
         [MemberData(nameof(CommonSecurityDescriptor_GetBinaryForm_TestData))]
-        [ActiveIssue(16919)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/16919")]
         public static void TestGetBinaryForm(bool isContainer, bool isDS, string sddl, string verifierSddl, int offset)
         {
             CommonSecurityDescriptor commonSecurityDescriptor = null;

--- a/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Cng.Tests
 
         private static readonly CngAlgorithm s_cngAlgorithm = new CngAlgorithm("AES");
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalTheory(nameof(SupportsPersistedSymmetricKeys))]
         // AES128-ECB-NoPadding 2 blocks.
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Cng.Tests
                 keyName => new AesCng(keyName));
         }
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
         public static void SetKey_DetachesFromPersistedKey()
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys), nameof(IsAdministrator))]
         public static void VerifyMachineKey()

--- a/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Cng.Tests
 
         private static readonly CngAlgorithm s_cngAlgorithm = new CngAlgorithm("3DES");
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalTheory(nameof(SupportsPersistedSymmetricKeys))]
         // 3DES192-ECB-NoPadding 2 blocks.
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Cng.Tests
                 keyName => new TripleDESCng(keyName));
         }
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
         public static void SetKey_DetachesFromPersistedKey()
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ActiveIssue(41610)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/41610")]
         [OuterLoop(/* Creates/Deletes a persisted key, limit exposure to key leaking */)]
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys), nameof(IsAdministrator))]
         public static void VerifyMachineKey()

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12BuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12BuilderTests.cs
@@ -403,7 +403,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                 Assert.Equal(EmptyHex, encoded.ByteArrayToHex());
             }
 
-            // [ActiveIssue(11046, TestPlatforms.AnyUnix)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/11046", TestPlatforms.AnyUnix)]
             if (withMac || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 X509Certificate2Collection collection = new X509Certificate2Collection();
@@ -458,7 +458,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
                 Assert.Equal(FullyEmptyHex, encoded.ByteArrayToHex());
             }
 
-            // [ActiveIssue(11046, TestPlatforms.AnyUnix)]
+            // [ActiveIssue("https://github.com/dotnet/corefx/issues/11046", TestPlatforms.AnyUnix)]
             if (withMac || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 X509Certificate2Collection collection = new X509Certificate2Collection();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ActiveIssue(29779)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/29779")]
         [ConditionalFact]
         [OuterLoop("May require using the network, to download CRLs and intermediates")]
         public void TestVerify()

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(36330)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/36330")]
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData(PROV_RSA_FULL, KeyNumber.Signature)]
         [InlineData(PROV_RSA_FULL, KeyNumber.Exchange)]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -212,7 +212,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(2910, TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/2910", TestPlatforms.AnyUnix)]
         public static void TestLoadSignedFile()
         {
             // X509Certificate2 can also extract the certificate from a signed file.

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
     [OuterLoop("These tests run serially at about 1 second each, and the code shouldn't change that often.")]
-    [ActiveIssue(41974, TestPlatforms.OSX)]
+    [ActiveIssue("https://github.com/dotnet/corefx/issues/41974", TestPlatforms.OSX)]
     public static class DynamicRevocationTests
     {
         // The CI machines are doing an awful lot of things at once, be generous with the timeout;
@@ -522,7 +522,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         chain.ChainPolicy.ApplicationPolicy.Add(s_tlsServerOid);
                         leafProblems |= X509ChainStatusFlags.NotValidForUsage;
 
-                        // [ActiveIssue(41969)]
+                        // [ActiveIssue("https://github.com/dotnet/corefx/issues/41969")]
                         // Linux reports this code at more levels than Windows does.
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                         {
@@ -605,7 +605,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         chain.ChainPolicy.ApplicationPolicy.Add(s_tlsServerOid);
                         leafProblems |= X509ChainStatusFlags.NotValidForUsage;
 
-                        // [ActiveIssue(41969)]
+                        // [ActiveIssue("https://github.com/dotnet/corefx/issues/41969")]
                         // Linux reports this code at more levels than Windows does.
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                         {

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(17001, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17001", TestPlatforms.OSX)]
         public void GetXml()
         {
             DSAKeyValue dsa = new DSAKeyValue();
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(17001, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17001", TestPlatforms.OSX)]
         public void GetXml_SameDsa()
         {
             using (DSA dsa = DSA.Create())

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -290,7 +290,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(17001, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/17001", TestPlatforms.OSX)]
         public void AsymmetricDSASignature()
         {
             SignedXml signedXml = MSDNSample();

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -11,7 +11,7 @@ namespace System.ServiceProcess.Tests
     {
         private const string KeyIsoSvcName = "KEYISO";
 
-        [ActiveIssue(19223)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/19223")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/19223
         public static void GetServices()
         {

--- a/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -209,7 +209,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a Unicode character array with UTF8 encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void EncoderUTF8ConvertUnicodeCharArrayPartial()
         {
             char[] chars = "\uD83D\uDE01Test".ToCharArray();
@@ -229,7 +229,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a ASCII+Unicode character array with ASCII encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void EncoderASCIIConvertMixedASCIIUnicodeCharArrayPartial()
         {
             char[] chars = "T\uD83D\uDE01est".ToCharArray();
@@ -251,7 +251,7 @@ namespace System.Text.Tests
         }
 
         // Call Convert to convert partial of a ASCII+Unicode character array with UTF8 encoder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/11057")]
         public void EncoderUTF8ConvertMixedASCIIUnicodeCharArrayPartial()
         {
             char[] chars = "T\uD83D\uDE01est".ToCharArray();

--- a/src/libraries/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -87,7 +87,7 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region Array
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeArray()
         {
@@ -106,7 +106,7 @@ namespace System.Text.Json.Tests
 ]", json);
         }
 
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void DeserializeArray()
         {
@@ -124,7 +124,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", data[2]);
         }
 
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeDefaultArray()
         {
@@ -330,7 +330,7 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region Dictionary
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeDictionary()
         {
@@ -349,7 +349,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", (string)a[3]);
         }
 
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void DeserializeDictionary()
         {
@@ -367,7 +367,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", data[3]);
         }
 
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void DeserializeDictionaryInterface()
         {
@@ -387,7 +387,7 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region SortedDictionary
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeSortedDictionary()
         {
@@ -406,7 +406,7 @@ namespace System.Text.Json.Tests
 }", json);
         }
 
-        [ActiveIssue(36643)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void DeserializeSortedDictionary()
         {

--- a/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -170,7 +170,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal('Y', JsonSerializer.Deserialize<char>("\"\u0059\""));
         }
 
-        [ActiveIssue(1037)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1037")]
         [Fact]
         public static void ParseNullStringToStructShouldThrowJsonException()
         {
@@ -182,7 +182,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(nullString));
         }
 
-        [ActiveIssue(1037)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/1037")]
         [Fact]
         public static async Task ParseNullStringShouldThrowJsonExceptionAsync()
         {

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -521,7 +521,7 @@ namespace System.Threading.Tasks.Tests
             TaskScheduler.UnobservedTaskException -= handler;
         }
 
-        [ActiveIssue(39155)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39155")]
         [Fact]
         public static async Task AsyncMethodsDropsStateMachineAndExecutionContextUponCompletion()
         {

--- a/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -30,7 +30,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [ActiveIssue(39155)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/39155")]
         [Fact]
         public static async Task TaskDropsExecutionContextUponCompletion()
         {

--- a/src/libraries/System.Threading/tests/InterlockedTests.cs
+++ b/src/libraries/System.Threading/tests/InterlockedTests.cs
@@ -40,7 +40,7 @@ namespace System.Threading.Tests
             Assert.Equal(0, count);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(38400)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/corefx/issues/38400")]
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -399,7 +399,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [ActiveIssue(34666)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/34666")]
         [Theory]
         [MemberData(nameof(CrossProcess_NamedMutex_ProtectedFileAccessAtomic_MemberData))]
         public void CrossProcess_NamedMutex_ProtectedFileAccessAtomic(string prefix)

--- a/src/libraries/System.Transactions.Local/tests/EnlistTest.cs
+++ b/src/libraries/System.Transactions.Local/tests/EnlistTest.cs
@@ -153,7 +153,7 @@ namespace System.Transactions.Tests
         /* We support only 1 durable with 2PC
          * On .net, this becomes a distributed transaction
          */
-        [ActiveIssue(13532)] //Distributed transactions are not supported.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13532")] //Distributed transactions are not supported.
         [Fact]
         public void Vol0_Dur1_2PC()
         {
@@ -458,7 +458,7 @@ namespace System.Transactions.Tests
          * > 1 durable, On .net this becomes a distributed transaction
          * We don't support this in mono yet.
          */
-        [ActiveIssue(13532)] //Distributed transactions are not supported.
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/13532")] //Distributed transactions are not supported.
         [Fact]
         public void Vol0_Dur2()
         {


### PR DESCRIPTION
Done with VS find and replace w/ regex:
Find what: `ActiveIssue\((\d+)`
Replace with: `ActiveIssue("https://github.com/dotnet/corefx/issues/$1"`

I then also searched for `ActiveIssue("https://github.com/dotnet/corefx/issues/\d{4}"` for 4, 3, 2, and 1, as those would be the only ones that could have instead been for dotnet/runtime instead of dotnet/corefx.  I found 1 instance where the url was wrong, and fixed it to point to runtime instead.

Relying on CI to find issues.

Fixes https://github.com/dotnet/runtime/issues/1746
cc: @jaredpar, @danmosemsft 