### PR TITLE
Reenable Http2_ServerSendsInvalidSettingsValue_Error test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -94,7 +94,7 @@ namespace System.Net.Test.Common
 
         public async Task<Http2LoopbackConnection> EstablishConnectionAsync(params SettingsEntry[] settingsEntries)
         {
-            (Http2LoopbackConnection connection, _) = await EstablishConnectionGetSettingsAsync().ConfigureAwait(false);
+            (Http2LoopbackConnection connection, _) = await EstablishConnectionGetSettingsAsync(settingsEntries).ConfigureAwait(false);
             return connection;
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -209,7 +209,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/35466")]
         [ConditionalTheory(nameof(SupportsAlpn))]
         [InlineData(SettingId.MaxFrameSize, 16383, ProtocolErrors.PROTOCOL_ERROR)]
         [InlineData(SettingId.MaxFrameSize, 162777216, ProtocolErrors.PROTOCOL_ERROR)]


### PR DESCRIPTION
It seems like we did not pass properly SettingsEntry in H2LoopbackServer. 
Tests are passing now.
```
    Discovering: System.Net.Http.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Http.Functional.Tests (found 1 of 1148 test case)
    Starting:    System.Net.Http.Functional.Tests (parallel test collections = on, max threads = 4)
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: MaxFrameSize, value: 16383, expectedError: PROTOCOL_ERROR) [STARTING]
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: MaxFrameSize, value: 16383, expectedError: PROTOCOL_ERROR) [FINISHED] Time: 0.6268973s
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: MaxFrameSize, value: 162777216, expectedError: PROTOCOL_ERROR) [STARTING]
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: MaxFrameSize, value: 162777216, expectedError: PROTOCOL_ERROR) [FINISHED] Time: 0.0191116s
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: InitialWindowSize, value: 2147483648, expectedError: FLOW_CONTROL_ERROR) [STARTING]
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http2.Http2_ServerSendsInvalidSettingsValue_Error(settingId: InitialWindowSize, value: 2147483648, expectedError: FLOW_CONTROL_ERROR) [FINISHED] Time: 0.0115572s
    Finished:    System.Net.Http.Functional.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Http.Functional.Tests  Total: 3, Errors: 0, Failed: 0, Skipped: 0, Time: 0.825s
```

fixes https://github.com/dotnet/runtime/issues/1581
fixes https://github.com/dotnet/corefx/issues/35466