### PR TITLE
Fix for IlAsm round-trip issue #803

### DIFF
--- a/src/coreclr/src/ilasm/assembler.cpp
+++ b/src/coreclr/src/ilasm/assembler.cpp
@@ -2452,7 +2452,6 @@ void Assembler::RecordTypeConstraints(GenericParamConstraintList* pGPCList, int 
                 }
             }
         }
-        m_pCustomDescrList = NULL;
     }
 }
 


### PR DESCRIPTION
Remove the unnecessary assignment m_pCustomDescrList = NULL;
from the method RecordTypeConstraints that was added with my original fix.