### PR TITLE
Fix unhandled exception line number issues

### DIFF
--- a/src/coreclr/src/vm/clrex.h
+++ b/src/coreclr/src/vm/clrex.h
@@ -30,6 +30,9 @@ struct StackTraceElement
     // TRUE if this element represents the last frame of the foreign
     // exception stack trace.
     BOOL			fIsLastFrameFromForeignStackTrace;
+    // TRUE if the ip needs to be adjusted back to the calling or
+    // throwing instruction.
+    BOOL            fAdjustOffset;
 
     bool operator==(StackTraceElement const & rhs) const
     {

--- a/src/coreclr/src/vm/debugdebugger.h
+++ b/src/coreclr/src/vm/debugdebugger.h
@@ -102,16 +102,20 @@ private:
         PCODE ip;
         // TRUE if this element represents the last frame of the foreign
         // exception stack trace.
-        BOOL			fIsLastFrameFromForeignStackTrace;
+        BOOL fIsLastFrameFromForeignStackTrace;
+        // TRUE if the dwOffset (native offset) needs to be adjusted back to the
+        // calling or throwing instruction.
+        BOOL fAdjustOffset;
 
         // Initialization done under TSL.
         // This is used when first collecting the stack frame data.
         void InitPass1(
             DWORD dwNativeOffset,
             MethodDesc *pFunc,
-            PCODE ip
-            , BOOL			fIsLastFrameFromForeignStackTrace = FALSE
-			);
+            PCODE ip,
+            BOOL fIsLastFrameFromForeignStackTrace = FALSE,
+            BOOL fAdjustOffset = FALSE
+        );
 
         // Initialization done outside the TSL.
         // This will init the dwILOffset field (and potentially anything else
@@ -131,7 +135,7 @@ public:
         DebugStackTraceElement* pElements;
         THREADBASEREF   TargetThread;
         AppDomain *pDomain;
-        BOOL	fDoWeHaveAnyFramesFromForeignStackTrace;
+        BOOL fDoWeHaveAnyFramesFromForeignStackTrace;
 
 
         GetStackFramesData() :  skip(0),

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -3557,10 +3557,15 @@ BOOL StackTraceInfo::AppendElement(BOOL bAllowAllocMem, UINT_PTR currentIP, UINT
         // the current exception). Hence, set the corresponding flag to FALSE.
         pStackTraceElem->fIsLastFrameFromForeignStackTrace = FALSE;
 
+        // We can assume that IP points to an the instruction after [call IL_Throw] when these conditions are met:
+        //  1. !pCf->HasFaulted() - It wasn't a "hardware" exception (Access violation, dev by 0, etc.)
+        //  2. !pCf->IsIPadjusted() - It hasn't been previously adjusted to point to the call (i.e. like [call IL_Throw], etc.)
+        pStackTraceElem->fAdjustOffset = !pCf->HasFaulted() && !pCf->IsIPadjusted();
+
         // This is a workaround to fix the generation of stack traces from exception objects so that
         // they point to the line that actually generated the exception instead of the line
         // following.
-        if (!(pCf->HasFaulted() || pCf->IsIPadjusted()) && pStackTraceElem->ip != 0)
+        if (!pStackTraceElem->fAdjustOffset && pStackTraceElem->ip != 0)
         {
             pStackTraceElem->ip -= 1;
         }

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -1333,7 +1333,12 @@ void ExceptionTracker::InitializeCrawlFrameForExplicitFrame(CrawlFrame* pcfThisF
 
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
 
+    // Clear various flags because the above INDEBUG sets them to true
     pcfThisFrame->isFrameless = false;
+    pcfThisFrame->isInterrupted = false;
+    pcfThisFrame->hasFaulted = false;
+    pcfThisFrame->isIPadjusted = false;
+
     pcfThisFrame->pFrame = pFrame;
     pcfThisFrame->pFunc = pFrame->GetFunction();
 
@@ -1416,6 +1421,12 @@ void ExceptionTracker::InitializeCrawlFrame(CrawlFrame* pcfThisFrame, Thread* pT
 
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
     pcfThisFrame->pRD = pRD;
+
+    // Clear various flags because the above INDEBUG sets them to true
+    pcfThisFrame->pFunc = NULL;
+    pcfThisFrame->isInterrupted = false;
+    pcfThisFrame->hasFaulted = false;
+    pcfThisFrame->isIPadjusted = false;
 
 #ifdef FEATURE_INTERPRETER
     pcfThisFrame->pFrame = NULL;
@@ -1571,7 +1582,6 @@ void ExceptionTracker::InitializeCrawlFrame(CrawlFrame* pcfThisFrame, Thread* pT
     }
 
     pcfThisFrame->pThread = pThread;
-    pcfThisFrame->hasFaulted = false;
 
     Frame* pTopFrame = pThread->GetFrame();
     pcfThisFrame->isIPadjusted = (FRAME_TOP != pTopFrame) && (pTopFrame->GetVTablePtr() != FaultingExceptionFrame::GetMethodFrameVPtr());

--- a/src/coreclr/src/vm/stackwalk.h
+++ b/src/coreclr/src/vm/stackwalk.h
@@ -102,6 +102,7 @@ public:
     inline Frame* GetFrame()       // will return NULL for "frameless methods"
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
 
         if (isFrameless)
             return NULL;
@@ -173,6 +174,7 @@ public:
     inline bool IsFrameless()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
 
         return isFrameless;
     }
@@ -183,6 +185,7 @@ public:
     inline bool IsActiveFrame()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFirst != 0xcc);
 
         return isFirst;
     }
@@ -193,6 +196,7 @@ public:
     inline bool IsActiveFunc()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFirst != 0xcc);
 
         return (pFunc && isFirst);
     }
@@ -204,6 +208,7 @@ public:
     bool IsInterrupted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isInterrupted != 0xcc);
 
         return (pFunc && isInterrupted /* && isFrameless?? */);
     }
@@ -214,6 +219,7 @@ public:
     bool HasFaulted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)hasFaulted != 0xcc);
 
         return (pFunc && hasFaulted /* && isFrameless?? */);
     }
@@ -225,6 +231,8 @@ public:
     bool IsNativeMarker()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNativeMarker != 0xcc);
+
         return isNativeMarker;
     }
 
@@ -239,6 +247,8 @@ public:
     bool IsNoFrameTransition()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNoFrameTransition != 0xcc);
+
         return isNoFrameTransition;
     }
 
@@ -249,6 +259,8 @@ public:
     TADDR GetNoFrameTransitionMarker()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNoFrameTransition != 0xcc);
+
         return (isNoFrameTransition ? taNoFrameTransitionMarker : NULL);
     }
 
@@ -259,6 +271,7 @@ public:
     bool IsIPadjusted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isIPadjusted != 0xcc);
 
         return (pFunc && isIPadjusted /* && isFrameless?? */);
     }
@@ -336,6 +349,7 @@ public:
     GCInfoToken GetGCInfoToken()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetGCInfoToken();
     }
@@ -343,6 +357,7 @@ public:
     PTR_VOID GetGCInfo()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetGCInfo();
     }
@@ -350,6 +365,7 @@ public:
     const METHODTOKEN& GetMethodToken()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetMethodToken();
     }
@@ -357,6 +373,7 @@ public:
     unsigned GetRelOffset()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetRelOffset();
     }
@@ -364,6 +381,7 @@ public:
     IJitManager*  GetJitManager()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetJitManager();
     }
@@ -371,6 +389,7 @@ public:
     ICodeManager* GetCodeManager()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetCodeManager();
     }


### PR DESCRIPTION
There are a few paths to get the place (DebugStackTrace::DebugStackTraceElement::InitPass2) where
the offset/ip needs an adjustment:

1) The System.Diagnostics.StackTrace constructors that take an exception object. The stack trace in
   the exception object is used (from the _stackTrace field).
2) Processing an unhandled exception for display (ExceptionTracker::ProcessOSExceptionNotification).
3) The System.Diagnostics.StackTrace constructors that don't take an exception object that get the
   stack trace of the current thread.

The changes for cases #1 and 2 start with StackTraceInfo/StackTraceElement structs (adding the
"fAdjustOffset" field) when the stack trace for an exception is generated and is put in the private
_stackTrace Exception object field.

When the stack trace for an exception is rendered to a string (via the GetStackFramesInternal FCALL)
the internal GetStackFramesData/DebugStackTraceElement structs are initialized and the new fAdjustOffset
field there is set from the one in StackTraceElement. That is where the IL offset is calculated and
this flag is used to decrement the native offset enough to point to actual instruction that caused the
exception.

For case #3 all this happens in the GetStackFramesInternal FCALL called from the managed constructor
building the GetStackFramesData/DebugStackTraceElement structs directly.

Fixes dotnet/coreclr#27765 and fixes dotnet/coreclr#25740.