### PR TITLE
Increase crossgen-comparison job timeout

### DIFF
--- a/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
@@ -75,9 +75,7 @@ jobs:
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml
     container: ${{ parameters.container }}
-
-    ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      timeoutInMinutes: 150 # 2.5 hrs
+    timeoutInMinutes: 90 # 1.5 hrs
 
     steps:
 
@@ -150,7 +148,7 @@ jobs:
         HelixTargetQueues: ${{ join(' ', parameters.helixQueues) }}
         ${{ if ne(variables['System.TeamProject'], 'internal') }}:
           Creator: $(Creator)
-        WorkItemTimeout: 2:00 # 2 hours
+        WorkItemTimeout: 1:30 # 1:30 hours
         WorkItemDirectory: '$(artifactsDirectory)'
         CorrelationPayloadDirectory: '$(coreClrRepoRoot)/tests/scripts'
         ${{ if ne(parameters.osName, 'Windows_NT') }}:


### PR DESCRIPTION
I've still seen timeouts in this job. Increasing timeout to 90 minutes per thread in: https://github.com/dotnet/runtime/issues/1282#issuecomment-570732769

cc: @dotnet/runtime-infrastructure @sandreenko 