### PR TITLE
Fix Linux tests mainv1, mainv2

### DIFF
--- a/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
+++ b/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
@@ -292,7 +292,7 @@ CLRTestExpectedExitCode=0
 
     <PropertyGroup>
       <BashEnvironmentVariables>
-        @(CLRTestBashEnvironmentVariable -> '%(Identity)', '%0d%0a')
+@(CLRTestBashEnvironmentVariable -> '%(Identity)', '%0a')
       </BashEnvironmentVariables>
     </PropertyGroup>
      


### PR DESCRIPTION
Don't use CR in Unix bash scripts.

This appears to be fallout from #583, which added a
second variable that then created a need to add newlines.

I hoped it would fix #1789, but it only fixes the "unset" error; the tests still fail.