### PR TITLE
[jit] Avoid generating wbarriers for vtype stores to the stack.

### DIFF
--- a/src/mono/mono/mini/alias-analysis.c
+++ b/src/mono/mono/mini/alias-analysis.c
@@ -255,9 +255,16 @@ handle_instruction:
 #endif
 			case OP_STORER8_MEMBASE_REG:
 			case OP_STOREV_MEMBASE:
+				tmp = NULL;
+				if (ins->opcode == OP_STOREV_MEMBASE) {
+					tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
+					if (tmp)
+						ins->flags |= MONO_INST_STACK_STORE;
+				}
 				if (ins->inst_offset != 0)
 					continue;
-				tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
+				if (!tmp)
+					tmp = (MonoInst *)g_hash_table_lookup (addr_loads, GINT_TO_POINTER (ins->dreg));
 				if (tmp) {
 					if (cfg->verbose_level > 2) { printf ("Found candidate store:"); mono_print_ins (ins); }
 					if (lower_store (cfg, ins, tmp)) {

--- a/src/mono/mono/mini/decompose.c
+++ b/src/mono/mono/mini/decompose.c
@@ -1287,7 +1287,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 
 					dreg = alloc_preg (cfg);
 					EMIT_NEW_BIALU_IMM (cfg, dest, OP_ADD_IMM, dreg, ins->inst_destbasereg, ins->inst_offset);
-					mini_emit_memory_copy (cfg, dest, src, src_var->klass, src_var->backend.is_pinvoke, 0);
+					mini_emit_memory_copy (cfg, dest, src, src_var->klass, src_var->backend.is_pinvoke, ins->flags);
 					break;
 				}
 				case OP_LOADV_MEMBASE: {

--- a/src/mono/mono/mini/memory-access.c
+++ b/src/mono/mono/mini/memory-access.c
@@ -347,7 +347,8 @@ mini_emit_wb_aware_memcpy (MonoCompile *cfg, MonoClass *klass, MonoInst *iargs[4
 }
 
 static void
-mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, int explicit_align, gboolean native)
+mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, int explicit_align, gboolean native,
+								gboolean stack_store)
 {
 	MonoInst *iargs [4];
 	int size;
@@ -402,8 +403,8 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 
 		mini_emit_write_barrier (cfg, dest, load);
 		return;
-
-	} else if (cfg->gen_write_barriers && (m_class_has_references (klass) || size_ins) && !native) { 	/* if native is true there should be no references in the struct */
+	} else if (cfg->gen_write_barriers && (m_class_has_references (klass) || size_ins) &&
+			   !native && !stack_store) { 	/* if native is true there should be no references in the struct */
 		/* Avoid barriers when storing to the stack */
 		if (!((dest->opcode == OP_ADD_IMM && dest->sreg1 == cfg->frame_reg) ||
 			  (dest->opcode == OP_LDADDR))) {
@@ -502,7 +503,7 @@ mini_emit_memory_store (MonoCompile *cfg, MonoType *type, MonoInst *dest, MonoIn
 		tmp_var = mono_compile_create_var (cfg, type, OP_LOCAL);
 		EMIT_NEW_TEMPSTORE (cfg, mov, tmp_var->inst_c0, value);
 		EMIT_NEW_VARLOADA (cfg, addr, tmp_var, tmp_var->inst_vtype);
-		mini_emit_memory_copy_internal (cfg, dest, addr, mono_class_from_mono_type_internal (type), 1, FALSE);
+		mini_emit_memory_copy_internal (cfg, dest, addr, mono_class_from_mono_type_internal (type), 1, FALSE, (ins_flag & MONO_INST_STACK_STORE) != 0);
 	} else {
 		MonoInst *ins;
 
@@ -592,7 +593,7 @@ mini_emit_memory_copy (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClas
 		mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
 	}
 
-	mini_emit_memory_copy_internal (cfg, dest, src, klass, explicit_align, native);
+	mini_emit_memory_copy_internal (cfg, dest, src, klass, explicit_align, native, (ins_flag & MONO_INST_STACK_STORE) != 0);
 
 	if (ins_flag & MONO_INST_VOLATILE) {
 		/* Volatile loads have acquire semantics, see 12.6.7 in Ecma 335 */

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -861,6 +861,8 @@ enum {
 	MONO_INST_LMF = 32,
 	/* On loads, the source address points to a constant value */
 	MONO_INST_INVARIANT_LOAD = 64,
+	/* On stores, the destination is the stack */
+	MONO_INST_STACK_STORE = 64,
 	/* On variables, the variable needs GC tracking */
 	MONO_INST_GC_TRACK = 128,
 	/*


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18556,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>The existing heuristic doesn't work with llvm.