### PR TITLE
JIT: refine handle blocking logic

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -2624,13 +2624,6 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
 
         case O2K_CONST_LONG:
 
-#ifdef _TARGET_64BIT_
-            // Don't propagate handles if we need to report relocs.
-            if (opts.compReloc && ((curAssertion->op2.u1.iconFlags & GTF_ICON_HDL_MASK) != 0))
-            {
-                return nullptr;
-            }
-#endif
             if (newTree->gtType == TYP_LONG)
             {
                 newTree->ChangeOperConst(GT_CNS_NATIVELONG);
@@ -2646,13 +2639,11 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
 
         case O2K_CONST_INT:
 
-#ifndef _TARGET_64BIT_
             // Don't propagate handles if we need to report relocs.
             if (opts.compReloc && ((curAssertion->op2.u1.iconFlags & GTF_ICON_HDL_MASK) != 0))
             {
                 return nullptr;
             }
-#endif
 
             if (curAssertion->op2.u1.iconFlags & GTF_ICON_HDL_MASK)
             {


### PR DESCRIPTION
Assertion prop uses `O2K_CONST_INT` for handles, even on 64 bit targets. Make
suitable adjustments to the handle propagation blocking logic.

Problem was introduced in #1593 and exposed by #1309.

Fixes #1777