### PR TITLE
Batch CI builds for PRI2 testing of CoreCLR

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: true
   branches:
     include:
     - master


### PR DESCRIPTION
This is consuming a lot of resources, CI Rolling builds should be batched.

cc: @dotnet/runtime-infrastructure 