### PR TITLE
Remove Windows_NT_arm64 run tests

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -387,7 +387,6 @@ jobs:
     - Linux_arm
     - Windows_NT_x86
     - Windows_NT_arm
-    - Windows_NT_arm64
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:


### PR DESCRIPTION
This leg is currently a no-op of around 10 mins which takes an agent per PR that touches CoreCLR.

We can consider adding it back whenever there is an open helix queue with enough agents to take PR and CI tests. 