### PR TITLE
Prohibit null key on HMAC.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACMD5.cs
@@ -20,6 +20,11 @@ namespace System.Security.Cryptography
 
         public HMACMD5(byte[] key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             this.HashName = HashAlgorithmNames.MD5;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.MD5, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
@@ -37,6 +42,11 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _hMacCommon.ChangeKey(value);
                 base.Key = _hMacCommon.ActualKey;
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA1.cs
@@ -21,6 +21,11 @@ namespace System.Security.Cryptography
 
         public HMACSHA1(byte[] key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             this.HashName = HashAlgorithmNames.SHA1;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA1, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
@@ -44,6 +49,11 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _hMacCommon.ChangeKey(value);
                 base.Key = _hMacCommon.ActualKey;
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA256.cs
@@ -24,6 +24,11 @@ namespace System.Security.Cryptography
 
         public HMACSHA256(byte[] key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             this.HashName = HashAlgorithmNames.SHA256;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA256, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
@@ -41,6 +46,11 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _hMacCommon.ChangeKey(value);
                 base.Key = _hMacCommon.ActualKey;
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA384.cs
@@ -24,6 +24,11 @@ namespace System.Security.Cryptography
 
         public HMACSHA384(byte[] key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             this.HashName = HashAlgorithmNames.SHA384;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA384, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
@@ -57,6 +62,11 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _hMacCommon.ChangeKey(value);
                 base.Key = _hMacCommon.ActualKey;
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HMACSHA512.cs
@@ -24,6 +24,11 @@ namespace System.Security.Cryptography
 
         public HMACSHA512(byte[] key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             this.HashName = HashAlgorithmNames.SHA512;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA512, key, BlockSize);
             base.Key = _hMacCommon.ActualKey;
@@ -55,6 +60,11 @@ namespace System.Security.Cryptography
             }
             set
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _hMacCommon.ChangeKey(value);
                 base.Key = _hMacCommon.ActualKey;
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HMacMD5_ThrowsArgumentNullForNullConstructorKey()
         {
-            Assert.Throws<ArgumentNullException>(() => new HMACMD5(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => new HMACMD5(null));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacMD5Tests.cs
@@ -85,5 +85,11 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         {
             VerifyHmacRfc2104_2();
         }
+
+        [Fact]
+        public void HMacMD5_ThrowsArgumentNullForNullConstructorKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HMACMD5(null));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HmacSha1_ThrowsArgumentNullForNullConstructorKey()
         {
-            Assert.Throws<ArgumentNullException>(() => new HMACSHA1(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => new HMACSHA1(null));
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha1Tests.cs
@@ -61,6 +61,12 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         }
 
         [Fact]
+        public void HmacSha1_ThrowsArgumentNullForNullConstructorKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HMACSHA1(null));
+        }
+
+        [Fact]
         public void HmacSha1_Rfc2202_1()
         {
             VerifyHmac(1, "b617318655057264e28bc0b6fb378c8ef146be00");

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
@@ -68,5 +68,11 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         {
             VerifyHmacRfc2104_2();
         }
+
+        [Fact]
+        public void HmacSha256_ThrowsArgumentNullForNullConstructorKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HMACSHA256(null));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha256Tests.cs
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HmacSha256_ThrowsArgumentNullForNullConstructorKey()
         {
-            Assert.Throws<ArgumentNullException>(() => new HMACSHA256(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => new HMACSHA256(null));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
@@ -83,7 +83,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HmacSha384_ThrowsArgumentNullForNullConstructorKey()
         {
-            Assert.Throws<ArgumentNullException>(() => new HMACSHA384(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => new HMACSHA384(null));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha384Tests.cs
@@ -79,5 +79,11 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         {
             VerifyHmacRfc2104_2();
         }
+
+        [Fact]
+        public void HmacSha384_ThrowsArgumentNullForNullConstructorKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HMACSHA384(null));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
@@ -79,5 +79,11 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         {
             VerifyHmacRfc2104_2();
         }
+
+        [Fact]
+        public void HmacSha512_ThrowsArgumentNullForNullConstructorKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HMACSHA512(null));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacSha512Tests.cs
@@ -83,7 +83,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         [Fact]
         public void HmacSha512_ThrowsArgumentNullForNullConstructorKey()
         {
-            Assert.Throws<ArgumentNullException>(() => new HMACSHA512(null));
+            AssertExtensions.Throws<ArgumentNullException>("key", () => new HMACSHA512(null));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
@@ -201,5 +201,14 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
                 Assert.Equal(baseline, offsetData);
             }
         }
+
+        [Fact]
+        public void InvalidKey_ThrowArgumentNullException()
+        {
+            using (HMAC hash = Create())
+            {
+                Assert.Throws<ArgumentNullException>(() => hash.Key = null);
+            }
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
@@ -207,7 +207,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
         {
             using (HMAC hash = Create())
             {
-                Assert.Throws<ArgumentNullException>(() => hash.Key = null);
+                AssertExtensions.Throws<ArgumentNullException>("value", () => hash.Key = null);
             }
         }
     }


### PR DESCRIPTION
Fixes #2002 

3.x and 2.1, and .NET Framework currently throw a NRE with a null HMAC key. dotnet/corefx/pull/42567 made changes that removed the NRE and caused a null byte[] to be converted to an empty span, thus an empty key is used. This change restores the throwing behavior of using a null key, using a better exception.

/cc @bartonjs 