### PR TITLE
Fix enterprise stress pipeline

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -50,8 +50,7 @@ steps:
   displayName: Test linuxclient connection to web server
 
 - bash: |
-    docker exec linuxclient bash /repo/src/coreclr/build.sh -release -skiptests -clang9
-    docker exec linuxclient bash /repo/libraries.sh /p:CoreCLRConfiguration=Release
+    docker exec linuxclient bash -c '/repo/src/coreclr/build.sh -release -skipnuget -clang9 && /repo/libraries.sh /p:CoreCLRConfiguration=Release'
   displayName: Build product sources
 
 - bash: |


### PR DESCRIPTION
in order to build the repo in enterprise tests we were running, `/repo/src/coreclr/build.sh -release -skiptests -clang9` -- but `-skiptests` is not processed in `build.sh` only valid in `build.cmd`, it is only supported in build.cmd, however, before this change: https://github.com/dotnet/runtime/pull/1753/files#diff-341bf51f34e3c6ab4a7abd4bc0a09880R394 I believe unprocessed args were not flowing correctly. After that change, they started flowing correctly and MSBuild is complaining about that:
```
MSBUILD : error MSB1001: Unknown switch.
Switch: -skiptests
```

And the `coreclr` build is complaining about that, but the way the enterprise testing is set, it builds libraries regardless of  the result, since `coreclr` is failing, it is not finding `System.Private.CoreLib`. 

https://github.com/dotnet/runtime/blob/03da9e995ce49869ccee3bbbcdbcd9086bab6c11/eng/pipelines/libraries/enterprise/linux.yml#L53-L54

Here I'm changing the arguments, removing `-skiptests` and adding `-skipnuget` to speed the build a little bit as they're not needed, and also chaining the commands with `&&` so that libraries is not built if coreclr  fails to build.