### PR TITLE
Reduce execution time of RegexCharacterSetTests

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Tests;
@@ -337,44 +336,54 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Match_Basic_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
         public void Match(string pattern, string input, RegexOptions options, int beginning, int length, bool expectedSuccess, string expectedValue)
         {
+            Regex r;
+
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, beginning);
             bool isDefaultCount = RegexHelpers.IsDefaultCount(input, options, length);
+
             if (options == RegexOptions.None)
             {
+                r = new Regex(pattern);
+
                 if (isDefaultStart && isDefaultCount)
                 {
                     // Use Match(string) or Match(string, string)
-                    VerifyMatch(new Regex(pattern).Match(input), expectedSuccess, expectedValue);
+                    VerifyMatch(r.Match(input), expectedSuccess, expectedValue);
                     VerifyMatch(Regex.Match(input, pattern), expectedSuccess, expectedValue);
 
-                    Assert.Equal(expectedSuccess, new Regex(pattern).IsMatch(input));
+                    Assert.Equal(expectedSuccess, r.IsMatch(input));
                     Assert.Equal(expectedSuccess, Regex.IsMatch(input, pattern));
                 }
                 if (beginning + length == input.Length)
                 {
                     // Use Match(string, int)
-                    VerifyMatch(new Regex(pattern).Match(input, beginning), expectedSuccess, expectedValue);
+                    VerifyMatch(r.Match(input, beginning), expectedSuccess, expectedValue);
 
-                    Assert.Equal(expectedSuccess, new Regex(pattern).IsMatch(input, beginning));
+                    Assert.Equal(expectedSuccess, r.IsMatch(input, beginning));
                 }
                 // Use Match(string, int, int)
-                VerifyMatch(new Regex(pattern).Match(input, beginning, length), expectedSuccess, expectedValue);
+                VerifyMatch(r.Match(input, beginning, length), expectedSuccess, expectedValue);
             }
+
+            r = new Regex(pattern, options);
+
             if (isDefaultStart && isDefaultCount)
             {
                 // Use Match(string) or Match(string, string, RegexOptions)
-                VerifyMatch(new Regex(pattern, options).Match(input), expectedSuccess, expectedValue);
+                VerifyMatch(r.Match(input), expectedSuccess, expectedValue);
                 VerifyMatch(Regex.Match(input, pattern, options), expectedSuccess, expectedValue);
 
                 Assert.Equal(expectedSuccess, Regex.IsMatch(input, pattern, options));
             }
+
             if (beginning + length == input.Length && (options & RegexOptions.RightToLeft) == 0)
             {
                 // Use Match(string, int)
-                VerifyMatch(new Regex(pattern, options).Match(input, beginning), expectedSuccess, expectedValue);
+                VerifyMatch(r.Match(input, beginning), expectedSuccess, expectedValue);
             }
+
             // Use Match(string, int, int)
-            VerifyMatch(new Regex(pattern, options).Match(input, beginning, length), expectedSuccess, expectedValue);
+            VerifyMatch(r.Match(input, beginning, length), expectedSuccess, expectedValue);
         }
 
         [Theory]
@@ -456,6 +465,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [OuterLoop("Can take several seconds")]
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(@"a\s+", RegexOptions.None)]
         [InlineData(@"a\s+", RegexOptions.Compiled)]
@@ -469,6 +479,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [OuterLoop("Can take several seconds")]
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
@@ -763,49 +774,60 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Match_Advanced_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
         public void Match(string pattern, string input, RegexOptions options, int beginning, int length, CaptureData[] expected)
         {
+            Regex r;
+
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, beginning);
             bool isDefaultCount = RegexHelpers.IsDefaultStart(input, options, length);
+
             if (options == RegexOptions.None)
             {
+                r = new Regex(pattern);
+
                 if (isDefaultStart && isDefaultCount)
                 {
                     // Use Match(string) or Match(string, string)
-                    VerifyMatch(new Regex(pattern).Match(input), true, expected);
+                    VerifyMatch(r.Match(input), true, expected);
                     VerifyMatch(Regex.Match(input, pattern), true, expected);
 
-                    Assert.True(new Regex(pattern).IsMatch(input));
+                    Assert.True(r.IsMatch(input));
                     Assert.True(Regex.IsMatch(input, pattern));
                 }
+
                 if (beginning + length == input.Length)
                 {
                     // Use Match(string, int)
-                    VerifyMatch(new Regex(pattern).Match(input, beginning), true, expected);
+                    VerifyMatch(r.Match(input, beginning), true, expected);
 
-                    Assert.True(new Regex(pattern).IsMatch(input, beginning));
+                    Assert.True(r.IsMatch(input, beginning));
                 }
                 else
                 {
                     // Use Match(string, int, int)
-                    VerifyMatch(new Regex(pattern).Match(input, beginning, length), true, expected);
+                    VerifyMatch(r.Match(input, beginning, length), true, expected);
                 }
             }
+
+            r = new Regex(pattern, options);
+
             if (isDefaultStart && isDefaultCount)
             {
                 // Use Match(string) or Match(string, string, RegexOptions)
-                VerifyMatch(new Regex(pattern, options).Match(input), true, expected);
+                VerifyMatch(r.Match(input), true, expected);
                 VerifyMatch(Regex.Match(input, pattern, options), true, expected);
 
                 Assert.True(Regex.IsMatch(input, pattern, options));
             }
+
             if (beginning + length == input.Length)
             {
                 // Use Match(string, int)
-                VerifyMatch(new Regex(pattern, options).Match(input, beginning), true, expected);
+                VerifyMatch(r.Match(input, beginning), true, expected);
             }
+
             if ((options & RegexOptions.RightToLeft) == 0)
             {
                 // Use Match(string, int, int)
-                VerifyMatch(new Regex(pattern, options).Match(input, beginning, length), true, expected);
+                VerifyMatch(r.Match(input, beginning, length), true, expected);
             }
         }
 
@@ -901,14 +923,16 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Match_Invalid()
         {
+            var r = new Regex("pattern");
+
             // Input is null
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern"));
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern", RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null, 0));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null, 0, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => r.Match(null));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => r.Match(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => r.Match(null, 0, 0));
 
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null));
@@ -916,26 +940,28 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Start is invalid
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", -1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", 6));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", 6, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.Match("input", -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.Match("input", -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.Match("input", 6));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.Match("input", 6, 0));
 
             // Length is invalid
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new Regex("pattern").Match("input", 0, -1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new Regex("pattern").Match("input", 0, 6));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => r.Match("input", 0, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => r.Match("input", 0, 6));
         }
 
         [Fact]
         public void IsMatch_Invalid()
         {
+            var r = new Regex("pattern");
+
             // Input is null
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.IsMatch(null, "pattern"));
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.IsMatch(null, "pattern", RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.IsMatch(null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").IsMatch(null));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").IsMatch(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => r.IsMatch(null));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => r.IsMatch(null, 0));
 
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null));
@@ -943,8 +969,8 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Start is invalid
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").IsMatch("input", -1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").IsMatch("input", 6));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.IsMatch("input", -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => r.IsMatch("input", 6));
         }
 
         [Fact]


### PR DESCRIPTION
I recently wrote a large, exhaustive set of tests to validate our handling of regex character sets.  Unfortunately it ends up being too much for our CI system.  We were validating ~440 different character sets, for both RegexOptions.None and RegexOptions.Compiled, and for each validating all 65,536 character inputs... that's ~58M regex matches.  In most cases locally it was taking around 15s, but on a loaded, underwhelming CI machine, it was taking minutes in some cases, and then getting killed by timeouts.

I've reduced the load (primarily by only validating the specified characters that should be included or excluded in cases where we're already testing both the positive and negative variants of the same set), while trying to keep a reasonable semblence of the coverage.

I also made it outerloop, and moved a few other longer-running regex tests to outerloop as well.  Locally on my machine innerloop regex tests drop from ~17s to ~3s.

Fixes (hopefully) https://github.com/dotnet/runtime/issues/2153
cc: @jaredpar, @danmosemsft, @ViktorHofer, @akoeplinger 