### PR TITLE
missing check for `readonly` case in x86 array ::Address stub

### DIFF
--- a/src/coreclr/src/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/src/vm/i386/stublinkerx86.cpp
@@ -4496,6 +4496,8 @@ VOID StubLinkerCPU::EmitArrayOpStub(const ArrayOpScript* pArrayOpScript)
             // needed.
             CodeLabel *Inner_passedTypeCheck = NewCodeLabel();
 
+            // test typeReg, typeReg
+            X86EmitR2ROp(0x85, typeReg, typeReg);
             X86EmitCondJump(Inner_passedTypeCheck, X86CondCode::kJZ);
 
             // Compare MT against the MT of the array.                     

--- a/src/coreclr/tests/src/Regressions/coreclr/9414/readonlyPrefix.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/9414/readonlyPrefix.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="readonlyPrefix.cs" />


### PR DESCRIPTION
The check was previously done off the flags after masking the lower 2 bits in the typedesc. The whole thing is now gone, so we need an explicit check.

Fixes:https://github.com/dotnet/runtime/issues/1782