### PR TITLE
Reconcile handling of EH vars

### DIFF
--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1383,7 +1383,7 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
 
 // Return Value:
 //    True iff "this" is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//    -- a block corresponding to an exit from the try of a try/finally. 
+//    -- a block corresponding to an exit from the try of a try/finally.
 //
 // Notes:
 //    In the flow graph, this becomes a block that calls the finally, and a second, immediately
@@ -1429,7 +1429,7 @@ bool BasicBlock::isBBCallAlwaysPair()
 //
 // Return Value:
 //    True iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//    -- a block corresponding to an exit from the try of a try/finally. 
+//    -- a block corresponding to an exit from the try of a try/finally.
 //
 // Notes:
 //    See notes on isBBCallAlwaysPair(), above.

--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1379,6 +1379,68 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
 }
 
 //------------------------------------------------------------------------
+// isBBCallAlwaysPair: Determine if this is hte first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pari
+
+// Return Value:
+//    True iff "this" is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
+//    -- a block corresponding to an exit from the try of a try/finally. 
+//
+// Notes:
+//    In the flow graph, this becomes a block that calls the finally, and a second, immediately
+//    following empty block (in the bbNext chain) to which the finally will return, and which
+//    branches unconditionally to the next block to be executed outside the try/finally.
+//    Note that code is often generated differently than this description. For example, on ARM,
+//    the target of the BBJ_ALWAYS is loaded in LR (the return register), and a direct jump is
+//    made to the 'finally'. The effect is that the 'finally' returns directly to the target of
+//    the BBJ_ALWAYS. A "retless" BBJ_CALLFINALLY is one that has no corresponding BBJ_ALWAYS.
+//    This can happen if the finally is known to not return (e.g., it contains a 'throw'). In
+//    that case, the BBJ_CALLFINALLY flags has BBF_RETLESS_CALL set. Note that ARM never has
+//    "retless" BBJ_CALLFINALLY blocks due to a requirement to use the BBJ_ALWAYS for
+//    generating code.
+//
+bool BasicBlock::isBBCallAlwaysPair()
+{
+#if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
+    if (this->bbJumpKind == BBJ_CALLFINALLY)
+#else
+    if ((this->bbJumpKind == BBJ_CALLFINALLY) && !(this->bbFlags & BBF_RETLESS_CALL))
+#endif
+    {
+#if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
+        // On ARM, there are no retless BBJ_CALLFINALLY.
+        assert(!(this->bbFlags & BBF_RETLESS_CALL));
+#endif
+        // Some asserts that the next block is a BBJ_ALWAYS of the proper form.
+        assert(this->bbNext != nullptr);
+        assert(this->bbNext->bbJumpKind == BBJ_ALWAYS);
+        assert(this->bbNext->bbFlags & BBF_KEEP_BBJ_ALWAYS);
+        assert(this->bbNext->isEmpty());
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+//------------------------------------------------------------------------
+// isBBCallAlwaysPairLast: Determine if this is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pari
+//
+// Return Value:
+//    True iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
+//    -- a block corresponding to an exit from the try of a try/finally. 
+//
+// Notes:
+//    See notes on isBBCallAlwaysPair(), above.
+//
+bool BasicBlock::isBBCallAlwaysPairLast()
+{
+    return (((bbFlags & BBF_KEEP_BBJ_ALWAYS) != 0) && (bbPreds != nullptr) && (bbPreds->flNext == nullptr) &&
+            bbPreds->flBlock->isBBCallAlwaysPair());
+}
+
+//------------------------------------------------------------------------
 // hasEHBoundaryIn: Determine if this block begins at an EH boundary.
 //
 // Return Value:
@@ -1421,14 +1483,6 @@ bool BasicBlock::hasEHBoundaryIn()
 bool BasicBlock::hasEHBoundaryOut()
 {
     bool returnVal = false;
-    // If a block is marked BBF_KEEP_BBJ_ALWAYS, it is always paired with its predecessor which is an
-    // EH boundary block. It must remain empty, and we must not have any live incoming vars in registers,
-    // in particular because we can't perform resolution if there are mismatches across edges.
-    if ((bbFlags & BBF_KEEP_BBJ_ALWAYS) != 0)
-    {
-        returnVal = true;
-    }
-
     if (bbJumpKind == BBJ_EHFILTERRET)
     {
         returnVal = true;

--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1436,8 +1436,7 @@ bool BasicBlock::isBBCallAlwaysPair()
 //
 bool BasicBlock::isBBCallAlwaysPairTail()
 {
-    return (((bbFlags & BBF_KEEP_BBJ_ALWAYS) != 0) && (bbPreds != nullptr) && (bbPreds->flNext == nullptr) &&
-            bbPreds->flBlock->isBBCallAlwaysPair());
+    return (bbPrev != nullptr) && bbPrev->isBBCallAlwaysPair();
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/block.cpp
+++ b/src/coreclr/src/jit/block.cpp
@@ -1425,7 +1425,7 @@ bool BasicBlock::isBBCallAlwaysPair()
 }
 
 //------------------------------------------------------------------------
-// isBBCallAlwaysPairLast: Determine if this is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pari
+// isBBCallAlwaysPairTail: Determine if this is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pari
 //
 // Return Value:
 //    True iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
@@ -1434,7 +1434,7 @@ bool BasicBlock::isBBCallAlwaysPair()
 // Notes:
 //    See notes on isBBCallAlwaysPair(), above.
 //
-bool BasicBlock::isBBCallAlwaysPairLast()
+bool BasicBlock::isBBCallAlwaysPairTail()
 {
     return (((bbFlags & BBF_KEEP_BBJ_ALWAYS) != 0) && (bbPreds != nullptr) && (bbPreds->flNext == nullptr) &&
             bbPreds->flBlock->isBBCallAlwaysPair());

--- a/src/coreclr/src/jit/block.h
+++ b/src/coreclr/src/jit/block.h
@@ -650,43 +650,11 @@ struct BasicBlock : private LIR::Range
     bool isValid();
 
     // Returns "true" iff "this" is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair --
-    // a block corresponding to an exit from the try of a try/finally.  In the flow graph,
-    // this becomes a block that calls the finally, and a second, immediately
-    // following empty block (in the bbNext chain) to which the finally will return, and which
-    // branches unconditionally to the next block to be executed outside the try/finally.
-    // Note that code is often generated differently than this description. For example, on ARM,
-    // the target of the BBJ_ALWAYS is loaded in LR (the return register), and a direct jump is
-    // made to the 'finally'. The effect is that the 'finally' returns directly to the target of
-    // the BBJ_ALWAYS. A "retless" BBJ_CALLFINALLY is one that has no corresponding BBJ_ALWAYS.
-    // This can happen if the finally is known to not return (e.g., it contains a 'throw'). In
-    // that case, the BBJ_CALLFINALLY flags has BBF_RETLESS_CALL set. Note that ARM never has
-    // "retless" BBJ_CALLFINALLY blocks due to a requirement to use the BBJ_ALWAYS for
-    // generating code.
-    bool isBBCallAlwaysPair()
-    {
-#if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
-        if (this->bbJumpKind == BBJ_CALLFINALLY)
-#else
-        if ((this->bbJumpKind == BBJ_CALLFINALLY) && !(this->bbFlags & BBF_RETLESS_CALL))
-#endif
-        {
-#if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
-            // On ARM, there are no retless BBJ_CALLFINALLY.
-            assert(!(this->bbFlags & BBF_RETLESS_CALL));
-#endif
-            // Some asserts that the next block is a BBJ_ALWAYS of the proper form.
-            assert(this->bbNext != nullptr);
-            assert(this->bbNext->bbJumpKind == BBJ_ALWAYS);
-            assert(this->bbNext->bbFlags & BBF_KEEP_BBJ_ALWAYS);
-            assert(this->bbNext->isEmpty());
-
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
+    // a block corresponding to an exit from the try of a try/finally.
+    bool isBBCallAlwaysPair();
+    // Returns "true" iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair --
+    // a block corresponding to an exit from the try of a try/finally.
+    bool isBBCallAlwaysPairLast();
 
     BBjumpKinds bbJumpKind; // jump (if any) at the end of this block
 

--- a/src/coreclr/src/jit/block.h
+++ b/src/coreclr/src/jit/block.h
@@ -654,7 +654,7 @@ struct BasicBlock : private LIR::Range
     bool isBBCallAlwaysPair();
     // Returns "true" iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair --
     // a block corresponding to an exit from the try of a try/finally.
-    bool isBBCallAlwaysPairLast();
+    bool isBBCallAlwaysPairTail();
 
     BBjumpKinds bbJumpKind; // jump (if any) at the end of this block
 

--- a/src/coreclr/src/jit/inline.cpp
+++ b/src/coreclr/src/jit/inline.cpp
@@ -1679,6 +1679,12 @@ CLRRandom* InlineStrategy::GetRandom()
         if (m_Compiler->compRandomInlineStress())
         {
             externalSeed = getJitStressLevel();
+            // We can set COMPlus_JitStressModeNames without setting COMPlus_JitStress,
+            // but we need external seed to be non-zero.
+            if (externalSeed == 0)
+            {
+                externalSeed = 2;
+            }
         }
 
 #endif // DEBUG

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -2411,23 +2411,37 @@ void Compiler::fgInterBlockLocalVarLiveness()
 
     for (block = fgFirstBB; block; block = block->bbNext)
     {
-        if (block->hasEHBoundaryIn())
+        if (block->bbCatchTyp != BBCT_NONE)
         {
             /* Note the set of variables live on entry to exception handler */
             VarSetOps::UnionD(this, exceptVars, block->bbLiveIn);
         }
 
-        if (block->hasEHBoundaryOut())
+        if (block->bbJumpKind == BBJ_EHFILTERRET)
+        {
+            /* Get the set of live variables on exit from a 'filter' */
+            VarSetOps::UnionD(this, filterVars, block->bbLiveOut);
+        }
+        else if (block->bbJumpKind == BBJ_EHFINALLYRET)
+        {
+            /* Get the set of live variables on exit from a 'finally' block */
+
+            VarSetOps::UnionD(this, finallyVars, block->bbLiveOut);
+        }
+#if defined(FEATURE_EH_FUNCLETS)
+        // Funclets are called and returned from, as such we can only count on the frame
+        // pointer being restored, and thus everything live in or live out must be on the
+        // stack
+        if (block->bbFlags & BBF_FUNCLET_BEG)
+        {
+            VarSetOps::UnionD(this, exceptVars, block->bbLiveIn);
+        }
+        if ((block->bbJumpKind == BBJ_EHFINALLYRET) || (block->bbJumpKind == BBJ_EHFILTERRET) ||
+            (block->bbJumpKind == BBJ_EHCATCHRET))
         {
             VarSetOps::UnionD(this, exceptVars, block->bbLiveOut);
-            if (block->bbJumpKind == BBJ_EHFINALLYRET)
-            {
-                // Live on exit from finally.
-                // We track these separately because, in addition to having EH live-out semantics,
-                // they must be marked must-init.
-                VarSetOps::UnionD(this, finallyVars, block->bbLiveOut);
-            }
         }
+#endif // FEATURE_EH_FUNCLETS
     }
 
     LclVarDsc* varDsc;

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -847,7 +847,7 @@ void LinearScan::setBlockSequence()
                     assert(!"Switch with single successor");
                 }
             }
-            if (block->isBBCallAlwaysPairLast() || (hasUniquePred && predBlock->hasEHBoundaryOut()))
+            if (block->isBBCallAlwaysPairTail() || (hasUniquePred && predBlock->hasEHBoundaryOut()))
             {
                 // Treat this as having incoming EH flow, since we can't insert resolution moves into
                 // the ALWAYS block of a BBCallAlwaysPair, and a unique pred with an EH out edge won't

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -847,7 +847,7 @@ void LinearScan::setBlockSequence()
                     assert(!"Switch with single successor");
                 }
             }
-            if (((predBlock->bbFlags & BBF_KEEP_BBJ_ALWAYS) != 0) || (hasUniquePred && predBlock->hasEHBoundaryOut()))
+            if (block->isBBCallAlwaysPairLast() || (hasUniquePred && predBlock->hasEHBoundaryOut()))
             {
                 // Treat this as having incoming EH flow, since we can't insert resolution moves into
                 // the ALWAYS block of a BBCallAlwaysPair, and a unique pred with an EH out edge won't


### PR DESCRIPTION
Modify `BasicBlock::hasEHBoundaryIn()` and `BasicBlock::hasEHBoundaryOut()` to reflect what liveness is doing, and change liveness to call those methods, and adjust the register allocator code appropriately.

It might make sense to extract the code that's basically the same, except that the register allocator doesn't need the `finallyVars` except as validation in the `DEBUG` case.

Fix #1786