### PR TITLE
Merge ReadyToRunCodegenNodeFactory into NodeFactory

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
     internal class ReadyToRunObjectWriter
     {
         // Nodefactory for which ObjectWriter is instantiated for.
-        private readonly ReadyToRunCodegenNodeFactory _nodeFactory;
+        private readonly NodeFactory _nodeFactory;
         private readonly string _objectFilePath;
         private readonly IEnumerable<DependencyNode> _nodes;
         private readonly PEReader _inputPeReader;
@@ -47,7 +47,7 @@ namespace ILCompiler.DependencyAnalysis
         Dictionary<string, NodeInfo> _previouslyWrittenNodeNames = new Dictionary<string, NodeInfo>();
 #endif
 
-        public ReadyToRunObjectWriter(PEReader inputPeReader, string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory, bool generateMapFile)
+        public ReadyToRunObjectWriter(PEReader inputPeReader, string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile)
         {
             _objectFilePath = objectFilePath;
             _nodes = nodes;
@@ -204,7 +204,7 @@ namespace ILCompiler.DependencyAnalysis
             r2rPeBuilder.AddObjectData(data, section, name, mapFile);
         }
 
-        public static void EmitObject(PEReader inputPeReader, string objectFilePath, IEnumerable<DependencyNode> nodes, ReadyToRunCodegenNodeFactory factory, bool generateMapFile)
+        public static void EmitObject(PEReader inputPeReader, string objectFilePath, IEnumerable<DependencyNode> nodes, NodeFactory factory, bool generateMapFile)
         {
             Console.WriteLine($@"Emitting R2R PE file: {objectFilePath}");
             ReadyToRunObjectWriter objectWriter = new ReadyToRunObjectWriter(inputPeReader, objectFilePath, nodes, factory, generateMapFile);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedCorHeaderNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedCorHeaderNode.cs
@@ -61,7 +61,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
             builder.RequireInitialPointerAlignment();
             builder.AddSymbol(this);
-            ReadyToRunCodegenNodeFactory r2rFactory = ((ReadyToRunCodegenNodeFactory)factory);
 
             BlobReader reader = _module.PEReader.GetEntireImage().GetReader();
             reader.Offset = _module.PEReader.PEHeaders.CorHeaderStartOffset;
@@ -76,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Metadata Directory
             ReadDirectoryEntry(ref reader);
-            var metadataBlob = r2rFactory.CopiedMetadataBlob(_module);
+            var metadataBlob = factory.CopiedMetadataBlob(_module);
             builder.EmitReloc(metadataBlob, RelocType.IMAGE_REL_BASED_ADDR32NB);
             builder.EmitInt(metadataBlob.Size);
 
@@ -89,7 +88,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Resources Directory
             if (ReadDirectoryEntry(ref reader).Size > 0)
             {
-                var managedResources = r2rFactory.CopiedManagedResources(_module);
+                var managedResources = factory.CopiedManagedResources(_module);
                 builder.EmitReloc(managedResources, RelocType.IMAGE_REL_BASED_ADDR32NB);
                 builder.EmitInt(managedResources.Size);
             }
@@ -101,7 +100,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Strong Name Signature Directory
             if (ReadDirectoryEntry(ref reader).Size > 0)
             {
-                var strongNameSignature = r2rFactory.CopiedStrongNameSignature(_module);
+                var strongNameSignature = factory.CopiedStrongNameSignature(_module);
                 builder.EmitReloc(strongNameSignature, RelocType.IMAGE_REL_BASED_ADDR32NB);
                 builder.EmitInt(strongNameSignature.Size);
             }
@@ -125,8 +124,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Managed Native (ReadyToRun) Header Directory
             ReadDirectoryEntry(ref reader);
-            builder.EmitReloc(r2rFactory.Header, RelocType.IMAGE_REL_BASED_ADDR32NB);
-            builder.EmitReloc(r2rFactory.Header, RelocType.IMAGE_REL_SYMBOL_SIZE);
+            builder.EmitReloc(factory.Header, RelocType.IMAGE_REL_BASED_ADDR32NB);
+            builder.EmitReloc(factory.Header, RelocType.IMAGE_REL_SYMBOL_SIZE);
 
             // Did we fully read the header?
             Debug.Assert(reader.Offset - headerSize == _module.PEReader.PEHeaders.CorHeaderStartOffset);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     var methodDefHandle = MetadataTokens.EntityHandle(TableIndex.MethodDef, i);
                     EcmaMethod method = _sourceModule.GetMethod(methodDefHandle) as EcmaMethod;
-                    builder.EmitReloc(((ReadyToRunCodegenNodeFactory)factory).CopiedMethodIL(method), RelocType.IMAGE_REL_BASED_ADDR32NB);
+                    builder.EmitReloc(factory.CopiedMethodIL(method), RelocType.IMAGE_REL_BASED_ADDR32NB);
                 }
 
                 // Skip the rest of the row
@@ -86,7 +86,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 EcmaField fieldDesc = (EcmaField)_sourceModule.GetField(fieldHandle);
                 Debug.Assert(fieldDesc.HasRva);
 
-                builder.EmitReloc(((ReadyToRunCodegenNodeFactory)factory).CopiedFieldRva(fieldDesc), RelocType.IMAGE_REL_BASED_ADDR32NB);
+                builder.EmitReloc(factory.CopiedFieldRva(fieldDesc), RelocType.IMAGE_REL_BASED_ADDR32NB);
                 builder.EmitShort(fieldToken);
             }
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
@@ -80,9 +80,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Section section = writer.NewSection();
             VertexArray vertexArray = new VertexArray(section);
             section.Place(vertexArray);
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
 
-            foreach (MethodWithGCInfo method in r2rFactory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
             {
                 MemoryStream methodDebugBlob = new MemoryStream();
                 
@@ -108,7 +107,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 BlobVertex debugBlob = new BlobVertex(methodDebugBlob.ToArray());
 
-                vertexArray.Set(r2rFactory.RuntimeFunctionsTable.GetIndex(method), new DebugInfoVertex(debugBlob));
+                vertexArray.Set(factory.RuntimeFunctionsTable.GetIndex(method), new DebugInfoVertex(debugBlob));
             }
 
             vertexArray.ExpandLayout();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly ImportThunk _delayLoadHelper;
 
         public DelayLoadHelperImport(
-            ReadyToRunCodegenNodeFactory factory, 
+            NodeFactory factory, 
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
             Signature instanceSignature, 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly SignatureContext _signatureContext;
 
         public DelayLoadHelperMethodImport(
-            ReadyToRunCodegenNodeFactory factory, 
+            NodeFactory factory, 
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
             MethodWithToken method,
@@ -51,8 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // Require compilation of the canonical version for instantiating stubs
                 MethodDesc canonMethod = _method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
-                ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
+                ISymbolNode canonMethodNode = factory.MethodEntrypoint(
                     new MethodWithToken(canonMethod, _method.Token, constrainedType: null),
                     isUnboxingStub: false,
                     isInstantiatingStub: false,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -39,13 +39,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder builder = new ObjectDataSignatureBuilder();
             builder.AddSymbol(this);
 
             if (!relocsOnly)
             {
-                SignatureContext innerContext = builder.EmitFixup(r2rFactory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, _signatureContext);
+                SignatureContext innerContext = builder.EmitFixup(factory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, _signatureContext);
 
                 builder.EmitMethodSignature(
                     new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null),

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExceptionInfoLookupTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExceptionInfoLookupTableNode.cs
@@ -65,11 +65,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private List<MethodWithGCInfo> _methodNodes;
         private List<int> _ehInfoOffsets;
 
-        private readonly ReadyToRunCodegenNodeFactory _nodeFactory;
+        private readonly NodeFactory _nodeFactory;
 
         private readonly EHInfoNode _ehInfoNode;
 
-        public ExceptionInfoLookupTableNode(ReadyToRunCodegenNodeFactory nodeFactory)
+        public ExceptionInfoLookupTableNode(NodeFactory nodeFactory)
             : base(nodeFactory.Target)
         {
             _nodeFactory = nodeFactory;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly MethodWithToken _method;
 
         public ExternalMethodImport(
-            ReadyToRunCodegenNodeFactory factory,
+            NodeFactory factory,
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             bool isUnboxingStub,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -34,7 +34,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
 
             if (!relocsOnly)
@@ -42,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.AddSymbol(this);
 
                 EcmaModule targetModule = _signatureContext.GetTargetModule(_fieldDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, _fixupKind, targetModule, _signatureContext);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, _signatureContext);
 
                 dataBuilder.EmitFieldSignature(_fieldDesc, innerContext);
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -57,8 +57,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(Array.Empty<byte>(), null, 1, null);
             }
 
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
-
             // Determine the need for module override
             EcmaModule targetModule;
             if (_methodArgument != null)
@@ -103,7 +101,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);
 
-            SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, fixupToEmit, targetModule, _signatureContext);
+            SignatureContext innerContext = dataBuilder.EmitFixup(factory, fixupToEmit, targetModule, _signatureContext);
             if (contextTypeToEmit != null)
             {
                 dataBuilder.EmitTypeSignature(contextTypeToEmit, innerContext);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _gcRefMap = _emitGCRefMap ? new GCRefMapNode(this) : null;
         }
 
-        public void MaterializeSignature(ReadyToRunCodegenNodeFactory r2rFactory)
+        public void MaterializeSignature(NodeFactory r2rFactory)
         {
             if (!_materializedSignature)
             {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
@@ -8,11 +8,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ImportSectionsTableNode : ArrayOfEmbeddedDataNode<ImportSectionNode>, ISignatureEmitter
     {
-        private readonly ReadyToRunCodegenNodeFactory _r2rFactory;
+        private readonly NodeFactory _r2rFactory;
 
         private bool _materializedSignature;
 
-        public ImportSectionsTableNode(ReadyToRunCodegenNodeFactory r2rFactory)
+        public ImportSectionsTableNode(NodeFactory r2rFactory)
             : base("ImportSectionsTableStart", "ImportSectionsTableEnd", new EmbeddedObjectNodeComparer(new CompilerComparer()))
         {
             _r2rFactory = r2rFactory;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly Kind _thunkKind;
 
-        public ImportThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell, bool useVirtualCall)
+        public ImportThunk(ReadyToRunHelper helperId, NodeFactory factory, Import instanceCell, bool useVirtualCall)
         {
             _helperCell = factory.GetReadyToRunHelperCell(helperId);
             _instanceCell = instanceCell;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -37,7 +37,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
             }
 
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             NativeWriter hashtableWriter = new NativeWriter();
 
             Section hashtableSection = hashtableWriter.NewSection();
@@ -47,15 +46,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Dictionary<byte[], BlobVertex> uniqueFixups = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
             Dictionary<byte[], BlobVertex> uniqueSignatures = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
 
-            foreach (MethodWithGCInfo method in r2rFactory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
             {
                 if (method.Method.HasInstantiation || method.Method.OwningType.HasInstantiation)
                 {
-                    int methodIndex = r2rFactory.RuntimeFunctionsTable.GetIndex(method);
+                    int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
 
                     bool enforceOwningType = false;
                     ModuleToken moduleToken = method.SignatureContext.GetModuleTokenForMethod(method.Method.GetTypicalMethodDefinition());
-                    if (moduleToken.Module != r2rFactory.InputModuleContext.GlobalContext)
+                    if (moduleToken.Module != factory.InputModuleContext.GlobalContext)
                     {
                         enforceOwningType = true;
                     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly MethodWithGCInfo _localMethod;
 
         public LocalMethodImport(
-            ReadyToRunCodegenNodeFactory factory,
+            NodeFactory factory,
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             MethodWithGCInfo localMethod,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -52,10 +52,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
             }
 
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             List<EntryPoint> ridToEntryPoint = new List<EntryPoint>();
 
-            foreach (MethodWithGCInfo method in r2rFactory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
             {
                 if (method.Method is EcmaMethod ecmaMethod)
                 {
@@ -69,7 +68,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         ridToEntryPoint.Add(EntryPoint.Null);
                     }
 
-                    int methodIndex = r2rFactory.RuntimeFunctionsTable.GetIndex(method);
+                    int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
                     ridToEntryPoint[(int)rid] = new EntryPoint(methodIndex, method);
                 }
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -58,7 +58,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(data: Array.Empty<byte>(), relocs: null, alignment: 0, definedSymbols: null);
             }
 
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);
 
@@ -100,7 +99,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
-            SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, fixupKind, method.Token.Module, _signatureContext);
+            SignatureContext innerContext = dataBuilder.EmitFixup(factory, fixupKind, method.Token.Module, _signatureContext);
 
             if (optimized && method.Token.TokenType == CorTokenType.mdtMethodDef)
             {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodGCInfoNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodGCInfoNode.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         protected override void OnMarked(NodeFactory factory)
         {
-            ((ReadyToRunCodegenNodeFactory)factory).RuntimeFunctionsGCInfo.AddEmbeddedObject(this);
+            factory.RuntimeFunctionsGCInfo.AddEmbeddedObject(this);
         }
 
         public int[] CalculateFuncletOffsets(NodeFactory factory)
@@ -82,8 +82,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (factory.Target.Architecture != Internal.TypeSystem.TargetArchitecture.X86)
                 {
                     bool isFilterFunclet = (_methodNode.FrameInfos[frameInfoIndex].Flags & FrameInfoFlags.Filter) != 0;
-                    ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
-                    ISymbolNode personalityRoutine = (isFilterFunclet ? r2rFactory.FilterFuncletPersonalityRoutine : r2rFactory.PersonalityRoutine);
+                    ISymbolNode personalityRoutine = (isFilterFunclet ? factory.FilterFuncletPersonalityRoutine : factory.PersonalityRoutine);
                     dataBuilder.EmitReloc(personalityRoutine, RelocType.IMAGE_REL_BASED_ADDR32NB);
                 }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -27,7 +27,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
 
             if (!relocsOnly)
@@ -35,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.AddSymbol(this);
 
                 EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
-                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
                 dataBuilder.EmitTypeSignature(_arrayType, innerContext);
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
@@ -27,7 +27,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
 
             if (!relocsOnly)
@@ -35,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.AddSymbol(this);
 
                 EcmaModule targetModule = _signatureContext.GetTargetModule(_typeDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.NewObject, targetModule, _signatureContext);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewObject, targetModule, _signatureContext);
                 dataBuilder.EmitTypeSignature(_typeDesc, innerContext);
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperImport.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     /// </summary>
     public class PrecodeHelperImport : Import
     {
-        public PrecodeHelperImport(ReadyToRunCodegenNodeFactory factory, Signature signature)
+        public PrecodeHelperImport(NodeFactory factory, Signature signature)
             : base(factory.PrecodeImports, signature)
         {
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
@@ -17,7 +17,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly MethodWithGCInfo _localMethod;
 
         public PrecodeMethodImport(
-            ReadyToRunCodegenNodeFactory factory,
+            NodeFactory factory,
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             MethodWithGCInfo localMethod,

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ProfileDataNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ProfileDataNode.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         protected override void OnMarked(NodeFactory factory)
         {
-            ((ReadyToRunCodegenNodeFactory)factory).ProfileDataSection.AddEmbeddedObject(this);
+            factory.ProfileDataSection.AddEmbeddedObject(this);
         }
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -16,10 +16,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private List<MethodWithGCInfo> _methodNodes;
         private Dictionary<MethodWithGCInfo, int> _insertedMethodNodes;
-        private readonly ReadyToRunCodegenNodeFactory _nodeFactory;
+        private readonly NodeFactory _nodeFactory;
         private int _tableSize = -1;
 
-        public RuntimeFunctionsTableNode(ReadyToRunCodegenNodeFactory nodeFactory)
+        public RuntimeFunctionsTableNode(NodeFactory nodeFactory)
             : base(nodeFactory.Target)
         {
             _nodeFactory = nodeFactory;
@@ -68,7 +68,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 LayoutRuntimeFunctions();
 
             ObjectDataBuilder runtimeFunctionsBuilder = new ObjectDataBuilder(factory, relocsOnly);
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
 
             // Add the symbol representing this object node
             runtimeFunctionsBuilder.AddSymbol(this);
@@ -88,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         // On Amd64, the 2nd word contains the EndOffset of the runtime function
                         runtimeFunctionsBuilder.EmitReloc(method, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: frameInfo.EndOffset);
                     }
-                    runtimeFunctionsBuilder.EmitReloc(r2rFactory.RuntimeFunctionsGCInfo.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, funcletOffsets[frameIndex]);
+                    runtimeFunctionsBuilder.EmitReloc(factory.RuntimeFunctionsGCInfo.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, funcletOffsets[frameIndex]);
                 }
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -605,7 +605,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return _builder.ToObjectData();
         }
 
-        public SignatureContext EmitFixup(ReadyToRunCodegenNodeFactory factory, ReadyToRunFixupKind fixupKind, EcmaModule targetModule, SignatureContext outerContext)
+        public SignatureContext EmitFixup(NodeFactory factory, ReadyToRunFixupKind fixupKind, EcmaModule targetModule, SignatureContext outerContext)
         {
             if (targetModule == outerContext.LocalContext)
             {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
@@ -23,14 +23,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
 
             if (!relocsOnly)
             {
                 dataBuilder.AddSymbol(this);
 
-                dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.StringHandle, _token.Module, _signatureContext);
+                dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.StringHandle, _token.Module, _signatureContext);
                 dataBuilder.EmitUInt(_token.TokenRid);
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -33,7 +33,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
 
             if (!relocsOnly)
@@ -41,7 +40,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.AddSymbol(this);
 
                 EcmaModule targetModule = _signatureContext.GetTargetModule(_typeDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, _fixupKind, targetModule, _signatureContext);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, _signatureContext);
                 dataBuilder.EmitTypeSignature(_typeDesc, innerContext);
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -37,9 +37,9 @@ namespace ILCompiler.DependencyAnalysis
 
     public sealed class ReadyToRunSymbolNodeFactory
     {
-        private readonly ReadyToRunCodegenNodeFactory _codegenNodeFactory;
+        private readonly NodeFactory _codegenNodeFactory;
 
-        public ReadyToRunSymbolNodeFactory(ReadyToRunCodegenNodeFactory codegenNodeFactory)
+        public ReadyToRunSymbolNodeFactory(NodeFactory codegenNodeFactory)
         {
             _codegenNodeFactory = codegenNodeFactory;
             CreateNodeCaches();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -197,13 +197,11 @@ namespace ILCompiler
 
         private bool _generateMapFile;
 
-        public new ReadyToRunCodegenNodeFactory NodeFactory { get; }
-
         public ReadyToRunSymbolNodeFactory SymbolNodeFactory { get; }
 
         internal ReadyToRunCodegenCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
-            ReadyToRunCodegenNodeFactory nodeFactory,
+            NodeFactory nodeFactory,
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             Logger logger,
@@ -218,7 +216,6 @@ namespace ILCompiler
             _resilient = resilient;
             _parallelism = parallelism;
             _generateMapFile = generateMapFile;
-            NodeFactory = nodeFactory;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);
 
             _inputFilePath = inputFilePath;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -141,7 +141,7 @@ namespace ILCompiler
                 return true;
             });
 
-            ReadyToRunCodegenNodeFactory factory = new ReadyToRunCodegenNodeFactory(
+            NodeFactory factory = new NodeFactory(
                 _context,
                 _compilationGroup,
                 _nameMangler,


### PR DESCRIPTION
This split existed because of a failed attempt to share too much of crossgen2 with the full AOT compiler. Now that we're sharing source files instead of entire assemblies, ILCompiler.ReadyToRun is free to claim the NodeFactory name.