### PR TITLE
CPU utilization computation fixes

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSourceHelper.Unix.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSourceHelper.Unix.cs
@@ -8,11 +8,9 @@ namespace System.Diagnostics.Tracing
 {
     internal static class RuntimeEventSourceHelper
     {
-        private static Interop.Sys.ProcessCpuInformation cpuInfo;
+        private static Interop.Sys.ProcessCpuInformation s_cpuInfo;
 
-        internal static int GetCpuUsage()
-        {
-            return Interop.Sys.GetCpuUtilization(ref cpuInfo);
-        }
+        internal static int GetCpuUsage() =>
+            Interop.Sys.GetCpuUtilization(ref s_cpuInfo) / Environment.ProcessorCount;
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSourceHelper.Windows.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSourceHelper.Windows.cs
@@ -6,10 +6,10 @@ namespace System.Diagnostics.Tracing
 {
     internal static class RuntimeEventSourceHelper
     {
-        private static long prevProcUserTime = 0;
-        private static long prevProcKernelTime = 0;
-        private static long prevSystemUserTime = 0;
-        private static long prevSystemKernelTime = 0;
+        private static long s_prevProcUserTime = 0;
+        private static long s_prevProcKernelTime = 0;
+        private static long s_prevSystemUserTime = 0;
+        private static long s_prevSystemKernelTime = 0;
 
         internal static int GetCpuUsage()
         {
@@ -27,21 +27,21 @@ namespace System.Diagnostics.Tracing
                 return 0;
             }
 
-            if (prevSystemUserTime == 0 && prevSystemKernelTime == 0) // These may be 0 when we report CPU usage for the first time, in which case we should just return 0.
+            if (s_prevSystemUserTime == 0 && s_prevSystemKernelTime == 0) // These may be 0 when we report CPU usage for the first time, in which case we should just return 0.
             {
                 cpuUsage = 0;
             }
             else
             {
-                long totalProcTime = (procUserTime - prevProcUserTime) + (procKernelTime - prevProcKernelTime);
-                long totalSystemTime = (systemUserTime - prevSystemUserTime) + (systemKernelTime - prevSystemKernelTime);
+                long totalProcTime = (procUserTime - s_prevProcUserTime) + (procKernelTime - s_prevProcKernelTime);
+                long totalSystemTime = (systemUserTime - s_prevSystemUserTime) + (systemKernelTime - s_prevSystemKernelTime);
                 cpuUsage = (int)(totalProcTime * 100 / totalSystemTime);
             }
 
-            prevProcUserTime = procUserTime;
-            prevProcKernelTime = procKernelTime;
-            prevSystemUserTime = systemUserTime;
-            prevSystemKernelTime = systemKernelTime;
+            s_prevProcUserTime = procUserTime;
+            s_prevProcKernelTime = procKernelTime;
+            s_prevSystemUserTime = systemUserTime;
+            s_prevSystemKernelTime = systemKernelTime;
 
             return cpuUsage;
         }

--- a/src/libraries/Native/Unix/System.Native/pal_time.h
+++ b/src/libraries/Native/Unix/System.Native/pal_time.h
@@ -43,6 +43,8 @@ DLLEXPORT uint64_t SystemNative_GetTimestamp(void);
  * for the CLR thread pool to regulate the number of worker threads.
  * Since there is no consistent API on Unix to get the CPU utilization
  * from a user process, getrusage and gettimeofday are used to
- * compute the current process's CPU utilization instead.
+ * compute the current process's CPU utilization instead. The CPU utilization
+ * returned is sum of utilization accross all processors, e.g. this function will
+ * return 200 when two cores are running at 100%.
  */
 DLLEXPORT int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.CpuUtilizationReader.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.CpuUtilizationReader.Unix.cs
@@ -11,7 +11,7 @@ namespace System.Threading
             private Interop.Sys.ProcessCpuInformation _cpuInfo;
 
             public int CurrentUtilization =>
-                Interop.Sys.GetCpuUtilization(ref cpuInfo) / Environment.ProcessorCount;
+                Interop.Sys.GetCpuUtilization(ref _cpuInfo) / Environment.ProcessorCount;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.CpuUtilizationReader.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.CpuUtilizationReader.Unix.cs
@@ -6,11 +6,12 @@ namespace System.Threading
 {
     internal partial class PortableThreadPool
     {
-        private class CpuUtilizationReader
+        private struct CpuUtilizationReader
         {
             private Interop.Sys.ProcessCpuInformation _cpuInfo;
 
-            public int CurrentUtilization => Interop.Sys.GetCpuUtilization(ref _cpuInfo); // Updates cpuInfo as a side effect for the next call
+            public int CurrentUtilization =>
+                Interop.Sys.GetCpuUtilization(ref cpuInfo) / Environment.ProcessorCount;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -20,7 +20,7 @@ namespace System.Threading
 
             private static LowLevelLock s_createdLock = new LowLevelLock();
 
-            private static readonly CpuUtilizationReader s_cpu = new CpuUtilizationReader();
+            private static CpuUtilizationReader s_cpu = new CpuUtilizationReader();
             private const int MaxRuns = 2;
 
             // TODO: CoreCLR: Worker Tracking in CoreCLR? (Config name: ThreadPool_EnableWorkerTracking)


### PR DESCRIPTION
- On Unix, move scalling for total number of processors from PAL to managed side, so that it can use container limit aware ProcessorCount
- Delete asserts for CPU utilization being between 0 and 100. These asserts can fail due to races or rounding errors.
- Converted a few classes to structs

Fixes #2195