### PR TITLE
Revert CPU clipping in the presence of CPU quota to 3.0, 2.x behavior.

### DIFF
--- a/src/coreclr/src/classlibnative/bcltype/system.cpp
+++ b/src/coreclr/src/classlibnative/bcltype/system.cpp
@@ -352,6 +352,13 @@ INT32 QCALLTYPE SystemNative::GetProcessorCount()
         processorCount = systemInfo.dwNumberOfProcessors;
     }
 
+#ifdef FEATURE_PAL
+    uint32_t cpuLimit;
+
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < (uint32_t)processorCount)
+        processorCount = cpuLimit;
+#endif
+
     END_QCALL;
 
     return processorCount;

--- a/src/coreclr/src/pal/src/thread/process.cpp
+++ b/src/coreclr/src/pal/src/thread/process.cpp
@@ -2547,6 +2547,12 @@ PAL_GetCPUBusyTime(
         {
             return 0;
         }
+
+        UINT cpuLimit;
+        if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < dwNumberOfProcessors)
+        {
+            dwNumberOfProcessors = cpuLimit;
+        }
     }
 
     if (getrusage(RUSAGE_SELF, &resUsage) == -1)

--- a/src/coreclr/src/utilcode/util.cpp
+++ b/src/coreclr/src/utilcode/util.cpp
@@ -1289,6 +1289,10 @@ int GetCurrentProcessCpuCount()
 
 #else // !FEATURE_PAL
     count = PAL_GetLogicalCpuCountFromOS();
+
+    uint32_t cpuLimit;
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)
+        count = cpuLimit;
 #endif // !FEATURE_PAL
 
     cCPUs = count;


### PR DESCRIPTION
Same change as in https://github.com/dotnet/coreclr/pull/27990