### PR TITLE
Remove Windows_NT_arm64 from checked libraries rolling tests

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -484,8 +484,6 @@ jobs:
     platforms:
     # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Windows_NT_x86
-    - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - Windows_NT_arm64
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:


### PR DESCRIPTION
Oops, I missed to remove this one as well and rolling builds are failing because no helix queues are provided:

> F:\workspace\_work\1\s\.packages\microsoft.dotnet.helix.sdk\5.0.0-beta.20063.2\tools\Microsoft.DotNet.Helix.Sdk.MultiQueue.targets(17,5): error : You must specify at least one target queue to send a job to helix. Use the HelixTargetQueues property or HelixTargetQueue items.

cc: @trylek 