### PR TITLE
Updated composite R2R format doc

### DIFF
--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -29,7 +29,7 @@ in the COFF header represent a full copy of the input IL and MSIL metadata it wa
 **Composite R2R files** currently conform to Windows PE executable file format as the
 native envelope. Moving forward we plan to gradually add support for platform-native
 executable formats (ELF on Linux, MachO on OSX) as the native envelopes. As a natural corollary
-There is no global CLI / COR header in the file. The ReadyToRun header structure is pointed to
+there is no global CLI / COR header in the file. The ReadyToRun header structure is pointed to
 by the well-known export symbol `RTR_HEADER` and has the `READYTORUN_FLAG_COMPOSITE` flag set.
 
 Input MSIL metadata and IL streams can be either embedded in the composite R2R file or left
@@ -113,7 +113,7 @@ struct READYTORUN_CORE_HEADER
 | READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE | 0x00000001 | Set if the original IL image was platform neutral. The platform neutrality is part of assembly name. This flag can be used to reconstruct the full original assembly name.
 | READYTORUN_FLAG_COMPOSITE               | 0x00000002 | The image represents a composite R2R file resulting from a combined compilation of a larger number of input MSIL assemblies.
 | READYTORUN_FLAG_EMBEDDED_MSIL           | 0x00000004 | Input MSIL is embedded in the R2R image.
-| READYTORUN_FLAG_COMPONENT               | 0x00000008 | This is 
+| READYTORUN_FLAG_COMPONENT               | 0x00000008 | This is a component assembly of a composite R2R image
 
 ## READYTORUN_SECTION
 
@@ -463,7 +463,7 @@ properly look up methods stored in this section in the composite R2R case.
 
 Manifest metadata is an [ECMA-335] metadata blob containing extra reference assemblies within
 the version bubble introduced by inlining on top of assembly references stored in the input MSIL.
-As of R2R version 3.1, the metadata is only searched for the AssemblyRef table. This is used to
+As of R2R version 3.1, the metadata is only used for the AssemblyRef table. This is used to
 translate module override indices in signatures to the actual reference modules (using either
 the `READYTORUN_FIXUP_ModuleOverride` bit flag on the signature fixup byte or the
 `ELEMENT_TYPE_MODULE_ZAPSIG` COR element type).
@@ -486,10 +486,9 @@ The module override index translation algorithm is as follows (**ILAR** = *the n
 
 **TODO**: document attribute presence encoding
 
-**Note**: We already know this table uses assembly-relative token encoding so it has similar
-characteristics like `READYTORUN_SECTION_AVAILABLE_TYPES` or `READYTORUN_SECTION_METHOD_ENTRYPOINTS`.
-No matter what component assembly-relative encoding we end up choosing for these tables, we
-should use the same encoding for ATTRIBUTEPRESENCE.
+**Note:** This is a per-assembly section. In single-file R2R files, it is pointed to directly by the
+main R2R header; in composite R2R files, each component module has its own attribute presence
+section pointed to by the `READYTORUN_SECTION_ASSEMBLIES_ENTRY` core header structure.
 
 ## READYTORUN_SECTION_INLINING_INFO2
 

--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -517,9 +517,8 @@ equivalent AssemblyRef indices. Just like in the AssemblyRef ECMA 335 table, the
 ```C++
 struct READYTORUN_SECTION_ASSEMBLIES_ENTRY
 {
-    IMAGE_DATA_DIRECTORY CorHeader;         // Input MSIL metadata COR header
-    IMAGE_DATA_DIRECTORY AvailableTypes;    // Available types table
-    IMAGE_DATA_DIRECTORY MethodEntrypoints; // Method entrypoint table
+    IMAGE_DATA_DIRECTORY CorHeader;        // Input MSIL metadata COR header (for composite R2R images with embedded MSIL metadata)
+    IMAGE_DATA_DIRECTORY ReadyToRunHeader; // READYTORUN_CORE_HEADER of the assembly in question
 };
 ```
 

--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -4,22 +4,15 @@ ReadyToRun File Format
 Revisions:
 * 1.1 - [Jan Kotas](https://github.com/jkotas) - 2015
 * 3.1 - [Tomas Rylek](https://github.com/trylek) - 2019
-* 3.2 - [Tomas Rylek](https://github.com/trylek) - 2020
+* 4.1 - [Tomas Rylek](https://github.com/trylek) - 2020
 
 # Introduction
 
 This document describes ReadyToRun format 3.1 implemented in CoreCLR as of June 2019 and not yet
-implemented proposed extensions 3.2 for the support of composite R2R file format. 
+implemented proposed extensions 4.1 for the support of composite R2R file format. 
 **Composite R2R file format** has basically the same structure as the traditional R2R file format
 defined in earlier revisions except that the output file represents a larger number of input MSIL
 assemblies compiled together as a logical unit.
-
-**Note**: The addition of the new composite R2R file format flavor doesn't require bumping up the
-major ReadyToRun format version number. This is because, according to the format definition, the
-composite R2R file format doesn't technically conform to the single-input R2R supported by older
-versions of CoreCLR so there's no risk of *"the old loader"* messing up by incorrectly trying to
-run *"the new file"*. The only downside is that the *"new composite R2R file"* won't run with the
-*"old loader"* and thus it will somewhat violate the design principle that R2R is a mere code cache.
 
 # PE Headers and CLI Headers
 
@@ -33,9 +26,11 @@ with the following customizations:
 The COR header and ECMA 335 metadata pointed to by the COM descriptor data directory item
 in the COFF header represent a full copy of the input IL and MSIL metadata it was generated from.
 
-For **Composite R2R files** there is no global CLI / COR header (as there are potentially
-multiple metadata blocks in the file). The ReadyToRun header structure is pointed to by the
-well-known export symbol `RTR_HEADER` and has the `READYTORUN_FLAG_COMPOSITE` flag set.
+**Composite R2R files** currently conform to Windows PE executable file format as the
+native envelope. Moving forward we plan to gradually add support for platform-native
+executable formats (ELF on Linux, MachO on OSX) as the native envelopes. As a natural corollary
+There is no global CLI / COR header in the file. The ReadyToRun header structure is pointed to
+by the well-known export symbol `RTR_HEADER` and has the `READYTORUN_FLAG_COMPOSITE` flag set.
 
 Input MSIL metadata and IL streams can be either embedded in the composite R2R file or left
 as separate files on disk. In case of embedded MSIL, the "actual" metadata for the individual
@@ -56,7 +51,19 @@ The limitations of the current format are:
 
 # Structures
 
-The structures and accompanying constants are defined in the [readytorun.h](https://github.com/dotnet/runtime/blob/master/src/coreclr/src/inc/readytorun.h) header file.
+The structures and accompanying constants are defined in the [readytorun.h]
+(https://github.com/dotnet/runtime/blob/master/src/coreclr/src/inc/readytorun.h) header file.
+Basically the entire R2R executable image is addressed through the READYTORUN_HEADER singleton
+pointed to by the well-known export RTR_HEADER in the export section of the native executable
+envelope.
+
+For single-file R2R executables, there's just one header representing all image sections.
+For composite and single exe, the global `READYTORUN_HEADER` includes a section of the type
+`READYTORUN_SECTION_ASSEMBLIES` representing the component assemblies comprising the composite
+R2R image. This table is parallel to (it used the same indexing as) the table
+`READYTORUN_MANIFEST_METADATA`. Each `READYTORUN_SECTION_ASSEMBLIES_ENTRY` record points
+to a `READYTORUN_CORE_HEADER` variable-length structure representing sections specific to the
+particular assembly.
 
 ## READYTORUN_HEADER
 
@@ -67,13 +74,8 @@ struct READYTORUN_HEADER
     USHORT                  MajorVersion;   // READYTORUN_VERSION_XXX
     USHORT                  MinorVersion;
 
-    DWORD                   Flags;          // READYTORUN_FLAG_XXX
-
-    DWORD                   NumberOfSections;
-
-    // Array of sections follows. The array entries are sorted by Type
-    // READYTORUN_SECTION   Sections[];
-};
+    READYTORUN_CORE_HEADER  CoreHeader;
+}
 ```
 
 ### READYTORUN_HEADER::Signature
@@ -90,13 +92,28 @@ MinorVersion increments are meant to compatible file format changes.
 successfully execute native code from images of version 2.9. The runtime should refuse to execute
 native code from image of version 3.0.
 
-### READYTORUN_HEADER::Flags
+## READYTORUN_CORE_HEADER
+
+```C++
+struct READYTORUN_CORE_HEADER
+{
+    DWORD                   Flags;          // READYTORUN_FLAG_XXX
+
+    DWORD                   NumberOfSections;
+
+    // Array of sections follows. The array entries are sorted by Type
+    // READYTORUN_SECTION   Sections[];
+};
+```
+
+### READYTORUN_CORE_HEADER::Flags
 
 | Flag                                    |      Value | Description
 |:----------------------------------------|-----------:|:-----------
 | READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE | 0x00000001 | Set if the original IL image was platform neutral. The platform neutrality is part of assembly name. This flag can be used to reconstruct the full original assembly name.
 | READYTORUN_FLAG_COMPOSITE               | 0x00000002 | The image represents a composite R2R file resulting from a combined compilation of a larger number of input MSIL assemblies.
 | READYTORUN_FLAG_EMBEDDED_MSIL           | 0x00000004 | Input MSIL is embedded in the R2R image.
+| READYTORUN_FLAG_COMPONENT               | 0x00000008 | This is 
 
 ## READYTORUN_SECTION
 
@@ -108,7 +125,7 @@ struct READYTORUN_SECTION
 };
 ```
 
-This ReadyToRun header is immediately followed by an array of `READYTORUN_SECTION` records
+The `READYTORUN_CORE_HEADER` structure is immediately followed by an array of `READYTORUN_SECTION` records
 representing the individual R2R sections. Number of elements in the array is `READYTORUN_HEADER::NumberOfSections`.
 Each record contains section type and its location within the binary. The array is sorted by section type
 to allow binary searching.
@@ -119,27 +136,24 @@ and execute the ready to run file.
 
 The following section types are defined and described later in this document:
 
-```C++
-enum ReadyToRunSectionType
-{
-    READYTORUN_SECTION_COMPILER_IDENTIFIER          = 100,
-    READYTORUN_SECTION_IMPORT_SECTIONS              = 101,
-    READYTORUN_SECTION_RUNTIME_FUNCTIONS            = 102,
-    READYTORUN_SECTION_METHODDEF_ENTRYPOINTS        = 103,
-    READYTORUN_SECTION_EXCEPTION_INFO               = 104,
-    READYTORUN_SECTION_DEBUG_INFO                   = 105,
-    READYTORUN_SECTION_DELAYLOAD_METHODCALL_THUNKS  = 106,
-    // 107 used by an older format of READYTORUN_SECTION_AVAILABLE_TYPES
-    READYTORUN_SECTION_AVAILABLE_TYPES              = 108,
-    READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS  = 109,
-    READYTORUN_SECTION_INLINING_INFO                = 110, // Added in V2.1
-    READYTORUN_SECTION_PROFILEDATA_INFO             = 111, // Added in V2.2
-    READYTORUN_SECTION_MANIFEST_METADATA            = 112, // Added in V2.3
-    READYTORUN_SECTION_ATTRIBUTEPRESENCE            = 113, // Added in V3.1
-    READYTORUN_SECTION_INLINING_INFO2               = 114, // Added in V4.1
-    READYTORUN_SECTION_ASSEMBLIES                   = 115, // Added in V3.2
-};
-```
+| ReadyToRunSectionType                          | Value | Scope (component assembly / entire image)
+|:-----------------------------------------------|------:|:-----------
+| READYTORUN_SECTION_COMPILER_IDENTIFIER         |   100 | Image
+| READYTORUN_SECTION_IMPORT_SECTIONS             |   101 | Image
+| READYTORUN_SECTION_RUNTIME_FUNCTIONS           |   102 | Image
+| READYTORUN_SECTION_METHODDEF_ENTRYPOINTS       |   103 | Assembly
+| READYTORUN_SECTION_EXCEPTION_INFO              |   104 | Assembly
+| READYTORUN_SECTION_DEBUG_INFO                  |   105 | Assembly
+| READYTORUN_SECTION_DELAYLOAD_METHODCALL_THUNKS |   106 | Assembly
+| ~~READYTORUN_SECTION_AVAILABLE_TYPES~~         |   107 | (obsolete - used by an older format)
+| READYTORUN_SECTION_AVAILABLE_TYPES             |   108 | Assembly
+| READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS |   109 | Image
+| READYTORUN_SECTION_INLINING_INFO               |   110 | Assembly (added in V2.1)
+| READYTORUN_SECTION_PROFILEDATA_INFO            |   111 | Image (added in V2.2)
+| READYTORUN_SECTION_MANIFEST_METADATA           |   112 | Image (added in V2.3)
+| READYTORUN_SECTION_ATTRIBUTEPRESENCE           |   113 | Assembly (added in V3.1)
+| READYTORUN_SECTION_INLINING_INFO2              |   114 | Image (added in V4.1)
+| READYTORUN_SECTION_ASSEMBLIES                  |   115 | Image (added in V4.1)
 
 ## READYTORUN_SECTION_COMPILER_IDENTIFIER
 
@@ -301,7 +315,8 @@ basic encoding, with extended encoding for large values).
 This section contains sorted array of `RUNTIME_FUNCTION` entries that describe all functions in the
 image with pointers to their unwind info. The standard Windows xdata/pdata format is used.
 ARM format is used for x86 to compensate for lack of x86 unwind info standard.
-The unwind info blob is immediately followed by GC info blob. The encoding slightly differs for amd64 which encodes an extra 4-byte representing the end RVA of the unwind info blob.
+The unwind info blob is immediately followed by GC info blob. The encoding slightly differs for amd64
+which encodes an extra 4-byte representing the end RVA of the unwind info blob.
 
 ### RUNTIME_FUNCTION (x86, arm, arm64, size = 8 bytes)
 
@@ -320,13 +335,13 @@ The unwind info blob is immediately followed by GC info blob. The encoding sligh
 
 ## READYTORUN_SECTION_METHODDEF_ENTRYPOINTS
 
-This section contains in native format sparse array (see 4 Native Format) that maps methoddef row to
-method entrypoint. Methoddef is used as index into the array. The element of the array is index of the
-method in `READYTORUN_SECTION_RUNTIME_FUNCTIONS`, followed by list of slots that needs to be
-filled before method can be executed executing.
+This section contains a native format sparse array (see 4 Native Format) that maps methoddef rows to
+method entrypoints. Methoddef is used as index into the array. The element of the array is index of the
+method in `READYTORUN_SECTION_RUNTIME_FUNCTIONS`, followed by list of slots that need to be
+filled before the method can start executing.
 
-The index of the method is shift left by 1 bit, with the low bit indicating whether the list of slots to fixup
-follows. The list of slots is encoded as follows (same encoding as used by NGen):
+The index of the method is left-shifted by 1 bit with the low bit indicating whether a list of slots
+to fix up follows. The list of slots is encoded as follows (same encoding as used by NGen):
 
 ```
 READYTORUN_IMPORT_SECTIONS absolute index
@@ -359,9 +374,9 @@ means that the i-th value is the sum of values [1..i].
 
 The list is terminated by a 0 (0 is not meaningful as valid delta).
 
-**Note:** This section is only present in single-file R2R files. In composite R2R files created
-by compiling multiple input MSIL assemblies, method entrypoints need to be split by assembly and
-are addressed through `READYTORUN_SECTION_ASSEMBLIES` section instead.
+**Note:** This is a per-assembly section. In single-file R2R files, it is pointed to directly by the
+main R2R header; in composite R2R files, each component module has its own entrypoint section pointed to
+by the `READYTORUN_SECTION_ASSEMBLIES_ENTRY` core header structure.
 
 ## READYTORUN_SECTION_EXCEPTION_INFO
 
@@ -418,9 +433,9 @@ This section contains a native hashtable of all defined & export types within th
 The version-resilient hashing algorithm used for hashing the type names is implemented in
 [vm/versionresilienthashcode.cpp](https://github.com/dotnet/runtime/blob/8c6b1314c95857b9e2f5c222a10f2f089ee02dfe/src/coreclr/src/vm/versionresilienthashcode.cpp#L75).
 
-**Note:** This section is only present in single-file R2R files. In composite R2R files created
-by compiling multiple input MSIL assemblies, the available types need to be split by assembly
-and are addressed through `READYTORUN_SECTION_ASSEMBLIES` section instead.
+**Note:** This is a per-assembly section. In single-file R2R files, it is pointed to directly by the
+main R2R header; in composite R2R files, each component module has its own available type section pointed to
+by the `READYTORUN_SECTION_ASSEMBLIES_ENTRY` core header structure.
 
 ## READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS
 
@@ -431,7 +446,7 @@ hash code calculation is implemented in
 the value, represented by the `EntryPointWithBlobVertex` class, stores the method index in the
 runtime function table, the fixups blob and a blob encoding the method signature.
 
-**Note:** In contrast to non-generic method entrypoints, this section is executable-wide for
+**Note:** In contrast to non-generic method entrypoints, this section is image-wide for
 composite R2R images. It represents all generics needed by all assemblies within the composite
 executable. As mentioned elsewhere in this document, CoreCLR runtime requires changes to
 properly look up methods stored in this section in the composite R2R case.
@@ -452,11 +467,6 @@ As of R2R version 3.1, the metadata is only searched for the AssemblyRef table. 
 translate module override indices in signatures to the actual reference modules (using either
 the `READYTORUN_FIXUP_ModuleOverride` bit flag on the signature fixup byte or the
 `ELEMENT_TYPE_MODULE_ZAPSIG` COR element type).
-
-**Disclaimer:** The manifest metadata is a new feature that hasn't shipped yet; it involves
-straightforward adaptation of a fragile nGen technology to ReadyToRun images as an expedite
-means for enabling new functionality (larger version bubble support). The precise details of
-this encoding are still work in progress and likely to further evolve.
 
 **Note:** It doesn't make sense to store references to assemblies external to the version bubble
 in the manifest metadata as there's no guarantee that their metadata token values remain
@@ -499,8 +509,8 @@ Foreign RIDs are only present if a fragile inlining was allowed at compile time.
 
 ## READYTORUN_SECTION_ASSEMBLIES (v4.1+)
 
-This section is only present in composite R2R files. It is a straight binary array of the
-entries `READYTORUN_SECTION_ASSEMBLIES_ENTRY` parallel to the indices in the manifest metadata
+This image-wide section is only present in the main R2R header of composite R2R files. It is an
+array of the entries `READYTORUN_SECTION_ASSEMBLIES_ENTRY` parallel to the indices in the manifest metadata
 AssemblyRef table in the sense that it's a linear table where the row indices correspond to the
 equivalent AssemblyRef indices. Just like in the AssemblyRef ECMA 335 table, the indexing is
 1-based (the first entry in the table corresponds to index 1).

--- a/docs/design/coreclr/botr/readytorun-format.md
+++ b/docs/design/coreclr/botr/readytorun-format.md
@@ -4,21 +4,42 @@ ReadyToRun File Format
 Revisions:
 * 1.1 - [Jan Kotas](https://github.com/jkotas) - 2015
 * 3.1 - [Tomas Rylek](https://github.com/trylek) - 2019
+* 3.2 - [Tomas Rylek](https://github.com/trylek) - 2020
 
 # Introduction
 
-This document describes ReadyToRun format implemented in CoreCLR as of June 2019.
+This document describes ReadyToRun format 3.1 implemented in CoreCLR as of June 2019 and not yet
+implemented proposed extensions 3.2 for the support of composite R2R file format. 
+**Composite R2R file format** has basically the same structure as the traditional R2R file format
+defined in earlier revisions except that the output file represents a larger number of input MSIL
+assemblies compiled together as a logical unit.
+
+**Note**: The addition of the new composite R2R file format flavor doesn't require bumping up the
+major ReadyToRun format version number. This is because, according to the format definition, the
+composite R2R file format doesn't technically conform to the single-input R2R supported by older
+versions of CoreCLR so there's no risk of *"the old loader"* messing up by incorrectly trying to
+run *"the new file"*. The only downside is that the *"new composite R2R file"* won't run with the
+*"old loader"* and thus it will somewhat violate the design principle that R2R is a mere code cache.
 
 # PE Headers and CLI Headers
 
-ReadyToRun images conform to CLI file format as described in ECMA-335, with the following
-customizations:
+**Single-file ReadyToRun images** conform to CLI file format as described in ECMA-335
+with the following customizations:
 
 - The PE file is always platform specific
 - CLI Header Flags field has set `COMIMAGE_FLAGS_IL_LIBRARY` (0x00000004) bit set
 - CLI Header `ManagedNativeHeader` points to READYTORUN_HEADER
 
-The image contains full copy of the IL and metadata that it was generated from.
+The COR header and ECMA 335 metadata pointed to by the COM descriptor data directory item
+in the COFF header represent a full copy of the input IL and MSIL metadata it was generated from.
+
+For **Composite R2R files** there is no global CLI / COR header (as there are potentially
+multiple metadata blocks in the file). The ReadyToRun header structure is pointed to by the
+well-known export symbol `RTR_HEADER` and has the `READYTORUN_FLAG_COMPOSITE` flag set.
+
+Input MSIL metadata and IL streams can be either embedded in the composite R2R file or left
+as separate files on disk. In case of embedded MSIL, the "actual" metadata for the individual
+component assemblies is accessed via the R2R section `READYTORUN_SECTION_ASSEMBLIES`.
 
 ## Future Improvements
 
@@ -53,12 +74,6 @@ struct READYTORUN_HEADER
     // Array of sections follows. The array entries are sorted by Type
     // READYTORUN_SECTION   Sections[];
 };
-
-struct READYTORUN_SECTION
-{
-    DWORD                   Type;           // READYTORUN_SECTION_XXX
-    IMAGE_DATA_DIRECTORY    Section;
-};
 ```
 
 ### READYTORUN_HEADER::Signature
@@ -80,6 +95,8 @@ native code from image of version 3.0.
 | Flag                                    |      Value | Description
 |:----------------------------------------|-----------:|:-----------
 | READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE | 0x00000001 | Set if the original IL image was platform neutral. The platform neutrality is part of assembly name. This flag can be used to reconstruct the full original assembly name.
+| READYTORUN_FLAG_COMPOSITE               | 0x00000002 | The image represents a composite R2R file resulting from a combined compilation of a larger number of input MSIL assemblies.
+| READYTORUN_FLAG_EMBEDDED_MSIL           | 0x00000004 | Input MSIL is embedded in the R2R image.
 
 ## READYTORUN_SECTION
 
@@ -91,8 +108,8 @@ struct READYTORUN_SECTION
 };
 ```
 
-This section contains array of `READYTORUN_SECTION` records immediately follows
-`READYTORUN_HEADER`. Number of elements in the array is `READYTORUN_HEADER::NumberOfSections`.
+This ReadyToRun header is immediately followed by an array of `READYTORUN_SECTION` records
+representing the individual R2R sections. Number of elements in the array is `READYTORUN_HEADER::NumberOfSections`.
 Each record contains section type and its location within the binary. The array is sorted by section type
 to allow binary searching.
 
@@ -120,6 +137,7 @@ enum ReadyToRunSectionType
     READYTORUN_SECTION_MANIFEST_METADATA            = 112, // Added in V2.3
     READYTORUN_SECTION_ATTRIBUTEPRESENCE            = 113, // Added in V3.1
     READYTORUN_SECTION_INLINING_INFO2               = 114, // Added in V4.1
+    READYTORUN_SECTION_ASSEMBLIES                   = 115, // Added in V3.2
 };
 ```
 
@@ -310,7 +328,7 @@ filled before method can be executed executing.
 The index of the method is shift left by 1 bit, with the low bit indicating whether the list of slots to fixup
 follows. The list of slots is encoded as follows (same encoding as used by NGen):
 
-``
+```
 READYTORUN_IMPORT_SECTIONS absolute index
     absolute slot index
     slot index delta
@@ -330,7 +348,7 @@ READYTORUN_IMPORT_SECTIONS index delta
     slot delta
     0
 0
-``
+```
 
 The fixup list is a stream of integers encoded as nibbles (1 nibble = 4 bits). 3 bits of a nibble are used to
 store 3 bits of the value, and the top bit indicates if the following nibble contains rest of the value. If the
@@ -340,6 +358,10 @@ The section and slot indices are delta-encoded offsets from that initial absolut
 means that the i-th value is the sum of values [1..i].
 
 The list is terminated by a 0 (0 is not meaningful as valid delta).
+
+**Note:** This section is only present in single-file R2R files. In composite R2R files created
+by compiling multiple input MSIL assemblies, method entrypoints need to be split by assembly and
+are addressed through `READYTORUN_SECTION_ASSEMBLIES` section instead.
 
 ## READYTORUN_SECTION_EXCEPTION_INFO
 
@@ -393,11 +415,26 @@ This section contains a native hashtable of all defined & export types within th
 |         0 | defined type
 |         1 | exported type
 
-The version-resilient hashing algorithm used for hashing the type names is implemented in [vm/versionresilienthashcode.cpp](https://github.com/dotnet/runtime/blob/8c6b1314c95857b9e2f5c222a10f2f089ee02dfe/src/coreclr/src/vm/versionresilienthashcode.cpp#L75).
+The version-resilient hashing algorithm used for hashing the type names is implemented in
+[vm/versionresilienthashcode.cpp](https://github.com/dotnet/runtime/blob/8c6b1314c95857b9e2f5c222a10f2f089ee02dfe/src/coreclr/src/vm/versionresilienthashcode.cpp#L75).
+
+**Note:** This section is only present in single-file R2R files. In composite R2R files created
+by compiling multiple input MSIL assemblies, the available types need to be split by assembly
+and are addressed through `READYTORUN_SECTION_ASSEMBLIES` section instead.
 
 ## READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS
 
-This section contains a native hashtable of all generic method instantiations compiled into the R2R executable. The key is the method instance signature; the appropriate version-resilient hash code calculation is implemented in [vm/versionresilienthashcode.cpp](https://github.com/dotnet/runtime/blob/master/src/coreclr/src/vm/versionresilienthashcode.cpp#L127); the value, represented by the `EntryPointWithBlobVertex` class, stores the method index in the runtime function table, the fixups blob and a blob encoding the method signature.
+This section contains a native hashtable of all generic method instantiations compiled into
+the R2R executable. The key is the method instance signature; the appropriate version-resilient
+hash code calculation is implemented in
+[vm/versionresilienthashcode.cpp](https://github.com/dotnet/runtime/blob/master/src/coreclr/src/vm/versionresilienthashcode.cpp#L127);
+the value, represented by the `EntryPointWithBlobVertex` class, stores the method index in the
+runtime function table, the fixups blob and a blob encoding the method signature.
+
+**Note:** In contrast to non-generic method entrypoints, this section is executable-wide for
+composite R2R images. It represents all generics needed by all assemblies within the composite
+executable. As mentioned elsewhere in this document, CoreCLR runtime requires changes to
+properly look up methods stored in this section in the composite R2R case.
 
 ## READYTORUN_SECTION_INLINING_INFO
 
@@ -409,11 +446,21 @@ This section contains a native hashtable of all generic method instantiations co
 
 ## READYTORUN_SECTION_MANIFEST_METADATA
 
-Manifest metadata is an [ECMA-335] metadata blob containing extra reference assemblies within the version bubble introduced by inlining on top of assembly references stored in the input MSIL. As of R2R version 3.1, the metadata is only searched for the AssemblyRef table. This is used to translate module override indices in signatures to the actual reference modules (using either the `READYTORUN_FIXUP_ModuleOverride` bit flag on the signature fixup byte or the `ELEMENT_TYPE_MODULE_ZAPSIG` COR element type).
+Manifest metadata is an [ECMA-335] metadata blob containing extra reference assemblies within
+the version bubble introduced by inlining on top of assembly references stored in the input MSIL.
+As of R2R version 3.1, the metadata is only searched for the AssemblyRef table. This is used to
+translate module override indices in signatures to the actual reference modules (using either
+the `READYTORUN_FIXUP_ModuleOverride` bit flag on the signature fixup byte or the
+`ELEMENT_TYPE_MODULE_ZAPSIG` COR element type).
 
-**Disclaimer:** The manifest metadata is a new feature that hasn't shipped yet; it involves straightforward adaptation of a fragile nGen technology to ReadyToRun images as an expedite means for enabling new functionality (larger version bubble support). The precise details of this encoding are still work in progress and likely to further evolve.
+**Disclaimer:** The manifest metadata is a new feature that hasn't shipped yet; it involves
+straightforward adaptation of a fragile nGen technology to ReadyToRun images as an expedite
+means for enabling new functionality (larger version bubble support). The precise details of
+this encoding are still work in progress and likely to further evolve.
 
-**Note:** It doesn't make sense to store references to assemblies external to the version bubble in the manifest metadata as there's no guarantee that their metadata token values remain constant; thus we cannot encode signatures relative to them.
+**Note:** It doesn't make sense to store references to assemblies external to the version bubble
+in the manifest metadata as there's no guarantee that their metadata token values remain
+constant; thus we cannot encode signatures relative to them.
 
 The module override index translation algorithm is as follows (**ILAR** = *the number of `AssemblyRef` rows in the input MSIL*):
 
@@ -429,6 +476,11 @@ The module override index translation algorithm is as follows (**ILAR** = *the n
 
 **TODO**: document attribute presence encoding
 
+**Note**: We already know this table uses assembly-relative token encoding so it has similar
+characteristics like `READYTORUN_SECTION_AVAILABLE_TYPES` or `READYTORUN_SECTION_METHOD_ENTRYPOINTS`.
+No matter what component assembly-relative encoding we end up choosing for these tables, we
+should use the same encoding for ATTRIBUTEPRESENCE.
+
 ## READYTORUN_SECTION_INLINING_INFO2
 
 The inlining information section captures what methods got inlined into other methods. It consists of a single _Native Format Hashtable_ (described below).
@@ -441,6 +493,26 @@ The entry of the hashtable is a counted sequence of compressed unsigned integers
 * RIDs of the inliners follow. They are encoded similarly to the way the inlinee is encoded (shifted left with the lowest bit indicating foreign RID). Instead of encoding the RID directly, RID delta (the difference between the previous RID and the current RID) is encoded. This allows better integer compression.
 
 Foreign RIDs are only present if a fragile inlining was allowed at compile time.
+
+**TODO:** It remains to be seen whether `READYTORUN_SECTION_METHODCALL_THUNKS` and / or
+`READYTORUN_SECTION_INLINING_INFO` also require changes specific to the composite R2R file format.
+
+## READYTORUN_SECTION_ASSEMBLIES (v4.1+)
+
+This section is only present in composite R2R files. It is a straight binary array of the
+entries `READYTORUN_SECTION_ASSEMBLIES_ENTRY` parallel to the indices in the manifest metadata
+AssemblyRef table in the sense that it's a linear table where the row indices correspond to the
+equivalent AssemblyRef indices. Just like in the AssemblyRef ECMA 335 table, the indexing is
+1-based (the first entry in the table corresponds to index 1).
+
+```C++
+struct READYTORUN_SECTION_ASSEMBLIES_ENTRY
+{
+    IMAGE_DATA_DIRECTORY CorHeader;         // Input MSIL metadata COR header
+    IMAGE_DATA_DIRECTORY AvailableTypes;    // Available types table
+    IMAGE_DATA_DIRECTORY MethodEntrypoints; // Method entrypoint table
+};
+```
 
 # Native Format
 

--- a/docs/design/features/readytorun-composite-format-design.md
+++ b/docs/design/features/readytorun-composite-format-design.md
@@ -89,6 +89,11 @@ contains all assemblies contained within the composite file. The linear indices 
 assemblies in the manifest metadata AssemblyRef table correspond to indexing within the
 `READYTORUN_SECTION_ASSEMBLIES` table.
 
+**Disclaimer:** The manifest metadata is a new feature that hasn't shipped yet; it involves
+straightforward adaptation of a fragile NGen technology to ReadyToRun images as an expedite
+means for enabling new functionality (larger version bubble support). The precise details of
+this encoding are still work in progress and likely to further evolve.
+
 **Note**: as of now it's unclear whether we need to support a hybrid scenario where the large
 version bubble is represented by an arbitrary mixture of single-input and composite R2R files.
 If that is the case, manifest metadata would need to be decoupled from the index to

--- a/docs/design/features/readytorun-composite-format-design.md
+++ b/docs/design/features/readytorun-composite-format-design.md
@@ -122,7 +122,8 @@ entrypoints need to be split per input assembly and are referenced from
 In single-input R2R PE files the  generic instantiations generated for the input MSIL assembly
 are placed in `READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS`. In composite R2R files, this
 section represents all instance entrypoints emitted within the composite build (i.e. generic
-instantiations needed by any of the input assemblies).
+instantiations needed by any of the input assemblies). CoreCLR runtime requires changes to
+properly look up methods stored in this section in the composite R2R case.
 
 # CoreCLR runtime changes
 

--- a/docs/design/features/readytorun-composite-format-design.md
+++ b/docs/design/features/readytorun-composite-format-design.md
@@ -1,0 +1,162 @@
+ReadyToRun File Format - Composite Format Design Notes
+======================================================
+
+Revisions:
+* 1 - [Tomas Rylek](https://github.com/trylek) - 1/27/2020
+
+# Introduction
+
+The purpose of this document is to summarize the necessary format and code changes to enable
+support for *Composite ReadyToRun Files* combining multiple input MSIL assemblies into a single
+ReadyToRun executable.
+
+# Traditional vs. composite R2R image
+
+The logical goal of a composite R2R image is to have a single PE R2R binary represent a semantic
+union of multiple input MSIL assemblies compiled as a unit by the R2R compiler to produce the
+composite output.
+
+Some motivations for producing composite R2R images include:
+
+* Better performance: compiling multiple MSIL assemblies into a single output R2R executable
+  creates an even tighter coupling than the large version bubble using separate files and the
+  compiler and runtime can be more efficient (e.g. by using large memory pages).
+* Easier deployment: desire to avoid having to deal with potentially hundreds or thousands of
+  assemblies.
+* Side-by-side deployment: a self-contained app doesn't need to care about the location of its
+  dependencies, their proper versions, about sharing them with other apps (including other
+  versions of the same app).
+
+Semantic requirements for the composite R2R format flow from the combination of the basic design
+principle that the R2R file is a code cache to save jitting time and from the fact that the
+tighter coupling can be utilized to improve codegen quality.
+
+## R2R file is a code cache
+
+A corollary of this basic principle is that the composite file must maintain full functionality
+of single-input R2R files w.r.t. things like reflection, dynamic or generics. To achieve this
+goal the composite R2R file must have access to the original MSIL metadata for all input
+assemblies represented by the output R2R file. We propose supporting two different configurations
+for this model:
+
+* Standalone MSIL - MSIL metadata and IL streams (the original managed assemblies) remain on
+disk as separate files next to the compiled R2R executable;
+* Embedded MSIL - metadata and IL are embedded as blobs in the compiled R2R executable so that
+the original managed assembly files are not needed at runtime.
+
+This is a substantial deviation from the previous format that only had one COR header
+addressed by the COM data directory entry in the COFF header. To achieve this goal,
+we propose using two complementary strategies:
+
+* In the composite R2R file with embedded metadata, there must be a new table of COR headers
+and metadata blobs representing the MSIL metadata from all the input assemblies. The table
+must be indexable by simple assembly name for fast lookup. 
+
+* in contrast to managed assemblies and single-input R2R executables, composite R2R files
+  don't expose any COR header (it's not meaningful as the file potentially contains a larger
+  number of IL files).
+
+**Note:** As of this proposal we're not addressing managed C++ code including both native and
+managed code. For pre-built native code, it's generally not possible to relocate RVA's as the
+fixup table information is not rich enough. As a consequence, it's simply not possible to roll
+multiple managed C++ modules containing native code into a single output R2R PE binary. We might
+be able to consider some mitigations like allowing a single managed binary containing native
+code in a composite build but I'm not sure whether they are worth the effort and desirable
+in general.
+
+# Structural format changes specific to composite build mode
+
+When a R2R file has the `READYTORUN_FLAG_COMPOSITE` bit set in the R2R header, it conforms to
+the composite file format. The main differences between composite and single-input R2R PE files
+are summarized below.
+
+## COFF, PE and metadata headers
+
+In single-input R2R PE files the COFF header (the COM descriptor directory entry) points at the
+COR header of the input MSIL metadata which then points at the R2R header (via the
+`ManagedNativeHeaderDirectory` field).
+
+In composite R2R files there is no global COR header and the R2R header is located through the
+well-known export symbol `RTR_HEADER`. The "actual" input assemblies are tracked under the new
+R2R header table `READYTORUN_SECTION_ASSEMBLIES`.
+
+## Manifest metadata and component assembly table
+
+In single-input R2R PE files compiled in the large version bubble mode, the metadata manifest
+contains the set of assemblies containing functions called from the input assembly (possibly
+with some transitivity due to inlining); in composite R2R PE files the manifest metadata
+contains all assemblies contained within the composite file. The linear indices of the
+assemblies in the manifest metadata AssemblyRef table correspond to indexing within the
+`READYTORUN_SECTION_ASSEMBLIES` table.
+
+**Note**: as of now it's unclear whether we need to support a hybrid scenario where the large
+version bubble is represented by an arbitrary mixture of single-input and composite R2R files.
+If that is the case, manifest metadata would need to be decoupled from the index to
+`READYTORUN_SECTION_ASSEMBLIES`.
+  
+Alternatively we could make it such that `READYTORUN_SECTION_MANIFEST_METADATA` holds all
+component assemblies of the current composite image at the beginning of the AssemblyRef table
+followed by the other needed assemblies *within the version bubble outside of the current
+composite image* - `READYTORUN_SECTION_ASSEMBLIES` would then contain fewer rows than the
+AssemblyRef table in the manifest metadata, corresponding to the initial rows for the
+assemblies within the composite image.
+
+## Per-assembly tables
+
+In single-input R2R PE files the R2R section `READYTORUN_SECTION_AVAILABLE_TYPES` encodes
+a native hashtable of types within a given assembly. In composite R2R files, the available
+types need to be split per input assembly and are referenced from `READYTORUN_SECTION_ASSEMBLIES`.
+
+In single-input R2R PE files the R2R section `READYTORUN_SECTION_METHOD_ENTRYPOINTS` encodes
+a native hashtable of methods within a given assembly. In composite R2R files, the method
+entrypoints need to be split per input assembly and are referenced from
+`READYTORUN_SECTION_ASSEMBLIES`.
+
+## Instance entrypoint table
+
+In single-input R2R PE files the  generic instantiations generated for the input MSIL assembly
+are placed in `READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS`. In composite R2R files, this
+section represents all instance entrypoints emitted within the composite build (i.e. generic
+instantiations needed by any of the input assemblies).
+
+# CoreCLR runtime changes
+
+CoreCLR runtime will need to become able to recognize the new composite R2R format by means
+of locating the well-known export `RTR_HEADER` and validating the ReadyToRun header (magic
+constant, version number and the `READYTORUN_FLAG_COMPOSITE` flag) and behave accordingly:
+
+* For composite files with embedded MSIL, we shouldn't need MVID checks for reference
+  assemblies within the tight version bubble represented by the single file.
+* We need to improve generic instantiation lookup algorithm to be able to locate all
+  instantiations emitted into the composite file.
+* CoreCLR runtime will need to parse the manifest metadata (and possibly the
+  `READYTORUN_SECTION_SIMPLE_ASSEMBLY_NAME_LOOKUP` section) and set up lookup structures to
+  facilitate fast assembly lookup for available types and method entrypoints.
+* The runtime will need to start consulting the `READYTORUN_SECTION_ASSEMBLIES` table to locate
+  MSIL metadata within the composite executable - this logic should definitely take precedence
+  to arbitrary files on the disk to satisfy consistency and security guarantees.
+
+# Tooling changes
+
+## R2RDump
+
+R2R dump will require fixing to support multiple ECMA metadata blobs in the composite R2R file,
+the new header sections and new ways of manipulating the available types and method entrypoint
+tables. We may temporarily consider adding some "minimalistic ILDASM" functionality to R2R dump
+in case it turns out to be much more involved to patch ILDASM itself to support the new format -
+at the very least the functionality to extract the ECMA-335 metadata blobs into separate files
+that could be subsequently opened by ILDASM or ILSpy.
+
+## ILDASM / ILSpy
+
+Ideally we should patch ILDASM / ILSpy to cleanly handle the composite R2R file format; sadly this may
+end up being a relatively complex change due to the presence of multiple MSIL metadata blocks in the
+file. 
+
+# Required diagnostic changes
+
+Active and passive diagnostics (live and dump debugging) will require new debugger support to
+understand the composite file, access the ECMA-335 metadata blocks and understand their
+correlation to the compiled R2R code. Additional changes will be likely needed to support
+profiling. Design discussions with the diagnostic team are only just starting so this is
+currently a big **TODO**.


### PR DESCRIPTION
I have resurrected my preliminary composite R2R format doc,
I rebased it to include some recent changes. For the process
itself, I assume I should first implement the self-contained
composite R2R format with standalone MSIL metadata as that's
the simplest scenario. After that I'll follow up w.r.t.
shared framework compilation and other scenarios (embedded MSIL,
single exe).

Thanks

Tomas