### PR TITLE
Do not look at Size when doing Auto layout

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -649,11 +649,6 @@ namespace Internal.TypeSystem
                 fieldOrdinal++;
             }
 
-            if (type.IsValueType)
-            {
-                cumulativeInstanceFieldPos = LayoutInt.Max(cumulativeInstanceFieldPos, new LayoutInt(layoutMetadata.Size));
-            }
-
             // The JITs like to copy full machine words,
             // so if the size is bigger than a void* round it up to minAlign
             // and if the size is smaller than void* round it up to next power of two

--- a/src/coreclr/tests/src/Regressions/coreclr/1770/autolayoutsize.cs
+++ b/src/coreclr/tests/src/Regressions/coreclr/1770/autolayoutsize.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Auto, Size = 16)]
+struct Foo
+{
+    private int _field;
+
+    static unsafe int Main()
+    {
+        return sizeof(Foo) == 4 ? 100 : -1;
+    }
+}

--- a/src/coreclr/tests/src/Regressions/coreclr/1770/autolayoutsize.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/1770/autolayoutsize.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="autolayoutsize.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Seems like the deleted line was copypasted from the Sequential/Explicit case, but it's incorrect.

Fixes #1770.

Cc @dotnet/crossgen-contrib 