### PR TITLE
Add additional error checking for mainv1, mainv2 tests

### DIFF
--- a/src/coreclr/tests/src/readytorun/tests/mainv1.csproj
+++ b/src/coreclr/tests/src/readytorun/tests/mainv1.csproj
@@ -34,17 +34,29 @@ IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
 )
+if not exist test.ni.dll (
+    echo FAILED to build test.ni.dll
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out fieldgetter.ni.dll fieldgetter.dll 
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
 )
+if not exist fieldgetter.ni.dll (
+    echo FAILED to build fieldgetter.ni.dll
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out mainv1.ni.exe mainv1.exe
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
+)
+if not exist mainv1.ni.exe (
+    echo FAILED to build mainv1.ni.exe
+    exit /b 1
 )
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
@@ -68,6 +80,11 @@ then
   echo Crossgen failed with exitcode: $__cgExitCode
   exit 1
 fi
+if [ ! -f test.ni.dll ]
+then
+  echo Failed to build test.ni.dll
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out fieldgetter.ni.dll fieldgetter.dll
 __cgExitCode=$?
 if [ $__cgExitCode -ne 0 ]
@@ -75,11 +92,21 @@ then
   echo Crossgen failed with exitcode: $__cgExitCode
   exit 1
 fi
+if [ ! -f fieldgetter.ni.dll ]
+then
+  echo Failed to build fieldgetter.ni.dll
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out mainv1.ni.exe mainv1.exe
 __cgExitCode=$?
 if [ $__cgExitCode -ne 0 ]
 then
   echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
+if [ ! -f mainv1.ni.exe ]
+then
+  echo Failed to build mainv1.ni.exe
   exit 1
 fi
 ]]></BashCLRTestPreCommands>

--- a/src/coreclr/tests/src/readytorun/tests/mainv1.csproj
+++ b/src/coreclr/tests/src/readytorun/tests/mainv1.csproj
@@ -19,18 +19,69 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 DEL test.dll
+if exist test.dll (
+    echo FAILED to delete test.dll
+    exit /b 1
+)
 COPY /Y ..\testv1\test\test.dll test.dll
+if not exist test.dll (
+    echo FAILED to copy test.dll
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out test.ni.dll test.dll 
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out fieldgetter.ni.dll fieldgetter.dll 
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out mainv1.ni.exe mainv1.exe
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 rm -f test.dll
+if [ -f test.dll ]
+then
+  echo Failed to delete test.dll
+  exit 1
+fi
 cp ../testv1/test/test.dll test.dll
+if [ ! -f test.dll ]
+then
+  echo Failed to copy test.dll
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out test.ni.dll test.dll
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out fieldgetter.ni.dll fieldgetter.dll
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out mainv1.ni.exe mainv1.exe
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/readytorun/tests/mainv2.csproj
+++ b/src/coreclr/tests/src/readytorun/tests/mainv2.csproj
@@ -32,11 +32,19 @@ IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
 )
+if not exist mainv2.ni.exe (
+    echo FAILED to build mainv2.ni.exe
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out fieldgetter.ni.dll fieldgetter.dll 
 set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
+)
+if not exist fieldgetter.ni.dll (
+    echo FAILED to build fieldgetter.ni.dll
+    exit /b 1
 )
 DEL test.dll
 if exist test.dll (
@@ -53,6 +61,10 @@ set CrossGenStatus=!ERRORLEVEL!
 IF NOT !CrossGenStatus!==0 (
     ECHO Crossgen failed with exitcode - !CrossGenStatus!
     Exit /b 1
+)
+if not exist test.ni.dll (
+    echo FAILED to build test.ni.dll
+    exit /b 1
 )
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
@@ -76,11 +88,21 @@ then
   echo Crossgen failed with exitcode: $__cgExitCode
   exit 1
 fi
+if [ ! -f mainv2.ni.exe ]
+then
+  echo Failed to build mainv2.ni.exe
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out fieldgetter.ni.dll fieldgetter.dll
 __cgExitCode=$?
 if [ $__cgExitCode -ne 0 ]
 then
   echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
+if [ ! -f fieldgetter.ni.dll ]
+then
+  echo Failed to build fieldgetter.ni.dll
   exit 1
 fi
 rm -f test.dll
@@ -100,6 +122,11 @@ __cgExitCode=$?
 if [ $__cgExitCode -ne 0 ]
 then
   echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
+if [ ! -f test.ni.dll ]
+then
+  echo Failed to build test.ni.dll
   exit 1
 fi
 ]]></BashCLRTestPreCommands>

--- a/src/coreclr/tests/src/readytorun/tests/mainv2.csproj
+++ b/src/coreclr/tests/src/readytorun/tests/mainv2.csproj
@@ -17,23 +17,91 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 DEL test.dll
+if exist test.dll (
+    echo FAILED to delete test.dll
+    exit /b 1
+)
 COPY /Y ..\testv1\test\test.dll test.dll
+if not exist test.dll (
+    echo FAILED to copy test.dll
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out mainv2.ni.exe mainv2.exe
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out fieldgetter.ni.dll fieldgetter.dll 
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 DEL test.dll
+if exist test.dll (
+    echo FAILED to delete test.dll
+    exit /b 1
+)
 COPY /Y ..\testv2\test\test.dll test.dll
+if not exist test.dll (
+    echo FAILED to copy test.dll
+    exit /b 1
+)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out test.ni.dll test.dll 
+set CrossGenStatus=!ERRORLEVEL!
+IF NOT !CrossGenStatus!==0 (
+    ECHO Crossgen failed with exitcode - !CrossGenStatus!
+    Exit /b 1
+)
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 rm -f test.dll
+if [ -f test.dll ]
+then
+  echo Failed to delete test.dll
+  exit 1
+fi
 cp ../testv1/test/test.dll test.dll
+if [ ! -f test.dll ]
+then
+  echo Failed to copy test.dll
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out mainv2.ni.exe mainv2.exe
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out fieldgetter.ni.dll fieldgetter.dll
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 rm -f test.dll
+if [ -f test.dll ]
+then
+  echo Failed to delete test.dll
+  exit 1
+fi
 cp ../testv2/test/test.dll test.dll
+if [ ! -f test.dll ]
+then
+  echo Failed to copy test.dll
+  exit 1
+fi
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out test.ni.dll test.dll
-
+__cgExitCode=$?
+if [ $__cgExitCode -ne 0 ]
+then
+  echo Crossgen failed with exitcode: $__cgExitCode
+  exit 1
+fi
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These have been silently failing due to mainv1.exe and mainv2.exe
changing to be built at mainv1.dll and mainv2.dll without
corresponding changes in the project files, due to insufficient
testing in the script.

Add this additional testing.