### PR TITLE
JIT: emit gc updates from RRR instruction forms

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -3428,7 +3428,8 @@ bool Compiler::compStressCompile(compStressArea stressArea, unsigned weight)
     // Should we allow unlimited stress ?
     if (stressArea > STRESS_COUNT_VARN && stressLevel == 2)
     {
-        return true;
+        doStress = true;
+        goto _done;
     }
 
     if (weight == MAX_STRESS_WEIGHT)

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -11575,6 +11575,21 @@ BYTE* emitter::emitOutputRRR(BYTE* dst, instrDesc* id)
 
     noway_assert(!id->idGCref());
 
+    if (!emitInsCanOnlyWriteSSE2OrAVXReg(id))
+    {
+        switch (id->idInsFmt())
+        {
+            case IF_RWR_RRD_RRD:
+            case IF_RWR_RRD_RRD_CNS:
+            case IF_RWR_RRD_RRD_RRD:
+                emitGCregDeadUpd(id->idReg1(), dst);
+                break;
+
+            default:
+                break;
+        }
+    }
+
     return dst;
 }
 


### PR DESCRIPTION
These do not produce GC refs, so make sure we end any GC liveness for the
destination register.

Also, make sure all gc stress modes announce themselves in the jit dump log.

Fixes #2186.