### PR TITLE
Remove "handles" from System.Threading.Semaphore.

### DIFF
--- a/src/mono/mono/metadata/icall-decl.h
+++ b/src/mono/mono/metadata/icall-decl.h
@@ -272,5 +272,8 @@ ICALL_EXPORT gpointer   ves_icall_System_Runtime_InteropServices_Marshal_ReAlloc
 ICALL_EXPORT      char* ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi    (const gunichar2*, int);
 ICALL_EXPORT gunichar2*	ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni	(const gunichar2*, int);
 
+ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_CreateSemaphore_icall     (gint32 initialCount, gint32 maximumCount, const gunichar2 *name, gint32 name_length, gint32 *win32error);
+ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_OpenSemaphore_icall       (const gunichar2 *name, gint32 name_length, gint32 rights, gint32 *win32error);
+ICALL_EXPORT MonoBoolean ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount);
 
 #endif // __MONO_METADATA_ICALL_DECL_H__

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -484,9 +484,9 @@ HANDLES(MUTEX_2, "OpenMutex_icall", ves_icall_System_Threading_Mutex_OpenMutex_i
 NOHANDLES(ICALL(MUTEX_3, "ReleaseMutex_internal", ves_icall_System_Threading_Mutex_ReleaseMutex_internal))
 
 ICALL_TYPE(SEMA, "System.Threading.Semaphore", SEMA_1)
-HANDLES(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall, gpointer, 5, (gint32, gint32, const_gunichar2_ptr, gint32, gint32_ptr))
-HANDLES(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall, gpointer, 4, (const_gunichar2_ptr, gint32, gint32, gint32_ptr))
-HANDLES(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal, MonoBoolean, 3, (gpointer, gint32, gint32_ref))
+NOHANDLES(ICALL(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall))
+NOHANDLES(ICALL(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall))
+NOHANDLES(ICALL(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal))
 
 ICALL_TYPE(THREAD, "System.Threading.Thread", THREAD_1)
 HANDLES(THREAD_1, "ClrState", ves_icall_System_Threading_Thread_ClrState, void, 2, (MonoInternalThread, guint32))

--- a/src/mono/mono/metadata/icall-def.h
+++ b/src/mono/mono/metadata/icall-def.h
@@ -1012,9 +1012,9 @@ NOHANDLES(ICALL(NATIVEC_4, "ResetEvent_internal",  ves_icall_System_Threading_Ev
 NOHANDLES(ICALL(NATIVEC_5, "SetEvent_internal",    ves_icall_System_Threading_Events_SetEvent_internal))
 
 ICALL_TYPE(SEMA, "System.Threading.Semaphore", SEMA_1)
-HANDLES(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall, gpointer, 5, (gint32, gint32, const_gunichar2_ptr, gint32, gint32_ptr))
-HANDLES(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall, gpointer, 4, (const_gunichar2_ptr, gint32, gint32, gint32_ptr))
-HANDLES(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal, MonoBoolean, 3, (gpointer, gint32, gint32_ref))
+NOHANDLES(ICALL(SEMA_1, "CreateSemaphore_icall", ves_icall_System_Threading_Semaphore_CreateSemaphore_icall))
+NOHANDLES(ICALL(SEMA_2, "OpenSemaphore_icall", ves_icall_System_Threading_Semaphore_OpenSemaphore_icall))
+NOHANDLES(ICALL(SEMA_3, "ReleaseSemaphore_internal", ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal))
 
 ICALL_TYPE(THREAD, "System.Threading.Thread", THREAD_1)
 HANDLES(THREAD_1, "Abort_internal(System.Threading.InternalThread,object)", ves_icall_System_Threading_Thread_Abort, void, 2, (MonoInternalThread, MonoObject))

--- a/src/mono/mono/metadata/w32semaphore-unix.c
+++ b/src/mono/mono/metadata/w32semaphore-unix.c
@@ -238,7 +238,7 @@ exit:
 
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
-	const gunichar2 *name, gint32 name_length, gint32 *win32error, MonoError *error)
+	const gunichar2 *name, gint32 name_length, gint32 *win32error)
 { 
 	if (maximumCount <= 0) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_SEMAPHORE, "%s: maximumCount <= 0", __func__);
@@ -258,14 +258,17 @@ invalid_parameter:
 	 */
 	mono_w32error_set_last (ERROR_SUCCESS);
 
+	ERROR_DECL (error);
+
 	gpointer sem = name ? namedsem_create (initialCount, maximumCount, name, name_length, error)
 			    : sem_create (initialCount, maximumCount);
 	*win32error = mono_w32error_get_last ();
+	mono_error_set_pending_exception (error);				\
 	return sem;
 }
 
 MonoBoolean
-ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount, MonoError *error)
+ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
 {
 	MonoW32Handle *handle_data = NULL;
 	MonoW32HandleSemaphore *sem_handle;
@@ -319,10 +322,11 @@ exit:
 
 gpointer
 ves_icall_System_Threading_Semaphore_OpenSemaphore_icall (const gunichar2 *name, gint32 name_length,
-	gint32 rights, gint32 *win32error, MonoError *error)
+	gint32 rights, gint32 *win32error)
 {
 	g_assert (name);
 	gpointer handle = NULL;
+	ERROR_DECL (error);
 
 	*win32error = ERROR_SUCCESS;
 
@@ -352,6 +356,7 @@ ves_icall_System_Threading_Semaphore_OpenSemaphore_icall (const gunichar2 *name,
 
 exit:
 	g_free (utf8_name);
+	mono_error_set_pending_exception (error);				\
 	return handle;
 }
 

--- a/src/mono/mono/metadata/w32semaphore-win32.c
+++ b/src/mono/mono/metadata/w32semaphore-win32.c
@@ -23,7 +23,7 @@ mono_w32semaphore_init (void)
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount, gint32 maximumCount,
-	const gunichar2 *name, gint32 name_length, gint32 *win32error, MonoError *error)
+	const gunichar2 *name, gint32 name_length, gint32 *win32error)
 { 
 	HANDLE sem;
 	MONO_ENTER_GC_SAFE;
@@ -35,14 +35,14 @@ ves_icall_System_Threading_Semaphore_CreateSemaphore_icall (gint32 initialCount,
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */
 
 MonoBoolean
-ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount, MonoError *error)
+ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
 {
 	return ReleaseSemaphore (handle, releaseCount, (PLONG)prevcount);
 }
 
 gpointer
 ves_icall_System_Threading_Semaphore_OpenSemaphore_icall (const gunichar2 *name, gint32 name_length,
-	gint32 rights, gint32 *win32error, MonoError *error)
+	gint32 rights, gint32 *win32error)
 {
 	HANDLE sem;
 	MONO_ENTER_GC_SAFE;


### PR DESCRIPTION
This PR is synchronized with mono/mono#18512.<br/>Do not edit this PR, changes here are overwritten when pushing to the other PR.<br/>Please merge both PRs at the same time.<br/><hr/><br/>Actually, there were no handles.
This reduces MonoError.