### PR TITLE
Fix concurrency issues in the regression test b426654

### DIFF
--- a/src/coreclr/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
+++ b/src/coreclr/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
@@ -30,7 +30,7 @@
   .field static assembly int32 s_Zero
   .field static assembly int32 s_i
   .field private static class cs1 s_obj
-  .field private static bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) s_timeUp
+  .field private static bool s_timeUp
   .field private object m_obj
   .field private object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) m_objVolatile
   .field private object[] m_objs
@@ -123,7 +123,7 @@
     IL_006b:  xor
     IL_006c:  stloc.0
     IL_006d:  volatile.
-              ldsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
+              ldsfld     bool cs1::s_timeUp
     IL_0072:  ldc.i4.0
     IL_0073:  ceq
     IL_0075:  stloc.2
@@ -187,7 +187,7 @@
 
     IL_0050:  stloc.0
     IL_0051:  volatile.
-              ldsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
+              ldsfld     bool cs1::s_timeUp
     IL_0056:  ldc.i4.0
     IL_0057:  ceq
     IL_0059:  stloc.2
@@ -203,7 +203,7 @@
     IL_0000:  nop
     IL_0001:  ldc.i4.1
     IL_0002:  volatile.
-              stsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
+              stsfld     bool cs1::s_timeUp
     IL_0007:  ret
   }
 
@@ -285,7 +285,8 @@
     IL_000c:  newobj     instance void cs1::.ctor()
     IL_0011:  stsfld     class cs1 cs1::s_obj
     IL_0016:  ldc.i4.0
-    IL_0017:  stsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
+    IL_0017:  volatile.
+              stsfld     bool cs1::s_timeUp
     IL_001c:  ret
   }
 

--- a/src/coreclr/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
+++ b/src/coreclr/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
@@ -30,7 +30,7 @@
   .field static assembly int32 s_Zero
   .field static assembly int32 s_i
   .field private static class cs1 s_obj
-  .field private static bool s_timeUp
+  .field private static bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) s_timeUp
   .field private object m_obj
   .field private object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) m_objVolatile
   .field private object[] m_objs
@@ -120,9 +120,10 @@
     IL_0068:  nop
     IL_0069:  ldloc.0
     IL_006a:  ldc.i4.1
-    IL_006b:  add
+    IL_006b:  xor
     IL_006c:  stloc.0
-    IL_006d:  ldsfld     bool cs1::s_timeUp
+    IL_006d:  volatile.
+              ldsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
     IL_0072:  ldc.i4.0
     IL_0073:  ceq
     IL_0075:  stloc.2
@@ -180,12 +181,13 @@
     IL_004c:  nop
     IL_004d:  ldloc.0
     IL_004e:  ldc.i4.1
-    IL_004f:  add
+    IL_004f:  xor
 
 
 
     IL_0050:  stloc.0
-    IL_0051:  ldsfld     bool cs1::s_timeUp
+    IL_0051:  volatile.
+              ldsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
     IL_0056:  ldc.i4.0
     IL_0057:  ceq
     IL_0059:  stloc.2
@@ -200,7 +202,8 @@
     .maxstack  8
     IL_0000:  nop
     IL_0001:  ldc.i4.1
-    IL_0002:  stsfld     bool cs1::s_timeUp
+    IL_0002:  volatile.
+              stsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
     IL_0007:  ret
   }
 
@@ -246,7 +249,7 @@
     IL_0035:  newobj     instance void [mscorlib]System.Threading.TimerCallback::.ctor(object,
                                                                                        native int)
     IL_003a:  ldnull
-    IL_003b:  ldc.i4     0x2710
+    IL_003b:  ldc.i4     0x1388
     IL_0040:  ldc.i4.m1
     IL_0041:  newobj     instance void [mscorlib]System.Threading.Timer::.ctor(class [mscorlib]System.Threading.TimerCallback,
                                                                                object,
@@ -264,6 +267,9 @@
     IL_004e:  ldstr      "Test SUCCESS"
     IL_0053:  call       void [System.Console]System.Console::WriteLine(string)
 
+    ldloc.2
+    callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+
     ldc.i4 100
     IL_0059:  ret
   }
@@ -279,7 +285,7 @@
     IL_000c:  newobj     instance void cs1::.ctor()
     IL_0011:  stsfld     class cs1 cs1::s_obj
     IL_0016:  ldc.i4.0
-    IL_0017:  stsfld     bool cs1::s_timeUp
+    IL_0017:  stsfld     bool modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::s_timeUp
     IL_001c:  ret
   }
 


### PR DESCRIPTION
After fixing the interruptible ranges by aligning intrinsics
inlined by Crossgen1 / 2 I have verified that the concurrency and
rooting fixes suggested by Kount finally fix the Crossgen2 build
of the test. I have made the following changes:

1) I have shortened the test to 5 seconds and I changed the add
instruction to xor so that the test cannot randomly start
overflowing again on some future faster HW.

2) I have changed the synchronization static s_timeUp to a volatile.
This probably doesn't matter on Intel but will most likely matter
a lot on ARM.

3) I have added a call to Dispose for the timeout timer to make
sure it remains rooted for the duration of the test.

Thanks

Tomas