### PR TITLE
enable GetAsync_SupportedSSLVersion_Succeeds

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -154,7 +154,6 @@ namespace System.Net.Http.Functional.Tests
 
         // We have tests that validate with SslStream, but that's limited by what the current OS supports.
         // This tests provides additional validation against an external server.
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/26186")]
         [OuterLoop("Avoid www.ssllabs.com dependency in innerloop.")]
         [Theory]
         [MemberData(nameof(SupportedSSLVersionServers))]


### PR DESCRIPTION
It seems like https://github.com/dotnet/corefx/pull/35605 missed one more test. With Win7 and RH6 gone, we should have more predictable environment. 
Note, that unlike most of the other Outerloop tests, this one uses `ssllab.com` instead of our Azure service. If the external dependency becomes problematic, this would be a great candidate for containerization like we did for enterprise testing. 

fixes https://github.com/dotnet/corefx/issues/26186