### PR TITLE
configure.ac: remove AC_SEARCH_LIBS for libintl

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -2948,13 +2948,6 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(shm_open)
 
 	dnl ********************************
-	dnl ***  Checks for gettext lib  ***
-	dnl ********************************
-	# This is needed for some hackery for AIX;
-	# Mono itself doesn't use it, but DllMap includes it
-	AC_SEARCH_LIBS([gettext], [intl])
-
-	dnl ********************************
 	dnl *** Checks for timezone stuff **
 	dnl ********************************
 	AC_CACHE_CHECK(for tm_gmtoff in struct tm, ac_cv_struct_tm_gmtoff,


### PR DESCRIPTION
<I>This PR is synchronized with mono/mono#18531.<br/>Do not edit this PR, changes here are overwritten when pushing to the other PR.<br/>Please merge both PRs at the same time.</I><br/><hr/><br/>This causes an additional dependency of mono on libintl which we didn't have before.
Reported by a user on gitter, it's problematic on macOS since it makes the mono binary depend on the libintl we ship in the Mono .pkg.

It was introduced in Mono 6.6 by https://github.com/mono/mono/commit/18e0ebfe89be0a175d2f904b9bb1ec6816daa318
