### PR TITLE
Attempt to fix restore internal tools

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -13,6 +13,7 @@ steps:
   - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: 'dotnet-core-internal-tooling'
+      forceReinstallCredentialProvider: true
 
   - task: DotNetCoreCLI@2
     displayName: Restore internal tools

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -47,6 +47,7 @@ jobs:
         - _warnAsErrorArg: ''
         - _testScopeArg: ''
         - _extraHelixArguments: ''
+        - _crossBuildPropertyArg: ''
 
         - librariesBuildArtifactName: ${{ format('libraries_bin_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-alpha1-015772"
+    "dotnet": "5.0.100-alpha.1.20073.4"
   },
   "native-tools": {
     "cmake": "3.14.2",

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -109,7 +109,6 @@
   <PropertyGroup>
     <!-- This is needed to embed build-time generated sources such as eventing and resource files to sourcelink PDBs. -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);AddUntrackedResourcesForSourceLink</CoreCompileDependsOn>
   </PropertyGroup>
 
   <!--
@@ -456,16 +455,5 @@
 
   <Import Project="CreateRuntimeRootILLinkDescriptorFile.targets" />
 
-  <Target Name="CreateRuntimeRootIlLinkDescFile" BeforeTargets="CoreCompile" DependsOnTargets="_CreateILLinkRuntimeRootDescriptorFile">
-  </Target>
-
-  <!-- This is working around dotnet/coreclr#26371 until dotnet/sourcelink#392 gets solved -->
-  <Target Name="AddUntrackedResourcesForSourceLink"
-          Condition="'$(BuildingInsideVisualStudio)' != 'true'"
-          BeforeTargets="CoreCompile"
-          DependsOnTargets="SetEmbeddedFilesFromSourceControlManagerUntrackedFiles;_GenerateResxSource" >
-    <ItemGroup>
-      <EmbeddedFiles Include="@(GeneratedResxSource)" />
-    </ItemGroup>
-  </Target>
+  <Target Name="CreateRuntimeRootIlLinkDescFile" BeforeTargets="CoreCompile" DependsOnTargets="_CreateILLinkRuntimeRootDescriptorFile"/>
 </Project>

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -115,7 +115,6 @@
   <PropertyGroup>
     <!-- This is needed to embed build-time generated sources such as eventing and resource files to sourcelink PDBs. -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);AddUntrackedResourcesForSourceLink</CoreCompileDependsOn>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Attempts to fix: https://github.com/dotnet/runtime/issues/2199

Arcade templates install NugetAuthenticator always, and then we were re-installing it with a service credential, but it wasn't installed because there was already one installed. So I'm forcing our installation.

Also, update the SDK we use to the latest daily build which fixes a lot of reliability bugs in NuGet.

I added an empty variable declaration that someone missed in another change causing a wrong parameter to be passed down when it was not declared.

**Note: I ran 2 official builds from my branch and they didn't hit the issue anymore**

cc: @dotnet/runtime-infrastructure 