### PR TITLE
Remove stray sos reference

### DIFF
--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -13,6 +13,5 @@ if(NOT CLR_CMAKE_PLATFORM_LINUX AND NOT FEATURE_CROSSBITNESS)
     list (APPEND CLR_CROSS_COMPONENTS_LIST
         mscordaccore
         mscordbi
-        sos
     )
 endif()


### PR DESCRIPTION
We removed SOS from the runtime code.  This stray reference remained in the CMake build system.