### PR TITLE
SmtpClientTest: re-enable TestZeroTimeout

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,7 +309,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/40711")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and may not time out for low values")]
         [PlatformSpecific(~TestPlatforms.OSX)] // on OSX, not all synchronous operations (e.g. connect) can be aborted by closing the socket.
         public void TestZeroTimeout()


### PR DESCRIPTION
This test will fail in CI. When it does, the exceptions that cause the failure will show up in the test output (per https://github.com/dotnet/runtime/pull/428).

cc @stephentoub 