### PR TITLE
Match blittability rules in crossgen2 with CoreCLR

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -43,16 +43,6 @@ namespace Internal.TypeSystem.Interop
                     continue;
                 }
 
-#if READYTORUN
-                if (!field.FieldType.IsValueType)
-                {
-                    // Types with fields of non-value types cannot be blittable
-                    // This check prevents possible infinite recursion where GetMarshallerKind would call back to IsBlittable e.g. for
-                    // the case of classes with pointer members to the class itself.
-                    return false;
-                }
-#endif
-
                 MarshallerKind marshallerKind = MarshalHelpers.GetMarshallerKind(
                     field.FieldType,
                     field.GetMarshalAsDescriptor(),


### PR DESCRIPTION
Fixes #483. Structs with pointer-typed fields are blittable.

After #1866 we no longer have to worry about the recursion because the code path that recursed into pointed-to types was deleted.

Cc @dotnet/crossgen-contrib 