### PR TITLE
[threading] Switch to a native implementation of LowLevelLifoSemaphore

### DIFF
--- a/src/mono/mono/metadata/icall-decl.h
+++ b/src/mono/mono/metadata/icall-decl.h
@@ -276,4 +276,11 @@ ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_CreateSemaphore_ic
 ICALL_EXPORT gpointer    ves_icall_System_Threading_Semaphore_OpenSemaphore_icall       (const gunichar2 *name, gint32 name_length, gint32 rights, gint32 *win32error);
 ICALL_EXPORT MonoBoolean ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount);
 
+#ifdef ENABLE_NETCORE
+ICALL_EXPORT gpointer ves_icall_System_Threading_LowLevelLifoSemaphore_InitInternal (void);
+ICALL_EXPORT void     ves_icall_System_Threading_LowLevelLifoSemaphore_DeleteInternal (gpointer sem_ptr);
+ICALL_EXPORT gint32   ves_icall_System_Threading_LowLevelLifoSemaphore_TimedWaitInternal (gpointer sem_ptr, gint32 timeout_ms);
+ICALL_EXPORT void     ves_icall_System_Threading_LowLevelLifoSemaphore_ReleaseInternal (gpointer sem_ptr, gint32 count);
+#endif
+
 #endif // __MONO_METADATA_ICALL_DECL_H__

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -467,6 +467,12 @@ NOHANDLES(ICALL(ILOCK_21, "Increment(long&)", ves_icall_System_Threading_Interlo
 NOHANDLES(ICALL(ILOCK_22, "MemoryBarrierProcessWide", ves_icall_System_Threading_Interlocked_MemoryBarrierProcessWide))
 NOHANDLES(ICALL(ILOCK_23, "Read(long&)", ves_icall_System_Threading_Interlocked_Read_Long))
 
+ICALL_TYPE(LIFOSEM, "System.Threading.LowLevelLifoSemaphore", LIFOSEM_1)
+NOHANDLES(ICALL(LIFOSEM_1, "DeleteInternal", ves_icall_System_Threading_LowLevelLifoSemaphore_DeleteInternal))
+NOHANDLES(ICALL(LIFOSEM_2, "InitInternal", ves_icall_System_Threading_LowLevelLifoSemaphore_InitInternal))
+NOHANDLES(ICALL(LIFOSEM_3, "ReleaseInternal", ves_icall_System_Threading_LowLevelLifoSemaphore_ReleaseInternal))
+NOHANDLES(ICALL(LIFOSEM_4, "TimedWaitInternal", ves_icall_System_Threading_LowLevelLifoSemaphore_TimedWaitInternal))
+
 ICALL_TYPE(MONIT, "System.Threading.Monitor", MONIT_0)
 HANDLES(MONIT_0, "Enter", ves_icall_System_Threading_Monitor_Monitor_Enter, void, 1, (MonoObject))
 HANDLES(MONIT_1, "Exit", mono_monitor_exit_icall, void, 1, (MonoObject))

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -60,6 +60,7 @@
 #include <mono/metadata/w32subset.h>
 #include <mono/metadata/mono-config.h>
 #include "mono/utils/mono-tls-inline.h"
+#include <mono/utils/lifo-semaphore.h>
 
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
@@ -6774,4 +6775,30 @@ ves_icall_System_Threading_Thread_GetCurrentProcessorNumber (MonoError *error)
 	return mono_native_thread_processor_id_get ();
 }
 
+gpointer
+ves_icall_System_Threading_LowLevelLifoSemaphore_InitInternal (void)
+{
+	return (gpointer)mono_lifo_semaphore_init ();
+}
+
+void
+ves_icall_System_Threading_LowLevelLifoSemaphore_DeleteInternal (gpointer sem_ptr)
+{
+	LifoSemaphore *sem = (LifoSemaphore *)sem_ptr;
+	mono_lifo_semaphore_delete (sem);
+}
+
+gint32
+ves_icall_System_Threading_LowLevelLifoSemaphore_TimedWaitInternal (gpointer sem_ptr, gint32 timeout_ms)
+{
+	LifoSemaphore *sem = (LifoSemaphore *)sem_ptr;
+	return mono_lifo_semaphore_timed_wait (sem, timeout_ms);
+}
+
+void
+ves_icall_System_Threading_LowLevelLifoSemaphore_ReleaseInternal (gpointer sem_ptr, gint32 count)
+{
+	LifoSemaphore *sem = (LifoSemaphore *)sem_ptr;
+	mono_lifo_semaphore_release (sem, count);
+}
 #endif

--- a/src/mono/mono/utils/Makefile.am
+++ b/src/mono/mono/utils/Makefile.am
@@ -161,6 +161,8 @@ monoutils_sources = \
 	mono-stack-unwinding.h	\
 	hazard-pointer.c	\
 	hazard-pointer.h	\
+	lifo-semaphore.c	\
+	lifo-semaphore.h	\
 	lock-free-queue.c	\
 	lock-free-queue.h	\
 	lock-free-alloc.c	\

--- a/src/mono/mono/utils/lifo-semaphore.c
+++ b/src/mono/mono/utils/lifo-semaphore.c
@@ -1,0 +1,92 @@
+#include <mono/utils/lifo-semaphore.h>
+
+LifoSemaphore *
+mono_lifo_semaphore_init (void)
+{
+	LifoSemaphore *semaphore;
+
+	semaphore = g_new0 (LifoSemaphore, 1);
+	if (semaphore == NULL)
+		return NULL;
+
+	mono_coop_mutex_init (&semaphore->mutex);
+
+	return semaphore;
+}
+
+void
+mono_lifo_semaphore_delete (LifoSemaphore *semaphore)
+{
+	g_assert (semaphore->head == NULL);
+	mono_coop_mutex_destroy (&semaphore->mutex);
+	g_free (semaphore);
+}
+
+int32_t
+mono_lifo_semaphore_timed_wait (LifoSemaphore *semaphore, int32_t timeout_ms)
+{
+	// FIXME: set correct clock? still relevant?
+	LifoSemaphoreWaitEntry wait_entry = {};
+
+	mono_coop_cond_init (&wait_entry.condition);
+	mono_coop_mutex_lock (&semaphore->mutex);
+
+	if (semaphore->pending_signals > 0) {
+		--semaphore->pending_signals;
+		mono_coop_cond_destroy (&wait_entry.condition);
+		mono_coop_mutex_unlock (&semaphore->mutex);
+		return 1;
+	}
+
+	// Enqueue out entry into the LIFO wait list
+	wait_entry.previous = NULL;
+	wait_entry.next = semaphore->head;
+	if (semaphore->head != NULL)
+		semaphore->head->previous = &wait_entry;
+	semaphore->head = &wait_entry;
+
+	// Wait for a signal or timeout
+	int wait_error = 0;
+	do {
+		wait_error = mono_coop_cond_timedwait (&wait_entry.condition, &semaphore->mutex, timeout_ms);
+	} while (wait_error == 0 && !wait_entry.signaled);
+
+	if (wait_error == -1) {
+		if (semaphore->head == &wait_entry)
+			semaphore->head = wait_entry.next;
+		if (wait_entry.next != NULL)
+			wait_entry.next->previous = wait_entry.previous;
+		if (wait_entry.previous != NULL)
+			wait_entry.previous->next = wait_entry.next;
+	}
+
+	mono_coop_cond_destroy (&wait_entry.condition);
+	mono_coop_mutex_unlock (&semaphore->mutex);
+
+	return wait_entry.signaled;
+}
+
+void
+mono_lifo_semaphore_release (LifoSemaphore *semaphore, uint32_t count)
+{
+	mono_coop_mutex_lock (&semaphore->mutex);
+
+	while (count > 0) {
+		LifoSemaphoreWaitEntry *wait_entry = semaphore->head;
+		if (wait_entry != NULL) {
+			semaphore->head = wait_entry->next;
+			if (semaphore->head != NULL)
+				semaphore->head->previous = NULL;
+			wait_entry->previous = NULL;
+			wait_entry->next = NULL;
+			wait_entry->signaled = 1;
+			mono_coop_cond_signal (&wait_entry->condition);
+			--count;
+		} else {
+			semaphore->pending_signals += count;
+			count = 0;
+		}
+	}
+
+	mono_coop_mutex_unlock (&semaphore->mutex);
+}

--- a/src/mono/mono/utils/lifo-semaphore.h
+++ b/src/mono/mono/utils/lifo-semaphore.h
@@ -1,0 +1,36 @@
+#ifndef __MONO_LIFO_SEMAPHORE_H__
+#define __MONO_LIFO_SEMAPHORE_H__
+
+#include <mono/utils/mono-coop-mutex.h>
+
+#include <unistd.h>
+
+typedef struct _LifoSemaphore LifoSemaphore;
+typedef struct _LifoSemaphoreWaitEntry LifoSemaphoreWaitEntry;
+
+struct _LifoSemaphoreWaitEntry {
+	MonoCoopCond condition;
+	int signaled;
+	LifoSemaphoreWaitEntry *previous;
+	LifoSemaphoreWaitEntry *next;
+};
+
+struct _LifoSemaphore {
+	MonoCoopMutex mutex;
+	LifoSemaphoreWaitEntry *head;
+	uint32_t pending_signals;
+};
+
+LifoSemaphore *
+mono_lifo_semaphore_init (void);
+
+void
+mono_lifo_semaphore_delete (LifoSemaphore *semaphore);
+
+int32_t
+mono_lifo_semaphore_timed_wait (LifoSemaphore *semaphore, int32_t timeout_ms);
+
+void
+mono_lifo_semaphore_release (LifoSemaphore *semaphore, uint32_t count);
+
+#endif // __MONO_LIFO_SEMAPHORE_H__

--- a/src/mono/msvc/libmonoutils-common.targets
+++ b/src/mono/msvc/libmonoutils-common.targets
@@ -108,6 +108,8 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-stack-unwinding.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\hazard-pointer.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\hazard-pointer.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\lifo-semaphore.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\lifo-semaphore.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\lock-free-queue.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\lock-free-queue.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\lock-free-alloc.c" />

--- a/src/mono/msvc/libmonoutils-common.targets.filters
+++ b/src/mono/msvc/libmonoutils-common.targets.filters
@@ -271,6 +271,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\hazard-pointer.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\lifo-semaphore.c">
+      <Filter>Source Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\lifo-semaphore.h">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\lock-free-queue.c">
       <Filter>Source Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClCompile>


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18557,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This change is motivated on two main fronts. The first is maintainability - the current managed implementation is difficult to understand and I worry diagnosing any potential issues would be a massive time sink. The second is performance - the current implementation appears to suffer from significant lock contention when running the TechEmpower plaintext benchmark. My hope is that the simpler, cleaner native implementation here will avoid both problems, but I don't want to merge it until we have benchmarking data. However, even if the numbers are similar, I still think it's worth merging just from a maintainability perspective.

The native LifoSemaphore implementation has only ever been tested on posix-like platforms, so Windows behavior is unknown. Currently the Windows implementation of LowLevelLifoSemaphore is very different, so unless we have need for the LifoSemaphore elsewhere in the runtime this isn't a concern.

Many thanks to @filipnavara for the initial implementation.