### PR TITLE
improve handling of kSecTrustResultRecoverableTrustFailure

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -396,9 +396,9 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
         return -6;
     }
 
-    CFIndex count = SecTrustGetCertificateCount(existingTrust);
+    CFIndex certificateCount = SecTrustGetCertificateCount(existingTrust);
 
-    for (CFIndex i = 0; i < count; i++)
+    for (CFIndex i = 0; i < certificateCount; i++)
     {
         SecCertificateRef item = SecTrustGetCertificateAtIndex(existingTrust, i);
         CFArrayAppendValue(certs, item);
@@ -433,6 +433,22 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         osStatus = SecTrustEvaluate(trust, &trustResult);
+
+        if (trustResult == kSecTrustResultRecoverableTrustFailure && osStatus == noErr && certificateCount > 1)
+        {
+            // If we get recoverable failure, let's try it again with full anchor list.
+            for (CFIndex i = 1; i < certificateCount; i++)
+            {
+                CFArrayAppendValue(anchors, SecTrustGetCertificateAtIndex(existingTrust, i));
+            }
+
+            osStatus = SecTrustSetAnchorCertificates(trust, anchors);
+            if (osStatus == noErr)
+            {
+                memset(&trustResult, 0, sizeof(SecTrustResultType));
+                osStatus = SecTrustEvaluate(trust, &trustResult);
+            }
+        }
 #pragma clang diagnostic pop
 
         if (osStatus == noErr && trustResult != kSecTrustResultUnspecified && trustResult != kSecTrustResultProceed)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -437,6 +437,7 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
         if (trustResult == kSecTrustResultRecoverableTrustFailure && osStatus == noErr && certificateCount > 1)
         {
             // If we get recoverable failure, let's try it again with full anchor list.
+            // We already stored just the first certificate into anchors; now we store the rest.
             for (CFIndex i = 1; i < certificateCount; i++)
             {
                 CFArrayAppendValue(anchors, SecTrustGetCertificateAtIndex(existingTrust, i));


### PR DESCRIPTION
According do the documentation for kSecTrustResultRecoverableTrustFailure

>This value indicates that you should not trust the chain as is, but that the chain could be trusted with some minor change to the evaluation context, such as ignoring expired certificates or adding another anchor to the set of trusted anchors.

This change implements the last suggestion. With this, we can connect to `apple.com` and `icloud.com` via TLS.

I did not want to add a dependency on another external server so I did not add any test for this change. We could possibly add Outerloop test to verify we can fetch from apple.com.

fixes #805