### PR TITLE
Fix Linux_x64_glibc condition to build RPM/Deb

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -422,7 +422,7 @@ jobs:
     displayName: Build
 
   # Only in glibc leg, we produce RPMs and Debs
-  - ${{ if eq(parameters.name, 'Linux_x64_glibc')}}:
+  - ${{ if and(eq(parameters.platform, 'Linux_x64'), eq(parameters.osSubgroup, ''))}}:
     - task: CopyFiles@2
       displayName: 'Copy built Portable linux-x64 binaries to staging directory'
       inputs:


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1860

Running validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=487931&view=results

Note that `osSubgroup = ''` is included in the new condition to intentionally exclude `linux-musl-x64`.