### PR TITLE
Fix bug in ZipFile.CreateFromDirectory method

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -352,7 +352,7 @@ namespace System.IO.Compression
         /// </param>
         public static void CreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName,
                                                CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding) =>
-            DoCreateFromDirectory(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding: null);
+            DoCreateFromDirectory(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding);
 
         private static void DoCreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName,
                                                   CompressionLevel? compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding)

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
@@ -83,6 +83,28 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        public void CreatedEmptyUtf32DirectoriesRoundtrip()
+        {
+            using (var tempFolder = new TempDirectory(GetTestFilePath()))
+            {
+                Encoding entryEncoding = Encoding.UTF32;
+                DirectoryInfo rootDir = new DirectoryInfo(tempFolder.Path);
+                rootDir.CreateSubdirectory("empty1");
+
+                string archivePath = GetTestFilePath();
+                ZipFile.CreateFromDirectory(
+                    rootDir.FullName, archivePath,
+                    CompressionLevel.Optimal, false, entryEncoding);
+
+                using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Read, entryEncoding))
+                {
+                    Assert.Equal(1, archive.Entries.Count);
+                    Assert.StartsWith("empty1", archive.Entries[0].FullName);
+                }
+            }
+        }
+
+        [Fact]
         public void CreatedEmptyRootDirectoryRoundtrips()
         {
             using (var tempFolder = new TempDirectory(GetTestFilePath()))


### PR DESCRIPTION
Following up on #1811, this PR fixes a minor bug in one of the `ZipFile.CreateFromDirectory` overloads.