### PR TITLE
Move official builds to OSX 10.14 pool

### DIFF
--- a/eng/pipelines/common/checkout-job.yml
+++ b/eng/pipelines/common/checkout-job.yml
@@ -32,11 +32,7 @@ jobs:
   displayName: Checkout
 
   pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: Hosted MacOS
-
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      name: Hosted Mac Internal
+    name: Hosted MacOS
 
   steps:
   - checkout: self

--- a/eng/pipelines/common/checkout-job.yml
+++ b/eng/pipelines/common/checkout-job.yml
@@ -32,7 +32,7 @@ jobs:
   displayName: Checkout
 
   pool:
-    name: Hosted MacOS
+    vmImage: 'macOS-10.14'
 
   steps:
   - checkout: self

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -83,12 +83,8 @@ jobs:
         ${{ if and(eq(parameters.osGroup, 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
           name: dnceng-freebsd-internal
 
-        # Official Build OSX Pool
-        ${{ if and(eq(parameters.osGroup, 'OSX'), ne(variables['System.TeamProject'], 'public')) }}:
-          name: Hosted Mac Internal
-
         # Public OSX Build Pool
-        ${{ if and(eq(parameters.osGroup, 'OSX'), eq(variables['System.TeamProject'], 'public')) }}:
+        ${{ if eq(parameters.osGroup, 'OSX') }}:
           name: Hosted macOS
 
         # Official Build Windows Pool

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -85,7 +85,7 @@ jobs:
 
         # Public OSX Build Pool
         ${{ if eq(parameters.osGroup, 'OSX') }}:
-          name: Hosted macOS
+          vmImage: 'macOS-10.14'
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:


### PR DESCRIPTION
Will not merge until: https://status.dev.azure.com/_event/172206840 is fixed.

Azure DevOps is dropping support of 10.13, we're already building CI and PRs in 10.14 and our tests are working just fine, so we're good to move official builds to use Hosted macOS with 10.14 machines.

cc: @dotnet/runtime-infrastructure @wfurt @Chrisboh @bartonjs 