### PR TITLE
Removing unnecessary uses of `unreached` from hwintrinsic importation

### DIFF
--- a/src/coreclr/src/jit/hwintrinsic.cpp
+++ b/src/coreclr/src/jit/hwintrinsic.cpp
@@ -688,7 +688,7 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             }
 
             default:
-                unreached();
+                return nullptr;
         }
 
         bool isMemoryStore = retNode->OperIsMemoryStore();

--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -26,7 +26,7 @@ static InstructionSet Arm64VersionOfIsa(InstructionSet isa)
         case InstructionSet_Crc32:
             return InstructionSet_Crc32_Arm64;
         default:
-            unreached();
+            return InstructionSet_NONE;
     }
 }
 
@@ -175,7 +175,7 @@ bool HWIntrinsicInfo::isFullyImplementedIsa(InstructionSet isa)
 
         default:
         {
-            unreached();
+            return false;
         }
     }
 }
@@ -220,7 +220,7 @@ bool HWIntrinsicInfo::isScalarIsa(InstructionSet isa)
 //
 GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdType, var_types baseType)
 {
-    unreached();
+    return nullptr;
 }
 
 //------------------------------------------------------------------------
@@ -400,8 +400,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
         default:
         {
-            unreached();
-            break;
+            return nullptr;
         }
     }
 

--- a/src/coreclr/src/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsicxarch.cpp
@@ -36,7 +36,7 @@ static InstructionSet X64VersionOfIsa(InstructionSet isa)
         case InstructionSet_POPCNT:
             return InstructionSet_POPCNT_X64;
         default:
-            unreached();
+            return InstructionSet_NONE;
     }
 }
 
@@ -289,7 +289,7 @@ bool HWIntrinsicInfo::isFullyImplementedIsa(InstructionSet isa)
 
         default:
         {
-            unreached();
+            return false;
         }
     }
 }
@@ -357,7 +357,7 @@ GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdT
         }
 
         default:
-            unreached();
+            return nullptr;
     }
 }
 
@@ -415,7 +415,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
         case InstructionSet_POPCNT_X64:
             return impPOPCNTIntrinsic(intrinsic, method, sig, mustExpand);
         default:
-            unreached();
+            return nullptr;
     }
 }
 
@@ -695,8 +695,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                     break;
 
                 default:
-                    unreached();
-                    break;
+                    return nullptr;
             }
 
             ssize_t imm8       = indexOp->AsIntCon()->IconValue();
@@ -854,8 +853,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 }
 
                 default:
-                    unreached();
-                    break;
+                    return nullptr;
             }
 
             if (simdSize == 32)
@@ -980,7 +978,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                         break;
 
                     default:
-                        unreached();
+                        return nullptr;
                 }
 
                 return gtNewSimdHWIntrinsicNode(retType, vectorOp, resIntrinsic, baseType, 16);
@@ -1050,7 +1048,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                     break;
 
                 default:
-                    unreached();
+                    return nullptr;
             }
 
             break;
@@ -1058,8 +1056,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
 
         default:
         {
-            unreached();
-            break;
+            return nullptr;
         }
     }
 
@@ -1387,7 +1384,7 @@ GenTree* Compiler::impBMI1OrBMI2Intrinsic(NamedIntrinsic        intrinsic,
         }
 
         default:
-            unreached();
+            return nullptr;
     }
 }
 


### PR DESCRIPTION
This removes unnecessary uses of `unreached` from the importation logic for the HWIntrinsics feature (as per https://github.com/dotnet/runtime/issues/2120).

I wasn't able to remove any usages from the hwintrinsic codegen, as there isn't a reasonable fallback path in that scenario.