### PR TITLE
Change debug info default variable tracking system.

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2394,11 +2394,11 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
-                varLiveKeeper->siUpdateVariableLiveRange(varDsc, lcl->GetLclNum())
+                varLiveKeeper->siUpdateVariableLiveRange(varDsc, lcl->GetLclNum());
 #endif // USING_VARIABLE_LIVE_RANGE
 
-                    // The new location is going live
-                    genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
+                // The new location is going live
+                genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
             }
         }
     }

--- a/src/coreclr/src/jit/codegeninterface.h
+++ b/src/coreclr/src/jit/codegeninterface.h
@@ -26,11 +26,11 @@
 #include "treelifeupdater.h"
 #include "emit.h"
 
-#if 1
+#if 0
 // Enable USING_SCOPE_INFO flag to use psiScope/siScope info to report variables' locations.
 #define USING_SCOPE_INFO
 #endif
-#if 0
+#if 1
 // Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
 // Note: if both USING_SCOPE_INFO and USING_VARIABLE_LIVE_RANGE are defined, then USING_SCOPE_INFO
 // information is reported to the debugger.


### PR DESCRIPTION
Varible Scope info is being disabled. Variable
Live Range is being enabled. Debug info generated
for debug code is the same, changes only impact on
optimized code.

Variable Live Range updates variable's location
each time something happens to variable's
liveness. For more information see
https://github.com/dotnet/runtime/blob/master/docs/design/features/variabletracking.md