### PR TITLE
Delete dead code in Crossgen's Program.cs

### DIFF
--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -77,11 +77,6 @@ namespace ILCompiler
                 default:
                     throw new NotImplementedException();
             }
-
-            // Workaround for https://github.com/dotnet/corefx/issues/25267
-            // If pointer size is 8, we're obviously not an X86 process...
-            if (_targetArchitecture == TargetArchitecture.X86 && IntPtr.Size == 8)
-                _targetArchitecture = TargetArchitecture.X64;
         }
 
         private void ProcessCommandLine()
@@ -260,20 +255,7 @@ namespace ILCompiler
                     }
                     else
                     {
-                        // Either single file, or multifile library, or multifile consumption.
-                        EcmaModule entrypointModule = null;
-                        foreach (var inputFile in typeSystemContext.InputFilePaths)
-                        {
-                            EcmaModule module = typeSystemContext.GetModuleFromPath(inputFile.Value);
-
-                            if (module.PEReader.PEHeaders.IsExe)
-                            {
-                                if (entrypointModule != null)
-                                    throw new Exception("Multiple EXE modules");
-                                entrypointModule = module;
-                            }
-                        }
-
+                        // Single assembly compilation.
                         compilationGroup = new ReadyToRunSingleAssemblyCompilationModuleGroup(
                             typeSystemContext, inputModules, versionBubbleModules, _commandLineOptions.CompileBubbleGenerics);
                     }


### PR DESCRIPTION
* We don't need a workaround for a desktop framework bug since we don't have an ambition to run on desktop framework anymore.
* We don't need the entrypoint module.