### PR TITLE
Fix unhandled exception line number issues

### DIFF
--- a/src/coreclr/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/src/debug/daccess/dacdbiimpl.cpp
@@ -3633,7 +3633,7 @@ void DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, Dac
             currentFrame.vmDomainFile.SetHostPtr(pDomainFile);
             currentFrame.ip = currentElement.ip;
             currentFrame.methodDef = currentElement.pFunc->GetMemberDef();
-            currentFrame.isLastForeignExceptionFrame = currentElement.fIsLastFrameFromForeignStackTrace;
+            currentFrame.isLastForeignExceptionFrame = (currentElement.flags & STEF_LAST_FRAME_FROM_FOREIGN_STACK_TRACE) != 0;
         }
     }
 }

--- a/src/coreclr/src/debug/daccess/task.cpp
+++ b/src/coreclr/src/debug/daccess/task.cpp
@@ -4091,9 +4091,11 @@ ClrDataMethodInstance::GetILOffsetsByAddress(
         for (ULONG32 i = 0; i < numMap; i++)
         {
             if (codeOffset >= map[i].nativeStartOffset &&
-                (((LONG)map[i].ilOffset == ICorDebugInfo::EPILOG &&
-                  !map[i].nativeEndOffset) ||
-                 codeOffset < map[i].nativeEndOffset))
+                // Found the entry if it is the epilog or the last entry and nativeEndOffset == 0. For methods that don't
+                // have a epilog (i.e. IL_Throw is the last instruction) the last map entry has a valid IL offset (not EPILOG)
+                // and nativeEndOffset == 0.
+                ((((LONG)map[i].ilOffset == ICorDebugInfo::EPILOG || i == (numMap - 1)) && map[i].nativeEndOffset == 0) ||
+                    codeOffset < map[i].nativeEndOffset))
             {
                 hits++;
 

--- a/src/coreclr/src/vm/clrex.h
+++ b/src/coreclr/src/vm/clrex.h
@@ -22,17 +22,23 @@ class AssemblySpec;
 class PEFile;
 class PEAssembly;
 
+enum StackTraceElementFlags
+{
+    // Set if this element represents the last frame of the foreign exception stack trace
+    STEF_LAST_FRAME_FROM_FOREIGN_STACK_TRACE = 0x0001,
+
+    // Set if the "ip" field has already been adjusted (decremented)
+    STEF_IP_ADJUSTED = 0x0002,
+};
+
+// This struct is used by SOS in the diagnostic repo and needs to remain backwards compatible.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2245
 struct StackTraceElement
 {
     UINT_PTR        ip;
     UINT_PTR        sp;
     PTR_MethodDesc  pFunc;
-    // TRUE if this element represents the last frame of the foreign
-    // exception stack trace.
-    BOOL			fIsLastFrameFromForeignStackTrace;
-    // TRUE if the ip needs to be adjusted back to the calling or
-    // throwing instruction.
-    BOOL            fAdjustOffset;
+    INT             flags;      // This is StackTraceElementFlags but it needs to always be "int" sized for compatibility with SOS.
 
     bool operator==(StackTraceElement const & rhs) const
     {
@@ -47,6 +53,8 @@ struct StackTraceElement
     }
 };
 
+// This struct is used by SOS in the diagnostic repo and needs to remain backwards compatible.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2669
 class StackTraceInfo
 {
 private:

--- a/src/coreclr/src/vm/clrex.h
+++ b/src/coreclr/src/vm/clrex.h
@@ -32,7 +32,7 @@ enum StackTraceElementFlags
 };
 
 // This struct is used by SOS in the diagnostic repo.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2245
+// See: https://github.com/dotnet/diagnostics/blob/9ff35f13af2f03a68a166cfd53f1a4bb32425f2f/src/SOS/Strike/strike.cpp#L2245
 struct StackTraceElement
 {
     UINT_PTR        ip;
@@ -54,7 +54,7 @@ struct StackTraceElement
 };
 
 // This struct is used by SOS in the diagnostic repo.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2669
+// See: https://github.com/dotnet/diagnostics/blob/9ff35f13af2f03a68a166cfd53f1a4bb32425f2f/src/SOS/Strike/strike.cpp#L2669
 class StackTraceInfo
 {
 private:

--- a/src/coreclr/src/vm/clrex.h
+++ b/src/coreclr/src/vm/clrex.h
@@ -30,6 +30,9 @@ struct StackTraceElement
     // TRUE if this element represents the last frame of the foreign
     // exception stack trace.
     BOOL			fIsLastFrameFromForeignStackTrace;
+    // TRUE if the ip needs to be adjusted back to the calling or
+    // throwing instruction.
+    BOOL            fAdjustOffset;
 
     bool operator==(StackTraceElement const & rhs) const
     {

--- a/src/coreclr/src/vm/clrex.h
+++ b/src/coreclr/src/vm/clrex.h
@@ -31,14 +31,14 @@ enum StackTraceElementFlags
     STEF_IP_ADJUSTED = 0x0002,
 };
 
-// This struct is used by SOS in the diagnostic repo and needs to remain backwards compatible.
+// This struct is used by SOS in the diagnostic repo.
 // See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2245
 struct StackTraceElement
 {
     UINT_PTR        ip;
     UINT_PTR        sp;
     PTR_MethodDesc  pFunc;
-    INT             flags;      // This is StackTraceElementFlags but it needs to always be "int" sized for compatibility with SOS.
+    INT             flags;      // This is StackTraceElementFlags but it needs to be "int" sized for compatibility with SOS.
 
     bool operator==(StackTraceElement const & rhs) const
     {
@@ -53,7 +53,7 @@ struct StackTraceElement
     }
 };
 
-// This struct is used by SOS in the diagnostic repo and needs to remain backwards compatible.
+// This struct is used by SOS in the diagnostic repo.
 // See: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/strike.cpp#L2669
 class StackTraceInfo
 {

--- a/src/coreclr/src/vm/debugdebugger.cpp
+++ b/src/coreclr/src/vm/debugdebugger.cpp
@@ -941,7 +941,6 @@ void DebugStackTrace::GetStackFramesHelper(Frame *pStartFrame,
     // This will compute IL offsets.
     for (INT32 i = 0; i < pData->cElements; i++)
     {
-        // pStartFrame is NULL when collecting frames for current thread.
         pData->pElements[i].InitPass2();
     }
 

--- a/src/coreclr/src/vm/debugdebugger.h
+++ b/src/coreclr/src/vm/debugdebugger.h
@@ -96,16 +96,11 @@ public:
 private:
 #endif // DACCESS_COMPILE
     struct DebugStackTraceElement {
-        DWORD dwOffset;  // native offset
+        DWORD dwOffset;     // native offset
         DWORD dwILOffset;
         MethodDesc *pFunc;
         PCODE ip;
-        // TRUE if this element represents the last frame of the foreign
-        // exception stack trace.
-        BOOL fIsLastFrameFromForeignStackTrace;
-        // TRUE if the dwOffset (native offset) needs to be adjusted back to the
-        // calling or throwing instruction.
-        BOOL fAdjustOffset;
+        INT flags;          // StackStackElementFlags
 
         // Initialization done under TSL.
         // This is used when first collecting the stack frame data.
@@ -113,8 +108,7 @@ private:
             DWORD dwNativeOffset,
             MethodDesc *pFunc,
             PCODE ip,
-            BOOL fIsLastFrameFromForeignStackTrace = FALSE,
-            BOOL fAdjustOffset = FALSE
+            INT flags       // StackStackElementFlags
         );
 
         // Initialization done outside the TSL.

--- a/src/coreclr/src/vm/debugdebugger.h
+++ b/src/coreclr/src/vm/debugdebugger.h
@@ -102,16 +102,20 @@ private:
         PCODE ip;
         // TRUE if this element represents the last frame of the foreign
         // exception stack trace.
-        BOOL			fIsLastFrameFromForeignStackTrace;
+        BOOL fIsLastFrameFromForeignStackTrace;
+        // TRUE if the dwOffset (native offset) needs to be adjusted back to the
+        // calling or throwing instruction.
+        BOOL fAdjustOffset;
 
         // Initialization done under TSL.
         // This is used when first collecting the stack frame data.
         void InitPass1(
             DWORD dwNativeOffset,
             MethodDesc *pFunc,
-            PCODE ip
-            , BOOL			fIsLastFrameFromForeignStackTrace = FALSE
-			);
+            PCODE ip,
+            BOOL fIsLastFrameFromForeignStackTrace = FALSE,
+            BOOL fAdjustOffset = FALSE
+        );
 
         // Initialization done outside the TSL.
         // This will init the dwILOffset field (and potentially anything else
@@ -131,7 +135,7 @@ public:
         DebugStackTraceElement* pElements;
         THREADBASEREF   TargetThread;
         AppDomain *pDomain;
-        BOOL	fDoWeHaveAnyFramesFromForeignStackTrace;
+        BOOL fDoWeHaveAnyFramesFromForeignStackTrace;
 
 
         GetStackFramesData() :  skip(0),

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -2367,7 +2367,7 @@ void StackTraceInfo::SaveStackTrace(BOOL bAllowAllocMem, OBJECTHANDLE hThrowable
                             // "numCurrentFrames" can be zero if the user created an EDI using
                             // an unthrown exception.
                             StackTraceElement & refLastElementFromForeignStackTrace = gc.stackTrace[numCurrentFrames - 1];
-                            refLastElementFromForeignStackTrace.fIsLastFrameFromForeignStackTrace = TRUE;
+                            refLastElementFromForeignStackTrace.flags |= STEF_LAST_FRAME_FROM_FOREIGN_STACK_TRACE;
                         }
                     }
 
@@ -3555,19 +3555,15 @@ BOOL StackTraceInfo::AppendElement(BOOL bAllowAllocMem, UINT_PTR currentIP, UINT
         // When we are building stack trace as we encounter managed frames during exception dispatch,
         // then none of those frames represent a stack trace from a foreign exception (as they represent
         // the current exception). Hence, set the corresponding flag to FALSE.
-        pStackTraceElem->fIsLastFrameFromForeignStackTrace = FALSE;
-
-        // We can assume that IP points to an the instruction after [call IL_Throw] when these conditions are met:
-        //  1. !pCf->HasFaulted() - It wasn't a "hardware" exception (Access violation, dev by 0, etc.)
-        //  2. !pCf->IsIPadjusted() - It hasn't been previously adjusted to point to the call (i.e. like [call IL_Throw], etc.)
-        pStackTraceElem->fAdjustOffset = !pCf->HasFaulted() && !pCf->IsIPadjusted();
+        pStackTraceElem->flags = 0;
 
         // This is a workaround to fix the generation of stack traces from exception objects so that
         // they point to the line that actually generated the exception instead of the line
         // following.
-        if (!pStackTraceElem->fAdjustOffset && pStackTraceElem->ip != 0)
+        if (!(pCf->HasFaulted() || pCf->IsIPadjusted()) && pStackTraceElem->ip != 0)
         {
             pStackTraceElem->ip -= 1;
+            pStackTraceElem->flags |= STEF_IP_ADJUSTED;
         }
 
         ++m_dFrameCount;

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -3557,10 +3557,15 @@ BOOL StackTraceInfo::AppendElement(BOOL bAllowAllocMem, UINT_PTR currentIP, UINT
         // the current exception). Hence, set the corresponding flag to FALSE.
         pStackTraceElem->fIsLastFrameFromForeignStackTrace = FALSE;
 
+        // We can assume that IP points to an the instruction after [call IL_Throw] when these conditions are met:
+        //  1. !pCf->HasFaulted() - It wasn't a "hardware" exception (Access violation, dev by 0, etc.)
+        //  2. !pCf->IsIPadjusted() - It hasn't been previously adjusted to point to the call (i.e. like [call IL_Throw], etc.)
+        pStackTraceElem->fAdjustOffset = !pCf->HasFaulted() && !pCf->IsIPadjusted();
+
         // This is a workaround to fix the generation of stack traces from exception objects so that
         // they point to the line that actually generated the exception instead of the line
         // following.
-        if (!(pCf->HasFaulted() || pCf->IsIPadjusted()) && pStackTraceElem->ip != 0)
+        if (!pStackTraceElem->fAdjustOffset && pStackTraceElem->ip != 0)
         {
             pStackTraceElem->ip -= 1;
         }

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -1333,7 +1333,7 @@ void ExceptionTracker::InitializeCrawlFrameForExplicitFrame(CrawlFrame* pcfThisF
 
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
 
-    // Clear various flags because the above INDEBUG sets them to true
+    // Clear various flags
     pcfThisFrame->isFrameless = false;
     pcfThisFrame->isInterrupted = false;
     pcfThisFrame->hasFaulted = false;
@@ -1422,7 +1422,7 @@ void ExceptionTracker::InitializeCrawlFrame(CrawlFrame* pcfThisFrame, Thread* pT
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
     pcfThisFrame->pRD = pRD;
 
-    // Clear various flags because the above INDEBUG sets them to true
+    // Clear various flags
     pcfThisFrame->pFunc = NULL;
     pcfThisFrame->isInterrupted = false;
     pcfThisFrame->hasFaulted = false;

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -1333,7 +1333,12 @@ void ExceptionTracker::InitializeCrawlFrameForExplicitFrame(CrawlFrame* pcfThisF
 
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
 
+    // Clear various flags because the above INDEBUG sets them to true
     pcfThisFrame->isFrameless = false;
+    pcfThisFrame->isInterrupted = false;
+    pcfThisFrame->hasFaulted = false;
+    pcfThisFrame->isIPadjusted = false;
+
     pcfThisFrame->pFrame = pFrame;
     pcfThisFrame->pFunc = pFrame->GetFunction();
 
@@ -1416,6 +1421,12 @@ void ExceptionTracker::InitializeCrawlFrame(CrawlFrame* pcfThisFrame, Thread* pT
 
     INDEBUG(memset(pcfThisFrame, 0xCC, sizeof(*pcfThisFrame)));
     pcfThisFrame->pRD = pRD;
+
+    // Clear various flags because the above INDEBUG sets them to true
+    pcfThisFrame->pFunc = NULL;
+    pcfThisFrame->isInterrupted = false;
+    pcfThisFrame->hasFaulted = false;
+    pcfThisFrame->isIPadjusted = false;
 
 #ifdef FEATURE_INTERPRETER
     pcfThisFrame->pFrame = NULL;
@@ -1571,7 +1582,6 @@ void ExceptionTracker::InitializeCrawlFrame(CrawlFrame* pcfThisFrame, Thread* pT
     }
 
     pcfThisFrame->pThread = pThread;
-    pcfThisFrame->hasFaulted = false;
 
     Frame* pTopFrame = pThread->GetFrame();
     pcfThisFrame->isIPadjusted = (FRAME_TOP != pTopFrame) && (pTopFrame->GetVTablePtr() != FaultingExceptionFrame::GetMethodFrameVPtr());

--- a/src/coreclr/src/vm/stackwalk.cpp
+++ b/src/coreclr/src/vm/stackwalk.cpp
@@ -1499,7 +1499,7 @@ void StackFrameIterator::ResetCrawlFrame()
     m_crawl.isFirst = true;
     m_crawl.isInterrupted = false;
     m_crawl.hasFaulted = false;
-    m_crawl.isIPadjusted = false;           // can be removed
+    m_crawl.isIPadjusted = false;
 
     m_crawl.isNativeMarker = false;
     m_crawl.isProfilerDoStackSnapshot = !!(this->m_flags & PROFILER_DO_STACK_SNAPSHOT);

--- a/src/coreclr/src/vm/stackwalk.h
+++ b/src/coreclr/src/vm/stackwalk.h
@@ -102,6 +102,7 @@ public:
     inline Frame* GetFrame()       // will return NULL for "frameless methods"
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
 
         if (isFrameless)
             return NULL;
@@ -173,6 +174,7 @@ public:
     inline bool IsFrameless()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
 
         return isFrameless;
     }
@@ -183,6 +185,7 @@ public:
     inline bool IsActiveFrame()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFirst != 0xcc);
 
         return isFirst;
     }
@@ -193,6 +196,7 @@ public:
     inline bool IsActiveFunc()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFirst != 0xcc);
 
         return (pFunc && isFirst);
     }
@@ -204,6 +208,7 @@ public:
     bool IsInterrupted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isInterrupted != 0xcc);
 
         return (pFunc && isInterrupted /* && isFrameless?? */);
     }
@@ -214,6 +219,7 @@ public:
     bool HasFaulted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)hasFaulted != 0xcc);
 
         return (pFunc && hasFaulted /* && isFrameless?? */);
     }
@@ -225,6 +231,8 @@ public:
     bool IsNativeMarker()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNativeMarker != 0xcc);
+
         return isNativeMarker;
     }
 
@@ -239,6 +247,8 @@ public:
     bool IsNoFrameTransition()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNoFrameTransition != 0xcc);
+
         return isNoFrameTransition;
     }
 
@@ -249,6 +259,8 @@ public:
     TADDR GetNoFrameTransitionMarker()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isNoFrameTransition != 0xcc);
+
         return (isNoFrameTransition ? taNoFrameTransitionMarker : NULL);
     }
 
@@ -259,6 +271,7 @@ public:
     bool IsIPadjusted()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isIPadjusted != 0xcc);
 
         return (pFunc && isIPadjusted /* && isFrameless?? */);
     }
@@ -336,6 +349,7 @@ public:
     GCInfoToken GetGCInfoToken()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetGCInfoToken();
     }
@@ -343,6 +357,7 @@ public:
     PTR_VOID GetGCInfo()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetGCInfo();
     }
@@ -350,6 +365,7 @@ public:
     const METHODTOKEN& GetMethodToken()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetMethodToken();
     }
@@ -357,6 +373,7 @@ public:
     unsigned GetRelOffset()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetRelOffset();
     }
@@ -364,6 +381,7 @@ public:
     IJitManager*  GetJitManager()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetJitManager();
     }
@@ -371,6 +389,7 @@ public:
     ICodeManager* GetCodeManager()
     {
         LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE((int)isFrameless != 0xcc);
         _ASSERTE(isFrameless);
         return codeInfo.GetCodeManager();
     }


### PR DESCRIPTION
There are a few paths to get the place (DebugStackTrace::DebugStackTraceElement::InitPass2) where
the offset/ip needs an adjustment:

1) The System.Diagnostics.StackTrace constructors that take an exception object. The stack trace in
   the exception object is used (from the _stackTrace field).
2) Processing an unhandled exception for display (ExceptionTracker::ProcessOSExceptionNotification).
3) The System.Diagnostics.StackTrace constructors that don't take an exception object that get the
   stack trace of the current thread.

For cases #1 and #2 the StackTraceInfo/StackTraceElement structs are built when the stack trace
for an exception is generated and is put in the private _stackTrace Exception object field. The
IP in each StackTraceElement is decremented for hardware exceptions and not for software exceptions because the CrawlFrame isInterrupted/hasFaulted fields are not initialized (always false). This is backwards for h/w exceptions leaf node frames but really can't be changed to be compatible with other code in the runtime and SOS.

The fIsLastFrameFromForeignStackTrace BOOL in the StackTraceElement/DebugStackTraceElement structs have been replaced with INT "flags" field defined by the StackTraceElementFlags enum. There is a new flag that is set (STEF_IP_ADJUSTED) if the IP has been already adjusted/decremented. This flag is used to adjust the native offset when it is converted to an IL offset for source/line number lookup in DebugStackTraceElement::InitPass2().

When the stack trace for an exception is rendered to a string (via the GetStackFramesInternal FCALL)
the internal GetStackFramesData/DebugStackTraceElement structs are initialized. This new "flags"
field is passed from the StackTraceElement to the DebugStackTraceElement struct.

For case #3 all this happens in the GetStackFramesInternal FCALL called from the managed constructor building the GetStackFramesData/DebugStackTraceElement structs directly.

Fixes issues #27765 and #25740.