### PR TITLE
Make sure R2RDump write to console in case --out is not specified

### DIFF
--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -480,6 +480,10 @@ namespace R2RDump
                 {
                     globalWriter = new StreamWriter(_options.Out.FullName);
                 }
+                else
+                {
+                    globalWriter = Console.Out;
+                }
 
                 foreach (FileInfo filename in _options.In)
                 {
@@ -498,7 +502,7 @@ namespace R2RDump
                         }
                     }
 
-                    if (!_options.Diff && globalWriter != null)
+                    if (!_options.Diff)
                     {
                         _writer = globalWriter;
                     }


### PR DESCRIPTION
This restores the behavior that when `--out` is not specified, it writes to the `stdout`.

This behavior is not particularly useful, but it is done consistently across the `*dump` (e.g. `dumpbin`, `cvdump`) tools we have.

This also fixes a `NullReferenceException` in `R2RDiff` in case `--out` is not specified. Note that `globalWriter` will not be initialized but used on line 519 (of the original version).