### PR TITLE
Emit Partial/PlatformNeutralSource flags in R2R header

### DIFF
--- a/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -7,7 +7,7 @@ using System;
 namespace Internal.ReadyToRunConstants
 {
     [Flags]
-    public enum ReadyToRunFlag
+    public enum ReadyToRunFlags
     {
         READYTORUN_FLAG_PlatformNeutralSource = 0x00000001,     // Set if the original IL assembly was platform-neutral
         READYTORUN_FLAG_SkipTypeValidation = 0x00000002,        // Set of methods with native code was determined using profile data

--- a/src/coreclr/src/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -263,6 +263,18 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public bool IsPlatformNeutral
+        {
+            get
+            {
+                PEHeaders peHeaders = PEReader.PEHeaders;
+                return peHeaders.PEHeader.Magic == PEMagic.PE32
+                    && (peHeaders.CorHeader.Flags & (CorFlags.Prefers32Bit | CorFlags.Requires32Bit)) != CorFlags.Requires32Bit
+                    && (peHeaders.CorHeader.Flags & CorFlags.ILOnly) != 0
+                    && peHeaders.CoffHeader.Machine == Machine.I386;
+            }
+        }
+
         public sealed override MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
         {
             var stringComparer = _metadataReader.StringComparer;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -4,6 +4,7 @@
 
 using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
+using Internal.ReadyToRunConstants;
 
 namespace ILCompiler
 {
@@ -52,5 +53,10 @@ namespace ILCompiler
         /// <param name="token">Module-based token for the type</param>
         /// <returns>Returns true the type was referenced by any of the input modules in the current compliation</returns>
         public abstract bool TryGetModuleTokenForExternalType(TypeDesc type, out ModuleToken token);
+
+        /// <summary>
+        /// Gets the flags to be stored in the generated ReadyToRun module header.
+        /// </summary>
+        public abstract ReadyToRunFlags GetReadyToRunFlags();
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
@@ -58,12 +58,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public readonly ISymbolNode StartSymbol;
         }
 
-        private List<HeaderItem> _items = new List<HeaderItem>();
-        private TargetDetails _target;
+        private readonly List<HeaderItem> _items = new List<HeaderItem>();
+        private readonly TargetDetails _target;
+        private readonly ReadyToRunFlags _flags;
 
-        public HeaderNode(TargetDetails target)
+        public HeaderNode(TargetDetails target, ReadyToRunFlags flags)
         {
             _target = target;
+            _flags = flags;
         }
 
         public void Add(ReadyToRunSectionType id, ObjectNode node, ISymbolNode startSymbol)
@@ -112,7 +114,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             builder.EmitShort((short)(ReadyToRunHeaderConstants.CurrentMinorVersion));
 
             // ReadyToRunHeader.Flags
-            builder.EmitInt((int)ReadyToRunFlag.READYTORUN_FLAG_NonSharedPInvokeStubs);
+            builder.EmitInt((int)_flags);
 
             // ReadyToRunHeader.NumberOfSections
             ObjectDataBuilder.Reservation sectionCountReservation = builder.ReserveInt();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -179,7 +179,8 @@ namespace ILCompiler.DependencyAnalysis
             SignatureContext signatureContext,
             CopiedCorHeaderNode corHeaderNode,
             ResourceData win32Resources,
-            AttributePresenceFilterNode attributePresenceFilterNode)
+            AttributePresenceFilterNode attributePresenceFilterNode,
+            HeaderNode headerNode)
         {
             TypeSystemContext = context;
             CompilationModuleGroup = compilationModuleGroup;
@@ -190,6 +191,7 @@ namespace ILCompiler.DependencyAnalysis
             InputModuleContext = signatureContext;
             CopiedCorHeaderNode = corHeaderNode;
             AttributePresenceFilter = attributePresenceFilterNode;
+            Header = headerNode;
             if (!win32Resources.IsEmpty)
                 Win32ResourcesNode = new Win32ResourcesNode(win32Resources);
 
@@ -548,8 +550,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
         {
-            Header = new HeaderNode(Target);
-
             var compilerIdentifierNode = new CompilerIdentifierNode(Target);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.CompilerIdentifier, compilerIdentifierNode, compilerIdentifierNode);
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -11,6 +11,7 @@ using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.Win32Resources;
 using Internal.IL;
 using Internal.JitInterface;
+using Internal.ReadyToRunConstants;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -141,6 +142,13 @@ namespace ILCompiler
                 return true;
             });
 
+            ReadyToRunFlags flags = ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs;
+            if (_inputModule.IsPlatformNeutral)
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNeutralSource;
+            flags |= _compilationGroup.GetReadyToRunFlags();
+
+            var header = new HeaderNode(_context.Target, flags);
+
             NodeFactory factory = new NodeFactory(
                 _context,
                 _compilationGroup,
@@ -149,7 +157,8 @@ namespace ILCompiler
                 signatureContext,
                 corHeaderNode,
                 win32Resources,
-                attributePresenceFilterNode);
+                attributePresenceFilterNode,
+                header);
 
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer());
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, comparer);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
-using Internal.TypeSystem.Interop;
-using ILCompiler.DependencyAnalysis.ReadyToRun;
+using Internal.ReadyToRunConstants;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
@@ -84,6 +82,17 @@ namespace ILCompiler
 
             _profileGuidedCompileRestrictionSet = true;
             _profileGuidedCompileRestriction = profileGuidedCompileRestriction;
+        }
+
+        public override ReadyToRunFlags GetReadyToRunFlags()
+        {
+            Debug.Assert(_profileGuidedCompileRestrictionSet);
+
+            ReadyToRunFlags flags = 0;
+            if (_profileGuidedCompileRestriction != null)
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_Partial;
+
+            return flags;
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-
+using Internal.ReadyToRunConstants;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -39,6 +39,12 @@ namespace ILCompiler
         {
             // Profiler guided restrictions are ignored for single method compilation
             return;
+        }
+
+        public override ReadyToRunFlags GetReadyToRunFlags()
+        {
+            // Partial by definition.
+            return ReadyToRunFlags.READYTORUN_FLAG_Partial;
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -110,11 +110,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 sb.AppendLine($"MajorVersion: 0x{MajorVersion:X4}");
                 sb.AppendLine($"MinorVersion: 0x{MinorVersion:X4}");
                 sb.AppendLine($"Flags: 0x{Flags:X8}");
-                foreach (ReadyToRunFlag flag in Enum.GetValues(typeof(ReadyToRunFlag)))
+                foreach (ReadyToRunFlags flag in Enum.GetValues(typeof(ReadyToRunFlags)))
                 {
                     if ((Flags & (uint)flag) != 0)
                     {
-                        sb.AppendLine($"  - {Enum.GetName(typeof(ReadyToRunFlag), flag)}");
+                        sb.AppendLine($"  - {Enum.GetName(typeof(ReadyToRunFlags), flag)}");
                     }
                 }
             }


### PR DESCRIPTION
I added the partial flag to the legacy crossgen in dotnet/coreclr#22680 but crossgen2 was missing it. Also added platform neutral source since it's easy.