### PR TITLE
Use HashCode.Add rather than HashCode.Combine

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -375,14 +375,14 @@ namespace System
             if (comparer == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparer);
 
-            int ret = 0;
+            HashCode hashCode = default;
 
             for (int i = (this.Length >= 8 ? this.Length - 8 : 0); i < this.Length; i++)
             {
-                ret = HashCode.Combine(ret, comparer.GetHashCode(GetValue(i)!));
+                hashCode.Add(comparer.GetHashCode(GetValue(i)!));
             }
 
-            return ret;
+            return hashCode.ToHashCode();
         }
 
         // Searches an array for a given element using a binary search algorithm.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
@@ -155,14 +155,14 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
-            int hashCode = 0;
+            HashCode hashCode = default;
 
             for (int i = 0; i < Count; i++)
             {
-                hashCode = HashCode.Combine(hashCode, this.GetElement(i).GetHashCode());
+                hashCode.Add(this.GetElement(i).GetHashCode());
             }
 
-            return hashCode;
+            return hashCode.ToHashCode();
         }
 
         /// <summary>Converts the current instance to an equivalent string representation.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
@@ -156,14 +156,14 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
-            int hashCode = 0;
+            HashCode hashCode = default;
 
             for (int i = 0; i < Count; i++)
             {
-                hashCode = HashCode.Combine(hashCode, this.GetElement(i).GetHashCode());
+                hashCode.Add(this.GetElement(i).GetHashCode());
             }
 
-            return hashCode;
+            return hashCode.ToHashCode();
         }
 
         /// <summary>Converts the current instance to an equivalent string representation.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -109,14 +109,14 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
-            int hashCode = 0;
+            HashCode hashCode = default;
 
             for (int i = 0; i < Count; i++)
             {
-                hashCode = HashCode.Combine(hashCode, this.GetElement(i).GetHashCode());
+                hashCode.Add(this.GetElement(i).GetHashCode());
             }
 
-            return hashCode;
+            return hashCode.ToHashCode();
         }
 
         /// <summary>Converts the current instance to an equivalent string representation.</summary>


### PR DESCRIPTION
Updates some places in the source to use `HashCode.Add` instead of `HashCode.Combine`. While not only being cleaner, there is also a slight performance benefit:

<details>
<summary>Vector256</summary>

```cs
public class VectorHash
{
    Vector256<byte> Vector;

    [GlobalSetup]
    public unsafe void Setup()
    {
        var data = stackalloc byte[Vector256<byte>.Count];

        for (int i = 0; i < Vector256<byte>.Count; i++)
            data[i] = (byte) (i + 1);

        Vector = Avx.LoadVector256(data);
    }

    [Benchmark]
    public unsafe int Combine()
    {
        var vec = Vector;
        int hashCode = 0;

        for (int i = 0; i < Vector256<byte>.Count; i++)
        {
            hashCode = HashCode.Combine(hashCode, vec.GetElement(i).GetHashCode());
        }

        return hashCode;
    }

    [Benchmark]
    public unsafe int Add()
    {
        var vec = Vector;
        var hashcode = new HashCode();

        for (int i = 0; i < Vector256<byte>.Count; i++)
        {
            hashcode.Add(vec.GetElement(i));
        }

        return hashcode.ToHashCode();

    }
}
```

</details>

|  Method |     Mean |   Error |  StdDev |
|-------- |---------:|--------:|--------:|
| Combine | 250.9 ns | 4.85 ns | 6.30 ns |
|     Add | 181.0 ns | 3.64 ns | 4.19 ns |


<details>
<summary>Array</summary>

```cs
public class ArrayHash
{
    Point[] data;

    [GlobalSetup]
    public unsafe void Setup()
    {
        data = new Point[]
        {
            new Point(25, 34),
            new Point(74, 67),
            new Point(35, 43),
            new Point(74, 47),
            new Point(33, 43),
            new Point(54, 12),
            new Point(63, 87),
            new Point(60, 92),
            new Point(96, 34),
            new Point(87, 61),
            new Point(45, 66),
            new Point(14, 52),
            new Point(97, 45),
            new Point(91, 77),
            new Point(32, 51),
            new Point(86, 89),
            new Point(80, 77),
            new Point(79, 94),
            new Point(23, 11),
            new Point(46, 90),
        };
    }

    [Benchmark]
    public unsafe int Combine()
    {
        int hashCode = 0;

        for (int i = 0; i < data.Length; i++)
        {
            hashCode = HashCode.Combine(hashCode, data[i].GetHashCode());
        }

        return hashCode;
    }

    [Benchmark]
    public unsafe int Add()
    {
        var hashcode = new HashCode();

        for (int i = 0; i < data.Length; i++)
        {
            hashcode.Add(data[i].GetHashCode());
        }

        return hashcode.ToHashCode();
    }
}
```

</details>

|  Method |     Mean |   Error |  StdDev |
|-------- |---------:|--------:|--------:|
| Combine | 148.2 ns | 2.84 ns | 2.65 ns |
|     Add | 117.0 ns | 0.55 ns | 0.46 ns |