### PR TITLE
Fix MSVC warn as errors...

### DIFF
--- a/src/coreclr/src/debug/daccess/dacfn.cpp
+++ b/src/coreclr/src/debug/daccess/dacfn.cpp
@@ -223,13 +223,13 @@ static BOOL DacReadAllAdapter(PVOID address, PVOID buffer, SIZE_T size)
     DAC_INSTANCE* inst = g_dacImpl->m_instances.Find((TADDR)address);
     if (inst == nullptr || inst->size < size)
     {
-        inst = g_dacImpl->m_instances.Alloc((TADDR)address, size, DAC_PAL);
+        inst = g_dacImpl->m_instances.Alloc((TADDR)address, (ULONG32)size, DAC_PAL);
         if (inst == nullptr)
         {
             return FALSE;
         }
         inst->noReport = 0;
-        HRESULT hr = DacReadAll((TADDR)address, inst + 1, size, false);
+        HRESULT hr = DacReadAll((TADDR)address, inst + 1, (ULONG32)size, false);
         if (FAILED(hr))
         {
             g_dacImpl->m_instances.ReturnAlloc(inst);

--- a/src/coreclr/src/debug/daccess/dacfn.cpp
+++ b/src/coreclr/src/debug/daccess/dacfn.cpp
@@ -246,7 +246,7 @@ static BOOL DacReadAllAdapter(PVOID address, PVOID buffer, SIZE_T size)
 }
 
 HRESULT
-DacVirtualUnwind(DWORD threadId, PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers)
+DacVirtualUnwind(ULONG32 threadId, PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers)
 {
     if (!g_dacImpl)
     {

--- a/src/coreclr/src/debug/di/shimremotedatatarget.cpp
+++ b/src/coreclr/src/debug/di/shimremotedatatarget.cpp
@@ -285,7 +285,7 @@ ShimRemoteDataTarget::ReadVirtual(
     }
     if (pcbRead != NULL)
     {
-        *pcbRead = (SUCCEEDED(hr) ? read : 0);
+        *pcbRead = ULONG32(SUCCEEDED(hr) ? read : 0);
     }
     return hr;
 }


### PR DESCRIPTION
Fixes MSVC compile/linker errors found while cross piling the Linux DAC to run on Windows

The declaration and implementation of DacVirtualUnwind didn't match.  The MSVC linker treated it as a mismatched implementation.

The others were MSVC type truncation messages which could lead to loss of data being treated as errors.