### PR TITLE
Make System.Guid readonly

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
@@ -4,15 +4,16 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
-    public partial struct Guid
+    public readonly partial struct Guid
     {
         // This will create a new random guid based on the https://www.ietf.org/rfc/rfc4122.txt
         public static unsafe Guid NewGuid()
         {
-            Guid g;
+            MutableGuid g;
             Interop.GetRandomBytes((byte*)&g, sizeof(Guid));
 
             const ushort VersionMask = 0xF000;
@@ -31,7 +32,7 @@ namespace System
                 g._d = (byte)((g._d & ~ClockSeqHiAndReservedMask) | ClockSeqHiAndReservedValue);
             }
 
-            return g;
+            return Unsafe.As<MutableGuid, Guid>(ref g);
         }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -1341,9 +1341,9 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
-    public partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable
+    public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.IFormattable
     {
-        private int _dummyPrimitive;
+        private readonly int _dummyPrimitive;
         public static readonly System.Guid Empty;
         public Guid(byte[] b) { throw null; }
         public Guid(int a, short b, short c, byte d, byte e, byte f, byte g, byte h, byte i, byte j, byte k) { throw null; }


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/issues/1718

This PR makes System.Guid as `readonly struct`. While none of the APIs mutate the instances, implementations of GUID parsing, copy and comparisons involve taking `ref`s of those fields and assigning new values, which is not allowed by C# with readonly fields.

To work around these with minimal code changes, `Unsafe.AsRef` is used whenever we need to pass something as `ref`. These were really just for bitwise-comparison or for MemoryMarshal.TryWrite.
I'm honestly surprised by the fact that MemoryMarshal.TryWrite takes `ref T` instead of `in T` as it does not mutate the passed reference.

For the parsing implementation, rather large portions of it were mutating the guid; I ended up type-punning by creating a structurally identical struct then `Unsafe.As`ing it.

Not sure if API review is required for this? All the public members should not mutate the instance already anyway (and would make this a mutable struct if any of them are, which is usually a bad idea)