### PR TITLE
Tweak documentation on NotNullAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -31,7 +31,7 @@ namespace System.Diagnostics.CodeAnalysis
 #endif
         sealed class MaybeNullAttribute : Attribute { }
 
-    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
 #if INTERNAL_NULLABLE_ATTRIBUTES
     internal


### PR DESCRIPTION
Tagging @BillWagner @stephentoub @RikkiGibson 

The use of `[NotNull]` on an input parameter is allowed. The typical example is an `AssertNotNull` method. That behavior was [specified](https://github.com/dotnet/csharplang/blob/master/meetings/2019/LDM-2019-05-15.md#simple-postconditions), but does not appear in the docs. Adding a mention.

I assume that changes here propagate to docs automatically.