### PR TITLE
Update Dotnet host for testing and add RuntimeFrameworkVersion to nca5.0 package testing

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,17 +4,17 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.20077.11">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.20080.9">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
+      <Sha>665983a01f9c604bc3f704f469acb8a08c619d8a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.20077.11">
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.20080.9">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
+      <Sha>665983a01f9c604bc3f704f469acb8a08c619d8a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.20077.11">
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.20080.9">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
+      <Sha>665983a01f9c604bc3f704f469acb8a08c619d8a</Sha>
     </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19563.3">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,17 +4,17 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.20071.1">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.20077.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>86bfd8d46b3817e2a027b23d829cd0d035cd8ad6</Sha>
+      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8743c312a9d1ce4035140046d44bb959c44f194f</Sha>
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.20077.11">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.19563.6">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>8743c312a9d1ce4035140046d44bb959c44f194f</Sha>
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.20077.11">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4011572bd462ad94bcfadb7c5b4dfcacfeae970a</Sha>
     </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19563.3">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,9 +71,9 @@
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20079.8</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20079.8</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
-    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.20071.1</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.19563.6</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <!-- CoreClr dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,9 +71,9 @@
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20079.8</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20079.8</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
-    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.20077.11</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.20080.9</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.20080.9</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.20080.9</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <!-- CoreClr dependencies -->

--- a/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
@@ -1,4 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
   <ItemGroup>
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App" />


### PR DESCRIPTION
In this PR we accidentally removed RuntimeFrameworkVersion for our package testing: https://github.com/dotnet/runtime/pull/445

Also, in https://github.com/dotnet/runtime/issues/1723#issuecomment-579190216 @janvorli noticed that we are using a pretty old dotnet host.

cc: @ViktorHofer @ericstj @dagood 