### PR TITLE
Update the CoreCLR testing workflow doc

### DIFF
--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -4,11 +4,13 @@ Details on test metadata can be found in [test-configuration.md](test-configurat
 
 ## Build All Tests
 
-1) Build the CoreCLR product
+1) Build the CoreCLR product in Release configuration
     * [Unix](../../building/coreclr/linux-instructions.md)
     * [OSX](../../building/coreclr/osx-instructions.md)
     * [Windows](../../building/coreclr/README.md)
-1) From the root directory run the following command:
+1) [Build the libraries](../../building/libraries/README.md) in Release configuration 
+1) If you don't want to use the release configuration for running the tests, build CoreCLR again in the configuration you want to test with.
+1) From the src/coreclr directory run the following command:
     * Non-Windows - `./build-test.sh`
     * Windows - `build-test.cmd`
     * Supply `-h` for usage flags

--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -4,12 +4,11 @@ Details on test metadata can be found in [test-configuration.md](test-configurat
 
 ## Build All Tests
 
-1) Build the CoreCLR product in Release configuration
+1) Build the CoreCLR product
     * [Unix](../../building/coreclr/linux-instructions.md)
     * [OSX](../../building/coreclr/osx-instructions.md)
     * [Windows](../../building/coreclr/README.md)
-1) [Build the libraries](../../building/libraries/README.md) in Release configuration 
-1) If you don't want to use the release configuration for running the tests, build CoreCLR again in the configuration you want to test with.
+1) [Build the libraries](../../building/libraries/README.md) in Release configuration. Pass the configuration of CoreCLR you just built to the build script (e.g. `/p:CoreCLRConfiguration=Debug`).
 1) From the src/coreclr directory run the following command:
     * Non-Windows - `./build-test.sh`
     * Windows - `build-test.cmd`


### PR DESCRIPTION
With JanV's help I learned that building CoreCLR tests now requires building the libraries in release mode which in turn requires building CoreCLR in release mode.

Obligatory https://www.xkcd.com/303/.