### PR TITLE
Optimize DateTime decomposition in CoreLib

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
@@ -22,6 +22,9 @@ namespace System.Buffers.Text
                 return false;
             }
 
+            value.GetDate(out int year, out int month, out int day);
+            value.GetTime(out int hour, out int minute, out int second);
+
             uint dayAbbrev = s_dayAbbreviationsLowercase[(int)value.DayOfWeek];
 
             destination[0] = (byte)dayAbbrev;
@@ -32,10 +35,10 @@ namespace System.Buffers.Text
             destination[3] = Utf8Constants.Comma;
             destination[4] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Day, destination, 5);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)day, destination, 5);
             destination[7] = Utf8Constants.Space;
 
-            uint monthAbbrev = s_monthAbbreviationsLowercase[value.Month - 1];
+            uint monthAbbrev = s_monthAbbreviationsLowercase[month - 1];
             destination[8] = (byte)monthAbbrev;
             monthAbbrev >>= 8;
             destination[9] = (byte)monthAbbrev;
@@ -43,16 +46,16 @@ namespace System.Buffers.Text
             destination[10] = (byte)monthAbbrev;
             destination[11] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteFourDecimalDigits((uint)value.Year, destination, 12);
+            FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 12);
             destination[16] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Hour, destination, 17);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 17);
             destination[19] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Minute, destination, 20);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)minute, destination, 20);
             destination[22] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Second, destination, 23);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)second, destination, 23);
             destination[25] = Utf8Constants.Space;
 
             destination[26] = GMT1Lowercase;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
@@ -22,6 +22,9 @@ namespace System.Buffers.Text
                 return false;
             }
 
+            value.GetDate(out int year, out int month, out int day);
+            value.GetTime(out int hour, out int minute, out int second);
+
             uint dayAbbrev = s_dayAbbreviations[(int)value.DayOfWeek];
 
             destination[0] = (byte)dayAbbrev;
@@ -32,10 +35,10 @@ namespace System.Buffers.Text
             destination[3] = Utf8Constants.Comma;
             destination[4] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Day, destination, 5);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)day, destination, 5);
             destination[7] = Utf8Constants.Space;
 
-            uint monthAbbrev = s_monthAbbreviations[value.Month - 1];
+            uint monthAbbrev = s_monthAbbreviations[month - 1];
             destination[8] = (byte)monthAbbrev;
             monthAbbrev >>= 8;
             destination[9] = (byte)monthAbbrev;
@@ -43,16 +46,16 @@ namespace System.Buffers.Text
             destination[10] = (byte)monthAbbrev;
             destination[11] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteFourDecimalDigits((uint)value.Year, destination, 12);
+            FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 12);
             destination[16] = Utf8Constants.Space;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Hour, destination, 17);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 17);
             destination[19] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Minute, destination, 20);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)minute, destination, 20);
             destination[22] = Utf8Constants.Colon;
 
-            FormattingHelpers.WriteTwoDecimalDigits((uint)value.Second, destination, 23);
+            FormattingHelpers.WriteTwoDecimalDigits((uint)second, destination, 23);
             destination[25] = Utf8Constants.Space;
 
             destination[26] = GMT1;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.Windows.cs
@@ -97,17 +97,17 @@ namespace System
             {
                 DateTime dt = new DateTime(ticks);
 
-                int year, month, day;
-                dt.GetDatePart(out year, out month, out day);
+                dt.GetDate(out int year, out int month, out int day);
+                dt.GetTime(out int hour, out int minute, out int second, out int millisecond);
 
                 systemTime.Year = (ushort)year;
                 systemTime.Month = (ushort)month;
                 systemTime.DayOfWeek = (ushort)dt.DayOfWeek;
                 systemTime.Day = (ushort)day;
-                systemTime.Hour = (ushort)dt.Hour;
-                systemTime.Minute = (ushort)dt.Minute;
-                systemTime.Second = (ushort)dt.Second;
-                systemTime.Milliseconds = (ushort)dt.Millisecond;
+                systemTime.Hour = (ushort)hour;
+                systemTime.Minute = (ushort)minute;
+                systemTime.Second = (ushort)second;
+                systemTime.Milliseconds = (ushort)millisecond;
                 hundredNanoSecond = 0;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -988,8 +988,7 @@ namespace System
             second = (int)m;
             n = Math.DivRem(n, 60, out m);
             minute = (int)m;
-            n = Math.DivRem(n, 24, out m);
-            hour = (int)m;
+            hour = (int)(n % 24);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1002,8 +1001,7 @@ namespace System
             second = (int)m;
             n = Math.DivRem(n, 60, out m);
             minute = (int)m;
-            n = Math.DivRem(n, 24, out m);
-            hour = (int)m;
+            hour = (int)(n % 24);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1015,8 +1013,7 @@ namespace System
             second = (int)m;
             n = Math.DivRem(n, 60, out m);
             minute = (int)m;
-            n = Math.DivRem(n, 24, out m);
-            hour = (int)m;
+            hour = (int)(n % 24);
         }
 
         // Returns the day-of-month part of this DateTime. The returned

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -509,7 +509,7 @@ namespace System
         public DateTime AddMonths(int months)
         {
             if (months < -120000 || months > 120000) throw new ArgumentOutOfRangeException(nameof(months), SR.ArgumentOutOfRange_DateTimeBadMonths);
-            GetDatePart(out int y, out int m, out int d);
+            GetDate(out int y, out int m, out int d);
             int i = m - 1 + months;
             if (i >= 0)
             {
@@ -935,10 +935,10 @@ namespace System
             return n - days[m - 1] + 1;
         }
 
-        // Exactly the same as GetDatePart(int part), except computing all of
-        // year/month/day rather than just one of them.  Used when all three
+        // Exactly the same as GetDatePart, except computing all of
+        // year/month/day rather than just one of them. Used when all three
         // are needed rather than redoing the computations for each.
-        internal void GetDatePart(out int year, out int month, out int day)
+        internal void GetDate(out int year, out int month, out int day)
         {
             long ticks = InternalTicks;
             // n = number of days since 1/1/0001
@@ -978,6 +978,45 @@ namespace System
             // compute month and day
             month = m;
             day = n - days[m - 1] + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void GetTime(out int hour, out int minute, out int second)
+        {
+            long n = InternalTicks / TicksPerSecond;
+            n = Math.DivRem(n, 60, out long m);
+            second = (int)m;
+            n = Math.DivRem(n, 60, out m);
+            minute = (int)m;
+            n = Math.DivRem(n, 24, out m);
+            hour = (int)m;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void GetTime(out int hour, out int minute, out int second, out int millisecond)
+        {
+            long n = InternalTicks / TicksPerMillisecond;
+            n = Math.DivRem(n, 1000, out long m);
+            millisecond = (int)m;
+            n = Math.DivRem(n, 60, out m);
+            second = (int)m;
+            n = Math.DivRem(n, 60, out m);
+            minute = (int)m;
+            n = Math.DivRem(n, 24, out m);
+            hour = (int)m;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void GetTimePrecise(out int hour, out int minute, out int second, out int tick)
+        {
+            long n = Math.DivRem(InternalTicks, TicksPerSecond, out long m);
+            tick = (int)m;
+            n = Math.DivRem(n, 60, out m);
+            second = (int)m;
+            n = Math.DivRem(n, 60, out m);
+            minute = (int)m;
+            n = Math.DivRem(n, 24, out m);
+            hour = (int)m;
         }
 
         // Returns the day-of-month part of this DateTime. The returned

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/EastAsianLunisolarCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/EastAsianLunisolarCalendar.cs
@@ -400,7 +400,8 @@ namespace System.Globalization
         private DateTime LunarToTime(DateTime time, int year, int month, int day)
         {
             LunarToGregorian(year, month, day, out int gy, out int gm, out int gd);
-            return GregorianCalendar.GetDefaultInstance().ToDateTime(gy, gm, gd, time.Hour, time.Minute, time.Second, time.Millisecond);
+            time.GetTime(out int hour, out int minute, out int second, out int millisecond);
+            return GregorianCalendar.GetDefaultInstance().ToDateTime(gy, gm, gd, hour, minute, second, millisecond);
         }
 
         private void TimeToLunar(DateTime time, out int year, out int month, out int day)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendar.cs
@@ -145,7 +145,7 @@ namespace System.Globalization
                     SR.Format(SR.ArgumentOutOfRange_Range, -120000, 120000));
             }
 
-            time.GetDatePart(out int y, out int m, out int d);
+            time.GetDate(out int y, out int m, out int d);
             int i = m - 1 + months;
             if (i >= 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/HebrewCalendar.cs
@@ -449,7 +449,7 @@ namespace System.Globalization
             DateTime time = new DateTime(ticks);
 
             // Save the Gregorian date values.
-            time.GetDatePart(out gregorianYear, out gregorianMonth, out gregorianDay);
+            time.GetDate(out gregorianYear, out gregorianMonth, out gregorianDay);
 
             DateBuffer lunarDate = new DateBuffer();    // lunar month and day for Jan 1
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/UmAlQuraCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/UmAlQuraCalendar.cs
@@ -282,7 +282,7 @@ namespace System.Globalization
             }
 
             dt = dt.AddDays(nDays);
-            dt.GetDatePart(out yg, out mg, out dg);
+            dt.GetDate(out yg, out mg, out dg);
         }
 
         private static long GetAbsoluteDateUmAlQura(int year, int month, int day)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.AdjustmentRule.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.AdjustmentRule.cs
@@ -119,8 +119,8 @@ namespace System
             //
             internal bool IsStartDateMarkerForBeginningOfYear() =>
                 !NoDaylightTransitions &&
-                DaylightTransitionStart.Month == 1 && DaylightTransitionStart.Day == 1 && DaylightTransitionStart.TimeOfDay.Hour == 0 &&
-                DaylightTransitionStart.TimeOfDay.Minute == 0 && DaylightTransitionStart.TimeOfDay.Second == 0 &&
+                DaylightTransitionStart.Month == 1 && DaylightTransitionStart.Day == 1 &&
+                DaylightTransitionStart.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond && // < 12:00:01 AM
                 _dateStart.Year == _dateEnd.Year;
 
             //
@@ -129,8 +129,8 @@ namespace System
             //
             internal bool IsEndDateMarkerForEndOfYear() =>
                 !NoDaylightTransitions &&
-                DaylightTransitionEnd.Month == 1 && DaylightTransitionEnd.Day == 1 && DaylightTransitionEnd.TimeOfDay.Hour == 0 &&
-                DaylightTransitionEnd.TimeOfDay.Minute == 0 && DaylightTransitionEnd.TimeOfDay.Second == 0 &&
+                DaylightTransitionEnd.Month == 1 && DaylightTransitionEnd.Day == 1 &&
+                DaylightTransitionEnd.TimeOfDay.TimeOfDay.Ticks < TimeSpan.TicksPerSecond && // < 12:00:01 AM
                 _dateStart.Year == _dateEnd.Year;
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.TransitionTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.TransitionTime.cs
@@ -99,7 +99,7 @@ namespace System
                     throw new ArgumentOutOfRangeException(nameof(dayOfWeek), SR.ArgumentOutOfRange_DayOfWeek);
                 }
 
-                timeOfDay.GetDatePart(out int timeOfDayYear, out int timeOfDayMonth, out int timeOfDayDay);
+                timeOfDay.GetDate(out int timeOfDayYear, out int timeOfDayMonth, out int timeOfDayDay);
                 if (timeOfDayYear != 1 || timeOfDayMonth != 1 || timeOfDayDay != 1 || (timeOfDay.Ticks % TimeSpan.TicksPerMillisecond != 0))
                 {
                     throw new ArgumentException(SR.Argument_DateTimeHasTicks, nameof(timeOfDay));

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -1751,17 +1751,24 @@ namespace System
         internal static DateTime TransitionTimeToDateTime(int year, TransitionTime transitionTime)
         {
             DateTime value;
-            DateTime timeOfDay = transitionTime.TimeOfDay;
+            TimeSpan timeOfDay = transitionTime.TimeOfDay.TimeOfDay;
 
             if (transitionTime.IsFixedDateRule)
             {
                 // create a DateTime from the passed in year and the properties on the transitionTime
 
+                int day = transitionTime.Day;
                 // if the day is out of range for the month then use the last day of the month
-                int day = DateTime.DaysInMonth(year, transitionTime.Month);
+                if (day > 28)
+                {
+                    int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
+                    if (day > daysInMonth)
+                    {
+                        day = daysInMonth;
+                    }
+                }
 
-                value = new DateTime(year, transitionTime.Month, (day < transitionTime.Day) ? day : transitionTime.Day,
-                            timeOfDay.Hour, timeOfDay.Minute, timeOfDay.Second, timeOfDay.Millisecond);
+                value = new DateTime(year, transitionTime.Month, day) + timeOfDay;
             }
             else
             {
@@ -1770,8 +1777,7 @@ namespace System
                     //
                     // Get the (transitionTime.Week)th Sunday.
                     //
-                    value = new DateTime(year, transitionTime.Month, 1,
-                            timeOfDay.Hour, timeOfDay.Minute, timeOfDay.Second, timeOfDay.Millisecond);
+                    value = new DateTime(year, transitionTime.Month, 1) + timeOfDay;
 
                     int dayOfWeek = (int)value.DayOfWeek;
                     int delta = (int)transitionTime.DayOfWeek - dayOfWeek;
@@ -1792,8 +1798,7 @@ namespace System
                     // If TransitionWeek is greater than 4, we will get the last week.
                     //
                     int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
-                    value = new DateTime(year, transitionTime.Month, daysInMonth,
-                            timeOfDay.Hour, timeOfDay.Minute, timeOfDay.Second, timeOfDay.Millisecond);
+                    value = new DateTime(year, transitionTime.Month, daysInMonth) + timeOfDay;
 
                     // This is the day of week for the last day of the month.
                     int dayOfWeek = (int)value.DayOfWeek;


### PR DESCRIPTION
Add uses of `DateTime.GetDate` (renamed from `GetDatePart`) where appropriate.
Add internal `DateTime.GetTime` method to eliminate duplicate computations.

Note that the change to `TimeZoneInfo.TransitionTimeToDateTime`, which adds `TimeOfDay` directly in ticks precision, can't break anything because the `TransitionTime` constructor ensures that `TimeOfDay` doesn't have sub-millisecond time.

Here are the relevant microbenchmarks in dotnet/performance, of which the rows with the bold text being the build with the changes:
<details><summary>System.Tests.Perf_DateTime</summary>

|Method|format|Mean|Error|StdDev|Median|Min|Max|Ratio|Gen 0|Gen 1|Gen 2|Allocated|
|- |- |-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|
|**ToString**|**?**|**292.30 ns**|**3.399 ns**|**2.838 ns**|**292.33 ns**|**286.58 ns**|**296.96 ns**|**0.99**|**0.0144**|**-**|**-**|**64 B**|
|ToString|?|295.86 ns|2.520 ns|2.104 ns|296.08 ns|291.85 ns|300.16 ns|1.00|0.0143|-|-|64 B|
|||||||||||||||
|**ToString**|**G**|**293.25 ns**|**3.067 ns**|**2.869 ns**|**293.66 ns**|**288.34 ns**|**297.03 ns**|**0.99**|**0.0143**|**-**|**-**|**64 B**|
|ToString|G|295.89 ns|3.830 ns|3.583 ns|295.99 ns|289.15 ns|303.13 ns|1.00|0.0143|-|-|64 B|
|||||||||||||||
|**ToString**|**o**|**66.41 ns**|**0.943 ns**|**0.882 ns**|**66.37 ns**|**64.78 ns**|**67.96 ns**|**0.72**|**0.0190**|**-**|**-**|**80 B**|
|ToString|o|92.34 ns|0.826 ns|0.773 ns|92.28 ns|91.13 ns|93.41 ns|1.00|0.0191|-|-|80 B|
|||||||||||||||
|**ToString**|**r**|**52.63 ns**|**0.433 ns**|**0.384 ns**|**52.64 ns**|**51.90 ns**|**53.41 ns**|**0.92**|**0.0190**|**-**|**-**|**80 B**|
|ToString|r|57.13 ns|0.514 ns|0.481 ns|56.93 ns|56.59 ns|58.31 ns|1.00|Base|0.0189|-|-|80 B|
|||||||||||||||
|**ToString**|**s**|**289.34 ns**|**3.105 ns**|**2.904 ns**|**289.99 ns**|**283.88 ns**|**292.82 ns**|**1.02**|**0.0150**|**-**|**-**|**64 B**|
|ToString|s|284.92 ns|1.898 ns|1.683 ns|285.08 ns|281.30 ns|287.85 ns|1.00|0.0151|-|-|64 B|
</details>
<details><summary>System.Tests.Perf_DateTimeOffset</summary>

|Method|format|value|Mean|Error|StdDev|Median|Min|Max|Ratio|Gen 0|Gen 1|Gen 2|Allocated|
|- |- |- |-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|
|**ToString**|**?**|**?**|**666.74 ns**|**6.687 ns**|**6.255 ns**|**664.85 ns**|**658.04 ns**|**681.22 ns**|**1.01**|**0.0296**|**-**|**-**|**128 B**|
|ToString|?|?|662.49 ns|5.139 ns|4.555 ns|663.86 ns|653.89 ns|670.28 ns|1.00|0.0294|-|-|128 B|
||||||||||||||||
|**ToString**|**?**|**12/30/2017 3:45:22 AM -08:00**|**658.87 ns**|**5.386 ns**|**5.038 ns**|**658.13 ns**|**651.09 ns**|**670.00 ns**|**0.98**|**0.0286**|**-**|**-**|**128 B**|
|ToString|?|12/30/2017 3:45:22 AM -08:00|671.86 ns|5.994 ns|5.607 ns|673.26 ns|663.39 ns|683.24 ns|1.00|0.0294|-|-|128 B|
||||||||||||||||
|**ToString**|**G**|**?**|**308.34 ns**|**4.298 ns**|**3.810 ns**|**308.64 ns**|**300.68 ns**|**315.02 ns**|**1.01**|**0.0148**|**-**|**-**|**64 B**|
|ToString|G|?|304.10 ns|2.380 ns|2.226 ns|304.11 ns|300.51 ns|307.61 ns|1.00|0.0150|-|-|64 B|
||||||||||||||||
|**ToString**|**o**|**?**|**76.22 ns**|**0.368 ns**|**0.308 ns**|**76.17 ns**|**75.78 ns**|**76.92 ns**|**0.69**|**0.0209**|**-**|**-**|**88 B**|
|ToString|o|?|110.96 ns|1.202 ns|1.066 ns|110.72 ns|109.07 ns|113.46 ns|1.00|0.0206|-|-|88 B|
||||||||||||||||
|**ToString**|**r**|**?**|**63.59 ns**|**0.742 ns**|**0.620 ns**|**63.76 ns**|**62.62 ns**|**64.42 ns**|**0.97**|**0.0190**|**-**|**-**|**80 B**|
|ToString|r|?|65.52 ns|0.940 ns|0.880 ns|65.33 ns|63.77 ns|67.45 ns|1.00|0.0190|-|-|80 B|
||||||||||||||||
|**ToString**|**s**|**?**|**304.85 ns**|**3.213 ns**|**3.006 ns**|**305.61 ns**|**298.44 ns**|**309.04 ns**|**1.00**|**0.0147**|**-**|**-**|**64 B**|
|ToString|s|?|305.75 ns|3.682 ns|3.444 ns|304.98 ns|300.63 ns|310.69 ns|1.00|0.0148|-|-|64 B|
</details>
<details><summary>System.Buffers.Text.Tests.Utf8FormatterTests.FormatterDateTimeOffsetNow</summary>

|Method|Mean|Error|StdDev|Median|Min|Max|Ratio|Gen 0|Gen 1|Gen 2|Allocated|
|- |-:|-:|-:|-:|-:|-:|-:|- |-:|-:|-:|
|**FormatterDateTimeOffsetNow**|**44.22 ns**|**0.473 ns**|**0.442 ns**|**44.35 ns**|**43.59 ns**|**45.01 ns**|**0.62**|-|-|-|-|
|FormatterDateTimeOffsetNow|71.83 ns|0.662 ns|0.587 ns|71.79 ns|71.00 ns|73.06 ns|1.00|-|-|-|-|
</details>
<details><summary>System.Text.Json.Tests.Perf_DateTimes</summary>

|Method|Formatted|SkipValidation|Mean|Error|StdDev|Median|Min|Max|Ratio|Gen0|Gen1|Gen2|Allocated|
|- |- |- |-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|-:|
|**WriteDateTimes**|**False**|**False**|**6.700 ms**|**0.0729 ms**|**0.0647 ms**|**6.700 ms**|**6.584 ms**|**6.801 ms**|**0.72**|**-**|**-**|**-**|**140 B**|
|WriteDateTimes|False|False|9.313 ms|0.1085 ms|0.0962 ms|9.310 ms|9.159 ms|9.498 ms|1.00|-|-|-|120 B|
||||||||||||||||
|**WriteDateTimes**|**False**|**True**|**6.513 ms**|**0.0543 ms**|**0.0453 ms**|**6.529 ms**|**6.428 ms**|**6.578 ms**|**0.71**|**-**|**-**|**-**|**120 B**|
|WriteDateTimes|False|True|9.149 ms|0.0635 ms|0.0563 ms|9.149 ms|9.025 ms|9.231 ms|1.00|-|-|-|120 B|
||||||||||||||||
|**WriteDateTimes**|**True**|**False**|**7.284 ms**|**0.0855 ms**|**0.0758 ms**|**7.270 ms**|**7.145 ms**|**7.394 ms**|**0.73**|**-**|**-**|**-**|**120 B**|
|WriteDateTimes|True|False|9.926 ms|0.1158 ms|0.1083 ms|9.918 ms|9.735 ms|10.091 ms|1.00|-|-|-|120 B|
||||||||||||||||
|**WriteDateTimes**|**True**|**True**|**7.343 ms**|**0.0763 ms**|**0.0714 ms**|**7.328 ms**|**7.250 ms**|**7.479 ms**|**0.73**|**-**|**-**|**-**|**141 B**|
|WriteDateTimes|True|True|10.120 ms|0.1492 ms|0.1323 ms|10.077 ms|9.938 ms|10.373 ms|1.00|-|-|-|120 B|
</details>