### PR TITLE
Remove generic parameter handling in validation

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -102,12 +102,6 @@ namespace ILCompiler
             {
                 ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
             }
-#if READYTORUN
-            else if (type.IsGenericParameter)
-            {
-                return type;
-            }
-#endif
             else
             {
                 // Validate classes, structs, enums, interfaces, and delegates


### PR DESCRIPTION
Just want to see what test this is failing because it feels a bit suspicious that we need to do this and there might be a bug somewhere.