### PR TITLE
Cleanup regex diagnostic output

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -101,6 +101,13 @@ namespace System.Text.RegularExpressions
             roptions = options;
             internalMatchTimeout = matchTimeout;
 
+#if DEBUG
+            if (Debug)
+            {
+                System.Diagnostics.Debug.Write($"Pattern:     {pattern}");
+            }
+#endif
+
             // Parse the input
             RegexTree tree = RegexParser.Parse(pattern, roptions, culture ?? ((options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture));
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -105,6 +105,11 @@ namespace System.Text.RegularExpressions
             if (Debug)
             {
                 System.Diagnostics.Debug.Write($"Pattern:     {pattern}");
+                RegexOptions displayOptions = options & ~RegexOptions.Debug;
+                if (displayOptions != RegexOptions.None)
+                    System.Diagnostics.Debug.Write($"Options:     {displayOptions}");
+                if (matchTimeout != Regex.InfiniteMatchTimeout)
+                    System.Diagnostics.Debug.Write($"Timeout:     {matchTimeout}");
             }
 #endif
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -357,15 +357,17 @@ namespace System.Text.RegularExpressions
 
             if (NegativeASCII != null)
             {
-                sb.Append(indent + "Negative table\n");
+                sb.Append(indent + "Negative table: ");
                 for (int i = 0; i < NegativeASCII.Length; i++)
                 {
                     if (NegativeASCII[i] != Pattern.Length)
                     {
-                        sb.Append(indent + "  " + Regex.Escape(Convert.ToString((char)i, CultureInfo.InvariantCulture)) + " " + NegativeASCII[i].ToString(CultureInfo.InvariantCulture) + "\n");
+                        sb.Append(" {" + Regex.Escape(Convert.ToString((char)i, CultureInfo.InvariantCulture)) + " " + NegativeASCII[i].ToString(CultureInfo.InvariantCulture) + "}");
                     }
                 }
             }
+
+            sb.Append("\n");
 
             return sb.ToString();
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -347,13 +347,14 @@ namespace System.Text.RegularExpressions
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append(indent + "BM Pattern: " + Pattern + "\n");
+            sb.Append(indent + "BM Pattern: " + Pattern);
+            sb.AppendLine();
             sb.Append(indent + "Positive: ");
             for (int i = 0; i < Positive.Length; i++)
             {
                 sb.Append(Positive[i].ToString(CultureInfo.InvariantCulture) + " ");
             }
-            sb.Append("\n");
+            sb.AppendLine();
 
             if (NegativeASCII != null)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -348,7 +348,7 @@ namespace System.Text.RegularExpressions
             StringBuilder sb = new StringBuilder();
 
             sb.Append(indent + "BM Pattern: " + Pattern);
-            sb.AppendLine();
+            sb.AppendLine(indent + "BM Pattern: " + Pattern);
             sb.Append(indent + "Positive: ");
             for (int i = 0; i < Positive.Length; i++)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -367,7 +367,7 @@ namespace System.Text.RegularExpressions
                 }
             }
 
-            sb.Append("\n");
+            sb.AppendLine();
 
             return sb.ToString();
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -347,8 +347,7 @@ namespace System.Text.RegularExpressions
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.Append(indent + "BM Pattern: " + Pattern);
-            sb.AppendLine(indent + "BM Pattern: " + Pattern);
+            sb.AppendLine($"{indent}BM Pattern: {Pattern}");
             sb.Append(indent + "Positive: ");
             for (int i = 0; i < Positive.Length; i++)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1522,7 +1522,7 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         public static readonly char[] Hex = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-        public static readonly string[] _categoryIdToName = PopulateCategoryIdToName();
+        public static readonly string[] CategoryIdToName = PopulateCategoryIdToName();
 
         private static string[] PopulateCategoryIdToName()
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1687,10 +1687,10 @@ namespace System.Text.RegularExpressions
 
             if ((short)ch < 0)
             {
-                return "\\P{" + _categoryIdToName[(-((short)ch) - 1)] + "}";
+                return "\\P{" + CategoryIdToName[(-((short)ch) - 1)] + "}";
             }
 
-            return "\\p{" + _categoryIdToName[(ch - 1)] + "}";
+            return "\\p{" + CategoryIdToName[(ch - 1)] + "}";
         }
 #endif
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1522,14 +1522,17 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         public static readonly char[] Hex = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-        public static readonly string[] Categories = new string[] {"Lu", "Ll", "Lt", "Lm", "Lo", InternalRegexIgnoreCase,
-                                                                     "Mn", "Mc", "Me",
-                                                                     "Nd", "Nl", "No",
-                                                                     "Zs", "Zl", "Zp",
-                                                                     "Cc", "Cf", "Cs", "Co",
-                                                                     "Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po",
-                                                                     "Sm", "Sc", "Sk", "So",
-                                                                     "Cn" };
+        public static readonly string[] _categoryIdToName = PopulateCategoryIdToName();
+
+        private static string[] PopulateCategoryIdToName()
+        {
+            // Populate category reverse lookup used for diagnostic output
+
+            var temp = new List<KeyValuePair<string, string>>(s_definedCategories);
+            temp.RemoveAll(kvp => kvp.Value.Length != 1);
+            temp.Sort((kvp1, kvp2) => ((short)kvp1.Value[0]).CompareTo((short)kvp2.Value[0]));
+            return temp.ConvertAll(kvp => kvp.Key).ToArray();
+        }
 
         /// <summary>
         /// Produces a human-readable description for a set string.
@@ -1684,10 +1687,10 @@ namespace System.Text.RegularExpressions
 
             if ((short)ch < 0)
             {
-                return "\\P{" + Categories[(-((short)ch) - 1)] + "}";
+                return "\\P{" + _categoryIdToName[(-((short)ch) - 1)] + "}";
             }
 
-            return "\\p{" + Categories[(ch - 1)] + "}";
+            return "\\p{" + _categoryIdToName[(ch - 1)] + "}";
         }
 #endif
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -292,7 +292,7 @@ namespace System.Text.RegularExpressions
             sb.AppendFormat("{0:D6} ", offset);
             sb.Append(OpcodeBacktracks(opcode & Mask) ? '*' : ' ');
             sb.Append(OperatorDescription(opcode));
-            sb.Append('(');
+            sb.Append(Indent());
 
             opcode &= Mask;
 
@@ -308,7 +308,6 @@ namespace System.Text.RegularExpressions
                 case Notoneloopatomic:
                 case Onelazy:
                 case Notonelazy:
-                    sb.Append("Ch = ");
                     sb.Append(RegexCharClass.CharDescription((char)Codes[offset + 1]));
                     break;
 
@@ -317,34 +316,32 @@ namespace System.Text.RegularExpressions
                 case Setloop:
                 case Setloopatomic:
                 case Setlazy:
-                    sb.Append("Set = ");
                     sb.Append(RegexCharClass.SetDescription(Strings[Codes[offset + 1]]));
                     break;
 
                 case Multi:
-                    sb.Append("String = ");
                     sb.Append(Strings[Codes[offset + 1]]);
                     break;
 
                 case Ref:
                 case Testref:
-                    sb.Append("Index = ");
+                    sb.Append("index = ");
                     sb.Append(Codes[offset + 1]);
                     break;
 
                 case Capturemark:
-                    sb.Append("Index = ");
+                    sb.Append("index = ");
                     sb.Append(Codes[offset + 1]);
                     if (Codes[offset + 2] != -1)
                     {
-                        sb.Append(", Unindex = ");
+                        sb.Append(", unindex = ");
                         sb.Append(Codes[offset + 2]);
                     }
                     break;
 
                 case Nullcount:
                 case Setcount:
-                    sb.Append("Value = ");
+                    sb.Append("value = ");
                     sb.Append(Codes[offset + 1]);
                     break;
 
@@ -354,7 +351,7 @@ namespace System.Text.RegularExpressions
                 case Lazybranchmark:
                 case Branchcount:
                 case Lazybranchcount:
-                    sb.Append("Addr = ");
+                    sb.Append("addr = ");
                     sb.Append(Codes[offset + 1]);
                     break;
             }
@@ -373,7 +370,7 @@ namespace System.Text.RegularExpressions
                 case Setloop:
                 case Setloopatomic:
                 case Setlazy:
-                    sb.Append(", Rep = ");
+                    sb.Append(", rep = ");
                     if (Codes[offset + 2] == int.MaxValue)
                         sb.Append("inf");
                     else
@@ -382,7 +379,7 @@ namespace System.Text.RegularExpressions
 
                 case Branchcount:
                 case Lazybranchcount:
-                    sb.Append(", Limit = ");
+                    sb.Append(", limit = ");
                     if (Codes[offset + 2] == int.MaxValue)
                         sb.Append("inf");
                     else
@@ -390,7 +387,7 @@ namespace System.Text.RegularExpressions
                     break;
             }
 
-            sb.Append(')');
+            string Indent() => new string(' ', Math.Max(1, 25 - sb.Length));
 
             return sb.ToString();
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 // This RegexCode class is internal to the regular expression package.
-// It provides operator constants for use by the Builder and the Machine.
 
 // Implementation notes:
 //

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1354,6 +1354,8 @@ namespace System.Text.RegularExpressions
             if ((Options & RegexOptions.IgnorePatternWhitespace) != 0) argSb.Append("-X");
             if ((Options & RegexOptions.ECMAScript) != 0) argSb.Append("-E");
 
+            argSb.Append(Indent());
+
             switch (Type)
             {
                 case Oneloop:
@@ -1364,23 +1366,25 @@ namespace System.Text.RegularExpressions
                 case Notonelazy:
                 case One:
                 case Notone:
-                    argSb.Append("(Ch = " + RegexCharClass.CharDescription(Ch) + ")");
+                    argSb.Append(RegexCharClass.CharDescription(Ch));
                     break;
                 case Capture:
-                    argSb.Append("(index = " + M.ToString(CultureInfo.InvariantCulture) + ", unindex = " + N.ToString(CultureInfo.InvariantCulture) + ")");
+                    argSb.Append("index = " + M);
+                    if (N != -1)
+                        argSb.Append(", unindex = " + N);
                     break;
                 case Ref:
                 case Testref:
-                    argSb.Append("(index = " + M.ToString(CultureInfo.InvariantCulture) + ")");
+                    argSb.Append("index = " + M);
                     break;
                 case Multi:
-                    argSb.Append("(String = " + Str + ")");
+                    argSb.Append(Str);
                     break;
                 case Set:
                 case Setloop:
                 case Setloopatomic:
                 case Setlazy:
-                    argSb.Append("(Set = " + RegexCharClass.SetDescription(Str!) + ")");
+                    argSb.Append(RegexCharClass.SetDescription(Str!));
                     break;
             }
 
@@ -1397,9 +1401,17 @@ namespace System.Text.RegularExpressions
                 case Setlazy:
                 case Loop:
                 case Lazyloop:
-                    argSb.Append("(Min = " + M.ToString(CultureInfo.InvariantCulture) + ", Max = " + (N == int.MaxValue ? "inf" : Convert.ToString(N, CultureInfo.InvariantCulture)) + ")");
+                    if (argSb[argSb.Length - 1] != ' ')
+                        argSb.Append(", ");
+                    argSb.Append("min = " + M + ", max = ");
+                    if (N == int.MaxValue)
+                        argSb.Append("inf");
+                    else
+                        argSb.Append(N);
                     break;
             }
+
+            string Indent() => new string(' ', Math.Max(1, 25 - argSb.Length));
 
             return argSb.ToString();
         }
@@ -1421,7 +1433,7 @@ namespace System.Text.RegularExpressions
                     curNode = curNode.Child(curChild);
                     curChild = 0;
 
-                    Debug.WriteLine(new string(' ', stack.Count) + curNode.Description());
+                    Debug.WriteLine(new string(' ', stack.Count * 2) + curNode.Description());
                 }
                 else
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1401,7 +1401,7 @@ namespace System.Text.RegularExpressions
                 case Setlazy:
                 case Loop:
                 case Lazyloop:
-                    if (argSb[argSb.Length - 1] != ' ')
+                    if (argSb[^1] != ' ')
                         argSb.Append(", ");
                     argSb.Append("min = " + M + ", max = ");
                     if (N == int.MaxValue)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1874,7 +1874,7 @@ namespace System.Text.RegularExpressions
                             else
                             {
                                 // Simple (unnamed) capture group.
-                                // Add unnamend parentheses if ExplicitCapture is not set
+                                // Add unnamed parentheses if ExplicitCapture is not set
                                 // and the next parentheses is not ignored.
                                 if (!UseOptionN() && !_ignoreNextParen)
                                 {
@@ -2313,7 +2313,7 @@ namespace System.Text.RegularExpressions
         private char CharAt(int i) => _pattern[i];
 
         /// <summary>Returns the char right of the current parsing position.</summary>
-        internal char RightChar() => _pattern[_currentPos];
+        private char RightChar() => _pattern[_currentPos];
 
         /// <summary>Returns the char i chars right of the current parsing position.</summary>
         private char RightChar(int i) => _pattern[_currentPos + i];


### PR DESCRIPTION
Updates to the diagnostic output you get if you pass `RegexOptions.Debug` _and_ have a debug-build of System.Text.RegularExpressions.dll

* Log the pattern itself
* Fix an actual bug in the char class output - introduced long ago when the implementation was changed, but the dumping was not. Generate the table from the implementation instead.
* Change Boyer-Moore logging to fewer lines: it's only interesting if there's a bug in B-M, probably.
* Improve the indenting and spacing of the node and code trees.

Example:
```
[8340] Pattern:     (abc|de){2,11}
[8340] Capture                  index = 0 
[8340]   Loop                     min = 2, max = 11 
[8340]     Capture                  index = 1 
[8340]       Alternate                 
[8340]         Multi                    abc 
[8340]         Multi                    de 
[8340] Direction:  left-to-right 
[8340] Firstchars: [ad] 
[8340] Prefix:     n/a 
[8340] Anchors:    None 
[8340]  
[8340] 000000 *Lazybranch       addr = 23 
[8340] 000002 *Setmark           
[8340] 000003 *Setcount         value = -1 
[8340] 000005 *Setmark           
[8340] 000006 *Lazybranch       addr = 12 
[8340] 000008  Multi            abc 
[8340] 000010 *Goto             addr = 14 
[8340] 000012  Multi            de 
[8340] 000014 *Capturemark      index = 1 
[8340] 000017 *Branchcount      addr = 5, limit = 9 
[8340] 000020 *Capturemark      index = 0 
[8340] 000023  Stop              
```

I did not change the execution logging, although that's very verbose and possibly ought to have a separate toggle.

And boo to all apps that ship and don't remove their debug output! I've opened bugs against VS in the past for this, they've fixed them and now I've another to open. Although, that's not the worst culprit. 