### PR TITLE
Add Installer project build skip functionality for servicing builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,34 @@
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
+    <!--
+      The NETStandard.Library targeting pack uses this patch version, which does not match the
+      runtime's. After publishing a new version of the NETStandard targeting pack in a servicing
+      release, increase this number by one.
+    -->
+    <NETStandardPatchVersion>0</NETStandardPatchVersion>
   </PropertyGroup>
+
+  <!--
+    Servicing build settings for Setup/Installer packages. Instructions:
+
+    * To enable a package build for the current patch release, set PatchVersion to match the current
+      patch version of that package. ("major.minor.patch".) This is normally the same as
+      PatchVersion above, but not always. Notably, NETStandard has its own patch version.
+    * When the PatchVersion property above is incremented at the beginning of the next servicing
+      release, all packages listed below automatically stop building because the property no longer
+      matches the metadata. (Do not delete the items!)
+
+    If the PatchVersion below is never changed from '0', the package will build in the 'master'
+    branch, and during a forked RTM release ("X.Y.0"). It will stop building for "X.Y.1" unless
+    manually enabled by updating the metadata.
+  -->
+  <ItemGroup>
+    <!-- Targeting packs are only patched in extreme cases. -->
+    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20071.3</MicrosoftDotNetApiCompatVersion>

--- a/src/installer/pkg/projects/netstandard/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netstandard/pkg/Directory.Build.props
@@ -3,14 +3,14 @@
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <ShortFrameworkName>netstandard</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
-
-    <ProductBandVersion>2.1</ProductBandVersion>
-    <ProductionVersion>$(ProductBandVersion).0</ProductionVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
+    <ProductBandVersion>2.1</ProductBandVersion>
+    <PatchVersion>$(NETStandardPatchVersion)</PatchVersion>
+
     <FrameworkListName>.NET Standard 2.1</FrameworkListName>
     <FrameworkListTargetFrameworkIdentifier>.NETStandard</FrameworkListTargetFrameworkIdentifier>
     <FrameworkListTargetFrameworkVersion>2.1</FrameworkListTargetFrameworkVersion>

--- a/src/installer/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/installer/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -14,10 +14,17 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETCoreTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "Microsoft.NETCore.App.Ref"))
             {
+                // Allow no targeting pack in case this is a servicing build.
+                // This condition should be tightened: https://github.com/dotnet/core-setup/issues/8830
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.IsTargetingPackForPlatform();
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",

--- a/src/installer/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
+++ b/src/installer/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
@@ -14,10 +14,17 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETStandardTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "NETStandard.Library.Ref"))
             {
+                // Allow no targeting pack in case this is a servicing build.
+                // This condition should be tightened: https://github.com/dotnet/core-setup/issues/8830
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",
                     "data/PackageOverrides.txt");


### PR DESCRIPTION
This ports servicing build infrastructure from Core-Setup 3.1 (https://github.com/dotnet/core-setup/issues/8735) that disables certain Installer projects as needed during product servicing.

I'm including a fix to make it work as expected for prerelease servicing releases, so details from https://github.com/dotnet/runtime/issues/639#issuecomment-575788698 describe this particular implementation:

> I think the right fix is [to have the settings apply unconditionally]
> 
> ```diff
> -  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
> +  <ItemGroup>
>      <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
>      <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
>    </ItemGroup>
> ```
> 
> With this:
> * During `master` builds, patch version for `Microsoft.NETCore.App` is always 0, so it gets built.
> * When `release/5.0` forks, patch stays 0, so it keeps getting built.
>   * After releasing `5.0.0`, version advances to `5.0.1`, and optionally becomes `5.0.1-servicing-12345`. This disables the targeting pack build due to the patch version not matching, as desired.
>   * Enabling it is same as always, set `PatchVersion="1"` to make it match

This PR isn't intended to change the current build outputs at all.

I tested by increasing the `PatchVersion` prop and seeing the expected artifacts stop building. This was tested more back with https://github.com/dotnet/arcade/pull/4318.

/cc @mmitche @nguerrera @dotnet/runtime-infrastructure 