### PR TITLE
Remove workaround for Build.SourcesDirectory variable in containers

### DIFF
--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -90,10 +90,7 @@ jobs:
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - _runtimeDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/${{ parameters.runtimeFlavor }}'
           - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
-          - ${{ if ne(parameters.container, '') }}:
-            - _runtimeArtifactsPathArg: '/p:RuntimeArtifactsPath=${_RUNTIMEDOWNLOADPATH}'
-          - ${{ if eq(parameters.container, '') }}:
-            - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
+          - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
 
           # WebAssembly uses linux implementation detail
           - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:


### PR DESCRIPTION
I spoke with AzDo and this is supposed to be fixed.

Fixes: https://github.com/dotnet/runtime/issues/1967

cc: @dotnet/runtime-infrastructure 