### PR TITLE
Allow allocating large object from free list while background sweeping SOH

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -34461,9 +34461,6 @@ void gc_heap::background_sweep()
         reset_seg = heap_segment_next_rw (reset_seg);
     }
 
-    generation* loh_gen = generation_of (max_generation + 1);
-    generation_allocation_segment (loh_gen) = heap_segment_rw (generation_start_segment (loh_gen));
-
     // We calculate dynamic data here because if we wait till we signal the lh event,
     // the allocation thread can change the fragmentation and we may read an intermediate
     // value (which can be greater than the generation size). Plus by that time it won't

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -34130,7 +34130,7 @@ void gc_heap::background_sweep()
     //block concurrent allocation for large objects
     dprintf (3, ("lh state: planning"));
 
-    for (int i = 0; i <= (max_generation + 1); i++)
+    for (int i = 0; i <= max_generation; i++)
     {
         generation* gen_to_reset = generation_of (i);
         generation_allocator (gen_to_reset)->clear();
@@ -34328,6 +34328,13 @@ void gc_heap::background_sweep()
                     generation_free_obj_space (gen) = 0;
                     generation_allocator (gen)->clear();
                     generation_free_list_space (gen) = 0;
+                    generation_free_list_allocated (gen) = 0;
+                    generation_end_seg_allocated (gen) = 0;
+                    generation_condemned_allocated (gen) = 0;
+                    generation_sweep_allocated (gen) = 0;
+                    generation_allocation_pointer (gen)= 0;
+                    generation_allocation_limit (gen) = 0;
+                    generation_allocation_segment (gen) = heap_segment_rw (generation_start_segment (gen));
 
                     dprintf (2, ("bgs: seg: %Ix, [%Ix, %Ix[%Ix", (size_t)seg,
                                     (size_t)heap_segment_mem (seg),


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1848

The change postponed the clearing of the free lists of the large object heap, that allows the free list to be used while the background small object heap sweeping is in progress. 

Stress tests involving large object allocation mixed with all the existing test cases survived the stress run over the weekend without crashing or deadlock. 