### PR TITLE
enable PostAsync_ReuseRequestContent_Success on Unix

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2217,7 +2217,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/31104", TestPlatforms.AnyUnix)]
         public async Task PostAsync_ReuseRequestContent_Success(Configuration.Http.RemoteServer remoteServer)
         {
             const string ContentString = "This is the content string.";


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/31104 originally failed on Platform handler and that is gone. I did run on MacOS and Linux and it was fine. We can investigate if we ever see failures beyond stability of Azure servers.

fixes https://github.com/dotnet/corefx/issues/31104