### PR TITLE
Initialize HashSizeValue for digest algorithms.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/MD5.cs
@@ -14,7 +14,10 @@ namespace System.Security.Cryptography
 
     public abstract class MD5 : HashAlgorithm
     {
-        protected MD5() { }
+        protected MD5()
+        {
+            HashSizeValue = 128;
+        }
 
         public static new MD5 Create() => new Implementation();
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA1.cs
@@ -14,7 +14,10 @@ namespace System.Security.Cryptography
 
     public abstract class SHA1 : HashAlgorithm
     {
-        protected SHA1() { }
+        protected SHA1()
+        {
+            HashSizeValue = 160;
+        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "This is the implementaton of SHA1")]
         public static new SHA1 Create() => new Implementation();

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA256.cs
@@ -14,7 +14,10 @@ namespace System.Security.Cryptography
 
     public abstract class SHA256 : HashAlgorithm
     {
-        protected SHA256() { }
+        protected SHA256()
+        {
+            HashSizeValue = 256;
+        }
 
         public static new SHA256 Create() => new Implementation();
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA384.cs
@@ -14,7 +14,10 @@ namespace System.Security.Cryptography
 
     public abstract class SHA384 : HashAlgorithm
     {
-        protected SHA384() { }
+        protected SHA384()
+        {
+            HashSizeValue = 384;
+        }
 
         public static new SHA384 Create() => new Implementation();
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/SHA512.cs
@@ -14,7 +14,10 @@ namespace System.Security.Cryptography
 
     public abstract class SHA512 : HashAlgorithm
     {
-        protected SHA512() { }
+        protected SHA512()
+        {
+            HashSizeValue = 512;
+        }
 
         public static new SHA512 Create() => new Implementation();
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/HashDerivedTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/HashDerivedTests.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Hashing.Algorithms.Tests
+{
+    public static class HashDerivedTests
+    {
+        [Fact]
+        public static void HashSize_SetForDerived_SHA1()
+        {
+            using DerivedSHA1 sha = new DerivedSHA1();
+            Assert.Equal(160, sha.HashSize);
+        }
+
+        [Fact]
+        public static void HashSize_SetForDerived_SHA256()
+        {
+            using DerivedSHA256 sha = new DerivedSHA256();
+            Assert.Equal(256, sha.HashSize);
+        }
+
+        [Fact]
+        public static void HashSize_SetForDerived_SHA384()
+        {
+            using DerivedSHA384 sha = new DerivedSHA384();
+            Assert.Equal(384, sha.HashSize);
+        }
+
+        [Fact]
+        public static void HashSize_SetForDerived_SHA512()
+        {
+            using DerivedSHA512 sha = new DerivedSHA512();
+            Assert.Equal(512, sha.HashSize);
+        }
+
+        [Fact]
+        public static void HashSize_SetForDerived_MD5()
+        {
+            using DerivedMD5 sha = new DerivedMD5();
+            Assert.Equal(128, sha.HashSize);
+        }
+
+        private class DerivedSHA1 : SHA1
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+
+        private class DerivedSHA256 : SHA256
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+
+        private class DerivedSHA384 : SHA384
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+
+        private class DerivedSHA512 : SHA512
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+
+        private class DerivedMD5 : MD5
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+
+        private class DerivedHMACMD5 : HMACMD5
+        {
+            public override void Initialize() => throw null;
+            protected override byte[] HashFinal() => throw null;
+            protected override void HashCore(byte[] array, int ibStart, int cbSize) => throw null;
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -188,6 +188,7 @@
     <Compile Include="ECDiffieHellmanTests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="ECDsaTests.cs" />
+    <Compile Include="HashDerivedTests.cs" />
     <Compile Include="PaddingModeTests.cs" />
     <Compile Include="PKCS1MaskGenerationMethodTest.cs" />
     <Compile Include="RC2Provider.cs" />


### PR DESCRIPTION
The abstract types SHAx and MD5 did not set HashSizeValue, which would lead to derived types to have HashSize a value of 0. This initializes the field to match .NET Framework behavior.

Fixes #2133 

cc @bartonjs 