### PR TITLE
Disable failing test

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -16,6 +16,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public ConnectTest(ITestOutputHelper output) : base(output) { }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1895")]
         [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(UnavailableWebSocketServers))]
         public async Task ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage(Uri server, string exceptionMessage, WebSocketError errorCode)


### PR DESCRIPTION
Disables `ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage`
as it's consistently failing in the outerloop jobs. Specifically the
libraries linux outerloop job.

Tracking Issue is #1895