### PR TITLE
Crossgen2 - precompile generic instantiations

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/AllMethodsOnTypeNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/AllMethodsOnTypeNode.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class AllMethodsOnTypeNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly TypeDesc _type;
+
+        public AllMethodsOnTypeNode(TypeDesc type)
+        {
+            _type = type;
+        }
+
+        public TypeDesc Type => _type;
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+
+        public override bool HasDynamicDependencies => false;
+
+        public override bool HasConditionalStaticDependencies => false;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            DependencyList dependencies = new DependencyList();
+
+            foreach (MethodDesc method in Type.GetAllMethods())
+            {
+                if (!method.IsGenericMethodDefinition && context.CompilationModuleGroup.VersionsWithMethodBody(method))
+                {
+                    dependencies.Add(context.MethodEntrypoint(method), $"Method on type {Type.ToString()}");
+                }
+            }
+
+            return dependencies;
+        }
+
+        protected override string GetName(NodeFactory factory) => $"All methods on type {Type.ToString()}";
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -75,13 +75,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (_typeDesc.HasInstantiation && !_typeDesc.IsGenericDefinition)
             {
-                foreach (MethodDesc method in _typeDesc.GetAllMethods())
-                {
-                    if (!method.IsGenericMethodDefinition && factory.CompilationModuleGroup.VersionsWithMethodBody(method))
-                    {
-                        dependencies.Add(factory.MethodEntrypoint(method), "Method on generic type instantiation");
-                    }
-                }
+                dependencies.Add(factory.AllMethodsOnType(_typeDesc), "Methods on generic type instantiation");
             }
             return dependencies;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -68,5 +68,22 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
         }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = new DependencyList();
+
+            if (_typeDesc.HasInstantiation && !_typeDesc.IsGenericDefinition)
+            {
+                foreach (MethodDesc method in _typeDesc.GetAllMethods())
+                {
+                    if (!method.IsGenericMethodDefinition && factory.CompilationModuleGroup.VersionsWithMethodBody(method))
+                    {
+                        dependencies.Add(factory.MethodEntrypoint(method), "Method on generic type instantiation");
+                    }
+                }
+            }
+            return dependencies;
+        }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -82,7 +82,12 @@ namespace ILCompiler.DependencyAnalysis
         private void CreateNodeCaches()
         {
             _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
-            _allMethodsOnType = new NodeCache<TypeDesc, AllMethodsOnTypeNode>(CreateAllMethodsOnTypeNode);
+
+            _allMethodsOnType = new NodeCache<TypeDesc, AllMethodsOnTypeNode>(type =>
+            {
+                return new AllMethodsOnTypeNode(type);
+            });
+
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(CreateGenericLookupFromDictionaryNode);
             _genericReadyToRunHelpersFromType = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(CreateGenericLookupFromTypeNode);
 
@@ -697,11 +702,6 @@ namespace ILCompiler.DependencyAnalysis
                 isInstantiatingStub: false,
                 isPrecodeImportRequired: false,
                 signatureContext: InputModuleContext);
-        }
-
-        protected override AllMethodsOnTypeNode CreateAllMethodsOnTypeNode(TypeDesc type)
-        {
-            return new AllMethodsOnTypeNode(type);
         }
 
         private ReadyToRunHelper GetGenericStaticHelper(ReadyToRunHelperId helperId)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -82,6 +82,7 @@ namespace ILCompiler.DependencyAnalysis
         private void CreateNodeCaches()
         {
             _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
+            _allMethodsOnType = new NodeCache<TypeDesc, AllMethodsOnTypeNode>(CreateAllMethodsOnTypeNode);
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(CreateGenericLookupFromDictionaryNode);
             _genericReadyToRunHelpersFromType = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(CreateGenericLookupFromTypeNode);
 
@@ -105,6 +106,13 @@ namespace ILCompiler.DependencyAnalysis
         public IMethodNode MethodEntrypoint(MethodDesc method)
         {
             return _methodEntrypoints.GetOrAdd(method);
+        }
+
+        private NodeCache<TypeDesc, AllMethodsOnTypeNode> _allMethodsOnType;
+
+        public AllMethodsOnTypeNode AllMethodsOnType(TypeDesc type)
+        {
+            return _allMethodsOnType.GetOrAdd(type);
         }
 
         private NodeCache<ReadyToRunGenericHelperKey, ISymbolNode> _genericReadyToRunHelpersFromDict;
@@ -689,6 +697,11 @@ namespace ILCompiler.DependencyAnalysis
                 isInstantiatingStub: false,
                 isPrecodeImportRequired: false,
                 signatureContext: InputModuleContext);
+        }
+
+        protected override AllMethodsOnTypeNode CreateAllMethodsOnTypeNode(TypeDesc type)
+        {
+            return new AllMethodsOnTypeNode(type);
         }
 
         private ReadyToRunHelper GetGenericStaticHelper(ReadyToRunHelperId helperId)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -101,6 +101,7 @@
     <Compile Include="..\..\Common\TypeSystem\Interop\InteropTypes.cs" Link="Interop\InteropTypes.cs" />
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.ReadyToRun.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\AllMethodsOnTypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />


### PR DESCRIPTION
This change adds precompilation of all methods on generic instantiations
of types that are encountered during compilation. In my powershell
startup time experiments, it shaved off about 110 methods from the ones
that needed to be jitted at runtime and looking at e.g.
System.Private.CoreLib.dll precompilation result, it is much closer to
the version we get from the old crossgen now.