### PR TITLE
Remove "ActiveIssue" attribute from test

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Directory.Move.cs
@@ -31,7 +31,6 @@ namespace System.IO.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/42507", TestPlatforms.OSX)]
         public void Directory_Move_Multiple_From_Watched_To_Unwatched_Mac(int filesCount)
         {
             // On Mac, the FSStream aggregate old events caused by the test setup.


### PR DESCRIPTION
Removes forgotten attributes. I re-test it on macOS and the test works fine.
Fixes dotnet/corefx#42507