### PR TITLE
Add Crossgen pack for crossgen2 tool

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -38,13 +38,13 @@
 
     <ItemsToSign Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll" />
 
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/crossgen2.exe" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/crossgen2.dll" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/ILCompiler.DependencyAnalysisFramework.dll" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/ILCompiler.ReadyToRun.dll" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/ILCompiler.TypeSystem.ReadyToRun.dll" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/clrjitilc.dll" />
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)crossgen2/jitinterface.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.exe" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.DependencyAnalysisFramework.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.ReadyToRun.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.TypeSystem.ReadyToRun.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)clrjitilc.dll" />
+    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)jitinterface.dll" />
 
     <ItemsToSign Include="@(CoreCLRCrossTargetItemsToSign)" />
 

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -59,6 +59,7 @@
   <!-- Set up artifact subpaths. -->
   <PropertyGroup>
     <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
+    <CoreCLRCrossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2'))</CoreCLRCrossgen2Dir>
 
     <LibrariesPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'packages', '$(LibrariesConfiguration)'))</LibrariesPackagesDir>
     <LibrariesShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(LibrariesPackagesDir)', 'Shipping'))</LibrariesShippingPackagesDir>

--- a/src/installer/pkg/Directory.Build.targets
+++ b/src/installer/pkg/Directory.Build.targets
@@ -44,6 +44,7 @@
       <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
       <TargetingPackBrandName>$(ProductBrandPrefix) Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
       <AppHostPackBrandName>$(ProductBrandPrefix) AppHost Pack - $(ProductBrandSuffix)</AppHostPackBrandName>
+      <CrossgenPackBrandName>$(ProductBrandPrefix) Crossgen Pack - $(ProductBrandSuffix)</CrossgenPackBrandName>
       <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
 
       <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>

--- a/src/installer/pkg/Directory.Build.targets
+++ b/src/installer/pkg/Directory.Build.targets
@@ -44,7 +44,7 @@
       <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
       <TargetingPackBrandName>$(ProductBrandPrefix) Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
       <AppHostPackBrandName>$(ProductBrandPrefix) AppHost Pack - $(ProductBrandSuffix)</AppHostPackBrandName>
-      <CrossgenPackBrandName>$(ProductBrandPrefix) Crossgen Pack - $(ProductBrandSuffix)</CrossgenPackBrandName>
+      <Crossgen2PackBrandName>$(ProductBrandPrefix) Crossgen2 Pack - $(ProductBrandSuffix)</Crossgen2PackBrandName>
       <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
 
       <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>

--- a/src/installer/pkg/projects/netcoreapp/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/Directory.Build.props
@@ -1,6 +1,18 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
+  <!--
+    Determine CoreCLR/Libraries OSGroup based on Installer OSGroup. For example,
+    Installer uses Unix when applicable, but others go straight to Linux.
+  -->
+  <PropertyGroup>
+    <CoreCLROSGroup Condition="'$(TargetsWindows)' == 'true'">Windows_NT</CoreCLROSGroup>
+    <CoreCLROSGroup Condition="'$(TargetsLinux)' == 'true'">Linux</CoreCLROSGroup>
+    <CoreCLROSGroup Condition="'$(TargetsOSX)' == 'true'">OSX</CoreCLROSGroup>
+    <CoreCLROSGroup Condition="'$(TargetsFreeBSD)' == 'true'">FreeBSD</CoreCLROSGroup>
+    <LibrariesOSGroup>$(CoreCLROSGroup)</LibrariesOSGroup>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ShortFrameworkName>dotnet</ShortFrameworkName>
   </PropertyGroup>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -13,7 +13,10 @@
   </PropertyGroup>
 
   <!-- Redistribute package content from other nuget packages. -->
-  <ItemGroup Condition="'$(FrameworkPackType)' != 'apphost' AND '$(ExcludeDepprojReference)' != 'true'">
+  <ItemGroup Condition="
+    '$(FrameworkPackType)' != 'apphost' AND
+    '$(FrameworkPackType)' != 'crossgen' AND
+    '$(ExcludeDepprojReference)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\netcoreapp.depproj">
       <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">RuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
     </ProjectReference>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -15,7 +15,7 @@
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup Condition="
     '$(FrameworkPackType)' != 'apphost' AND
-    '$(FrameworkPackType)' != 'crossgen' AND
+    '$(FrameworkPackType)' != 'crossgen2' AND
     '$(ExcludeDepprojReference)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\netcoreapp.depproj">
       <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">RuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen.pkgproj
@@ -1,5 +1,28 @@
 <Project>
 
+  <!--
+    Use framework pack tooling to support building RID-specific crossgen packs.
+    Consider porting to central infrastructure: https://github.com/dotnet/runtime/issues/1867
+  -->
+  <PropertyGroup>
+    <FrameworkPackType>crossgen</FrameworkPackType>
+    <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
+  </PropertyGroup>
+
+  <!--
+    Get installer properties, in particular for MSIs.
+    Consider porting to central infrastructure: https://github.com/dotnet/runtime/issues/1867
+  -->
+  <Target Name="GetCrossgenPackInstallerProperties"
+          Condition="'$(FrameworkPackType)' == 'crossgen'"
+          BeforeTargets="GetInstallerProperties">
+    <PropertyGroup>
+      <InstallerName>$(ShortFrameworkName)-crossgen-pack</InstallerName>
+      <WixProductMoniker>$(CrossgenPackBrandName)</WixProductMoniker>
+      <VSInsertionShortComponentName>CrossgenPack</VSInsertionShortComponentName>
+    </PropertyGroup>
+  </Target>
+
   <PropertyGroup>
     <RIDPropsFile>$(MSBuildThisFileDirectory)crossgenRIDs.props</RIDPropsFile>
   </PropertyGroup>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen.pkgproj
@@ -1,0 +1,62 @@
+<Project>
+
+  <PropertyGroup>
+    <RIDPropsFile>$(MSBuildThisFileDirectory)crossgenRIDs.props</RIDPropsFile>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <Crossgen2RuntimeConfigFile>$(IntermediateOutputPath)crossgen2.runtimeconfig.json</Crossgen2RuntimeConfigFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)crossgen2$(ExeSuffix)" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)ILCompiler*.dll" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)Microsoft.DiaSymReader.dll" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)System.CommandLine.dll" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjitilc$(LibraryFileExtension)" />
+    <ArchitectureSpecificToolFile Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)jitinterface$(LibraryFileExtension)" />
+
+    <ArchitectureSpecificToolFile Include="$(Crossgen2RuntimeConfigFile)" />
+
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Target Name="WriteCrossgen2RuntimeConfig"
+          BeforeTargets="GetPackageFiles">
+    <PropertyGroup>
+      <!--
+        We're publishing crossgen2 in its own package as framework dependent application for now
+        since we only have two simple scenarios we want to support in the short term: win_x64 to
+        win_x64 and linux_x64 to linux_x64 compilations. Once we have more complex targets,
+        especially cross-platform and cross-architecture, crossgen2 will become a self-contained
+        package.
+      -->
+      <Crossgen2RuntimeConfigContents>
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp5.0",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "5.0.100-alpha1-015772"
+    }
+  }
+}
+      </Crossgen2RuntimeConfigContents>
+    </PropertyGroup>
+
+    <!-- Emit the runtime config json file that will be packaged with crossgen2 -->
+    <WriteLinesToFile
+      File="$(Crossgen2RuntimeConfigFile)"
+      Lines="$(Crossgen2RuntimeConfigContents)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+</Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -1,11 +1,11 @@
 <Project>
 
   <!--
-    Use framework pack tooling to support building RID-specific crossgen packs.
+    Use framework pack tooling to support building RID-specific crossgen2 packs.
     Consider porting to central infrastructure: https://github.com/dotnet/runtime/issues/1867
   -->
   <PropertyGroup>
-    <FrameworkPackType>crossgen</FrameworkPackType>
+    <FrameworkPackType>crossgen2</FrameworkPackType>
     <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
   </PropertyGroup>
 
@@ -13,13 +13,13 @@
     Get installer properties, in particular for MSIs.
     Consider porting to central infrastructure: https://github.com/dotnet/runtime/issues/1867
   -->
-  <Target Name="GetCrossgenPackInstallerProperties"
-          Condition="'$(FrameworkPackType)' == 'crossgen'"
+  <Target Name="GetCrossgen2PackInstallerProperties"
+          Condition="'$(FrameworkPackType)' == 'crossgen2'"
           BeforeTargets="GetInstallerProperties">
     <PropertyGroup>
-      <InstallerName>$(ShortFrameworkName)-crossgen-pack</InstallerName>
-      <WixProductMoniker>$(CrossgenPackBrandName)</WixProductMoniker>
-      <VSInsertionShortComponentName>CrossgenPack</VSInsertionShortComponentName>
+      <InstallerName>$(ShortFrameworkName)-crossgen2-pack</InstallerName>
+      <WixProductMoniker>$(Crossgen2PackBrandName)</WixProductMoniker>
+      <VSInsertionShortComponentName>Crossgen2Pack</VSInsertionShortComponentName>
     </PropertyGroup>
   </Target>
 

--- a/src/installer/pkg/projects/netcoreapp/pkg/crossgenRIDs.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/crossgenRIDs.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <!-- Crossgen2 currently only builds for a subset of RIDs. -->
+  <PropertyGroup>
+    <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(OutputRid)</PackageRID>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <OfficialBuildRID Include="linux-x64" />
+    <OfficialBuildRID Include="linux-musl-x64" />
+    <OfficialBuildRID Include="win-x64"/>
+  </ItemGroup>
+
+</Project>

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -3,11 +3,6 @@
   <PropertyGroup>
     <FrameworkPackageName>Microsoft.NETCore.App</FrameworkPackageName>
     <BuildFullPlatformManifest>false</BuildFullPlatformManifest>
-    <CoreCLROSGroup Condition="'$(TargetsWindows)' == 'true'">Windows_NT</CoreCLROSGroup>
-    <CoreCLROSGroup Condition="'$(TargetsLinux)' == 'true'">Linux</CoreCLROSGroup>
-    <CoreCLROSGroup Condition="'$(TargetsOSX)' == 'true'">OSX</CoreCLROSGroup>
-    <CoreCLROSGroup Condition="'$(TargetsFreeBSD)' == 'true'">FreeBSD</CoreCLROSGroup>
-    <LibrariesOSGroup>$(CoreCLROSGroup)</LibrariesOSGroup>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/publish/Directory.Build.targets
+++ b/src/installer/publish/Directory.Build.targets
@@ -39,7 +39,7 @@
         Include="
           $(DownloadDirectory)**\Microsoft.*.Runtime.*.nupkg;
           $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg;
-          $(DownloadDirectory)**\Microsoft.*.App.Crossgen.*.nupkg"
+          $(DownloadDirectory)**\Microsoft.*.App.Crossgen2.*.nupkg"
         Exclude="@(DownloadedSymbolNupkgFile)" />
 
       <!-- VS insertion packages, carrying RID-specific installers. -->

--- a/src/installer/publish/Directory.Build.targets
+++ b/src/installer/publish/Directory.Build.targets
@@ -38,7 +38,8 @@
       <RuntimeNupkgFile
         Include="
           $(DownloadDirectory)**\Microsoft.*.Runtime.*.nupkg;
-          $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg"
+          $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg;
+          $(DownloadDirectory)**\Microsoft.*.App.Crossgen.*.nupkg"
         Exclude="@(DownloadedSymbolNupkgFile)" />
 
       <!-- VS insertion packages, carrying RID-specific installers. -->


### PR DESCRIPTION
For https://github.com/dotnet/runtime/issues/906.

~Requires support in the shared framework tooling: PR https://github.com/dotnet/arcade/pull/4650.~

~I have this test build that produced the Crossgen pack by temporarily inlining the sharedfx tooling update: https://dev.azure.com/dnceng/internal/_build/results?buildId=487241~

New test build for Crossgen2 pack: https://dev.azure.com/dnceng/internal/_build/results?buildId=488118&view=results