### PR TITLE
[mono-corelib] Throw exception on an invalid use of short form opcode…

### DIFF
--- a/src/mono/netcore/CoreFX.issues.rsp
+++ b/src/mono/netcore/CoreFX.issues.rsp
@@ -183,7 +183,6 @@
 -noclass System.Reflection.Emit.Tests.CustomAttributeBuilderTests
 -nomethod System.Reflection.Emit.Tests.SignatureHelperAddArgument.*
 -nomethod System.Reflection.Emit.Tests.SignatureHelperGetPropertySigHelper.*
--nomethod System.Reflection.Emit.Tests.ILGeneratorEmit3.Emit_OpCodes_LocalBuilder_TooManyLocals_ThrowsInvalidOperationException
 -nomethod System.Reflection.Emit.Tests.ILGeneratorEmit3.Emit_OpCodes_LocalBuilder_LocalFromDifferentMethod_ThrowsArgumentException
 -nomethod System.Reflection.Emit.Tests.ILGeneratorDeclareLocal.DeclareLocal_TypeCreated_ThrowsInvalidOperationException
 -nomethod System.Reflection.Emit.Tests.ILGeneratorDeclareLocal.DeclareLocal_GlobalFunctionsCreated_ThrowsInvalidOperationException

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.Mono.cs
@@ -645,6 +645,9 @@ namespace System.Reflection.Emit {
 				throw new ArgumentException ("Trying to emit a local from a different ILGenerator.");
 
 			uint pos = local.position;
+			if ((opcode == OpCodes.Ldloca_S || opcode == OpCodes.Ldloc_S || opcode == OpCodes.Stloc_S) && pos > 255)
+				throw new InvalidOperationException ("Opcodes using a short-form index cannot address a local position over 255.");
+
 			bool load_addr = false;
 			bool is_store = false;
 			bool is_load = false;


### PR DESCRIPTION
…s for locals.