### PR TITLE
Performance improvements in LINQ methods All() & Any() for List<T> & Array

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -67,6 +67,8 @@ namespace System.Linq
                         return true;
                     }
                 }
+
+                return false;
             }
 
             if (source is TSource[] array)
@@ -78,6 +80,8 @@ namespace System.Linq
                         return true;
                     }
                 }
+
+                return false;
             }
 
             foreach (TSource element in source)
@@ -113,6 +117,8 @@ namespace System.Linq
                         return false;
                     }
                 }
+
+                return true;
             }
 
             if (source is TSource[] array)
@@ -124,6 +130,8 @@ namespace System.Linq
                         return false;
                     }
                 }
+
+                return true;
             }
 
             foreach (TSource element in source)

--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -57,6 +57,29 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
+            if (source is List<TSource> list)
+            {
+                for (var index = 0; index < list.Count; index++)
+                {
+                    var element = list[index];
+                    if (predicate(element))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            if (source is TSource[] array)
+            {
+                foreach (TSource element in array)
+                {
+                    if (predicate(element))
+                    {
+                        return true;
+                    }
+                }
+            }
+
             foreach (TSource element in source)
             {
                 if (predicate(element))
@@ -78,6 +101,29 @@ namespace System.Linq
             if (predicate == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
+            }
+
+            if (source is List<TSource> list)
+            {
+                for (var index = 0; index < list.Count; index++)
+                {
+                    var element = list[index];
+                    if (!predicate(element))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (source is TSource[] array)
+            {
+                foreach (TSource element in array)
+                {
+                    if (!predicate(element))
+                    {
+                        return false;
+                    }
+                }
             }
 
             foreach (TSource element in source)

--- a/src/libraries/System.Linq/tests/AllTests.cs
+++ b/src/libraries/System.Linq/tests/AllTests.cs
@@ -57,6 +57,18 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.All(predicate));
         }
 
+        [Theory]
+        [MemberData(nameof(All_TestData))]
+        public void AllList(IEnumerable<int> source, Func<int, bool> predicate, bool expected) {
+            Assert.Equal(expected, System.Linq.Enumerable.ToList(source).All(predicate));
+        }
+
+        [Theory]
+        [MemberData(nameof(All_TestData))]
+        public void AllArray(IEnumerable<int> source, Func<int, bool> predicate, bool expected) {
+            Assert.Equal(expected, System.Linq.Enumerable.ToArray(source).All(predicate));
+        }
+
         [Theory, MemberData(nameof(All_TestData))]
         public void AllRunOnce(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {

--- a/src/libraries/System.Linq/tests/AnyTests.cs
+++ b/src/libraries/System.Linq/tests/AnyTests.cs
@@ -21,6 +21,38 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SameResultsRepeatCallsIntArray() {
+            var array = new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 };
+
+            Func<int, bool> predicate = IsEven;
+            Assert.Equal(array.All(predicate), array.All(predicate));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsListOfInt() {
+            var list = new List<int>() { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 };
+
+            Func<int, bool> predicate = IsEven;
+            Assert.Equal(list.All(predicate), list.All(predicate));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsIntArray() {
+            var array = new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 };
+
+            Func<int, bool> predicate = IsEven;
+            Assert.Equal(array.Any(predicate), array.Any(predicate));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsListOfInt() {
+            var list = new List<int> { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 };
+
+            Func<int, bool> predicate = IsEven;
+            Assert.Equal(list.Any(predicate), list.Any(predicate));
+        }
+
+        [Fact]
         public void SameResultsRepeatCallsStringQuery()
         {
             var q = from x in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS", string.Empty }
@@ -62,6 +94,26 @@ namespace System.Linq.Tests
         public void Any(IEnumerable<int> source, bool expected)
         {
             Assert.Equal(expected, source.Any());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestDataWithPredicate))]
+        public void AnyList(IEnumerable<int> source, Func<int, bool> predicate, bool expected) {
+            if (predicate == null) {
+                Assert.Equal(expected, new List<int>(source).Any());
+            } else {
+                Assert.Equal(expected, new List<int>(source).Any(predicate));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestDataWithPredicate))]
+        public void AnyArray(IEnumerable<int> source, Func<int, bool> predicate, bool expected) {
+            if (predicate == null) {
+                Assert.Equal(expected, System.Linq.Enumerable.ToArray(source).Any());
+            } else {
+                Assert.Equal(expected, System.Linq.Enumerable.ToArray(source).Any(predicate));
+            }
         }
 
         public static IEnumerable<object[]> TestDataWithPredicate()


### PR DESCRIPTION
The performance on LINQ methods All() & Any() for List<T> & Array can be improved using a typecheck and a normal for-loop instead of a for-each on the IEnumerable. This improves the speed and also reduce the allocations. 

I have created the following Benchmarks to verify this.

```
[MemoryDiagnoser]
public class AllBM
{

    [Params(10, 100, 1000, 10000)]
    public int Size;

    private IEnumerable<int> _range;
    private List<int> _list;
    private int[] _array;

    [GlobalSetup]
    public void Setup()
    {
        _range = System.Linq.Enumerable.Range(0, Size);
        _list = new List<int>(_range);
        _array = _list.ToArray();
    }

    [Benchmark]
    public bool AllNewOnAll()
    {
        Func<int, bool> fp = n => n < Size;
        return _range.All(fp) && _list.All(fp) && _array.All(fp);
    }

    [Benchmark]
    public bool AllOriginalOnAll()
    {
        Func<int, bool> fp = n => n < Size;
        return System.Linq.Enumerable.All(_range, fp) && System.Linq.Enumerable.All(_list, fp) && System.Linq.Enumerable.All(_array, fp);
    }
}
```

This is the result for the All benchmark, the performance is more than 50% faster!

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-2600K CPU 3.40GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


```
|           Method |  Size |         Mean |       Error |      StdDev |       Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |------ |-------------:|------------:|------------:|-------------:|-------:|------:|------:|----------:|
|      **AllNewOnAll** |    **10** |     **161.8 ns** |     **1.63 ns** |     **1.52 ns** |     **161.8 ns** | **0.0248** |     **-** |     **-** |     **104 B** |
| AllOriginalOnAll |    10 |     349.8 ns |     8.12 ns |    23.02 ns |     341.1 ns | 0.0420 |     - |     - |     176 B |
|      **AllNewOnAll** |   **100** |   **1,156.7 ns** |    **22.92 ns** |    **57.08 ns** |   **1,145.1 ns** | **0.0248** |     **-** |     **-** |     **104 B** |
| AllOriginalOnAll |   100 |   2,373.9 ns |    51.18 ns |    73.40 ns |   2,338.8 ns | 0.0420 |     - |     - |     176 B |
|      **AllNewOnAll** |  **1000** |  **10,229.6 ns** |   **193.89 ns** |   **181.36 ns** |  **10,200.8 ns** | **0.0153** |     **-** |     **-** |     **104 B** |
| AllOriginalOnAll |  1000 |  22,951.4 ns |   325.13 ns |   304.12 ns |  22,844.5 ns | 0.0305 |     - |     - |     176 B |
|      **AllNewOnAll** | **10000** | **102,523.6 ns** | **1,991.58 ns** | **2,791.92 ns** | **102,090.3 ns** |      **-** |     **-** |     **-** |     **104 B** |
| AllOriginalOnAll | 10000 | 219,583.7 ns | 2,479.81 ns | 2,319.62 ns | 218,873.6 ns |      - |     - |     - |     176 B |

```
[MemoryDiagnoser]
public class AnyBM
{

    [Params(10, 100, 1000, 10000)]
    public int Size;

    private IEnumerable<int> _range;
    private List<int> _list;
    private int[] _array;

    [GlobalSetup]
    public void Setup()
    {
        _range = System.Linq.Enumerable.Range(0, Size);
        _list = new List<int>(_range);
        _array = _list.ToArray();
    }

    [Benchmark]
    public bool AnyNew()
    {
        int limit = Size - 5;
        Func<int, bool> fp = n => n > limit;
        return _range.Any(fp) && _list.Any(fp) && _array.Any(fp);
    }

    [Benchmark]
    public bool AnyOriginal()
    {
        int limit = Size - 5;
        Func<int, bool> fp = n => n > limit;
        return System.Linq.Enumerable.Any(_range, fp) && System.Linq.Enumerable.Any(_list, fp) && System.Linq.Enumerable.Any(_array, fp);
    }

}
```

This is the result for the Any benchmark, the performance is more than 50% faster!

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-2600K CPU 3.40GHz (Sandy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.101
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


```
|      Method |  Size |         Mean |       Error |      StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |------ |-------------:|------------:|------------:|-------:|------:|------:|----------:|
|      **AnyNew** |    **10** |     **130.8 ns** |     **2.94 ns** |     **4.67 ns** | **0.0305** |     **-** |     **-** |     **128 B** |
| AnyOriginal |    10 |     276.3 ns |     5.96 ns |    11.33 ns | 0.0477 |     - |     - |     200 B |
|      **AnyNew** |   **100** |   **1,034.8 ns** |    **15.84 ns** |    **14.04 ns** | **0.0305** |     **-** |     **-** |     **128 B** |
| AnyOriginal |   100 |   2,336.0 ns |    37.78 ns |    33.49 ns | 0.0458 |     - |     - |     200 B |
|      **AnyNew** |  **1000** |   **9,993.6 ns** |   **293.88 ns** |   **430.77 ns** | **0.0305** |     **-** |     **-** |     **128 B** |
| AnyOriginal |  1000 |  23,402.7 ns |   468.82 ns |   701.70 ns | 0.0305 |     - |     - |     200 B |
|      **AnyNew** | **10000** |  **97,747.5 ns** | **2,117.20 ns** | **3,168.93 ns** |      **-** |     **-** |     **-** |     **128 B** |
| AnyOriginal | 10000 | 228,344.5 ns | 1,708.71 ns | 1,598.33 ns |      - |     - |     - |     200 B |

I hope this is convincing
