### PR TITLE
Improve thunk call disassembly in R2RDump

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -203,42 +203,42 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\tVersion: {Version}");
-            sb.AppendLine($"\tCodeLength: {CodeLength}");
-            sb.AppendLine($"\tReturnKind: {Enum.GetName(typeof(ReturnKinds), ReturnKind)}");
-            sb.AppendLine($"\tValidRangeStart: {ValidRangeStart}");
-            sb.AppendLine($"\tValidRangeEnd: {ValidRangeEnd}");
+            sb.AppendLine($"    Version: {Version}");
+            sb.AppendLine($"    CodeLength: {CodeLength}");
+            sb.AppendLine($"    ReturnKind: {Enum.GetName(typeof(ReturnKinds), ReturnKind)}");
+            sb.AppendLine($"    ValidRangeStart: {ValidRangeStart}");
+            sb.AppendLine($"    ValidRangeEnd: {ValidRangeEnd}");
             if (SecurityObjectStackSlot != -1)
-                sb.AppendLine($"\tSecurityObjectStackSlot: caller.sp{SecurityObjectStackSlot:+#;-#;+0}");
+                sb.AppendLine($"    SecurityObjectStackSlot: caller.sp{SecurityObjectStackSlot:+#;-#;+0}");
 
             if (GSCookieStackSlot != -1)
             {
-                sb.AppendLine($"\tGSCookieStackSlot: caller.sp{GSCookieStackSlot:+#;-#;+0}");
-                sb.AppendLine($"GS cookie valid range: [{ValidRangeStart};{ValidRangeEnd})");
+                sb.AppendLine($"    GSCookieStackSlot: caller.sp{GSCookieStackSlot:+#;-#;+0}");
+                sb.AppendLine($"    GS cookie valid range: [{ValidRangeStart};{ValidRangeEnd})");
             }
 
             if (PSPSymStackSlot != -1)
             {
                 if (_machine == Machine.Amd64)
                 {
-                    sb.AppendLine($"\tPSPSymStackSlot: initial.sp{PSPSymStackSlot:+#;-#;+0}");
+                    sb.AppendLine($"    PSPSymStackSlot: initial.sp{PSPSymStackSlot:+#;-#;+0}");
                 }
                 else
                 {
-                    sb.AppendLine($"\tPSPSymStackSlot: caller.sp{PSPSymStackSlot:+#;-#;+0}");
+                    sb.AppendLine($"    PSPSymStackSlot: caller.sp{PSPSymStackSlot:+#;-#;+0}");
                 }
             }
 
             if (GenericsInstContextStackSlot != -1)
             {
-                sb.AppendLine($"\tGenericsInstContextStackSlot: caller.sp{GenericsInstContextStackSlot:+#;-#;+0}");
+                sb.AppendLine($"    GenericsInstContextStackSlot: caller.sp{GenericsInstContextStackSlot:+#;-#;+0}");
             }
 
             if (_machine == Machine.Amd64)
             {
                 if (StackBaseRegister != 0xffffffff)
-                    sb.AppendLine($"\tStackBaseRegister: {(Amd64.Registers)StackBaseRegister}");
-                sb.AppendLine($"\tWants Report Only Leaf: {_wantsReportOnlyLeaf}");
+                    sb.AppendLine($"    StackBaseRegister: {(Amd64.Registers)StackBaseRegister}");
+                sb.AppendLine($"    Wants Report Only Leaf: {_wantsReportOnlyLeaf}");
             }
             else if (_machine == Machine.ArmThumb2 || _machine == Machine.Arm64)
             {
@@ -246,29 +246,29 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 {
                     if (_machine == Machine.ArmThumb2)
                     {
-                        sb.AppendLine($"\tStackBaseRegister: {(Arm.Registers)StackBaseRegister}");
+                        sb.AppendLine($"    StackBaseRegister: {(Arm.Registers)StackBaseRegister}");
                     }
                     else
                     {
-                        sb.AppendLine($"\tStackBaseRegister: {(Arm64.Registers)StackBaseRegister}");
+                        sb.AppendLine($"    StackBaseRegister: {(Arm64.Registers)StackBaseRegister}");
                     }
                 }
 
-                sb.AppendLine($"\tHas Tailcalls: {_wantsReportOnlyLeaf}");
+                sb.AppendLine($"    Has Tailcalls: {_wantsReportOnlyLeaf}");
             }
 
-            sb.AppendLine($"\tSize of parameter area: 0x{SizeOfStackOutgoingAndScratchArea:X}");
+            sb.AppendLine($"    Size of parameter area: 0x{SizeOfStackOutgoingAndScratchArea:X}");
             if (SizeOfEditAndContinuePreservedArea != 0xffffffff)
-                sb.AppendLine($"\tSizeOfEditAndContinuePreservedArea: 0x{SizeOfEditAndContinuePreservedArea:X}");
+                sb.AppendLine($"    SizeOfEditAndContinuePreservedArea: 0x{SizeOfEditAndContinuePreservedArea:X}");
             if (ReversePInvokeFrameStackSlot != -1)
-                sb.AppendLine($"\tReversePInvokeFrameStackSlot: {ReversePInvokeFrameStackSlot}");
-            sb.AppendLine($"\tNumSafePoints: {NumSafePoints}");
-            sb.AppendLine($"\tNumInterruptibleRanges: {NumInterruptibleRanges}");
-            sb.AppendLine($"\tSafePointOffsets:");
+                sb.AppendLine($"    ReversePInvokeFrameStackSlot: {ReversePInvokeFrameStackSlot}");
+            sb.AppendLine($"    NumSafePoints: {NumSafePoints}");
+            sb.AppendLine($"    NumInterruptibleRanges: {NumInterruptibleRanges}");
+            sb.AppendLine($"    SafePointOffsets:");
             foreach (SafePointOffset offset in SafePointOffsets)
             {
                 IEnumerable<BaseGcSlot> liveSlotsForOffset = (LiveSlotsAtSafepoints != null ? LiveSlotsAtSafepoints[offset.Index] : Enumerable.Empty<BaseGcSlot>());
-                sb.Append($"\t\t0x{offset.Value:X4}: ");
+                sb.Append($"        0x{offset.Value:X4}: ");
                 bool haveLiveSlots = false;
                 GcSlotFlags slotFlags = GcSlotFlags.GC_SLOT_INVALID;
                 foreach (BaseGcSlot slot in liveSlotsForOffset)
@@ -289,14 +289,14 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 }
                 sb.AppendLine();
             }
-            sb.AppendLine($"\tInterruptibleRanges:");
+            sb.AppendLine($"    InterruptibleRanges:");
             foreach (InterruptibleRange range in InterruptibleRanges)
             {
-                sb.AppendLine($"\t\tstart:{range.StartOffset}, end:{range.StopOffset}");
+                sb.AppendLine($"        start:{range.StartOffset}, end:{range.StopOffset}");
             }
-            sb.AppendLine($"\tSlotTable:");
+            sb.AppendLine($"    SlotTable:");
             sb.Append(SlotTable.ToString());
-            sb.AppendLine($"\tSize: {Size} bytes");
+            sb.AppendLine($"    Size: {Size} bytes");
 
             return sb.ToString();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -133,11 +133,11 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\t\tNumSlots({NumSlots}) = NumRegisters({NumRegisters}) + NumStackSlots({NumStackSlots}) + NumUntracked({NumUntracked})");
-            sb.AppendLine($"\t\tGcSlots:");
+            sb.AppendLine($"        NumSlots({NumSlots}) = NumRegisters({NumRegisters}) + NumStackSlots({NumStackSlots}) + NumUntracked({NumUntracked})");
+            sb.AppendLine($"        GcSlots:");
             foreach (GcSlot slot in GcSlots)
             {
-                sb.Append("\t\t\t");
+                sb.Append(' ', 12);
                 slot.WriteTo(sb, _machine, GcSlotFlags.GC_SLOT_INVALID);
                 sb.AppendLine();
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -143,8 +143,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\tVersion: {Version}");
-            sb.Append($"\tFlags: 0x{Flags:X8} (");
+            sb.AppendLine($"    Version: {Version}");
+            sb.Append($"    Flags: 0x{Flags:X8} (");
             if (Flags == (byte)UnwindFlags.UNW_FLAG_NHANDLER)
             {
                 sb.Append(" UNW_FLAG_NHANDLER");
@@ -160,27 +160,27 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             }
             sb.AppendLine(" )");
 
-            sb.AppendLine($"\tSizeOfProlog: {SizeOfProlog}");
-            sb.AppendLine($"\tCountOfUnwindCodes: {CountOfUnwindCodes}");
-            sb.AppendLine($"\tFrameRegister: {FrameRegister}");
-            sb.AppendLine($"\tFrameOffset: {FrameOffset}");
-            sb.AppendLine($"\tUnwind Codes:");
-            sb.AppendLine($"\t\t------------------");
+            sb.AppendLine($"    SizeOfProlog: {SizeOfProlog}");
+            sb.AppendLine($"    CountOfUnwindCodes: {CountOfUnwindCodes}");
+            sb.AppendLine($"    FrameRegister: {FrameRegister}");
+            sb.AppendLine($"    FrameOffset: {FrameOffset}");
+            sb.AppendLine($"    Unwind Codes:");
+            sb.AppendLine($"        ------------------");
             for (int i = 0; i < CountOfUnwindCodes; i++)
             {
                 if (!UnwindCodeArray[i].IsOpInfo)
                     continue;
-                sb.AppendLine($"\t\tCodeOffset: 0x{UnwindCodeArray[i].CodeOffset:X2}");
-                sb.AppendLine($"\t\tUnwindOp: {UnwindCodeArray[i].UnwindOp}({(byte)UnwindCodeArray[i].UnwindOp})");
-                sb.AppendLine($"\t\tOpInfo: {UnwindCodeArray[i].OpInfoStr}");
+                sb.AppendLine($"        CodeOffset: 0x{UnwindCodeArray[i].CodeOffset:X2}");
+                sb.AppendLine($"        UnwindOp: {UnwindCodeArray[i].UnwindOp}({(byte)UnwindCodeArray[i].UnwindOp})");
+                sb.AppendLine($"        OpInfo: {UnwindCodeArray[i].OpInfoStr}");
                 if (UnwindCodeArray[i].NextFrameOffset != -1)
                 {
-                    sb.AppendLine($"\t\tFrameOffset: {UnwindCodeArray[i].NextFrameOffset}");
+                    sb.AppendLine($"        FrameOffset: {UnwindCodeArray[i].NextFrameOffset}");
                 }
-                sb.AppendLine($"\t\t------------------");
+                sb.AppendLine($"        ------------------");
             }
-            sb.AppendLine($"\tPersonalityRoutineRVA: 0x{PersonalityRoutineRVA:X8}");
-            sb.AppendLine($"\tSize: {Size} bytes");
+            sb.AppendLine($"        PersonalityRoutineRVA: 0x{PersonalityRoutineRVA:X8}");
+            sb.AppendLine($"        Size: {Size} bytes");
 
             return sb.ToString();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
@@ -37,9 +37,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"\t\tEpilog Start Offset: 0x{EpilogStartOffset:X5} Actual offset = 0x{EpilogStartOffset * 2:X5} Offset from main function begin = 0x{EpilogStartOffsetFromMainFunctionBegin:X6}");
-            sb.AppendLine($"\t\tCondition: {Condition} (0x{Condition:X})" + ((Condition == 0xE) ? " (always)" : ""));
-            sb.Append($"\t\tEpilog Start Index: {EpilogStartIndex} (0x{EpilogStartIndex:X})");
+            sb.AppendLine($"        Epilog Start Offset: 0x{EpilogStartOffset:X5} Actual offset = 0x{EpilogStartOffset * 2:X5} Offset from main function begin = 0x{EpilogStartOffsetFromMainFunctionBegin:X6}");
+            sb.AppendLine($"        Condition: {Condition} (0x{Condition:X})" + ((Condition == 0xE) ? " (always)" : ""));
+            sb.Append($"        Epilog Start Index: {EpilogStartIndex} (0x{EpilogStartIndex:X})");
             return sb.ToString();
         }
     }
@@ -127,30 +127,30 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"\tCodeWords: {CodeWords}");
-            sb.AppendLine($"\tEpilogCount: {EpilogCount}");
-            sb.AppendLine($"\tFBit: {FBit}");
-            sb.AppendLine($"\tEBit: {EBit}");
-            sb.AppendLine($"\tXBit: {XBit}");
-            sb.AppendLine($"\tVers: {Vers}");
-            sb.AppendLine($"\tFunctionLength: {FunctionLength}");
+            sb.AppendLine($"    CodeWords: {CodeWords}");
+            sb.AppendLine($"    EpilogCount: {EpilogCount}");
+            sb.AppendLine($"    FBit: {FBit}");
+            sb.AppendLine($"    EBit: {EBit}");
+            sb.AppendLine($"    XBit: {XBit}");
+            sb.AppendLine($"    Vers: {Vers}");
+            sb.AppendLine($"    FunctionLength: {FunctionLength}");
             if (CodeWords == 0 && EpilogCount == 0)
             {
-                sb.AppendLine("\t---- Extension word ----");
-                sb.AppendLine($"\tExtended Code Words: {CodeWords}");
-                sb.AppendLine($"\tExtended Epilog Count: {EpilogCount}");
+                sb.AppendLine("    ---- Extension word ----");
+                sb.AppendLine($"    Extended Code Words: {CodeWords}");
+                sb.AppendLine($"    Extended Epilog Count: {EpilogCount}");
             }
             if (EpilogCount == 0)
             {
-                sb.AppendLine("\tNo epilogs");
+                sb.AppendLine("    No epilogs");
             }
             else
             {
                 for (int i = 0; i < Epilogs.Length; i++)
                 {
-                    sb.AppendLine("\t\t-------------------------");
+                    sb.AppendLine("        -------------------------");
                     sb.AppendLine(Epilogs[i].ToString());
-                    sb.AppendLine("\t\t-------------------------");
+                    sb.AppendLine("        -------------------------");
                 }
             }
             return sb.ToString();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
@@ -37,9 +37,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"\t\tEpilog Start Offset: 0x{EpilogStartOffset:X5} Actual offset = 0x{EpilogStartOffset * 4:X5} Offset from main function begin = 0x{EpilogStartOffsetFromMainFunctionBegin:X6}");
-            sb.AppendLine($"\t\tCondition: {Condition} (0x{Condition:X})" + ((Condition == 0xE) ? " (always)" : ""));
-            sb.Append($"\t\tEpilog Start Index: {EpilogStartIndex} (0x{EpilogStartIndex:X})");
+            sb.AppendLine($"        Epilog Start Offset: 0x{EpilogStartOffset:X5} Actual offset = 0x{EpilogStartOffset * 4:X5} Offset from main function begin = 0x{EpilogStartOffsetFromMainFunctionBegin:X6}");
+            sb.AppendLine($"        Condition: {Condition} (0x{Condition:X})" + ((Condition == 0xE) ? " (always)" : ""));
+            sb.Append($"        Epilog Start Index: {EpilogStartIndex} (0x{EpilogStartIndex:X})");
             return sb.ToString();
         }
     }
@@ -128,29 +128,29 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"\tCodeWords: {CodeWords}");
-            sb.AppendLine($"\tEpilogCount: {EpilogCount}");
-            sb.AppendLine($"\tEBit: {EBit}");
-            sb.AppendLine($"\tXBit: {XBit}");
-            sb.AppendLine($"\tVers: {Vers}");
-            sb.AppendLine($"\tFunctionLength: {FunctionLength}");
+            sb.AppendLine($"    CodeWords: {CodeWords}");
+            sb.AppendLine($"    EpilogCount: {EpilogCount}");
+            sb.AppendLine($"    EBit: {EBit}");
+            sb.AppendLine($"    XBit: {XBit}");
+            sb.AppendLine($"    Vers: {Vers}");
+            sb.AppendLine($"    FunctionLength: {FunctionLength}");
             if (CodeWords == 0 && EpilogCount == 0)
             {
-                sb.AppendLine("\t---- Extension word ----");
-                sb.AppendLine($"\tExtended Code Words: {CodeWords}");
-                sb.AppendLine($"\tExtended Epilog Count: {EpilogCount}");
+                sb.AppendLine("    ---- Extension word ----");
+                sb.AppendLine($"    Extended Code Words: {CodeWords}");
+                sb.AppendLine($"    Extended Epilog Count: {EpilogCount}");
             }
             if (EpilogCount == 0)
             {
-                sb.AppendLine("\tNo epilogs");
+                sb.AppendLine("    No epilogs");
             }
             else
             {
                 for (int i = 0; i < Epilogs.Length; i++)
                 {
-                    sb.AppendLine("\t\t-------------------------");
+                    sb.AppendLine("        -------------------------");
                     sb.AppendLine(Epilogs[i].ToString());
-                    sb.AppendLine("\t\t-------------------------");
+                    sb.AppendLine("        -------------------------");
                 }
             }
             return sb.ToString();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
@@ -52,12 +52,12 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\tCodeLength: {CodeLength} bytes");
-            sb.AppendLine($"\tInfoHdr:");
+            sb.AppendLine($"    CodeLength: {CodeLength} bytes");
+            sb.AppendLine($"    InfoHdr:");
             sb.AppendLine($"{Header}");
             sb.AppendLine($"{SlotTable}");
 
-            sb.AppendLine($"\tSize: {Size} bytes");
+            sb.AppendLine($"    Size: {Size} bytes");
 
             return sb.ToString();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
@@ -56,30 +56,30 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                 {
                     if (StackOffset < 0)
                     {
-                        sb.AppendLine($"\t\t\t[{Register}-{-StackOffset}]");
+                        sb.AppendLine($"            [{Register}-{-StackOffset}]");
                     }
                     else
                     {
-                        sb.AppendLine($"\t\t\t[{Register}+{StackOffset}]");
+                        sb.AppendLine($"            [{Register}+{StackOffset}]");
                     }
                 }
                 else
                 {
-                    sb.AppendLine($"\t\t\tBeginOffset: {BeginOffset}");
-                    sb.AppendLine($"\t\t\tEndOffset: {EndOffset}");
+                    sb.AppendLine($"            BeginOffset: {BeginOffset}");
+                    sb.AppendLine($"            EndOffset: {EndOffset}");
                     if (Register.Equals("BP"))
                     {
-                        sb.AppendLine($"\t\t\t[{Register}-{-StackOffset}]");
+                        sb.AppendLine($"            [{Register}-{-StackOffset}]");
                     }
                     else
                     {
-                        sb.AppendLine($"\t\t\t[{Register}+{-StackOffset}]");
+                        sb.AppendLine($"            [{Register}+{-StackOffset}]");
                     }
                 }
 
-                sb.AppendLine($"\t\t\tFlags: {Flags}");
+                sb.AppendLine($"            Flags: {Flags}");
 
-                sb.Append($"\t\t\tLowBits: ");
+                sb.Append($"            LowBits: ");
                 if ((Flags & GcSlotFlags.GC_SLOT_UNTRACKED) != 0)
                 {
                     if((LowBits & pinned_OFFSET_FLAG) != 0) sb.Append("pinned ");
@@ -111,12 +111,12 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\t\tGcSlots:");
-            sb.AppendLine($"\t\t\t-------------------------");
+            sb.AppendLine($"        GcSlots:");
+            sb.AppendLine($"            -------------------------");
             foreach (GcSlot slot in GcSlots)
             {
                 sb.Append(slot.ToString());
-                sb.AppendLine($"\t\t\t-------------------------");
+                sb.AppendLine($"            -------------------------");
             }
 
             return sb.ToString();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -93,60 +93,60 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         {
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine($"\t\tPrologSize: {PrologSize}");
-            sb.AppendLine($"\t\tEpilogSize: {EpilogSize}");
-            sb.AppendLine($"\t\tEpilogCount: {EpilogCount}");
-            sb.Append("\t\tEpilogAtEnd: ");
+            sb.AppendLine($"        PrologSize: {PrologSize}");
+            sb.AppendLine($"        EpilogSize: {EpilogSize}");
+            sb.AppendLine($"        EpilogCount: {EpilogCount}");
+            sb.Append("        EpilogAtEnd: ");
             sb.AppendLine(EpilogAtEnd ? "yes" : "no");
 
-            sb.Append($"\t\tCallee-saved regs  = ");
+            sb.Append($"        Callee-saved regs  = ");
             if (EdiSaved) sb.Append("EDI");
             if (EsiSaved) sb.Append("ESI");
             if (EbxSaved) sb.Append("EBX");
             if (EbpSaved) sb.Append("EBP");
             sb.AppendLine();
 
-            sb.Append($"\t\tEbpFrame: ");
+            sb.Append($"        EbpFrame: ");
             sb.AppendLine(EbpFrame ? "yes" : "no");
-            sb.Append($"\t\tFully Interruptible: ");
+            sb.Append($"        Fully Interruptible: ");
             sb.AppendLine(Interruptible ? "yes" : "no");
-            sb.Append($"\t\tDoubleAlign: ");
+            sb.Append($"        DoubleAlign: ");
             sb.AppendLine(DoubleAlign ? "yes" : "no");
-            sb.AppendLine($"\t\tArguments Size: {ArgCount} DWORDs");
-            sb.AppendLine($"\t\tStack Frame Size: {FrameSize} DWORDs");
-            sb.AppendLine($"\t\tUntrackedCnt: {UntrackedCnt}");
-            sb.AppendLine($"\t\tVarPtrTableSize: {VarPtrTableSize}");
+            sb.AppendLine($"        Arguments Size: {ArgCount} DWORDs");
+            sb.AppendLine($"        Stack Frame Size: {FrameSize} DWORDs");
+            sb.AppendLine($"        UntrackedCnt: {UntrackedCnt}");
+            sb.AppendLine($"        VarPtrTableSize: {VarPtrTableSize}");
 
-            if (Security) sb.AppendLine($"\t\tSecurity Check Obj: yes");
-            if (Handlers) sb.AppendLine($"\t\tHandlers: yes");
-            if (Localloc) sb.AppendLine($"\t\tLocalloc: yes");
-            if (EditNcontinue) sb.AppendLine($"\t\tEditNcontinue: yes");
-            if (Varargs) sb.AppendLine($"\t\tVarargs: yes");
-            if (ProfCallbacks) sb.AppendLine($"\t\tProfCallbacks: yes");
+            if (Security) sb.AppendLine($"        Security Check Obj: yes");
+            if (Handlers) sb.AppendLine($"        Handlers: yes");
+            if (Localloc) sb.AppendLine($"        Localloc: yes");
+            if (EditNcontinue) sb.AppendLine($"        EditNcontinue: yes");
+            if (Varargs) sb.AppendLine($"        Varargs: yes");
+            if (ProfCallbacks) sb.AppendLine($"        ProfCallbacks: yes");
 
-            sb.AppendLine($"\t\tGenericsContext: {GenericsContext}");
-            sb.AppendLine($"\t\tGenericsContextIsMethodDesc: {GenericsContextIsMethodDesc}");
-            sb.AppendLine($"\t\tReturnKind: {ReturnKind}");
-            sb.AppendLine($"\t\tRevPInvokeOffset: {RevPInvokeOffset}");
+            sb.AppendLine($"        GenericsContext: {GenericsContext}");
+            sb.AppendLine($"        GenericsContextIsMethodDesc: {GenericsContextIsMethodDesc}");
+            sb.AppendLine($"        ReturnKind: {ReturnKind}");
+            sb.AppendLine($"        RevPInvokeOffset: {RevPInvokeOffset}");
 
             if (GsCookieOffset != INVALID_GS_COOKIE_OFFSET)
             {
-                sb.Append("\t\tGuardStack cookie = [");
+                sb.Append("        GuardStack cookie = [");
                 sb.Append(EbpFrame ? "EBP-" : "ESP+");
                 sb.AppendLine($"{GsCookieOffset}]\n");
             }
             if (SyncStartOffset != INVALID_GS_COOKIE_OFFSET)
             {
-                sb.AppendLine($"\t\tSync region = [{SyncStartOffset},{SyncEndOffset}]");
+                sb.AppendLine($"        Sync region = [{SyncStartOffset},{SyncEndOffset}]");
             }
 
-            sb.Append($"\t\tEpilogs:");
+            sb.Append($"        Epilogs:");
             foreach (int epilog in Epilogs)
             {
                 sb.AppendLine($" {epilog}");
             }
             if (HasArgTabOffset)
-                sb.AppendLine($"\t\tArgTabOffset: {ArgTabOffset}");
+                sb.AppendLine($"        ArgTabOffset: {ArgTabOffset}");
 
             return sb.ToString();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"\tFunctionLength: {FunctionLength}");
+            sb.AppendLine($"    FunctionLength: {FunctionLength}");
             return sb.ToString();
         }
     }

--- a/src/coreclr/src/tools/r2rdump/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rdump/CommandLineOptions.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Invocation;
 using System.IO;
 
 namespace R2RDump
@@ -21,6 +18,7 @@ namespace R2RDump
             command.AddOption(new Option(new[] { "--header" }, "Dump R2R header", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--disasm", "-d" }, "Show disassembly of methods or runtime functions", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--naked" }, "Naked dump suppresses most compilation details like placement addresses", new Argument<bool>()));
+            command.AddOption(new Option(new[] { "--hide-offsets", "--ho" }, "Hide offsets in naked disassembly", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--query", "-q" }, "Query method by exact name, signature, row ID or token", new Argument<string[]>()));
             command.AddOption(new Option(new[] { "--keyword", "-k" }, "Search method by keyword", new Argument<string[]>()));
             command.AddOption(new Option(new[] { "--runtimefunction", "-f" }, "Get one runtime function by id or relative virtual address", new Argument<string[]>()));
@@ -32,6 +30,7 @@ namespace R2RDump
             command.AddOption(new Option(new[] { "--normalize", "-n" }, "Normalize dump by sorting the various tables and methods (default = unsorted i.e. file order)", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--verbose", "-v" }, "Dump disassembly, unwindInfo, gcInfo and sectionContents", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--diff" }, "Compare two R2R images", new Argument<bool>()));
+            command.AddOption(new Option(new[] { "--diff-hide-same-disasm" }, "In matching method diff dump, hide functions with identical disassembly", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--reference", "-r" }, "Explicit reference assembly files", new Argument<FileInfo[]>()));
             command.AddOption(new Option(new[] { "--referencePath", "--rp" }, "Search paths for reference assemblies", new Argument<DirectoryInfo[]>()));
             command.AddOption(new Option(new[] { "--inlineSignatureBinary", "--isb" }, "Embed binary signature into its textual representation", new Argument<bool>()));

--- a/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
@@ -168,7 +168,7 @@ namespace R2RDump
                         }
                         else
                         {
-                            nakedInstruction.Append('\t');
+                            nakedInstruction.Append("    ");
                         }
                         nakedInstruction.Append(line.Substring(colon).TrimStart());
                         nakedInstruction.Append('\n');

--- a/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/src/tools/r2rdump/CoreDisTools.cs
@@ -140,6 +140,8 @@ namespace R2RDump
             }
 
             int instrSize = CoreDisTools.GetInstruction(_disasm, rtf, imageOffset, rtfOffset, _reader.Image, out instruction);
+            CoreDisTools.ClearOutputBuffer();
+
             instruction = instruction.Replace('\t', ' ');
 
             if (_options.Naked)
@@ -159,8 +161,15 @@ namespace R2RDump
                             colon += 3;
                         }
 
-                        nakedInstruction.Append($"{(rtfOffset + rtf.CodeOffset),8:x4}:");
-                        nakedInstruction.Append("  ");
+                        if (!_options.HideOffsets)
+                        {
+                            nakedInstruction.Append($"{(rtfOffset + rtf.CodeOffset),8:x4}:");
+                            nakedInstruction.Append("  ");
+                        }
+                        else
+                        {
+                            nakedInstruction.Append('\t');
+                        }
                         nakedInstruction.Append(line.Substring(colon).TrimStart());
                         nakedInstruction.Append('\n');
                     }
@@ -312,23 +321,73 @@ namespace R2RDump
         /// <param name="instruction">Textual representation of the instruction</param>
         private void ProbeCommonIntelQuirks(RuntimeFunction rtf, int imageOffset, int rtfOffset, int instrSize, ref string instruction)
         {
+            int instructionRVA = rtf.StartAddress + rtfOffset;
+            int nextInstructionRVA = instructionRVA + instrSize;
             if (instrSize == 2 && IsIntelJumpInstructionWithByteOffset(imageOffset + rtfOffset))
             {
                 sbyte offset = (sbyte)_reader.Image[imageOffset + rtfOffset + 1];
-                int target = rtf.StartAddress + rtfOffset + instrSize + offset;
-                ReplaceRelativeOffset(ref instruction, target, rtf);
+                ReplaceRelativeOffset(ref instruction, nextInstructionRVA + offset, rtf);
             }
             else if (instrSize == 5 && IsIntel1ByteJumpInstructionWithIntOffset(imageOffset + rtfOffset))
             {
                 int offset = BitConverter.ToInt32(_reader.Image, imageOffset + rtfOffset + 1);
-                int target = rtf.StartAddress + rtfOffset + instrSize + offset;
-                ReplaceRelativeOffset(ref instruction, target, rtf);
+                ReplaceRelativeOffset(ref instruction, nextInstructionRVA + offset, rtf);
+            }
+            else if (instrSize == 5 && IsIntelCallInstructionWithIntOffset(imageOffset + rtfOffset))
+            {
+                int offset = BitConverter.ToInt32(_reader.Image, imageOffset + rtfOffset + 1);
+                int targetRVA = nextInstructionRVA + offset;
+                int targetImageOffset = _reader.GetOffset(targetRVA);
+                bool pointsOutsideRuntimeFunction = (targetRVA < rtf.StartAddress || targetRVA >= rtf.StartAddress + rtf.Size);
+                if (pointsOutsideRuntimeFunction && IsIntel2ByteIndirectJumpPCRelativeInstruction(targetImageOffset, out int instructionRelativeOffset))
+                {
+                    int thunkTargetRVA = targetRVA + instructionRelativeOffset;
+                    bool haveImportCell = _reader.ImportCellNames.TryGetValue(thunkTargetRVA, out string importCellName);
+
+                    if (_options.Naked && haveImportCell)
+                    {
+                        ReplaceRelativeOffset(ref instruction, $@"qword ptr [{importCellName}]", rtf);
+                    }
+                    else
+                    {
+                        ReplaceRelativeOffset(ref instruction, targetRVA, rtf);
+                        if (haveImportCell)
+                        {
+                            int instructionEnd = instruction.IndexOf('\n');
+                            StringBuilder builder = new StringBuilder(instruction, 0, instructionEnd, capacity: 256);
+                            AppendComment(builder, @$"JMP [0x{thunkTargetRVA:X4}]: {importCellName}");
+                            builder.AppendLine();
+                            instruction = builder.ToString();
+                        }
+                    }
+                }
+                else if (pointsOutsideRuntimeFunction && IsAnotherRuntimeFunctionWithinMethod(targetRVA, rtf, out int runtimeFunctionIndex))
+                {
+                    string runtimeFunctionName = string.Format("RUNTIME_FUNCTION[{0}]", runtimeFunctionIndex);
+
+                    if (_options.Naked)
+                    {
+                        ReplaceRelativeOffset(ref instruction, runtimeFunctionName, rtf);
+                    }
+                    else
+                    {
+                        ReplaceRelativeOffset(ref instruction, targetRVA, rtf);
+                        int instructionEnd = instruction.IndexOf('\n');
+                        StringBuilder builder = new StringBuilder(instruction, 0, instructionEnd, capacity: 256);
+                        AppendComment(builder, runtimeFunctionName);
+                        builder.AppendLine();
+                        instruction = builder.ToString();
+                    }
+                }
+                else
+                {
+                    ReplaceRelativeOffset(ref instruction, nextInstructionRVA + offset, rtf);
+                }
             }
             else if (instrSize == 6 && IsIntel2ByteJumpInstructionWithIntOffset(imageOffset + rtfOffset))
             {
                 int offset = BitConverter.ToInt32(_reader.Image, imageOffset + rtfOffset + 2);
-                int target = rtf.StartAddress + rtfOffset + instrSize + offset;
-                ReplaceRelativeOffset(ref instruction, target, rtf);
+                ReplaceRelativeOffset(ref instruction, nextInstructionRVA + offset, rtf);
             }
         }
 
@@ -390,22 +449,49 @@ namespace R2RDump
             String targetName;
             if (_reader.ImportCellNames.TryGetValue(importCellRva, out targetName))
             {
-                int fill = 61 - builder.Length;
-                if (fill > 0)
-                {
-                    builder.Append(' ', fill);
-                }
-                builder.Append(" // ");
-                builder.Append(targetName);
+                AppendComment(builder, targetName);
             }
+        }
+
+        /// <summary>
+        /// Append a given comment to the string builder.
+        /// </summary>
+        /// <param name="builder">String builder to append comment to</param>
+        /// <param name="comment">Comment to append</param>
+        private void AppendComment(StringBuilder builder, string comment)
+        {
+            int fill = 61 - builder.Length;
+            if (fill > 0)
+            {
+                builder.Append(' ', fill);
+            }
+            builder.Append(" // ");
+            builder.Append(comment);
         }
 
         /// <summary>
         /// Replace relative offset in the disassembled instruction with the true target RVA.
         /// </summary>
-        /// <param name="instruction"></param>
-        /// <param name="target"></param>
+        /// <param name="instruction">Disassembled instruction to modify</param>
+        /// <param name="target">Target string to replace offset with</param>
+        /// <param name="rtf">Runtime function being disassembled</param>
         private void ReplaceRelativeOffset(ref string instruction, int target, RuntimeFunction rtf)
+        {
+            int outputOffset = target;
+            if (_options.Naked)
+            {
+                outputOffset -= rtf.StartAddress;
+            }
+            ReplaceRelativeOffset(ref instruction, string.Format("0x{0:X4}", outputOffset), rtf);
+        }
+
+        /// <summary>
+        /// Replace relative offset in the disassembled instruction with an arbitrary string.
+        /// </summary>
+        /// <param name="instruction">Disassembled instruction to modify</param>
+        /// <param name="replacementString">String to replace offset with</param>
+        /// <param name="rtf">Runtime function being disassembled</param>
+        private void ReplaceRelativeOffset(ref string instruction, string replacementString, RuntimeFunction rtf)
         {
             int numberEnd = instruction.IndexOf('\n');
             int number = numberEnd;
@@ -421,12 +507,7 @@ namespace R2RDump
 
             StringBuilder translated = new StringBuilder();
             translated.Append(instruction, 0, number);
-            int outputOffset = target;
-            if (_options.Naked)
-            {
-                outputOffset -= rtf.StartAddress;
-            }
-            translated.AppendFormat("0x{0:x4}", outputOffset);
+            translated.Append(replacementString);
             translated.Append(instruction, numberEnd, instruction.Length - numberEnd);
             instruction = translated.ToString();
         }
@@ -447,16 +528,22 @@ namespace R2RDump
         }
 
         /// <summary>
+        /// Returns true for the call relative opcode with signed 4-byte offset.
+        /// </summary>
+        /// <param name="imageOffset">Offset within the PE image byte array</param>
+        private bool IsIntelCallInstructionWithIntOffset(int imageOffset)
+        {
+            return _reader.Image[imageOffset] == 0xE8; // CALL rel32
+        }
+
+        /// <summary>
         /// Returns true when this is one of the x86 / amd64 near jump / call opcodes
         /// with signed 4-byte offset.
         /// </summary>
         /// <param name="imageOffset">Offset within the PE image byte array</param>
         private bool IsIntel1ByteJumpInstructionWithIntOffset(int imageOffset)
         {
-            byte opCode = _reader.Image[imageOffset];
-            return opCode == 0xE8 // call near
-                || opCode == 0xE9 // jmp near
-                ;
+            return _reader.Image[imageOffset] == 0xE9; // JMP rel32
         }
 
         /// <summary>
@@ -470,6 +557,59 @@ namespace R2RDump
             byte opCode2 = _reader.Image[imageOffset + 1];
             return opCode1 == 0x0F &&
                 (opCode2 >= 0x80 && opCode2 <= 0x8F); // near conditional jumps
+        }
+
+        /// <summary>
+        /// Returns true when this is the 2-byte instruction for indirect jump
+        /// with RIP-relative offset.
+        /// </summary>
+        /// <param name="imageOffset">Offset within the PE image byte array</param>
+        /// <returns></returns>
+        private bool IsIntel2ByteIndirectJumpPCRelativeInstruction(int imageOffset, out int instructionRelativeOffset)
+        {
+            byte opCode1 = _reader.Image[imageOffset + 0];
+            byte opCode2 = _reader.Image[imageOffset + 1];
+            int offsetDelta = 6;
+
+            if (opCode1 == 0x48 && opCode2 == 0x8B && _reader.Image[imageOffset + 2] == 0x15) // MOV RDX, [R2R module]
+            {
+                imageOffset += 7;
+                offsetDelta += 7;
+                opCode1 = _reader.Image[imageOffset + 0];
+                opCode2 = _reader.Image[imageOffset + 1];
+            }
+
+            if (opCode1 == 0xFF && opCode2 == 0x25)
+            {
+                // JMP [RIP + rel32]
+                instructionRelativeOffset = offsetDelta + BitConverter.ToInt32(_reader.Image, imageOffset + 2);
+                return true;
+            }
+
+            instructionRelativeOffset = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Check whether a given target RVA corresponds to another runtime function within the same method.
+        /// </summary>
+        /// <param name="rva">Target RVA to analyze</param>
+        /// <param name="rtf">Runtime function being disassembled</param>
+        /// <param name="runtimeFunctionIndex">Output runtime function index if found, -1 otherwise</param>
+        /// <returns>true if target runtime function has been found, false otherwise</returns>
+        private bool IsAnotherRuntimeFunctionWithinMethod(int rva, RuntimeFunction rtf, out int runtimeFunctionIndex)
+        {
+            for (int rtfIndex = 0; rtfIndex < rtf.Method.RuntimeFunctions.Count; rtfIndex++)
+            {
+                if (rva == rtf.Method.RuntimeFunctions[rtfIndex].StartAddress)
+                {
+                    runtimeFunctionIndex = rtfIndex;
+                    return true;
+                }
+            }
+
+            runtimeFunctionIndex = -1;
+            return false;
         }
     }
 }

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -19,10 +19,10 @@ namespace R2RDump
             if (theThis.BoundsList.Count > 0)
                 writer.WriteLine("Debug Info");
 
-            writer.WriteLine("\tBounds:");
+            writer.WriteLine("    Bounds:");
             for (int i = 0; i < theThis.BoundsList.Count; ++i)
             {
-                writer.Write('\t');
+                writer.Write("    ");
                 if (!dumpOptions.Naked)
                 {
                     writer.Write($"Native Offset: 0x{theThis.BoundsList[i].NativeOffset:X}, ");
@@ -38,51 +38,51 @@ namespace R2RDump
             }
 
             if (theThis.VariablesList.Count > 0)
-                writer.WriteLine("\tVariable Locations:");
+                writer.WriteLine("    Variable Locations:");
 
             for (int i = 0; i < theThis.VariablesList.Count; ++i)
             {
                 var varLoc = theThis.VariablesList[i];
-                writer.WriteLine($"\tVariable Number: {varLoc.VariableNumber}");
-                writer.WriteLine($"\tStart Offset: 0x{varLoc.StartOffset:X}");
-                writer.WriteLine($"\tEnd Offset: 0x{varLoc.EndOffset:X}");
-                writer.WriteLine($"\tLoc Type: {varLoc.VariableLocation.VarLocType}");
+                writer.WriteLine($"    Variable Number: {varLoc.VariableNumber}");
+                writer.WriteLine($"    Start Offset: 0x{varLoc.StartOffset:X}");
+                writer.WriteLine($"    End Offset: 0x{varLoc.EndOffset:X}");
+                writer.WriteLine($"    Loc Type: {varLoc.VariableLocation.VarLocType}");
 
                 switch (varLoc.VariableLocation.VarLocType)
                 {
                     case VarLocType.VLT_REG:
                     case VarLocType.VLT_REG_FP:
                     case VarLocType.VLT_REG_BYREF:
-                        writer.WriteLine($"\tRegister: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
                         break;
                     case VarLocType.VLT_STK:
                     case VarLocType.VLT_STK_BYREF:
-                        writer.WriteLine($"\tBase Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
-                        writer.WriteLine($"\tStack Offset: {varLoc.VariableLocation.Data2}");
+                        writer.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data2}");
                         break;
                     case VarLocType.VLT_REG_REG:
-                        writer.WriteLine($"\tRegister 1: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
-                        writer.WriteLine($"\tRegister 2: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
+                        writer.WriteLine($"    Register 1: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Register 2: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
                         break;
                     case VarLocType.VLT_REG_STK:
-                        writer.WriteLine($"\tRegister: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
-                        writer.WriteLine($"\tBase Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
-                        writer.WriteLine($"\tStack Offset: {varLoc.VariableLocation.Data3}");
+                        writer.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
+                        writer.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data3}");
                         break;
                     case VarLocType.VLT_STK_REG:
-                        writer.WriteLine($"\tStack Offset: {varLoc.VariableLocation.Data1}");
-                        writer.WriteLine($"\tBase Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
-                        writer.WriteLine($"\tRegister: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data3)}");
+                        writer.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data1}");
+                        writer.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data2)}");
+                        writer.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data3)}");
                         break;
                     case VarLocType.VLT_STK2:
-                        writer.WriteLine($"\tBase Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
-                        writer.WriteLine($"\tStack Offset: {varLoc.VariableLocation.Data2}");
+                        writer.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data2}");
                         break;
                     case VarLocType.VLT_FPSTK:
-                        writer.WriteLine($"\tOffset: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Offset: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
                         break;
                     case VarLocType.VLT_FIXED_VA:
-                        writer.WriteLine($"\tOffset: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
+                        writer.WriteLine($"    Offset: {DebugInfo.GetPlatformSpecificRegister(theThis.Machine, varLoc.VariableLocation.Data1)}");
                         break;
                     default:
                         throw new BadImageFormatException("Unexpected var loc type");

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -26,6 +26,7 @@ namespace R2RDump
         public bool Header { get; set; }
         public bool Disasm { get; set; }
         public bool Naked { get; set; }
+        public bool HideOffsets { get; set; }
 
         public string[] Query { get; set; }
         public string[] Keyword { get; set; }
@@ -39,6 +40,7 @@ namespace R2RDump
         public bool Normalize { get; set; }
         public bool Verbose { get; set; }
         public bool Diff { get; set; }
+        public bool DiffHideSameDisasm { get; set; }
         public bool IgnoreSensitive { get; set; }
 
         public FileInfo[] Reference { get; set; }
@@ -167,13 +169,15 @@ namespace R2RDump
         public DumpOptions Options => _options;
 
         public ReadyToRunReader Reader => _r2r;
+
+        public Disassembler Disassembler => _disassembler;
     }
 
     class R2RDump
     {
         private readonly DumpOptions _options;
         private readonly Dictionary<ReadyToRunSection.SectionType, bool> _selectedSections = new Dictionary<ReadyToRunSection.SectionType, bool>();
-        private TextWriter _writer;
+        private readonly TextWriter _writer;
         private Dumper _dumper;
 
         private R2RDump(DumpOptions options)
@@ -186,6 +190,15 @@ namespace R2RDump
                 _options.Unwind = true;
                 _options.GC = true;
                 _options.SectionContents = true;
+            }
+
+            if (_options.Out != null)
+            {
+                _writer = new StreamWriter(_options.Out.FullName);
+            }
+            else
+            {
+                _writer = Console.Out;
             }
         }
 
@@ -475,15 +488,6 @@ namespace R2RDump
                 }
 
                 Dumper previousDumper = null;
-                TextWriter globalWriter = null;
-                if (_options.Out != null)
-                {
-                    globalWriter = new StreamWriter(_options.Out.FullName);
-                }
-                else
-                {
-                    globalWriter = Console.Out;
-                }
 
                 foreach (FileInfo filename in _options.In)
                 {
@@ -502,28 +506,25 @@ namespace R2RDump
                         }
                     }
 
-                    if (!_options.Diff)
-                    {
-                        _writer = globalWriter;
-                    }
-                    else
-                    {
-                        string outFile = r2r.Filename + ".r2rdump";
-                        _writer = new StreamWriter(outFile, append: false, encoding: Encoding.ASCII);
-                    }
-                    _dumper = new TextDumper(r2r, _writer, disassembler, _options);
 
                     if (!_options.Diff)
                     {
                         // output the ReadyToRun info
+                        _dumper = new TextDumper(r2r, _writer, disassembler, _options);
                         Dump(r2r);
                     }
-                    else if (previousDumper != null)
+                    else
                     {
-                        new R2RDiff(previousDumper, _dumper, globalWriter).Run();
+                        string perFileOutput = filename.FullName + ".common-methods.r2r";
+                        _dumper = new TextDumper(r2r, new StreamWriter(perFileOutput), disassembler, _options);
+                        if (previousDumper != null)
+                        {
+                            new R2RDiff(previousDumper, _dumper, _writer).Run();
+                        }
+                        previousDumper?.Writer?.Flush();
+                        previousDumper = _dumper;
                     }
 
-                    previousDumper = _dumper;
                 }
             }
             catch (Exception e)
@@ -541,8 +542,9 @@ namespace R2RDump
                 {
                     disassembler.Dispose();
                 }
-                // close output stream
-                _writer.Close();
+                // flush output stream
+                _dumper?.Writer?.Flush();
+                _writer?.Flush();
             }
 
             return 0;

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -189,8 +189,8 @@ namespace R2RDump
         /// </summary>
         internal override void DumpDisasm(RuntimeFunction rtf, int imageOffset)
         {
-            int indent = (_options.Naked ? 11 : 32);
-            string indentString = new string(' ', indent);
+            int indent = (_options.Naked ? _options.HideOffsets ? 8 : 11 : 32);
+            string indentString = new string('\t', indent / 8) + new string(' ', indent % 8);
             int rtfOffset = 0;
             int codeOffset = rtf.CodeOffset;
             while (rtfOffset < rtf.Size)
@@ -225,7 +225,6 @@ namespace R2RDump
                  */
                 _writer.Write(instr);
 
-                CoreDisTools.ClearOutputBuffer();
                 rtfOffset += instrSize;
                 codeOffset += instrSize;
             }

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -189,8 +189,8 @@ namespace R2RDump
         /// </summary>
         internal override void DumpDisasm(RuntimeFunction rtf, int imageOffset)
         {
-            int indent = (_options.Naked ? _options.HideOffsets ? 8 : 11 : 32);
-            string indentString = new string('\t', indent / 8) + new string(' ', indent % 8);
+            int indent = (_options.Naked ? _options.HideOffsets ? 4 : 11 : 32);
+            string indentString = new string(' ', indent);
             int rtfOffset = 0;
             int codeOffset = rtf.CodeOffset;
             while (rtfOffset < rtf.Size)
@@ -319,10 +319,10 @@ namespace R2RDump
                         }
                         int unwindRva = NativeReader.ReadInt32(_r2r.Image, ref rtfOffset);
                         _writer.WriteLine($"Index: {rtfIndex}");
-                        _writer.WriteLine($"\tStartRva: 0x{startRva:X8}");
+                        _writer.WriteLine($"        StartRva: 0x{startRva:X8}");
                         if (endRva != -1)
-                            _writer.WriteLine($"\tEndRva: 0x{endRva:X8}");
-                        _writer.WriteLine($"\tUnwindRva: 0x{unwindRva:X8}");
+                            _writer.WriteLine($"        EndRva: 0x{endRva:X8}");
+                        _writer.WriteLine($"        UnwindRva: 0x{unwindRva:X8}");
                         rtfIndex++;
                     }
                     break;


### PR DESCRIPTION
This change improves the disassembly of thunk-based calls to R2R
helpers used by Crossgen1 and considered for Crossgen2 to improve
disassembly quality and facilitate easier comparison of Crossgen1
vs. Crossgen2 codegen.

I have also added new options for hiding the instruction offsets
in the disassembly and for omitting functions with identical
disassembly in the common functions diff output. For SPC this
reduced the size of the dump in <code>--naked --hide-offsets
--diff-hide-same-disasm</code> mode by about one half.

In view of the fact that Andrew wasn't too happy about my change
to stop logging to the console I further simplified the related
code by basically reverting that aspect of my change in a more
radical manner.

I have also moved the call to CoreDisTools.ClearOutputBuffer
into CoreDisTools.GetInstruction so that we don't need to call it
manually in the higher-level code.

Thanks

Tomas