### PR TITLE
Workaround AzDo issue when evaluating Build.SourcesDirectory variable  in a docker container

### DIFF
--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -78,7 +78,10 @@ jobs:
         - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
           - _coreClrDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/coreclr'
           - _coreClrArtifactName: 'CoreCLRProduct_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveCoreClrBuildConfig }}'
-          - _coreClrArtifactsPathArg: ' /p:CoreCLRArtifactsPath=${_CORECLRDOWNLOADPATH}'
+          - ${{ if ne(parameters.container, '') }}:
+            - _coreClrArtifactsPathArg: '/p:CoreCLRArtifactsPath=${_CORECLRDOWNLOADPATH}'
+          - ${{ if eq(parameters.container, '') }}:
+            - _coreClrArtifactsPathArg: ' /p:CoreCLRArtifactsPath=$(_coreClrDownloadPath)'
 
           # WebAssembly uses linux implementation detail
           - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:
@@ -112,7 +115,7 @@ jobs:
       - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
         - template: /eng/pipelines/common/download-artifact-step.yml
           parameters:
-            unpackFolder: ${_CORECLRDOWNLOADPATH}
+            unpackFolder: $(_coreClrDownloadPath)
             artifactFileName: '$(_coreClrArtifactName)$(archiveExtension)'
             artifactName: '$(_coreClrArtifactName)'
             displayName: 'CoreCLR build drop'

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -78,7 +78,7 @@ jobs:
         - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
           - _coreClrDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/coreclr'
           - _coreClrArtifactName: 'CoreCLRProduct_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveCoreClrBuildConfig }}'
-          - _coreClrArtifactsPathArg: ' /p:CoreCLRArtifactsPath=$(_coreClrDownloadPath)'
+          - _coreClrArtifactsPathArg: ' /p:CoreCLRArtifactsPath=${_CORECLRDOWNLOADPATH}'
 
           # WebAssembly uses linux implementation detail
           - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:
@@ -112,7 +112,7 @@ jobs:
       - ${{ if ne(parameters.liveCoreClrBuildConfig, '') }}:
         - template: /eng/pipelines/common/download-artifact-step.yml
           parameters:
-            unpackFolder: $(_coreClrDownloadPath)
+            unpackFolder: ${_CORECLRDOWNLOADPATH}
             artifactFileName: '$(_coreClrArtifactName)$(archiveExtension)'
             artifactName: '$(_coreClrArtifactName)'
             displayName: 'CoreCLR build drop'


### PR DESCRIPTION
Since we don't know how long it is going to take for a fix to roll out from AzDo use a workaround they suggested for issue: https://github.com/dotnet/runtime/issues/1967

We can revert this change once their fix rolls out. 