### PR TITLE
Change debug info default variable tracking system

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2412,11 +2412,11 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
-                varLiveKeeper->siUpdateVariableLiveRange(varDsc, lcl->GetLclNum())
+                varLiveKeeper->siUpdateVariableLiveRange(varDsc, lcl->GetLclNum());
 #endif // USING_VARIABLE_LIVE_RANGE
 
-                    // The new location is going live
-                    genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
+                // The new location is going live
+                genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
             }
         }
     }

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -11466,11 +11466,11 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveDescriptor::startLiveRang
     // Is the first "VariableLiveRange" or the previous one has been closed so its "m_EndEmitLocation" is valid
     noway_assert(m_VariableLiveRanges->empty() || m_VariableLiveRanges->back().m_EndEmitLocation.Valid());
 
-    if (!m_VariableLiveRanges->empty() && m_VariableLiveRanges->back().m_EndEmitLocation.IsPreviousIns(emit) &&
+    if (!m_VariableLiveRanges->empty() && m_VariableLiveRanges->back().m_EndEmitLocation.IsPreviousInsNum(emit) &&
         siVarLoc::Equals(&varLocation, &(m_VariableLiveRanges->back().m_VarLocation)))
     {
-        // The variable is being born at the exactly same place just one assembly instructtion.
-        // We assume it never died.
+        // The variable is being born just after the instruction at which it died.
+        // In this case, i.e. an update of the variable's value, we coalesce the live ranges.
         m_VariableLiveRanges->back().m_EndEmitLocation.Init();
     }
     else

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -11466,8 +11466,7 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveDescriptor::startLiveRang
     // Is the first "VariableLiveRange" or the previous one has been closed so its "m_EndEmitLocation" is valid
     noway_assert(m_VariableLiveRanges->empty() || m_VariableLiveRanges->back().m_EndEmitLocation.Valid());
 
-    if (!m_VariableLiveRanges->empty() &&
-        m_VariableLiveRanges->back().m_EndEmitLocation.IsPreviousIns(emit) &&
+    if (!m_VariableLiveRanges->empty() && m_VariableLiveRanges->back().m_EndEmitLocation.IsPreviousIns(emit) &&
         siVarLoc::Equals(&varLocation, &(m_VariableLiveRanges->back().m_VarLocation)))
     {
         // The variable is being born at the exactly same place just one assembly instructtion.
@@ -11480,7 +11479,7 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveDescriptor::startLiveRang
         m_VariableLiveRanges->emplace_back(varLocation, emitLocation(), emitLocation());
         m_VariableLiveRanges->back().m_StartEmitLocation.CaptureLocation(emit);
     }
-    
+
 #ifdef DEBUG
     if (!m_VariableLifeBarrier->hasLiveRangesToDump())
     {

--- a/src/coreclr/src/jit/codegeninterface.h
+++ b/src/coreclr/src/jit/codegeninterface.h
@@ -26,11 +26,11 @@
 #include "treelifeupdater.h"
 #include "emit.h"
 
-#if 1
+#if 0
 // Enable USING_SCOPE_INFO flag to use psiScope/siScope info to report variables' locations.
 #define USING_SCOPE_INFO
 #endif
-#if 0
+#if 1
 // Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
 // Note: if both USING_SCOPE_INFO and USING_VARIABLE_LIVE_RANGE are defined, then USING_SCOPE_INFO
 // information is reported to the debugger.

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -69,7 +69,7 @@ UNATIVE_OFFSET emitLocation::GetFuncletPrologOffset(emitter* emit) const
 bool emitLocation::IsPreviousIns(const emitter* emit) const
 {
     assert(Valid());
-    bool sameGroup = ig == emit->emitCurIG;
+    bool sameGroup  = ig == emit->emitCurIG;
     bool sameInsNum = emitGetInsNumFromCodePos(codePos) == emitGetInsNumFromCodePos(emit->emitCurOffset()) - 1;
     return sameGroup && sameInsNum;
 }

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -66,18 +66,18 @@ UNATIVE_OFFSET emitLocation::GetFuncletPrologOffset(emitter* emit) const
 }
 
 //------------------------------------------------------------------------
-// IsPreviousIns: Returns true if the emitter is on the next instruction
-//  of the same group than this emitLocation.
+// IsPreviousInsNum: Returns true if the emitter is on the next instruction
+//  of the same group as this emitLocation.
 //
 // Arguments:
 //  emit - an emitter* instance
 //
-bool emitLocation::IsPreviousIns(const emitter* emit) const
+bool emitLocation::IsPreviousInsNum(const emitter* emit) const
 {
     assert(Valid());
-    bool sameGroup  = ig == emit->emitCurIG;
-    bool sameInsNum = emitGetInsNumFromCodePos(codePos) == emitGetInsNumFromCodePos(emit->emitCurOffset()) - 1;
-    return sameGroup && sameInsNum;
+    bool isSameGroup  = (ig == emit->emitCurIG);
+    bool isSameInsNum = (emitGetInsNumFromCodePos(codePos) == emitGetInsNumFromCodePos(emit->emitCurOffset()) - 1);
+    return isSameGroup && isSameInsNum;
 }
 
 #ifdef DEBUG

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -65,6 +65,15 @@ UNATIVE_OFFSET emitLocation::GetFuncletPrologOffset(emitter* emit) const
     return emit->emitCurIGsize;
 }
 
+// Returns true if the emitter is on the next instruction of the same group than this emitLocation
+bool emitLocation::IsPreviousIns(const emitter* emit) const
+{
+    assert(Valid());
+    bool sameGroup = ig == emit->emitCurIG;
+    bool sameInsNum = emitGetInsNumFromCodePos(codePos) == emitGetInsNumFromCodePos(emit->emitCurOffset()) - 1;
+    return sameGroup && sameInsNum;
+}
+
 #ifdef DEBUG
 void emitLocation::Print() const
 {

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -65,7 +65,13 @@ UNATIVE_OFFSET emitLocation::GetFuncletPrologOffset(emitter* emit) const
     return emit->emitCurIGsize;
 }
 
-// Returns true if the emitter is on the next instruction of the same group than this emitLocation
+//------------------------------------------------------------------------
+// IsPreviousIns: Returns true if the emitter is on the next instruction
+//  of the same group than this emitLocation.
+//
+// Arguments:
+//  emit - an emitter* instance
+//
 bool emitLocation::IsPreviousIns(const emitter* emit) const
 {
     assert(Valid());

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -191,7 +191,7 @@ public:
 
     UNATIVE_OFFSET GetFuncletPrologOffset(emitter* emit) const;
 
-    bool emitLocation::IsPreviousIns(const emitter* emit) const;
+    bool emitLocation::IsPreviousInsNum(const emitter* emit) const;
 
 #ifdef DEBUG
     void Print() const;

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -191,6 +191,8 @@ public:
 
     UNATIVE_OFFSET GetFuncletPrologOffset(emitter* emit) const;
 
+    bool emitLocation::IsPreviousIns(const emitter* emit) const;
+
 #ifdef DEBUG
     void Print() const;
 #endif // DEBUG
@@ -2389,7 +2391,7 @@ inline unsigned emitGetInsOfsFromCodePos(unsigned codePos)
     return (codePos >> 16);
 }
 
-inline unsigned emitter::emitCurOffset()
+inline unsigned emitter::emitCurOffset() const
 {
     unsigned codePos = emitCurIGinsCnt + (emitCurIGsize << 16);
 

--- a/src/coreclr/src/jit/emitpub.h
+++ b/src/coreclr/src/jit/emitpub.h
@@ -65,7 +65,7 @@ void emitFinishPrologEpilogGeneration();
 /************************************************************************/
 
 void*    emitCurBlock();
-unsigned emitCurOffset();
+unsigned emitCurOffset() const;
 
 UNATIVE_OFFSET emitCodeOffset(void* blockPtr, unsigned codeOffs);
 


### PR DESCRIPTION
Varible Scope info is being disabled. Variable
Live Range is being enabled. Debug info generated
for debug code is the same, changes only impact on
optimized code.

Variable Live Range updates variable's location
each time something happens to variable's
liveness. For more information see
https://github.com/dotnet/runtime/blob/master/docs/design/features/variabletracking.md