### PR TITLE
Allow passing IntPtr values with UnmanagedType.AsAny.

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6210,6 +6210,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 	case MONO_TYPE_I4:
 	case MONO_TYPE_U4:
 	case MONO_TYPE_PTR:
+	case MONO_TYPE_I:
 	case MONO_TYPE_I1:
 	case MONO_TYPE_U1:
 	case MONO_TYPE_BOOLEAN:

--- a/src/mono/mono/tests/libtest.c
+++ b/src/mono/mono/tests/libtest.c
@@ -1834,6 +1834,9 @@ mono_test_asany (void *ptr, int what)
 			return 1;
 		}
 	}
+	case 5: {
+		return (*(intptr_t*)ptr == 5) ? 0 : 1;
+	}
 	default:
 		g_assert_not_reached ();
 	}

--- a/src/mono/mono/tests/pinvoke2.cs
+++ b/src/mono/mono/tests/pinvoke2.cs
@@ -1088,6 +1088,9 @@ public unsafe class Tests {
 		catch (ArgumentException) {
 		}
 
+		if (mono_test_asany (new IntPtr(5), 5) != 0)
+			return 7;
+
 		return 0;
 	}
 


### PR DESCRIPTION
This PR is synchronized with mono/mono#18544.<br/>Do not edit this PR, changes here are overwritten when pushing to the other PR.<br/>Please merge both PRs at the same time.<br/><hr/><br/>This is used by the SplashScreen class of WindowsBase in .NET Core to pass a NULL pointer.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
