### PR TITLE
Fix compilation of dbgtransportsession

### DIFF
--- a/src/coreclr/src/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/src/debug/shared/dbgtransportsession.cpp
@@ -1664,11 +1664,13 @@ void DbgTransportSession::TransportWorker()
         // We now loop receiving messages and processing them until the state changes.
         while (m_eState == SS_Open)
         {
+#ifndef RIGHT_SIDE_COMPILE
             // temporary data block used in DCB messages
             DebuggerIPCControlBlockTransport dcbt;
 
             // temporary virtual stack unwind context buffer
             CONTEXT frameContext;
+#endif
 
             // Read a message header block.
             if (!ReceiveBlock((PBYTE)&sReceiveHeader, sizeof(MessageHeader)))


### PR DESCRIPTION
Fix unused variable warnings when RIGHT_SIDE_COMPILE is not defined.  These are treated as errors when cross compiling on Windows for Linux.