### PR TITLE
Fix documentation of R2R inline tracking map

### DIFF
--- a/src/coreclr/src/vm/inlinetracking.h
+++ b/src/coreclr/src/vm/inlinetracking.h
@@ -228,8 +228,6 @@ typedef DPTR(InlineTrackingMap) PTR_InlineTrackingMap;
 //
 // The resulting serialized format is a sequence of blobs:
 // 1) Header (4 byte aligned)
-//       short   MajorVersion - currently set to 1, increment on breaking change
-//       short   MinorVersion - currently set to 0, increment on non-breaking format addition
 //       int     SizeOfInlineIndex - size in bytes of the inline index
 //
 // 2) InlineIndex - Immediately following header. This is a sorted (by ZapInlineeRecord.key) array of ZapInlineeRecords, given a method token (32 bits)


### PR DESCRIPTION
Don't want this to show up as a diff when we upgrade the format later. Version is not included in the format. We can key off the R2R version when decoding this.