### PR TITLE
Fix dumping of GCSlotFlags in R2RDump

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -26,13 +26,10 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 Index = index;
                 RegisterNumber = registerNumber;
                 StackSlot = stack;
+                Flags = flags;
                 if (isUntracked)
                 {
-                    Flags = GcSlotFlags.GC_SLOT_UNTRACKED;
-                }
-                else
-                {
-                    Flags = flags;
+                    Flags |= GcSlotFlags.GC_SLOT_UNTRACKED;
                 }
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -239,6 +239,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         RT_Illegal = 0xFF
     };
 
+    [Flags]
     public enum GcSlotFlags
     {
         GC_SLOT_BASE = 0x0,


### PR DESCRIPTION
There were two issues. If a slot was marked as untracked, we were
replacing whatever flags there were set by GC_SLOT_UNTRACKED. After
fixing that, the other problem was that the GCSlotFlags were not marked
as Flags and so we were not printing it as combination of flags.