### PR TITLE
Added opt-in flag to enable non-public members

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -453,6 +453,7 @@ namespace System.Text.Json
     {
         public JsonSerializerOptions() { }
         public bool AllowTrailingCommas { get { throw null; } set { } }
+        public bool AllowPrivateProperties { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonConverter> Converters { get { throw null; } }
         public int DefaultBufferSize { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -138,7 +138,10 @@ namespace System.Text.Json
                     {
                         CreateObject = options.MemberAccessorStrategy.CreateConstructor(type);
 
-                        PropertyInfo[] properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                        BindingFlags bindingFlags = options.AllowPrivateProperties
+                            ? BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                            : BindingFlags.Instance | BindingFlags.Public;
+                        PropertyInfo[] properties = type.GetProperties(bindingFlags);
 
                         Dictionary<string, JsonPropertyInfo> cache = CreatePropertyCache(properties.Length);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -29,6 +29,7 @@ namespace System.Text.Json
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
         private bool _allowTrailingCommas;
+        private bool _allowPrivateProperties;
         private bool _haveTypesBeenCreated;
         private bool _ignoreNullValues;
         private bool _ignoreReadOnlyProperties;
@@ -63,6 +64,26 @@ namespace System.Text.Json
             {
                 VerifyMutable();
                 _allowTrailingCommas = value;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether non-public properties should be serialized and deserialized.
+        /// The default value is false.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public bool AllowPrivateProperties
+        {
+            get
+            {
+                return _allowPrivateProperties;
+            }
+            set
+            {
+                VerifyMutable();
+                _allowPrivateProperties = value;
             }
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -12,6 +12,30 @@ namespace System.Text.Json.Serialization.Tests
     public static class PropertyVisibilityTests
     {
         [Fact]
+        public static void Serialize_NonPublicProperty_RequiresOptIn()
+        {
+            var obj = new ClassWithPrivateProperty { PrivateProperty = true };
+            var allowNonPublic = new JsonSerializerOptions { AllowPrivateProperties = true };
+
+            string jsonDefault = JsonSerializer.Serialize(obj);
+            string jsonNonPublic = JsonSerializer.Serialize(obj, allowNonPublic);
+
+            Assert.Equal(@"{}", jsonDefault);
+            Assert.Equal(@"{""PrivateProperty"":true}", jsonNonPublic);
+
+            var objDefault = JsonSerializer.Deserialize<ClassWithPrivateProperty>(jsonDefault);
+            var objNonPublic = JsonSerializer.Deserialize<ClassWithPrivateProperty>(jsonNonPublic, allowNonPublic);
+
+            Assert.False(objDefault.PrivateProperty);
+            Assert.True(objNonPublic.PrivateProperty);
+        }
+
+        public class ClassWithPrivateProperty
+        {
+            internal bool PrivateProperty { get; set; }
+        }
+
+        [Fact]
         public static void NoSetter()
         {
             var obj = new ClassWithNoSetter();


### PR DESCRIPTION
Fixes #2242. It's a breaking change.

Unfortunately, not able to test locally because of:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(231,5): error MSB8065: Custom build for item "D:\Repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-Windows_NT-Debug-x64\CMakeFiles\fe7a6c5df725904c22996c4fd4406c45\INSTALL_force.rule" succeeded, but specified output "d:\repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-windows_nt-debug-x64\cmakefiles\install_force" has not been created. This may cause incremental build to work incorrectly. [D:\Repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-Windows_NT-Debug-x64\install.vcxproj] [D:\Repos\dotnet\runtime\src\libraries\Native\build-native.proj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(231,5): error MSB8065: Custom build for item "D:\Repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-Windows_NT-Debug-x64\CMakeFiles\fe7a6c5df725904c22996c4fd4406c45\INSTALL_force.rule" succeeded, but specified output "d:\repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-windows_nt-debug-x64\cmakefiles\install_force" has not been created. This may cause incremental build to work incorrectly. [D:\Repos\dotnet\runtime\artifacts\obj\native\netcoreapp5.0-Windows_NT-Debug-x64\install.vcxproj] [D:\Repos\dotnet\runtime\src\libraries\Native\build-native.proj]
```