### PR TITLE
Use bitmask operation to check if a slot is untracked

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -598,7 +598,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 // count the number of set bits in the couldBeLive bit array
                 foreach (var slot in SlotTable.GcSlots)
                 {
-                    if (slot.Flags == GcSlotFlags.GC_SLOT_UNTRACKED)
+                    if ((slot.Flags & GcSlotFlags.GC_SLOT_UNTRACKED) != 0)
                         break;
 
                     if (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             {
                 StringBuilder sb = new StringBuilder();
 
-                if (Flags == GcSlotFlags.GC_SLOT_UNTRACKED)
+                if ((Flags & GcSlotFlags.GC_SLOT_UNTRACKED) != 0)
                 {
                     if (StackOffset < 0)
                     {
@@ -80,7 +80,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                 sb.AppendLine($"\t\t\tFlags: {Flags}");
 
                 sb.Append($"\t\t\tLowBits: ");
-                if (Flags == GcSlotFlags.GC_SLOT_UNTRACKED)
+                if ((Flags & GcSlotFlags.GC_SLOT_UNTRACKED) != 0)
                 {
                     if((LowBits & pinned_OFFSET_FLAG) != 0) sb.Append("pinned ");
                     if ((LowBits & byref_OFFSET_FLAG) != 0) sb.Append("byref ");


### PR DESCRIPTION
This fixes `R2RDump` of `System.Private.CoreLib` x64 after https://github.com/dotnet/runtime/commit/ae2fbae161bc0607db35ad706d969066cf51e7e7