### PR TITLE
Unify char.IsControl and Rune.IsControl

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -472,11 +472,10 @@ namespace System
 
         public static bool IsControl(char c)
         {
-            if (IsLatin1(c))
-            {
-                return GetLatin1UnicodeCategory(c) == UnicodeCategory.Control;
-            }
-            return CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.Control;
+            // This works because 'c' can never be -1.
+            // See comments in Rune.IsControl for more information.
+
+            return (((uint)c + 1) & ~0x80u) <= 0x20u;
         }
 
         public static bool IsControl(string s, int index)
@@ -487,12 +486,9 @@ namespace System
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
-            char c = s[index];
-            if (IsLatin1(c))
-            {
-                return GetLatin1UnicodeCategory(c) == UnicodeCategory.Control;
-            }
-            return CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.Control;
+
+            // Control chars are always in the BMP, so don't need to worry about surrogate handling.
+            return IsControl(s[index]);
         }
 
         public static bool IsDigit(string s, int index)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -1133,8 +1133,8 @@ namespace System.Text
         {
             // Per the Unicode stability policy, the set of control characters
             // is forever fixed at [ U+0000..U+001F ], [ U+007F..U+009F ]. No
-            // characters will ever be added to the "control characters" group.
-            // See http://www.unicode.org/policies/stability_policy.html.
+            // characters will ever be added to or removed from the "control characters"
+            // group. See https://www.unicode.org/policies/stability_policy.html.
 
             // Logic below depends on Rune.Value never being -1 (since Rune is a validating type)
             // 00..1F (+1) => 01..20 (&~80) => 01..20


### PR DESCRIPTION
Was reviewing https://github.com/dotnet/aspnetcore/pull/18134 with @pranavkm offline and realized that there's some low hanging fruit we can address in `char.IsControl`. This implementation removes the branch and table lookup and rips the logic from `Rune.IsControl`. After codegen it's only three instructions: `add`, `and`, `cmp`.

Not perf-critical. Just cleanup.