### PR TITLE
Use latest System.Memory for ns2.0 refs

### DIFF
--- a/src/libraries/restore/binplacePackages/binplacePackages.depproj
+++ b/src/libraries/restore/binplacePackages/binplacePackages.depproj
@@ -29,7 +29,7 @@
   <!-- This is to make sure that nothing unintended gets restored for netcoreapp. -->
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <!-- runtime dependency: System.Diagnostics.PerformanceCounters netcoreapp2.0,net461 -->
-    <PackageReference Include="System.Memory" Version="4.5.2" Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetsNetfx)' == 'true' or ('$(TargetsNetStandard)' == 'true' and '$(NETStandardVersion)' &gt;= 1.1)" />
+    <PackageReference Include="System.Memory" Version="4.5.3" Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetsNetfx)' == 'true' or ('$(TargetsNetStandard)' == 'true' and '$(NETStandardVersion)' &gt;= 1.1)" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" Condition="'$(TargetsNetStandardLowerThan21)' == 'true' or '$(TargetsNetfx)' == 'true'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetsNetfx)' == 'true' or '$(TargetsNetStandard)' == 'true'" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" Condition="'$(TargetsNetfx)' == 'true'" />


### PR DESCRIPTION
Looks like this regressed here https://github.com/dotnet/corefx/pull/41270/files#r370406355  (likely bad merge resolution). 