### PR TITLE
Local live builds not picking up runtime config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,14 +34,7 @@
     <NetFrameworkCurrent>net472</NetFrameworkCurrent>
   </PropertyGroup>
 
-  <!-- Honor the generic RuntimeConfiguration property. -->
-  <PropertyGroup>
-    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
-    <!-- There's no checked configuration on Mono. -->
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' == 'checked'">Debug</MonoConfiguration>
-  </PropertyGroup>
+  <Import Project="$(RepositoryEngineeringDir)Configurations.props" />
 
   <!--
     Get ProjectToBuild and '<subset>ProjectToBuild' items. Using the items lets projects handle

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,8 +36,7 @@
 
   <!-- Honor the generic RuntimeConfiguration property. -->
   <PropertyGroup>
-    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(Configuration)</RuntimeConfiguration>
-    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">Debug</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
     <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
     <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
     <!-- There's no checked configuration on Mono. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
     <RepositoryEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'eng'))</RepositoryEngineeringDir>
     <ArtifactsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>
     <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
+    <ArtifactsObjDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'obj'))</ArtifactsObjDir>
   </PropertyGroup>
 
   <!-- The TFMs to build and test against. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,16 @@
     <NetFrameworkCurrent>net472</NetFrameworkCurrent>
   </PropertyGroup>
 
+  <!-- Honor the generic RuntimeConfiguration property. -->
+  <PropertyGroup>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(Configuration)</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">Debug</RuntimeConfiguration>
+    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
+    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
+    <!-- There's no checked configuration on Mono. -->
+    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' == 'checked'">Debug</MonoConfiguration>
+  </PropertyGroup>
+
   <!--
     Get ProjectToBuild and '<subset>ProjectToBuild' items. Using the items lets projects handle
     $(Subset) automatically when creating project-to-project dependencies.
@@ -50,14 +60,6 @@
     <DocsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'docs'))</DocsDir>
     <ManPagesDir>$([MSBuild]::NormalizeDirectory('$(DocsDir)', 'manpages'))</ManPagesDir>
     <CoreLibSharedDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'System.Private.CoreLib', 'src'))</CoreLibSharedDir>
-  </PropertyGroup>
-
-  <!-- Honor the generic RuntimeConfiguration property. -->
-  <PropertyGroup>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
-    <!-- There's no checked configuration on Mono. -->
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' == 'checked'">Debug</MonoConfiguration>
   </PropertyGroup>
 
   <!-- Packaging properties -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -15,6 +15,7 @@
       https://github.com/dotnet/arcade/issues/388
   -->
 
+  <Import Project="$(MSBuildThisFileDirectory)Configurations.props" />
   <Import Project="$(MSBuildThisFileDirectory)Subsets.props" />
 
   <Target Name="CheckSpecifiedSubsetValidity"

--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -1,0 +1,10 @@
+<Project>
+  <!-- Honor the generic RuntimeConfiguration property. -->
+  <PropertyGroup>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
+    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
+    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
+    <!-- There's no checked configuration on Mono. -->
+    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' == 'checked'">Debug</MonoConfiguration>
+  </PropertyGroup>
+</Project>

--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -2,6 +2,7 @@
   <!-- Honor the generic RuntimeConfiguration property. -->
   <PropertyGroup>
     <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(Configuration)</RuntimeConfiguration>
     <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
     <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
     <!-- There's no checked configuration on Mono. -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -104,19 +104,19 @@
 
   <ItemDefinitionGroup Condition="'$(CoreCLRConfiguration)' != ''">
     <CoreClrProjectToBuild>
-      <Properties>Configuration=$(CoreCLRConfiguration)</Properties>
+      <AdditionalProperties>Configuration=$(CoreCLRConfiguration)</AdditionalProperties>
     </CoreClrProjectToBuild>
   </ItemDefinitionGroup>
 
   <ItemDefinitionGroup Condition="'$(MonoConfiguration)' != ''">
     <MonoProjectToBuild>
-      <Properties>Configuration=$(MonoConfiguration)</Properties>
+      <AdditionalProperties>Configuration=$(MonoConfiguration)</AdditionalProperties>
     </MonoProjectToBuild>
   </ItemDefinitionGroup>
 
   <ItemDefinitionGroup Condition="'$(LibrariesConfiguration)' != ''">
     <LibrariesProjectToBuild>
-      <Properties>Configuration=$(LibrariesConfiguration)</Properties>
+      <AdditionalProperties>Configuration=$(LibrariesConfiguration)</AdditionalProperties>
     </LibrariesProjectToBuild>
   </ItemDefinitionGroup>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -102,14 +102,6 @@
     <ProjectToBuild Include="$(RepoToolsLocalDir)regenerate-readme-table.proj" />
   </ItemGroup>
 
-  <!-- Honor the generic RuntimeConfiguration property. -->
-  <PropertyGroup>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' != 'checked'">$(RuntimeConfiguration)</MonoConfiguration>
-    <!-- There's no checked configuration on Mono. -->
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == '' and '$(RuntimeConfiguration.ToLower())' == 'checked'">Debug</MonoConfiguration>
-  </PropertyGroup>
-
   <ItemDefinitionGroup Condition="'$(CoreCLRConfiguration)' != ''">
     <CoreClrProjectToBuild>
       <Properties>Configuration=$(CoreCLRConfiguration)</Properties>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <CoreCLROSGroup Condition="'$(CoreCLROSGroup)' == ''">$(OSGroup)</CoreCLROSGroup>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(Configuration)</CoreCLRConfiguration>
+    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
     <MonoOSGroup Condition="'$(MonoOSGroup)' == ''">$(OSGroup)</MonoOSGroup>
     <MonoConfiguration Condition="'$(MonoConfiguration)' == ''">$(Configuration)</MonoConfiguration>
     <LibrariesOSGroup Condition="'$(LibrariesOSGroup)' == ''">$(OSGroup)</LibrariesOSGroup>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <CoreCLROSGroup Condition="'$(CoreCLROSGroup)' == ''">$(OSGroup)</CoreCLROSGroup>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
     <MonoOSGroup Condition="'$(MonoOSGroup)' == ''">$(OSGroup)</MonoOSGroup>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == ''">$(RuntimeConfiguration)</MonoConfiguration>
     <LibrariesOSGroup Condition="'$(LibrariesOSGroup)' == ''">$(OSGroup)</LibrariesOSGroup>
     <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
 

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -4,7 +4,7 @@
     <CoreCLROSGroup Condition="'$(CoreCLROSGroup)' == ''">$(OSGroup)</CoreCLROSGroup>
     <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>
     <MonoOSGroup Condition="'$(MonoOSGroup)' == ''">$(OSGroup)</MonoOSGroup>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == ''">$(Configuration)</MonoConfiguration>
+    <MonoConfiguration Condition="'$(MonoConfiguration)' == ''">$(RuntimeConfiguration)</MonoConfiguration>
     <LibrariesOSGroup Condition="'$(LibrariesOSGroup)' == ''">$(OSGroup)</LibrariesOSGroup>
     <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
 

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -36,7 +36,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }} -bl
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }} -bl -ci
       displayName: Build product
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -1,5 +1,6 @@
 parameters:
   buildConfig: ''
+  runtimeConfig: ''
   archType: ''
   osGroup: ''
   osSubgroup: ''
@@ -11,8 +12,8 @@ parameters:
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: ${{ format('runtime_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    displayName: ${{ format('Runtime Build {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    name: ${{ format('build_{0}{1}_{2}_{3}_runtime{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.runtimeConfig) }}
+    displayName: ${{ format('Build {0}{1} {2} {3} Runtime {4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.runtimeConfig) }}
     dependsOn: checkout
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
@@ -35,5 +36,5 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -arch ${{ parameters.archType }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }}
       displayName: Build product

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -36,7 +36,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }} -bl -ci
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }} -ci
       displayName: Build product
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -36,5 +36,14 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -c ${{ parameters.buildConfig }} -runtimeConfiguration ${{ parameters.runtimeConfig }} -arch ${{ parameters.archType }} -bl
       displayName: Build product
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
+        PublishLocation: Container
+        ArtifactName: $(Agent.Os)_PublishBuildAssets
+      continueOnError: true
+      condition: always()

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -46,6 +46,7 @@ jobs:
     - OSX_x64
     jobParameters:
       testGroup: innerloop
+      runtimeConfig: debug
 
 #
 # Build the combined runtime repo
@@ -58,3 +59,4 @@ jobs:
     - Linux_x64
     jobParameters:
       testGroup: innerloop
+      runtimeConfig: release

--- a/src/coreclr/build.cmd
+++ b/src/coreclr/build.cmd
@@ -386,7 +386,8 @@ if %__RestoreOptData% EQU 1 (
     echo %__MsgPrefix%Restoring the OptimizationData Package
     powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng\common\msbuild.ps1" /clp:nosummary %__ArcadeScriptArgs%^
         %OptDataProjectFilePath% /t:Restore^
-        %__CommonMSBuildArgs% %__UnprocessedBuildArgs%
+        %__CommonMSBuildArgs% %__UnprocessedBuildArgs%^
+        /nodereuse:false
     if not !errorlevel! == 0 (
         echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to restore the optimization data package.
         set __exitCode=!errorlevel!

--- a/src/coreclr/build.sh
+++ b/src/coreclr/build.sh
@@ -53,7 +53,8 @@ restore_optdata()
         echo "Restoring the OptimizationData package"
         "$__RepoRootDir/eng/common/msbuild.sh" /clp:nosummary $__ArcadeScriptArgs \
                                                $OptDataProjectFilePath /t:Restore /m \
-                                               $__CommonMSBuildArgs $__UnprocessedBuildArgs
+                                               $__CommonMSBuildArgs $__UnprocessedBuildArgs \
+                                               /nodereuse:false
         local exit_code="$?"
         if [[ "$exit_code" != 0 ]]; then
             echo "${__ErrMsgPrefix}Failed to restore the optimization data package."

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
   <PropertyGroup>
     <CoreCLROSGroup Condition="'$(CoreCLROSGroup)' == ''">$(_bc_OSGroup)</CoreCLROSGroup>
+    <MonoOSGroup Condition="'$(MonoCLROSGroup)' == ''">$(_bc_OSGroup)</MonoOSGroup>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.targets" />

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -1,9 +1,6 @@
 <Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
   <PropertyGroup>
     <CoreCLROSGroup Condition="'$(CoreCLROSGroup)' == ''">$(_bc_OSGroup)</CoreCLROSGroup>
-    <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(_bc_ConfigurationGroup)</CoreCLRConfiguration>
-    <MonoOSGroup Condition="'$(MonoCLROSGroup)' == ''">$(_bc_OSGroup)</MonoOSGroup>
-    <MonoConfiguration Condition="'$(MonoConfiguration)' == ''">$(_bc_ConfigurationGroup)</MonoConfiguration>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.targets" />

--- a/src/libraries/shims/manual/Directory.Build.props
+++ b/src/libraries/shims/manual/Directory.Build.props
@@ -14,9 +14,7 @@
     <!-- Use runtime assemblies for the TargetFramework, using build configuration OSGroup -->
     <RefPath>$(ArtifactsBinDir)runtime/$(TargetFramework)-$(_bc_OSGroup)-$(_bc_ConfigurationGroup)-$(ArchGroup)/</RefPath>
     <CoreCLROSGroup>$(_bc_OSGroup)</CoreCLROSGroup>
-    <CoreCLRConfiguration>$(_bc_ConfigurationGroup)</CoreCLRConfiguration>
     <MonoOSGroup>$(_bc_OSGroup)</MonoOSGroup>
-    <MonoConfiguration>$(_bc_ConfigurationGroup)</MonoConfiguration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The local live builds were not properly picking up the runtime
configuration varaible. This meant that libraries always attempted to
build against a Debug CoreCLR even if the developer specified
`-runtimeConfiguration Release`