### PR TITLE
Support 32 byte alignment of code on xarch

### DIFF
--- a/src/coreclr/src/inc/corinfo.h
+++ b/src/coreclr/src/inc/corinfo.h
@@ -217,11 +217,11 @@ TODO: Talk about initializing strutures before use
 #endif
 #endif
 
-SELECTANY const GUID JITEEVersionIdentifier = { /* 13028353-152c-4886-b05b-fa76ee8169cf */
-    0x13028353,
-    0x152c,
-    0x4886,
-    {0xb0, 0x5b, 0xfa, 0x76, 0xee, 0x81, 0x69, 0xcf}
+SELECTANY const GUID JITEEVersionIdentifier = { /* 96fc0c0a-9f77-450d-9663-ee33ae0fcae8 */
+    0x96fc0c0a,
+    0x9f77,
+    0x450d,
+    {0x96, 0x63, 0xee, 0x33, 0xae, 0x0f, 0xca, 0xe8}
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/src/inc/corjit.h
+++ b/src/coreclr/src/inc/corjit.h
@@ -179,6 +179,8 @@ enum CorJitAllocMemFlag
     CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will be use the normal alignment
     CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN   = 0x00000001, // The code will be 16-byte aligned
     CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
+    CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
+    CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
 };
 
 inline CorJitAllocMemFlag operator |(CorJitAllocMemFlag a, CorJitAllocMemFlag b)

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4615,6 +4615,15 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 #endif
 
+#ifdef _TARGET_XARCH_
+    // For x64/x86, align Tier1 methods to 32 byte boundaries
+    //
+    if (emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
+    {
+        allocMemFlag = CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN;
+    }
+#endif
+
     if (emitConsDsc.align16)
     {
         allocMemFlag = static_cast<CorJitAllocMemFlag>(allocMemFlag | CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN);

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4615,7 +4615,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 #endif
 
-#ifdef _TARGET_XARCH_
+#ifdef TARGET_XARCH
     // For x64/x86, align Tier1 methods to 32 byte boundaries if
     // they are larger than 16 bytes and contain a loop.
     //

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4616,9 +4616,10 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
 
 #ifdef _TARGET_XARCH_
-    // For x64/x86, align Tier1 methods to 32 byte boundaries
+    // For x64/x86, align Tier1 methods to 32 byte boundaries if
+    // they are larger than 16 bytes and contain a loop.
     //
-    if (emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
+    if (emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1) && (emitTotalHotCodeSize > 16) && emitComp->fgHasLoops)
     {
         allocMemFlag = CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN;
     }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
@@ -764,6 +764,8 @@ namespace Internal.JitInterface
         CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will be use the normal alignment
         CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN = 0x00000001, // The code will be 16-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
+        CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
+        CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
     }
 
     public enum CorJitFuncKind

--- a/src/coreclr/src/tools/crossgen2/jitinterface/jitwrapper.cpp
+++ b/src/coreclr/src/tools/crossgen2/jitinterface/jitwrapper.cpp
@@ -27,11 +27,11 @@ private:
     uint64_t corJitFlags;
 };
 
-static const GUID JITEEVersionIdentifier = { /* 13028353-152c-4886-b05b-fa76ee8169cf */
-    0x13028353,
-    0x152c,
-    0x4886,
-    {0xb0, 0x5b, 0xfa, 0x76, 0xee, 0x81, 0x69, 0xcf}
+static const GUID JITEEVersionIdentifier = { /* 96fc0c0a-9f77-450d-9663-ee33ae0fcae8 */
+    0x96fc0c0a,
+    0x9f77,
+    0x450d,
+    {0x96, 0x63, 0xee, 0x33, 0xae, 0x0f, 0xca, 0xe8}
 };
 
 class Jit

--- a/src/coreclr/src/vm/codeman.cpp
+++ b/src/coreclr/src/vm/codeman.cpp
@@ -2551,7 +2551,11 @@ CodeHeader* EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t re
 
     unsigned alignment = CODE_SIZE_ALIGN;
 
-    if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
+    if ((flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+    {
+        alignment = max(alignment, 32);
+    }
+    else if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
     {
         alignment = max(alignment, 16);
     }

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12065,7 +12065,11 @@ void CEEJitInfo::allocMem (
     S_SIZE_T totalSize = S_SIZE_T(codeSize);
 
     size_t roDataAlignment = sizeof(void*);
-    if ((flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)!= 0)
+    if ((flag & CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN)!= 0)
+    {
+        roDataAlignment = 32;
+    }
+    else if ((flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)!= 0)
     {
         roDataAlignment = 16;
     }
@@ -12075,9 +12079,18 @@ void CEEJitInfo::allocMem (
     }
     if (roDataSize > 0)
     {
-        size_t codeAlignment = ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN)!= 0)
-                               ? 16 : sizeof(void*);
+        size_t codeAlignment = sizeof(void*);
+
+        if ((flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+        {
+            codeAlignment = 32;
+        }
+        else if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
+        {
+            codeAlignment = 16;
+        }
         totalSize.AlignUp(codeAlignment);
+
         if (roDataAlignment > codeAlignment) {
             // Add padding to align read-only data.
             totalSize += (roDataAlignment - codeAlignment);

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -1085,7 +1085,11 @@ void ZapInfo::allocMem(
 
     UINT align = DEFAULT_CODE_ALIGN;
 
-    if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) && !IsReadyToRunCompilation()) align = max(align, 16);
+    if (!IsReadyToRunCompilation())
+    {
+        if (flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) align = max(align, 32);
+        else if (flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) align = max(align, 16);
+    }
 
     m_pCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, hotCodeSize, align);
     *hotCodeBlock = m_pCode->GetData();
@@ -1104,7 +1108,11 @@ void ZapInfo::allocMem(
 
     if (roDataSize > 0)
     {
-        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
+        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN)
+        {
+            align = 32;
+        }
+        else if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
         {
             align = 16;
         }

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -1085,11 +1085,7 @@ void ZapInfo::allocMem(
 
     UINT align = DEFAULT_CODE_ALIGN;
 
-    if (!IsReadyToRunCompilation())
-    {
-        if (flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) align = max(align, 32);
-        else if (flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) align = max(align, 16);
-    }
+    if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) && !IsReadyToRunCompilation()) align = max(align, 16);
 
     m_pCode = ZapCodeBlob::NewAlignedBlob(m_pImage, NULL, hotCodeSize, align);
     *hotCodeBlock = m_pCode->GetData();
@@ -1108,11 +1104,7 @@ void ZapInfo::allocMem(
 
     if (roDataSize > 0)
     {
-        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN)
-        {
-            align = 32;
-        }
-        else if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
+        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
         {
             align = 16;
         }


### PR DESCRIPTION
Update jit and runtime to allow jit to ask for code to be 32 byte aligned.
Request 32 byte alignment for Tier1 methods on x86/x64.

Add minimal crossgen support; one can imagine requesting or choosing 32 byte
alignment for crossgenned code, but that is left as future work.

This should provide some measure of performance stability, in particular for
microbenchmarks or other code where performance depends crucially on a few
branches.

It may or may not improve performance. If/when there are regressions we can
contemplate updating the jit to add intra-method padding to address alignment
sensitive code layout (e.g. dotnet/coreclr#11607).

This will require a jit GUID update in addition to the changes here.