### PR TITLE
Fix assert 'treeWithCall == call'

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6975,6 +6975,14 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
     }
 #endif
 
+#ifdef DEBUG
+    if (opts.compGcChecks && (info.compRetType == TYP_REF))
+    {
+        failTailCall("COMPlus_JitGCChecks or stress might have interposed a call to CORINFO_HELP_CHECK_OBJ, invalidating tailcall opportunity");
+        return nullptr;
+    }
+#endif
+
     // We have to ensure to pass the incoming retValBuf as the
     // outgoing one. Using a temp will not do as this function will
     // not regain control to do the copy. This can happen when inlining
@@ -16560,6 +16568,12 @@ void Compiler::fgMorph()
 
                 fgEnsureFirstBBisScratch();
                 fgNewStmtAtEnd(fgFirstBB, op);
+
+                if (verbose)
+                {
+                    printf("\ncompGcChecks tree:\n");
+                    gtDispTree(op);
+                }
             }
         }
     }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6978,7 +6978,8 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 #ifdef DEBUG
     if (opts.compGcChecks && (info.compRetType == TYP_REF))
     {
-        failTailCall("COMPlus_JitGCChecks or stress might have interposed a call to CORINFO_HELP_CHECK_OBJ, invalidating tailcall opportunity");
+        failTailCall("COMPlus_JitGCChecks or stress might have interposed a call to CORINFO_HELP_CHECK_OBJ, "
+                     "invalidating tailcall opportunity");
         return nullptr;
     }
 #endif


### PR DESCRIPTION
This assert was occurring when we have:
- a potential optimistic tail call
- of a function that returns a ref type
- that is also an inline candidate
- whose inline is rejected
- with `COMPlus_JitGCChecks` stress mode that injects a
call to `CORINFO_HELP_CHECK_OBJ` at the `RETURN`
- where we decide to go ahead with the optimistic tailcall
but it is no longer in legal tailcall position.

To fix, simply disallow a tailcall if we are doing
`COMPlus_JitGCChecks` in a function with a ref type return, that
would have inserted the problemmatic call.

Fixes #1821