### PR TITLE
Tweak codegen for Regex's FindFirstChar

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
@@ -125,10 +125,18 @@ namespace System.Text.RegularExpressions
             Stfld(RegexField(nameof(Regex.factory)));
 
             // Store the timeout (no need to validate as it should have happened in RegexCompilationInfo)
-            // base.internalMatchTimeout = TimeSpan.FromTick(matchTimeout.Ticks);
-            Ldthis();
-            LdcI8(matchTimeout.Ticks);
-            Call(typeof(TimeSpan).GetMethod(nameof(TimeSpan.FromTicks), BindingFlags.Public | BindingFlags.Static)!);
+            if (matchTimeout == Regex.InfiniteMatchTimeout)
+            {
+                // base.internalMatchTimeout = Regex.InfiniteMatchTimeout;
+                _ilg.Emit(OpCodes.Ldsfld, RegexField(nameof(Regex.InfiniteMatchTimeout)));
+            }
+            else
+            {
+                // base.internalMatchTimeout = TimeSpan.FromTick(matchTimeout.Ticks);
+                Ldthis();
+                LdcI8(matchTimeout.Ticks);
+                Call(typeof(TimeSpan).GetMethod(nameof(TimeSpan.FromTicks), BindingFlags.Public | BindingFlags.Static)!);
+            }
             Stfld(RegexField(nameof(Regex.internalMatchTimeout)));
 
             // Set capsize, caps, capnames, capslist.
@@ -221,7 +229,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Gets the named instance field from the Regex type.</summary>
         private static FieldInfo RegexField(string fieldname) =>
-            typeof(Regex).GetField(fieldname, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+            typeof(Regex).GetField(fieldname, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)!;
 
         /// <summary>Saves the assembly to a file in the current directory based on the assembly's name.</summary>
         internal void Save()


### PR DESCRIPTION
- We can avoid some field reads by storing a few into locals.
- If we emit a minimum length check, we can avoid doing a less stringent check later on that's fully covered by the length check.
- The negative switch table generated for Boyer-Moore often ends up with many duplicated cases, and we're emitting duplicate code for each.  We can coalesce them where possible.

cc: @danmosemsft, @eerhardt, @pgovind, @ViktorHofer 