### PR TITLE
Change reinterpret_cast use to memcpy

### DIFF
--- a/src/coreclr/src/vm/diagnosticsprotocol.h
+++ b/src/coreclr/src/vm/diagnosticsprotocol.h
@@ -24,7 +24,7 @@ bool TryParse(uint8_t *&bufferCursor, uint32_t &bufferLen, T &result)
 
     if (bufferLen < sizeof(T))
         return false;
-    result = *(reinterpret_cast<T *>(bufferCursor));
+    memcpy(&result, bufferCursor, sizeof(T));
     bufferCursor += sizeof(T);
     bufferLen -= sizeof(T);
     return true;


### PR DESCRIPTION
* prevents unaligned address access on some ARM OSes that fault on that
---
Changes use of `reinterpret_cast` to `memcpy` in EventPipe IPC read/write operations.

resolves #2067 

I'm going to be doing some local tests to convince myself that memory is still being accounted for.  I'll flip the bit on PR status after that.

CC - @tommcdon 