### PR TITLE
Fix pipeline trigger for running libraries tests against Mono

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -369,7 +369,7 @@ jobs:
 
 #
 # Libraries Test Build
-# Only when CoreCLR or Libraries is changed
+# Only when CoreCLR, Mono or Libraries is changed
 #
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -387,6 +387,7 @@ jobs:
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
+          eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #

--- a/src/mono/netcore/CoreFX.issues.rsp
+++ b/src/mono/netcore/CoreFX.issues.rsp
@@ -543,6 +543,9 @@
 # Requires precise GC (should be ignored in dotnet/corefx for mono)
 -nomethod System.Threading.Tasks.Tests.ExecutionContextFlowTest.TaskCompletionSourceDoesntCaptureExecutionContext
 
+# flaky, causes stack overflow
+-nomethod System.Threading.Tasks.Tests.TaskContinueWithTests.LongContinuationChain_ContinueWith_DoesNotStackOverflow
+
 ####################################################################
 ##  System.Threading.ThreadPool.Tests
 ####################################################################


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/1934

Also disables one test that seems to be flaky on Mono.