### PR TITLE
[testing] Update TraceEvent package version and bypass corner case in EventPipe

### DIFF
--- a/src/coreclr/dependencies.props
+++ b/src/coreclr/dependencies.props
@@ -8,7 +8,7 @@
   <!-- Tests/infrastructure dependency versions. -->
   <PropertyGroup>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.43</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
+    <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.49</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
     <CommandLineParserVersion>2.2.0</CommandLineParserVersion>
 

--- a/src/coreclr/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Runtime.InteropServices;
@@ -173,6 +174,16 @@ namespace Tracing.Tests.Common
 
         private int Validate()
         {
+            // FIXME: This is a bandaid fix for a deadlock in EventPipeEventSource caused by
+            // the lazy caching in the Regex library.  The caching creates a ConcurrentDictionary
+            // and because it is the first one in the process, it creates and EventSource which
+            // results in a deadlock over a lock in EventPipe.  This line should be removed once the
+            // underlying issue is fixed.
+            //
+            // see: https://github.com/dotnet/runtime/pull/1794 for details on the issue
+            //
+            var emptyConcurrentDictionary = new ConcurrentDictionary<string, string>();
+
             var isClean = EnsureCleanEnvironment();
             if (!isClean)
                 return -1;

--- a/src/coreclr/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/common/IpcTraceTest.cs
@@ -176,13 +176,15 @@ namespace Tracing.Tests.Common
         {
             // FIXME: This is a bandaid fix for a deadlock in EventPipeEventSource caused by
             // the lazy caching in the Regex library.  The caching creates a ConcurrentDictionary
-            // and because it is the first one in the process, it creates and EventSource which
-            // results in a deadlock over a lock in EventPipe.  This line should be removed once the
-            // underlying issue is fixed.
+            // and because it is the first one in the process, it creates an EventSource which
+            // results in a deadlock over a lock in EventPipe.  These lines should be removed once the
+            // underlying issue is fixed by forcing these events to try to be written _before_ we shutdown.
             //
             // see: https://github.com/dotnet/runtime/pull/1794 for details on the issue
             //
             var emptyConcurrentDictionary = new ConcurrentDictionary<string, string>();
+            emptyConcurrentDictionary["foo"] = "bar";
+            var __count = emptyConcurrentDictionary.Count;
 
             var isClean = EnsureCleanEnvironment();
             if (!isClean)


### PR DESCRIPTION
The fix (Microsoft/PerfView#1047) that resolves dotnet/coreclr#26241 is in version 2.0.48 of TraceEvent, so the failure can still occur randomly.  This change updates the version used in testing to include the fix.

resolves dotnet/coreclr#26241

CC @tommcdon 