### PR TITLE
Enable nullable annotations for System.Dynamic.Runtime

### DIFF
--- a/src/libraries/System.Dynamic.Runtime/ref/System.Dynamic.Runtime.csproj
+++ b/src/libraries/System.Dynamic.Runtime/ref/System.Dynamic.Runtime.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configurations>$(NetCoreAppCurrent)-Debug;$(NetCoreAppCurrent)-Release</Configurations>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Dynamic.Runtime.cs" />

--- a/src/libraries/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
+++ b/src/libraries/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>System.Dynamic.Runtime</RootNamespace>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <Configurations>$(NetCoreAppCurrent)-Debug;$(NetCoreAppCurrent)-Release</Configurations>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Linq.Expressions" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/40623

This is an uninhabited project with ref assembly [type forwarding definitions](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Dynamic.Runtime/ref/System.Dynamic.Runtime.Forwards.cs). This change merely enables nullable annotations to the project for the sake of consistency.