### PR TITLE
Use a consistent rootfs location

### DIFF
--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -700,7 +700,7 @@ fi
 if [ $__CrossBuild == 1 ]; then
     export CROSSCOMPILE=1
     if ! [[ -n "$ROOTFS_DIR" ]]; then
-        export ROOTFS_DIR="$__RepoRootDir/eng/common/cross/rootfs/$__BuildArch"
+        export ROOTFS_DIR="$__RepoRootDir/.tools/rootfs/$__BuildArch"
     fi
 fi
 

--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -183,7 +183,7 @@ __cmake_defines="${__cmake_defines} ${__arch_define}"
 # Configure environment if we are doing a cross compile.
 if [ "$__CrossBuild" == 1 ]; then
     if ! [[ -n $ROOTFS_DIR ]]; then
-        export ROOTFS_DIR="$RootRepo/eng/common/cross/rootfs/$__build_arch"
+        export ROOTFS_DIR="$RootRepo/.tools/rootfs/$__build_arch"
     fi
 fi
 


### PR DESCRIPTION
Make sure we have the same rootfs location across build scripts when ROOTFS_DIR is not explicitly specified. Currently we have different default values in different places.

#### build-rootfs.sh (Arcade)
https://github.com/dotnet/runtime/blob/9c82a36c23235c4d50954cb33a4d5d89b787a1aa/eng/common/cross/build-rootfs.sh#L183-L185

#### coreclr/build.sh
https://github.com/dotnet/runtime/blob/9c82a36c23235c4d50954cb33a4d5d89b787a1aa/src/coreclr/build.sh#L628-L630

#### coreclr/build-test.sh
https://github.com/dotnet/runtime/blob/9c82a36c23235c4d50954cb33a4d5d89b787a1aa/src/coreclr/build-test.sh#L702-L704
