### PR TITLE
Port stubbed out Regex.CompileToAssembly

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -22,6 +22,7 @@
     <Compile Include="System\Text\RegularExpressions\Regex.Replace.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Split.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Timeout.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexAssemblyCompiler.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexBoyerMoore.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCode.cs" />
@@ -69,6 +70,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
     <!-- References required for compiled feature -->
+    <Reference Include="System.Reflection.Emit" />
     <Reference Include="System.Reflection.Emit.ILGeneration" />
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -201,25 +201,33 @@ namespace System.Text.RegularExpressions
         /// instantiating a non-compiled regex.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout)
-        {
-            return RegexCompiler.Compile(code, options, hasTimeout);
-        }
+        private static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout) =>
+            RegexCompiler.Compile(code, options, hasTimeout);
 #endif
 
-        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname)
-        {
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CompileToAssembly);
-        }
+        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname) =>
+            CompileToAssembly(regexinfos, assemblyname, null, null);
 
-        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[] attributes)
-        {
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CompileToAssembly);
-        }
+        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes) =>
+            CompileToAssembly(regexinfos, assemblyname, attributes, null);
 
-        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[] attributes, string resourceFile)
+        public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes, string? resourceFile)
         {
+            if (assemblyname is null)
+            {
+                throw new ArgumentNullException(nameof(assemblyname));
+            }
+
+            if (regexinfos is null)
+            {
+                throw new ArgumentNullException(nameof(regexinfos));
+            }
+
+#if DEBUG // until it can be fully implemented
+            RegexCompiler.CompileToAssembly(regexinfos, assemblyname, attributes, resourceFile);
+#else
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CompileToAssembly);
+#endif
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
@@ -1,0 +1,273 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+
+#if DEBUG // until it can be fully implemented
+namespace System.Text.RegularExpressions
+{
+    /// <summary>Compiles a Regex to an assembly that can be saved to disk.</summary>
+    internal sealed class RegexAssemblyCompiler : RegexCompiler
+    {
+        /// <summary>Type count used to augment generated type names to create unique names.</summary>
+        private static int s_typeCount = 0;
+
+        private AssemblyBuilder _assembly;
+        private ModuleBuilder _module;
+        private TypeBuilder? _type;
+        private MethodBuilder? _method;
+
+        internal RegexAssemblyCompiler(AssemblyName an, CustomAttributeBuilder[]? attribs, string? resourceFile) :
+            base(persistsAssembly: true)
+        {
+            if (resourceFile != null)
+            {
+                // Unmanaged resources are not supported: _assembly.DefineUnmanagedResource(resourceFile);
+                throw new PlatformNotSupportedException();
+            }
+
+            _assembly = AssemblyBuilder.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run); // TODO https://github.com/dotnet/corefx/issues/39227: AssemblyBuilderAccess.Save
+            _module = _assembly.DefineDynamicModule(an.Name + ".dll");
+            if (attribs != null)
+            {
+                foreach (CustomAttributeBuilder attr in attribs)
+                {
+                    _assembly.SetCustomAttribute(attr);
+                }
+            }
+        }
+
+        internal void GenerateRegexType(string pattern, RegexOptions options, string name, bool isPublic, RegexCode code, RegexTree tree, TimeSpan matchTimeout)
+        {
+            _code = code;
+            _codes = code.Codes;
+            _strings = code.Strings;
+            _fcPrefix = code.FCPrefix;
+            _bmPrefix = code.BMPrefix;
+            _anchors = code.Anchors;
+            _trackcount = code.TrackCount;
+            _options = options;
+
+            // Pick a name for the class.
+            string typenumString = ((uint)Interlocked.Increment(ref s_typeCount)).ToString();
+
+            // Generate the RegexRunner-derived type.
+            DefineType($"{name}Runner{typenumString}", false, typeof(RegexRunner));
+
+            DefineMethod("Go", null);
+            GenerateGo();
+            BakeMethod();
+
+            DefineMethod("FindFirstChar", typeof(bool));
+            GenerateFindFirstChar();
+            BakeMethod();
+
+            DefineMethod("InitTrackCount", null);
+            GenerateInitTrackCount();
+            BakeMethod();
+
+            Type runnertype = BakeType();
+
+            // Generate a RegexRunnerFactory-derived type.
+            DefineType($"{name}Factory{typenumString}", false, typeof(RegexRunnerFactory));
+            DefineMethod("CreateInstance", typeof(RegexRunner));
+            GenerateCreateInstance(runnertype);
+            BakeMethod();
+            Type factory = BakeType();
+
+            FieldInfo internalMatchTimeoutField = RegexField(nameof(Regex.internalMatchTimeout));
+            ConstructorBuilder defaultCtor, timeoutCtor;
+
+            DefineType(name, isPublic, typeof(Regex));
+            {
+                // Define default constructor:
+                _method = null;
+                defaultCtor = _type!.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+                _ilg = defaultCtor.GetILGenerator();
+                {
+                    // call base constructor
+                    Ldthis();
+                    _ilg.Emit(OpCodes.Call, typeof(Regex).GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, Array.Empty<ParameterModifier>())!);
+
+                    // set pattern
+                    Ldthis();
+                    Ldstr(pattern);
+                    Stfld(RegexField(nameof(Regex.pattern)));
+
+                    // set options
+                    Ldthis();
+                    Ldc((int)options);
+                    Stfld(RegexField(nameof(Regex.roptions)));
+
+                    // set timeout (no need to validate as it should have happened in RegexCompilationInfo)
+                    Ldthis();
+                    LdcI8(matchTimeout.Ticks);
+                    Call(typeof(TimeSpan).GetMethod(nameof(TimeSpan.FromTicks), BindingFlags.Static | BindingFlags.Public)!);
+                    Stfld(internalMatchTimeoutField);
+
+                    // set factory
+                    Ldthis();
+                    Newobj(factory.GetConstructor(Type.EmptyTypes)!);
+                    Stfld(RegexField(nameof(Regex.factory)));
+
+                    // set caps
+                    if (code.Caps != null)
+                    {
+                        GenerateCreateHashtable(RegexField(nameof(Regex.caps)), code.Caps);
+                    }
+
+                    // set capnames
+                    if (tree.CapNames != null)
+                    {
+                        GenerateCreateHashtable(RegexField(nameof(Regex.capnames)), tree.CapNames);
+                    }
+
+                    // set capslist
+                    if (tree.CapsList != null)
+                    {
+                        Ldthis();
+                        Ldc(tree.CapsList.Length);
+                        _ilg.Emit(OpCodes.Newarr, typeof(string));  // create new string array
+                        FieldInfo capslistField = RegexField(nameof(Regex.capslist));
+                        Stfld(capslistField);
+                        for (int i = 0; i < tree.CapsList.Length; i++)
+                        {
+                            Ldthisfld(capslistField);
+
+                            Ldc(i);
+                            Ldstr(tree.CapsList[i]);
+                            _ilg.Emit(OpCodes.Stelem_Ref);
+                        }
+                    }
+
+                    // set capsize
+                    Ldthis();
+                    Ldc(code.CapSize);
+                    Stfld(RegexField(nameof(Regex.capsize)));
+
+                    // set runnerref and replref by calling InitializeReferences()
+                    Ldthis();
+                    Call(typeof(Regex).GetMethod("InitializeReferences", BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!);
+
+                    Ret();
+                }
+
+                // Constructor with the timeout parameter:
+                // We only generate a constructor with a timeout parameter if the regex information supplied has a non-infinite timeout.
+                // If it has an infinite timeout, then the generated code is not going to respect the timeout.
+                if (matchTimeout != Regex.InfiniteMatchTimeout)
+                {
+                    _method = null;
+                    timeoutCtor = _type.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(TimeSpan) });
+                    _ilg = timeoutCtor.GetILGenerator();
+                    {
+                        // Call the default constructor:
+                        Ldthis();
+                        _ilg.Emit(OpCodes.Call, defaultCtor);
+
+                        // Validate timeout:
+                        _ilg.Emit(OpCodes.Ldarg_1);
+                        Call(typeof(Regex).GetMethod(nameof(Regex.ValidateMatchTimeout), BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!);
+
+                        // Set timeout:
+                        Ldthis();
+                        _ilg.Emit(OpCodes.Ldarg_1);
+                        Stfld(internalMatchTimeoutField);
+
+                        Ret();
+                    }
+                }
+            }
+
+            // bake the type
+            _type.CreateType();
+            _type = null;
+            _method = null;
+            _ilg = null;
+        }
+
+        private void GenerateInitTrackCount()
+        {
+            Ldthis();
+            Ldc(_trackcount);
+            Stfld(s_runtrackcountField);
+            Ret();
+        }
+
+        internal void GenerateCreateHashtable(FieldInfo field, Hashtable ht)
+        {
+            MethodInfo addMethod = typeof(Hashtable).GetMethod(nameof(Hashtable.Add), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
+
+            Ldthis();
+            Newobj(typeof(Hashtable).GetConstructor(Type.EmptyTypes)!);
+
+            Stfld(field);
+
+            IDictionaryEnumerator en = ht.GetEnumerator();
+            while (en.MoveNext())
+            {
+                Ldthisfld(field);
+
+                if (en.Key is int key)
+                {
+                    Ldc(key);
+                    _ilg!.Emit(OpCodes.Box, typeof(int));
+                }
+                else
+                {
+                    Ldstr((string)en.Key);
+                }
+
+                Ldc((int)en.Value!);
+                _ilg!.Emit(OpCodes.Box, typeof(int));
+                Callvirt(addMethod);
+            }
+        }
+
+        private FieldInfo RegexField(string fieldname) =>
+            typeof(Regex).GetField(fieldname, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!;
+
+        internal void Save()
+        {
+            // Save the assembly to the current directory.
+            string fileName = _assembly.GetName().Name + ".dll";
+
+            // TODO https://github.com/dotnet/corefx/issues/39227: _assembly.Save(fileName)
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CompileToAssembly);
+        }
+
+        /// <summary>Generates a very simple factory method.</summary>
+        internal void GenerateCreateInstance(Type newtype)
+        {
+            Newobj(newtype.GetConstructor(Type.EmptyTypes)!);
+            Ret();
+        }
+
+        /// <summary>Begins the definition of a new type with a specified base class</summary>
+        internal void DefineType(string typename, bool isPublic, Type inheritfromclass) =>
+            _type = _module.DefineType(typename, TypeAttributes.Class | (isPublic ? TypeAttributes.Public : TypeAttributes.NotPublic), inheritfromclass);
+
+        /// <summary>Begins the definition of a new method (no args) with a specified return value.</summary>
+        internal void DefineMethod(string methname, Type? returntype)
+        {
+            _method = _type!.DefineMethod(methname, MethodAttributes.Public | MethodAttributes.Virtual, returntype, null);
+            _ilg = _method.GetILGenerator();
+        }
+
+        /// <summary>Ends the definition of a method</summary>
+        internal void BakeMethod() => _method = null;
+
+        /// <summary>Ends the definition of a class and returns the type</summary>
+        internal Type BakeType()
+        {
+            Type retval = _type!.CreateType()!;
+            _type = null;
+            return retval!;
+        }
+    }
+}
+#endif

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -172,7 +172,7 @@ namespace System.Text.RegularExpressions
                 RegexTree tree = RegexParser.Parse(pattern, options, (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
                 RegexCode code = RegexWriter.Write(tree);
 
-                c.GenerateRegexType(pattern, options, fullname, regexinfos[i].IsPublic, code, tree, regexinfos[i].MatchTimeout);
+                c.GenerateRegexType(pattern, options, fullname, regexinfos[i].IsPublic, code, regexinfos[i].MatchTimeout);
             }
 
             c.Save();
@@ -4603,9 +4603,6 @@ namespace System.Text.RegularExpressions
             // it lets IL emit handle all the gory details for us.  It also is ok from an
             // endianness perspective because the compilation happens on the same machine
             // that runs the compiled code.
-            // TODO https://github.com/dotnet/corefx/issues/39227: If that were to ever change,
-            // this would need to be revisited, such as by doubling the string length, and using
-            // just the lower byte of the char, e.g. (byte)lookup[x].
             string bitVectorString = string.Create(8, (charClass, invariant), (dest, state) => // String length is 8 chars == 16 bytes == 128 bits.
             {
                 for (int i = 0; i < 128; i++)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System.Text.RegularExpressions
@@ -29,7 +27,7 @@ namespace System.Text.RegularExpressions
         private static readonly FieldInfo s_runtrackField = RegexRunnerField("runtrack");
         private static readonly FieldInfo s_runstackposField = RegexRunnerField("runstackpos");
         private static readonly FieldInfo s_runstackField = RegexRunnerField("runstack");
-        private static readonly FieldInfo s_runtrackcountField = RegexRunnerField("runtrackcount");
+        protected static readonly FieldInfo s_runtrackcountField = RegexRunnerField("runtrackcount");
 
         private static readonly MethodInfo s_doubleStackMethod = RegexRunnerMethod("DoubleStack");
         private static readonly MethodInfo s_doubleTrackMethod = RegexRunnerMethod("DoubleTrack");
@@ -77,6 +75,8 @@ namespace System.Text.RegularExpressions
         private const int MaxRecursionDepth = 20;
 
         protected ILGenerator? _ilg;
+        /// <summary>true if the compiled code is saved for later use, potentially on a different machine.</summary>
+        private readonly bool _persistsAssembly;
 
         // tokens representing local variables
         private LocalBuilder? _runtextbegLocal;
@@ -129,6 +129,11 @@ namespace System.Text.RegularExpressions
         private const int Uniquecount = 10;
         private const int LoopTimeoutCheckCount = 2048; // A conservative value to guarantee the correct timeout handling.
 
+        protected RegexCompiler(bool persistsAssembly)
+        {
+            _persistsAssembly = persistsAssembly;
+        }
+
         private static FieldInfo RegexRunnerField(string fieldname) => typeof(RegexRunner).GetField(fieldname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
 
         private static MethodInfo RegexRunnerMethod(string methname) => typeof(RegexRunner).GetMethod(methname, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)!;
@@ -137,7 +142,42 @@ namespace System.Text.RegularExpressions
         /// Entry point to dynamically compile a regular expression.  The expression is compiled to
         /// an in-memory assembly.
         /// </summary>
-        internal static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout) => new RegexLWCGCompiler().FactoryInstanceFromCode(code, options, hasTimeout);
+        internal static RegexRunnerFactory Compile(RegexCode code, RegexOptions options, bool hasTimeout) =>
+            new RegexLWCGCompiler().FactoryInstanceFromCode(code, options, hasTimeout);
+
+#if DEBUG // until it can be fully implemented
+        /// <summary>
+        /// Entry point to dynamically compile a regular expression.  The expression is compiled to
+        /// an assembly saved to a file.
+        /// </summary>
+        internal static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes, string? resourceFile)
+        {
+            var c = new RegexAssemblyCompiler(assemblyname, attributes, resourceFile);
+
+            for (int i = 0; i < regexinfos.Length; i++)
+            {
+                if (regexinfos[i] is null)
+                {
+                    throw new ArgumentNullException(nameof(regexinfos), SR.ArgumentNull_ArrayWithNullElements);
+                }
+
+                string pattern = regexinfos[i].Pattern;
+
+                RegexOptions options = regexinfos[i].Options | RegexOptions.Compiled; // ensure compiled is set; it enables more optimization specific to compilation
+
+                string fullname = regexinfos[i].Namespace.Length == 0 ?
+                    regexinfos[i].Name :
+                    regexinfos[i].Namespace + "." + regexinfos[i].Name;
+
+                RegexTree tree = RegexParser.Parse(pattern, options, (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
+                RegexCode code = RegexWriter.Write(tree);
+
+                c.GenerateRegexType(pattern, options, fullname, regexinfos[i].IsPublic, code, tree, regexinfos[i].MatchTimeout);
+            }
+
+            c.Save();
+        }
+#endif
 
         /// <summary>
         /// Keeps track of an operation that needs to be referenced in the backtrack-jump
@@ -245,10 +285,10 @@ namespace System.Text.RegularExpressions
         private int Code() => _regexopcode & RegexCode.Mask;
 
         /// <summary>A macro for _ilg.Emit(Opcodes.Ldstr, str)</summary>
-        private void Ldstr(string str) => _ilg!.Emit(OpCodes.Ldstr, str);
+        protected void Ldstr(string str) => _ilg!.Emit(OpCodes.Ldstr, str);
 
         /// <summary>A macro for the various forms of Ldc.</summary>
-        private void Ldc(int i)
+        protected void Ldc(int i)
         {
             Debug.Assert(_ilg != null);
 
@@ -277,13 +317,16 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Ldc_I8).</summary>
-        private void LdcI8(long i) => _ilg!.Emit(OpCodes.Ldc_I8, i);
+        protected void LdcI8(long i) => _ilg!.Emit(OpCodes.Ldc_I8, i);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Dup).</summary>
         private void Dup() => _ilg!.Emit(OpCodes.Dup);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Ret).</summary>
-        private void Ret() => _ilg!.Emit(OpCodes.Ret);
+        protected void Ret() => _ilg!.Emit(OpCodes.Ret);
+
+        /// <summary>A macro for _ilg.Emit(OpCodes.Newobj, constructor).</summary>
+        protected void Newobj(ConstructorInfo constructor) => _ilg!.Emit(OpCodes.Newobj, constructor);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Rem_Un).</summary>
         private void RemUn() => _ilg!.Emit(OpCodes.Rem_Un);
@@ -346,10 +389,10 @@ namespace System.Text.RegularExpressions
         private void Stloc(LocalBuilder lt) => _ilg!.Emit(OpCodes.Stloc_S, lt);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Ldarg_0).</summary>
-        private void Ldthis() => _ilg!.Emit(OpCodes.Ldarg_0);
+        protected void Ldthis() => _ilg!.Emit(OpCodes.Ldarg_0);
 
         /// <summary>A macro for Ldthis(); Ldfld();</summary>
-        private void Ldthisfld(FieldInfo ft)
+        protected void Ldthisfld(FieldInfo ft)
         {
             Ldthis();
             Ldfld(ft);
@@ -374,13 +417,13 @@ namespace System.Text.RegularExpressions
         private void Ldfld(FieldInfo ft) => _ilg!.Emit(OpCodes.Ldfld, ft);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Stfld).</summary>
-        private void Stfld(FieldInfo ft) => _ilg!.Emit(OpCodes.Stfld, ft);
+        protected void Stfld(FieldInfo ft) => _ilg!.Emit(OpCodes.Stfld, ft);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Callvirt, mt).</summary>
-        private void Callvirt(MethodInfo mt) => _ilg!.Emit(OpCodes.Callvirt, mt);
+        protected void Callvirt(MethodInfo mt) => _ilg!.Emit(OpCodes.Callvirt, mt);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Call, mt).</summary>
-        private void Call(MethodInfo mt) => _ilg!.Emit(OpCodes.Call, mt);
+        protected void Call(MethodInfo mt) => _ilg!.Emit(OpCodes.Call, mt);
 
         /// <summary>A macro for _ilg.Emit(OpCodes.Brfalse) (long form).</summary>
         private void BrfalseFar(Label l) => _ilg!.Emit(OpCodes.Brfalse, l);
@@ -2417,16 +2460,12 @@ namespace System.Text.RegularExpressions
                 // If we're doing a case-insensitive comparison, we need to lower case each character,
                 // so we just go character-by-character.  But if we're not, we try to process multiple
                 // characters at a time; this is helpful not only for throughput but also in reducing
-                // the amount of IL and asm that results from this unrolling.
-                if (!caseInsensitive)
+                // the amount of IL and asm that results from this unrolling. Also, this optimization
+                // is subject to endianness issues if the generated code is used on a machine with a
+                // different endianness; for now, we simply disable the optimization if the generated
+                // code is being saved. TODO https://github.com/dotnet/corefx/issues/39227.
+                if (!caseInsensitive && !_persistsAssembly)
                 {
-                    // TODO https://github.com/dotnet/corefx/issues/39227:
-                    // If/when we implement CompileToAssembly, this code will either need to be special-cased
-                    // to not be used when saving out the assembly, or it'll need to be augmented to emit an
-                    // endianness check into the IL.  The code below is creating int/long constants based on
-                    // reading the comparison string at compile time, and the machine doing the compilation
-                    // could be of a different endianness than the machine running the compiled assembly.
-
                     // On 64-bit, process 4 characters at a time until the string isn't at least 4 characters long.
                     if (IntPtr.Size == 8)
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -13,6 +13,10 @@ namespace System.Text.RegularExpressions
         private static readonly Type[] s_paramTypes = new Type[] { typeof(RegexRunner) };
         private static int s_regexCount = 0;
 
+        public RegexLWCGCompiler() : base(persistsAssembly: false)
+        {
+        }
+
         /// <summary>The top-level driver. Initializes everything then calls the Generate* methods.</summary>
         public RegexRunnerFactory FactoryInstanceFromCode(RegexCode code, RegexOptions options, bool hasTimeout)
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.CompileToAssembly.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.CompileToAssembly.Tests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    public class RegexCompileToAssemblyTests
+    {
+        [Fact]
+        public void CompileToAssembly_InvalidArgs_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("assemblyname", () => Regex.CompileToAssembly(null, null));
+            AssertExtensions.Throws<ArgumentNullException>("assemblyname", () => Regex.CompileToAssembly(null, null, null));
+            AssertExtensions.Throws<ArgumentNullException>("assemblyname", () => Regex.CompileToAssembly(null, null, null, null));
+
+            AssertExtensions.Throws<ArgumentNullException>("regexinfos", () => Regex.CompileToAssembly(null, new AssemblyName("abcd")));
+            AssertExtensions.Throws<ArgumentNullException>("regexinfos", () => Regex.CompileToAssembly(null, new AssemblyName("abcd"), null));
+            AssertExtensions.Throws<ArgumentNullException>("regexinfos", () => Regex.CompileToAssembly(null, new AssemblyName("abcd"), null, null));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void CompileToAssembly_PNSE()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() =>
+                Regex.CompileToAssembly(
+                    new[] { new RegexCompilationInfo("abcd", RegexOptions.None, "abcd", "", true) },
+                    new AssemblyName("abcd")));
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.CompileToAssembly.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.CompileToAssembly.Tests.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
-    public class RegexCompileToAssemblyTests
+    public class RegexCompileToAssemblyTests : FileCleanupTestBase
     {
         [Fact]
         public void CompileToAssembly_InvalidArgs_Throws()
@@ -29,6 +31,40 @@ namespace System.Text.RegularExpressions.Tests
                 Regex.CompileToAssembly(
                     new[] { new RegexCompilationInfo("abcd", RegexOptions.None, "abcd", "", true) },
                     new AssemblyName("abcd")));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void CompileToAssembly_CanRunGeneratedRegex()
+        {
+            (RegexCompilationInfo rci, string validInput, string invalidInput)[] regexes = new[]
+            {
+                (new RegexCompilationInfo("abcd", RegexOptions.None, "Namespace1", "Type1", ispublic: true), "123abcd123", "123abed123"),
+                (new RegexCompilationInfo("(a|b|cde)+", RegexOptions.None, "Namespace2.Sub", "Type2", ispublic: true), "abcde", "cd"),
+            };
+
+            string assemblyName = Path.GetRandomFileName();
+
+            string cwd = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = TestDirectory;
+            try
+            {
+                Regex.CompileToAssembly(
+                    regexes.Select(r => r.rci).ToArray(),
+                    new AssemblyName(assemblyName));
+            }
+            finally
+            {
+                Environment.CurrentDirectory = cwd;
+            }
+
+            Assembly a = Assembly.LoadFrom(Path.Combine(TestDirectory, assemblyName + ".dll"));
+            foreach ((RegexCompilationInfo rci, string validInput, string invalidInput) in regexes)
+            {
+                Regex r = (Regex)Activator.CreateInstance(a.GetType($"{rci.Namespace}.{rci.Name}"));
+                Assert.True(r.IsMatch(validInput));
+                Assert.False(r.IsMatch(invalidInput));
+            }
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="GroupCollectionTests.cs" />
     <Compile Include="MatchCollectionTests.cs" />
     <Compile Include="MonoRegexTests.cs" />
+    <Compile Include="Regex.CompileToAssembly.Tests.cs" />
     <Compile Include="Regex.Ctor.Tests.cs" />
     <Compile Include="Regex.Cache.Tests.cs" />
     <Compile Include="Regex.EscapeUnescape.Tests.cs" />


### PR DESCRIPTION
This ports Regex.CompileToAssembly... but don't get too excited.  The "only" thing missing is the ability to actually save the Assembly out, which is obviously critical.  I'm putting this commit up because I've been using the generated assembly to help debug/improve the code generation, using temporary hacks locally to get the Assembly saved to disk.  Hopefully in the near future we can have a permanent solution in place.  In the meantime, everything here is under an ifdef for DEBUG.

Contributes to https://github.com/dotnet/corefx/issues/39227
cc: @danmosemsft, @jkotas, @davidwrighton, @ViktorHofer, @mjsabby 

(I've been using https://github.com/Lokad/ILPack to save the assemblies, with this tweak on top of this PR: https://github.com/stephentoub/runtime/commit/645dbfe7ef894a5af5d464340fb576046055c600.  It doesn't work 100%, in particular it chokes on `ReadOnlySpan<char>.get_Item`, and I had to put in a hack to get it to work, at which point it successfully saves the assembly well enough that I can use ILSpy or .NET Reflector to decompile it and get decent source for debugging.)