### PR TITLE
Delete dead ctor in RegexParseException

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseException.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseException.cs
@@ -11,24 +11,16 @@ namespace System.Text.RegularExpressions
     {
         private readonly RegexParseError _error; // tests access this via private reflection
 
-        /// <summary>
-        /// The error that happened during parsing.
-        /// </summary>
+        /// <summary>Gets the error that happened during parsing.</summary>
         public RegexParseError Error => _error;
 
-        /// <summary>
-        /// The offset in the supplied pattern.
-        /// </summary>
+        /// <summary>Gets the offset in the supplied pattern.</summary>
         public int Offset { get; }
 
         public RegexParseException(RegexParseError error, int offset, string message) : base(message)
         {
             _error = error;
             Offset = offset;
-        }
-
-        private RegexParseException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)


### PR DESCRIPTION
It'll never be used because the exception gets serialized as its base type and thus is never deserialized.

cc: @ViktorHofer 