### PR TITLE
JIT: check that constant handles are not OK2_CONST_LONGs

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1644,6 +1644,7 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
             // so no handle bits should be set here.
             assert((assertion->op2.u1.iconFlags & GTF_ICON_HDL_MASK) == 0);
         }
+        break;
 
         default:
             // for all other 'assertion->op2.kind' values we don't check anything

--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1081,11 +1081,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     if (op2->gtOper == GT_CNS_INT)
                     {
 #ifdef _TARGET_ARM_
-                        // Do not Constant-Prop immediate values that require relocation
-                        if (op2->AsIntCon()->ImmedValNeedsReloc(this))
-                        {
-                            goto DONE_ASSERTION;
-                        }
                         // Do not Constant-Prop large constants for ARM
                         // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had
                         // target_ssize_t type.
@@ -1642,6 +1637,13 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
             }
         }
         break;
+
+        case O2K_CONST_LONG:
+        {
+            // All handles should be represented by O2K_CONST_INT,
+            // so no handle bits should be set here.
+            assert((assertion->op2.u1.iconFlags & GTF_ICON_HDL_MASK) == 0);
+        }
 
         default:
             // for all other 'assertion->op2.kind' values we don't check anything

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6482,6 +6482,7 @@ public:
             struct IntVal
             {
                 ssize_t  iconVal;   // integer
+                unsigned padding;   // unused; ensures iconFlags does not overlap lconVal
                 unsigned iconFlags; // gtFlags
             };
             struct Range // integer subrange


### PR DESCRIPTION
Follow-up from #1788.

Also remove an arm-only handle block that should now be redundant.