### PR TITLE
Avoid large switch in compiled FindFirstChar

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -29,6 +29,10 @@ namespace System.Text.RegularExpressions
         public readonly bool CaseInsensitive;
         private readonly CultureInfo _culture;
 
+        /// <summary>The maximum pattern length for which we'll attempt to create a Boyer-Moore table.</summary>
+        /// <remarks>This is limited in order to minimize the overhead of constructing a Regex.</remarks>
+        public const int MaxLimit = 50_000; // must be <= char.MaxValue for RegexCompiler to compile Boyer-Moore correctly
+
         /// <summary>
         /// Constructs a Boyer-Moore state machine for searching for the string
         /// pattern. The string must not be zero-length.
@@ -38,6 +42,7 @@ namespace System.Text.RegularExpressions
             // Sorry, you just can't use Boyer-Moore to find an empty pattern.
             // We're doing this for your own protection. (Really, for speed.)
             Debug.Assert(pattern.Length != 0, "RegexBoyerMoore called with an empty string. This is bad for perf");
+            Debug.Assert(pattern.Length <= MaxLimit, "RegexBoyerMoore can take a long time for large patterns");
             Debug.Assert(!caseInsensitive || pattern.ToLower(culture) == pattern, "RegexBoyerMoore called with a pattern which is not lowercased with caseInsensitive true.");
 
             Pattern = pattern;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -94,18 +94,18 @@ namespace System.Text.RegularExpressions
         public const int Back2 = 256; // bit to indicate that we're backtracking on a second branch.
         public const int Ci = 512;    // bit to indicate that we're case-insensitive.
 
-        public readonly RegexTree Tree;                  // the optimized parse tree
-        public readonly int[] Codes;                     // the code
-        public readonly string[] Strings;                // the string/set table
-        public readonly int[]?[] StringsAsciiLookup;     // the ASCII lookup table optimization for the sets in Strings
-        public readonly int TrackCount;                  // how many instructions use backtracking
-        public readonly Hashtable? Caps;                 // mapping of user group numbers -> impl group slots
-        public readonly int CapSize;                     // number of impl group slots
-        public readonly RegexPrefix? FCPrefix;           // the set of candidate first characters (may be null)
-        public int[]? FCPrefixAsciiLookup;               // the ASCII lookup table optimization for the set of candidate first characters if there are any
-        public readonly RegexBoyerMoore? BMPrefix;       // the fixed prefix string as a Boyer-Moore machine (may be null)
-        public readonly int Anchors;                     // the set of zero-length start anchors (RegexFCD.Bol, etc)
-        public readonly bool RightToLeft;                // true if right to left
+        public readonly RegexTree Tree;              // the optimized parse tree
+        public readonly int[] Codes;                 // the code
+        public readonly string[] Strings;            // the string/set table
+        public readonly int[]?[] StringsAsciiLookup; // the ASCII lookup table optimization for the sets in Strings
+        public readonly int TrackCount;              // how many instructions use backtracking
+        public readonly Hashtable? Caps;             // mapping of user group numbers -> impl group slots
+        public readonly int CapSize;                 // number of impl group slots
+        public readonly RegexPrefix? FCPrefix;       // the set of candidate first characters, if available
+        public int[]? FCPrefixAsciiLookup;           // the ASCII lookup table optimization for FCPrefix if it exists; only used by the interpreter
+        public readonly RegexBoyerMoore? BMPrefix;   // the fixed prefix string as a Boyer-Moore machine, if available
+        public readonly int Anchors;                 // the set of zero-length start anchors (RegexFCD.Bol, etc)
+        public readonly bool RightToLeft;            // true if right to left
 
         public RegexCode(RegexTree tree, int[] codes, string[] strings, int trackcount,
                          Hashtable? caps, int capsize,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -355,6 +355,9 @@ namespace System.Text.RegularExpressions
         /// <summary>A macro for _ilg.Emit(OpCodes.Sub) or _ilg.Emit(OpCodes.Add).</summary>
         private void Sub(bool negate) => _ilg!.Emit(negate ? OpCodes.Add : OpCodes.Sub);
 
+        /// <summary>A macro for _ilg.Emit(OpCodes.Neg).</summary>
+        private void Neg() => _ilg!.Emit(OpCodes.Neg);
+
         /// <summary>A macro for _ilg.Emit(OpCodes.Mul).</summary>
         private void Mul() => _ilg!.Emit(OpCodes.Mul);
 
@@ -1183,17 +1186,14 @@ namespace System.Text.RegularExpressions
                 Br(lStart);
 
                 MarkLabel(lDefaultAdvance);
-
                 Ldc(_code.RightToLeft ? -_bmPrefix.Pattern.Length : _bmPrefix.Pattern.Length);
 
                 MarkLabel(lAdvance);
-
                 Ldloc(_runtextposLocal);
                 Add();
                 Stloc(_runtextposLocal);
 
                 MarkLabel(lStart);
-
                 Ldloc(_runtextposLocal);
                 Ldloc(limitLocal);
                 if (!_code.RightToLeft)
@@ -1224,47 +1224,53 @@ namespace System.Text.RegularExpressions
                 Ldc(_bmPrefix.HighASCII - _bmPrefix.LowASCII);
                 Bgtun(lDefaultAdvance);
 
-                var table = new Label[_bmPrefix.HighASCII - _bmPrefix.LowASCII + 1];
-
-                // Mapping from negative ASCII value to the label that loads it.
-                // As we create labels, we check to see if the table already has
-                // the value, and only create the label if it doesn't.  Then when
-                // spitting out the code for each label, we try to remove the entry
-                // from the dictionary, and only if we're successful (because it
-                // wasn't already removed) do we spit the code.
-                var labelMap = new Dictionary<int, Label>();
-
-                for (int i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
+                int negativeRange = _bmPrefix.HighASCII - _bmPrefix.LowASCII + 1;
+                if (negativeRange > 1)
                 {
-                    Label label;
-                    if (_bmPrefix.NegativeASCII[i] == beforefirst)
+                    // Create a string to store the lookup table we use to find the offset.
+                    Debug.Assert(_bmPrefix.Pattern.Length <= char.MaxValue, "RegexBoyerMoore should have limited the size allowed.");
+                    string negativeLookup = string.Create(negativeRange, (thisRef: this, beforefirst), (span, state) =>
                     {
-                        label = lDefaultAdvance;
-                    }
-                    else if (!labelMap.TryGetValue(_bmPrefix.NegativeASCII[i], out label))
+                        // Store the offsets into the string.  RightToLeft has negative offsets, so to support it with chars (unsigned), we negate
+                        // the values to be stored in the string, and then at run time after looking up the offset in the string, negate it again.
+                        for (int i = 0; i < span.Length; i++)
+                        {
+                            int offset = state.thisRef._bmPrefix!.NegativeASCII[i + state.thisRef._bmPrefix.LowASCII];
+                            if (offset == state.beforefirst)
+                            {
+                                offset = state.thisRef._bmPrefix.Pattern.Length;
+                            }
+                            else if (state.thisRef._code!.RightToLeft)
+                            {
+                                offset = -offset;
+                            }
+                            Debug.Assert(offset >= 0 && offset <= char.MaxValue);
+                            span[i] = (char)offset;
+                        }
+                    });
+
+                    // offset = lookupString[ch];
+                    // goto Advance;
+                    Ldstr(negativeLookup);
+                    Ldloc(chLocal);
+                    Callvirt(s_stringGetCharsMethod);
+                    if (_code.RightToLeft)
                     {
-                        label = DefineLabel();
-                        labelMap.Add(_bmPrefix.NegativeASCII[i], label);
+                        Neg();
                     }
-                    table[i - _bmPrefix.LowASCII] = label;
                 }
-
-                Ldloc(chLocal);
-                Switch(table);
-
-                for (int i = _bmPrefix.LowASCII; i <= _bmPrefix.HighASCII; i++)
+                else
                 {
-                    if (_bmPrefix.NegativeASCII[i] == beforefirst ||
-                        !labelMap.Remove(_bmPrefix.NegativeASCII[i]))
+                    // offset = value;
+                    Debug.Assert(negativeRange == 1);
+                    int offset = _bmPrefix.NegativeASCII[_bmPrefix.LowASCII];
+                    if (offset == beforefirst)
                     {
-                        continue;
+                        offset = _code.RightToLeft ? -_bmPrefix.Pattern.Length : _bmPrefix.Pattern.Length;
                     }
-
-                    MarkLabel(table[i - _bmPrefix.LowASCII]);
-
-                    Ldc(_bmPrefix.NegativeASCII[i]);
-                    BrFar(lAdvance);
+                    Ldc(offset);
                 }
+                BrFar(lAdvance);
 
                 MarkLabel(lPartialMatch);
 
@@ -2698,7 +2704,6 @@ namespace System.Text.RegularExpressions
                     node.Type == RegexNode.Oneloopatomic ||
                     node.Type == RegexNode.Notoneloopatomic ||
                     node.Type == RegexNode.Setloopatomic);
-                Debug.Assert(node.M < int.MaxValue);
 
                 // If this is actually a repeater, emit that instead.
                 if (node.M == node.N)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -105,13 +105,13 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Oneloopatomic:
                     case RegexNode.Onelazy:
 
-                        // In release, cutoff at a length to which we can still reasonably construct a string
+                        // In release, cutoff at a length to which we can still reasonably construct a string and Boyer-Moore search.
                         // In debug, use a smaller cutoff to exercise the cutoff path in tests
                         const int Cutoff =
 #if DEBUG
                             50;
 #else
-                            1_000_000;
+                            RegexBoyerMoore.MaxLimit;
 #endif
 
                         if (curNode.M > 0 && curNode.M < Cutoff)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -2,33 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// This RegexWriter class is internal to the Regex package.
-// It builds a block of regular expression codes (RegexCode)
-// from a RegexTree parse tree.
-
-// Implementation notes:
-//
-// This step is as simple as walking the tree and emitting
-// sequences of codes.
-//
-
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>Builds a block of regular expression codes (RegexCode) from a RegexTree parse tree.</summary>
     internal ref struct RegexWriter
     {
+        // These must be unused RegexNode type bits.
         private const int BeforeChild = 64;
         private const int AfterChild = 128;
-        // Distribution of common patterns indicates an average amount of 56 op codes.
-        private const int EmittedSize = 56;
+
+        // Distribution of common patterns indicates an average amount of 56 op codes. Since we're stackalloc'ing,
+        // we can afford to make it a bit higher and a power of two for simplicity.
+        private const int EmittedSize = 64;
         private const int IntStackSize = 32;
 
+        private readonly Dictionary<string, int> _stringTable;
         private ValueListBuilder<int> _emitted;
         private ValueListBuilder<int> _intStack;
-        private readonly Dictionary<string, int> _stringTable;
         private Hashtable? _caps;
         private int _trackCount;
 
@@ -73,12 +67,14 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// The top level RegexCode generator. It does a depth-first walk
-        /// through the tree and calls EmitFragment to emits code before
-        /// and after each child of an interior node, and at each leaf.
+        /// through the tree and calls EmitFragment to emit code before
+        /// and after each child of an interior node and at each leaf.
+        /// It also computes various information about the tree, such as
+        /// prefix data to help with optimizations.
         /// </summary>
         public RegexCode RegexCodeFromRegexTree(RegexTree tree)
         {
-            // construct sparse capnum mapping if some numbers are unused
+            // Construct sparse capnum mapping if some numbers are unused.
             int capsize;
             if (tree.CapNumList == null || tree.CapTop == tree.CapNumList.Length)
             {
@@ -90,17 +86,21 @@ namespace System.Text.RegularExpressions
                 capsize = tree.CapNumList.Length;
                 _caps = tree.Caps;
                 for (int i = 0; i < tree.CapNumList.Length; i++)
+                {
                     _caps[tree.CapNumList[i]] = i;
+                }
             }
 
-            RegexNode? curNode = tree.Root;
-            int curChild = 0;
-
+            // Every written code begins with a lazy branch.  This will be back-patched
+            // to point to the ending Stop after the whole expression has been written.
             Emit(RegexCode.Lazybranch, 0);
 
+            // Emit every node.
+            RegexNode curNode = tree.Root;
+            int curChild = 0;
             while (true)
             {
-                int curNodeChildCount = curNode!.ChildCount();
+                int curNodeChildCount = curNode.ChildCount();
                 if (curNodeChildCount == 0)
                 {
                     EmitFragment(curNode.Type, curNode, 0);
@@ -116,39 +116,51 @@ namespace System.Text.RegularExpressions
                 }
 
                 if (_intStack.Length == 0)
+                {
                     break;
+                }
 
                 curChild = _intStack.Pop();
-                curNode = curNode.Next;
+                curNode = curNode.Next!;
 
-                EmitFragment(curNode!.Type | AfterChild, curNode, curChild);
+                EmitFragment(curNode.Type | AfterChild, curNode, curChild);
                 curChild++;
             }
 
+            // Patch the starting Lazybranch, emit the final Stop, and get the resulting code array.
             PatchJump(0, _emitted.Length);
             Emit(RegexCode.Stop);
-
-            RegexPrefix? fcPrefix = RegexFCD.FirstChars(tree);
-            RegexPrefix prefix = RegexFCD.Prefix(tree);
-            bool rtl = (tree.Options & RegexOptions.RightToLeft) != 0;
-
-            CultureInfo culture = (tree.Options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
-
-            RegexBoyerMoore? bmPrefix = null;
-            if (prefix.Prefix.Length > 1 && prefix.Prefix.Length <= RegexBoyerMoore.MaxLimit) // if it's <= 1 || > MaxLimit, perf is better using fcPrefix
-            {
-                bmPrefix = new RegexBoyerMoore(prefix.Prefix, prefix.CaseInsensitive, rtl, culture);
-            }
-
-            int anchors = RegexFCD.Anchors(tree);
             int[] emitted = _emitted.AsSpan().ToArray();
 
+            bool rtl = (tree.Options & RegexOptions.RightToLeft) != 0;
+
+            // Compute prefixes to help optimize FindFirstChar.
+            RegexBoyerMoore? bmPrefix = null;
+            RegexPrefix? fcPrefix = null;
+            RegexPrefix prefix = RegexFCD.Prefix(tree);
+            if (prefix.Prefix.Length > 1 && prefix.Prefix.Length <= RegexBoyerMoore.MaxLimit) // if it's <= 1 || > MaxLimit, perf is better using fcPrefix
+            {
+                // Compute a Boyer-Moore prefix if we find a single string of sufficient length that always begins the expression.
+                CultureInfo culture = (tree.Options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
+                bmPrefix = new RegexBoyerMoore(prefix.Prefix, prefix.CaseInsensitive, rtl, culture);
+            }
+            else
+            {
+                // If we didn't find such a string, try to compute the characters set that might begin the string.
+                fcPrefix = RegexFCD.FirstChars(tree);
+            }
+
+            // Compute any anchors starting the expression.
+            int anchors = RegexFCD.Anchors(tree);
+
+            // Convert the string table into an ordered string array/
             var strings = new string[_stringTable.Count];
             foreach (KeyValuePair<string, int> stringEntry in _stringTable)
             {
                 strings[stringEntry.Value] = stringEntry.Key;
             }
 
+            // Return all that in a RegexCode object.
             return new RegexCode(tree, emitted, strings, _trackCount, _caps, capsize, bmPrefix, fcPrefix, anchors, rtl);
         }
 
@@ -169,30 +181,32 @@ namespace System.Text.RegularExpressions
         private void Emit(int op)
         {
             if (RegexCode.OpcodeBacktracks(op))
+            {
                 _trackCount++;
+            }
 
             _emitted.Append(op);
         }
 
-        /// <summary>
-        /// Emits a one-argument operation.
-        /// </summary>
+        /// <summary>Emits a one-argument operation.</summary>
         private void Emit(int op, int opd1)
         {
             if (RegexCode.OpcodeBacktracks(op))
+            {
                 _trackCount++;
+            }
 
             _emitted.Append(op);
             _emitted.Append(opd1);
         }
 
-        /// <summary>
-        /// Emits a two-argument operation.
-        /// </summary>
+        /// <summary>Emits a two-argument operation.</summary>
         private void Emit(int op, int opd1, int opd2)
         {
             if (RegexCode.OpcodeBacktracks(op))
+            {
                 _trackCount++;
+            }
 
             _emitted.Append(op);
             _emitted.Append(opd1);
@@ -220,16 +234,10 @@ namespace System.Text.RegularExpressions
         /// for an array of capture slots. Instead of doing the hash
         /// at match time, it's done at compile time, here.
         /// </summary>
-        private int MapCapnum(int capnum)
-        {
-            if (capnum == -1)
-                return -1;
-
-            if (_caps != null)
-                return (int)_caps[capnum]!;
-            else
-                return capnum;
-        }
+        private int MapCapnum(int capnum) =>
+            capnum == -1 ? -1 :
+            _caps != null ? (int)_caps[capnum]! :
+            capnum;
 
         /// <summary>
         /// The main RegexCode generator. It does a depth-first walk
@@ -267,15 +275,14 @@ namespace System.Text.RegularExpressions
                     {
                         if (curIndex < node.ChildCount() - 1)
                         {
-                            int LBPos = _intStack.Pop();
+                            int lazyBranchPos = _intStack.Pop();
                             _intStack.Append(_emitted.Length);
                             Emit(RegexCode.Goto, 0);
-                            PatchJump(LBPos, _emitted.Length);
+                            PatchJump(lazyBranchPos, _emitted.Length);
                         }
                         else
                         {
-                            int I;
-                            for (I = 0; I < curIndex; I++)
+                            for (int i = 0; i < curIndex; i++)
                             {
                                 PatchJump(_intStack.Pop(), _emitted.Length);
                             }
@@ -307,7 +314,10 @@ namespace System.Text.RegularExpressions
                                 PatchJump(Branchpos, _emitted.Length);
                                 Emit(RegexCode.Forejump);
                                 if (node.ChildCount() > 1)
+                                {
                                     break;
+                                }
+
                                 // else fallthrough
                                 goto case 1;
                             }
@@ -399,21 +409,13 @@ namespace System.Text.RegularExpressions
                     break;
 
                 case RegexNode.Require | BeforeChild:
-                    // NOTE: the following line causes lookahead/lookbehind to be
-                    // NON-BACKTRACKING. It can be commented out with (*)
-                    Emit(RegexCode.Setjump);
-
-
+                    Emit(RegexCode.Setjump); // causes lookahead/lookbehind to be non-backtracking
                     Emit(RegexCode.Setmark);
                     break;
 
                 case RegexNode.Require | AfterChild:
                     Emit(RegexCode.Getmark);
-
-                    // NOTE: the following line causes lookahead/lookbehind to be
-                    // NON-BACKTRACKING. It can be commented out with (*)
-                    Emit(RegexCode.Forejump);
-
+                    Emit(RegexCode.Forejump); // causes lookahead/lookbehind to be non-backtracking
                     break;
 
                 case RegexNode.Prevent | BeforeChild:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -135,7 +135,7 @@ namespace System.Text.RegularExpressions
             CultureInfo culture = (tree.Options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
 
             RegexBoyerMoore? bmPrefix = null;
-            if (prefix.Prefix.Length > 1) // if it's == 1, we're better off using fcPrefix
+            if (prefix.Prefix.Length > 1 && prefix.Prefix.Length <= RegexBoyerMoore.MaxLimit) // if it's <= 1 || > MaxLimit, perf is better using fcPrefix
             {
                 bmPrefix = new RegexBoyerMoore(prefix.Prefix, prefix.CaseInsensitive, rtl, culture);
             }


### PR DESCRIPTION
Rather than branching for each value, we can get the value from a lookup table.

As part of this I set a maximum length of the prefix for which we use Boyer-Moore at 50K characters, as without the change trying with very large inputs takes a very long time to construct the Boyer-Moore tables (our test runner timed out when I tried 65K) and with the change having a limit <= char.MaxValue simplifies things, but I hope no one ever comes close to having anywhere near that long a prefix in their regex.

This doesn't really move any throughput needles, but it makes the generated code smaller, and it does lead to less branching.

cc: @danmosemsft, @eerhardt, @pgovind, @ViktorHofer 