### PR TITLE
Enable overriding CoreCLR and Libraries configurations in root build

### DIFF
--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -8,7 +8,7 @@ Here is one example of a daily workflow for a developer working mainly on the li
 :: From root in the morning:
 git clean -xdf
 git pull upstream master & git push origin master
-build -subsetCategory corelcr -c Release
+build -subsetCategory coreclr -c Release
 build -subsetCategory libraries -coreclrConfiguration Release
 
 :: The above you may only perform once in a day, or when
@@ -33,7 +33,7 @@ The instructions for Linux are essentially the same:
 # From root in the morning:
 git clean -xdf
 git pull upstream master & git push origin master
-./build.sh -subsetcategory corclr -c Release
+./build.sh -subsetcategory coreclr -c Release
 ./build.sh -subsetcategory libraries -coreclrconfiguration Release
 
 # The above you may only perform once in a day, or when

--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -33,8 +33,8 @@ The instructions for Linux are essentially the same:
 # From root in the morning:
 git clean -xdf
 git pull upstream master & git push origin master
-./build.sh -subsetCategory corclr -c Release
-./build.sh -subsetCategory libraries -coreclrConfiguration Release
+./build.sh -subsetcategory corclr -c Release
+./build.sh -subsetcategory libraries -coreclrconfiguration Release
 
 # The above you may only perform once in a day, or when
 # you pull down significant new changes.
@@ -59,7 +59,7 @@ These example commands will build a release CoreCLR (and CoreLib), debug librari
 
 For Linux:
 ```
-./build.sh -coreclrConfiguration Release
+./build.sh -coreclrconfiguration Release
 ```
 
 For Windows:

--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -8,10 +8,8 @@ Here is one example of a daily workflow for a developer working mainly on the li
 :: From root in the morning:
 git clean -xdf
 git pull upstream master & git push origin master
-cd src\coreclr
-build -release -skiptests
-cd ..\..\
-build -subsetCategory libraries /p:CoreCLRConfiguration=Release
+build -subsetCategory corelcr -c Release
+build -subsetCategory libraries -coreclrConfiguration Release
 
 :: The above you may only perform once in a day, or when
 :: you pull down significant new changes.
@@ -35,10 +33,8 @@ The instructions for Linux are essentially the same:
 # From root in the morning:
 git clean -xdf
 git pull upstream master & git push origin master
-cd src/coreclr
-build -release -skiptests
-cd ../../
-./build.sh -subsetCategory libraries /p:CoreCLRConfiguration=Release
+./build.sh -subsetCategory corclr -c Release
+./build.sh -subsetCategory libraries -coreclrConfiguration Release
 
 # The above you may only perform once in a day, or when
 # you pull down significant new changes.
@@ -59,18 +55,16 @@ The steps above may be all you need to know to make a change. Want more details 
 
 This document explains how to work on libraries. In order to work on library projects or run library tests it is necessary to have built CoreCLR (aka, the "runtime") to give the libraries something to run on. You should normally build CoreCLR in release configuration and libraries in debug configuration. If you haven't already done so, please read [this document](../../README.md#Configurations) to understand configurations.
 
-These example commands will build a release CoreCLR (and CoreLib) and debug libraries:
+These example commands will build a release CoreCLR (and CoreLib), debug libraries, and debug installer:
 
 For Linux:
 ```
-src/coreclr/build.sh -release -skiptests
-./build.sh -subsetCategory libraries /p:CoreCLRConfiguration=Release
+./build.sh -coreclrConfiguration Release
 ```
 
 For Windows:
 ```
-src\coreclr\build.cmd -release -skiptests
-build.cmd -subsetCategory libraries /p:CoreCLRConfiguration=Release
+./build.cmd -coreclrConfiguration Release
 ```
 
 Detailed information about building and testing CoreCLR and the libraries is in the documents linked below.

--- a/docs/workflow/testing/coreclr/testing.md
+++ b/docs/workflow/testing/coreclr/testing.md
@@ -8,7 +8,7 @@ Details on test metadata can be found in [test-configuration.md](test-configurat
     * [Unix](../../building/coreclr/linux-instructions.md)
     * [OSX](../../building/coreclr/osx-instructions.md)
     * [Windows](../../building/coreclr/README.md)
-1) [Build the libraries](../../building/libraries/README.md) in Release configuration. Pass the configuration of CoreCLR you just built to the build script (e.g. `/p:CoreCLRConfiguration=Debug`).
+1) [Build the libraries](../../building/libraries/README.md) in Release configuration. Pass the configuration of CoreCLR you just built to the build script (e.g. `-coreclrConfiguration Debug`).
 1) From the src/coreclr directory run the following command:
     * Non-Windows - `./build-test.sh`
     * Windows - `build-test.cmd`

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -96,6 +96,18 @@
     <ProjectToBuild Include="$(RepoToolsLocalDir)regenerate-readme-table.proj" />
   </ItemGroup>
 
+  <ItemDefinitionGroup Condition="'$(CoreCLRConfiguration)' != ''">
+    <CoreClrProjectToBuild>
+      <Properties>Configuration=$(CoreCLRConfiguration)</Properties>
+    </CoreClrProjectToBuild>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(LibrariesConfiguration)' != ''">
+    <LibrariesProjectToBuild>
+      <Properties>Configuration=$(LibrariesConfiguration)</Properties>
+    </LibrariesProjectToBuild>
+  </ItemDefinitionGroup>
+
   <!-- CoreClr sets -->
   <ItemGroup Condition="$(_subsetCategory.Contains('coreclr')) and $(_subset.Contains('all'))">
     <CoreClrProjectToBuild Include="$(CoreClrProjectRoot)coreclr.proj" BuildInParallel="false" />

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -14,6 +14,8 @@ Param(
   [string]$arch,
   [string]$subsetCategory,
   [string]$subset,
+  [string]$coreClrConfiguration,
+  [string]$librariesConfiguration,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -125,11 +125,11 @@ while [[ $# > 0 ]]; do
       arguments="$arguments /p:BuildNativeStripSymbols=true"
       shift 1
       ;;
-     -coreclrConfiguration)
+     -coreclrconfiguration)
       arguments="$arguments /p:CoreCLRConfiguration=$2"
       shift 2
       ;;
-     -librariesConfiguration)
+     -librariesconfiguration)
       arguments="$arguments /p:LibrariesConfiguration=$2"
       shift 2
       ;;

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -125,6 +125,14 @@ while [[ $# > 0 ]]; do
       arguments="$arguments /p:BuildNativeStripSymbols=true"
       shift 1
       ;;
+     -coreclrConfiguration)
+      arguments="$arguments /p:CoreCLRConfiguration=$2"
+      shift 2
+      ;;
+     -librariesConfiguration)
+      arguments="$arguments /p:LibrariesConfiguration=$2"
+      shift 2
+      ;;
       *)
       ea=$1
 


### PR DESCRIPTION
Override the configuration of the CoreCLR and Libraries builds during the root build when CoreCLRConfiguration and LibrariesConfiguration are specified respectively.

Fixes #840 