### PR TITLE
[wasm][debugger] Cancel Existing Single Step Request When Creating New

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -740,6 +740,7 @@ static void* create_breakpoint_events (GPtrArray *ss_reqs, GPtrArray *bp_reqs, M
 static void process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, int il_offset);
 static int ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *args);
 static void ss_args_destroy (SingleStepArgs *ss_args);
+static int handle_multiple_ss_requests (void);
 
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (fixed_buffer, "System.Runtime.CompilerServices", "FixedBufferAttribute")
 
@@ -970,6 +971,7 @@ debugger_agent_init (void)
 	cbs.process_breakpoint_events = process_breakpoint_events;
 	cbs.ss_create_init_args = ss_create_init_args;
 	cbs.ss_args_destroy = ss_args_destroy;
+	cbs.handle_multiple_ss_requests = handle_multiple_ss_requests;
 
 	mono_de_init (&cbs);
 
@@ -4966,6 +4968,12 @@ ss_args_destroy (SingleStepArgs *ss_args)
 {
 	if (ss_args->frames)
 		free_frames ((StackFrame**)ss_args->frames, ss_args->nframes);
+}
+
+static int
+handle_multiple_ss_requests (void)
+{
+	return DE_ERR_NOT_IMPLEMENTED;
 }
 
 static int

--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -1489,8 +1489,12 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 
 	// FIXME: Multiple requests
 	if (the_ss_req) {
-		DEBUG_PRINTF (0, "Received a single step request while the previous one was still active.\n");
-		return DE_ERR_NOT_IMPLEMENTED;
+		err = rt_callbacks.handle_multiple_ss_requests ();
+
+		if (err == DE_ERR_NOT_IMPLEMENTED) {
+			DEBUG_PRINTF (0, "Received a single step request while the previous one was still active.\n");		
+			return DE_ERR_NOT_IMPLEMENTED;
+		}
 	}
 
 	DEBUG_PRINTF (1, "[dbg] Starting single step of thread %p (depth=%s).\n", thread, ss_depth_to_string (depth));

--- a/src/mono/mono/mini/debugger-engine.h
+++ b/src/mono/mono/mini/debugger-engine.h
@@ -251,6 +251,7 @@ typedef struct {
 
 	int (*ss_create_init_args) (SingleStepReq *ss_req, SingleStepArgs *args);
 	void (*ss_args_destroy) (SingleStepArgs *ss_args);
+	int (*handle_multiple_ss_requests)(void);
 } DebuggerEngineCallbacks;
 
 

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -291,6 +291,12 @@ ss_args_destroy (SingleStepArgs *ss_args)
 	//nothing to do	
 }
 
+static int
+handle_multiple_ss_requests (void) {
+	mono_de_cancel_ss ();
+	return 1;
+}
+
 void
 mono_wasm_debugger_init (void)
 {
@@ -313,6 +319,7 @@ mono_wasm_debugger_init (void)
 		.process_breakpoint_events = process_breakpoint_events,
 		.ss_create_init_args = ss_create_init_args,
 		.ss_args_destroy = ss_args_destroy,
+		.handle_multiple_ss_requests = handle_multiple_ss_requests,
 	};
 
 	mono_debug_init (MONO_DEBUG_FORMAT_MONO);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18608,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When stepping out of a c# breakpoint into the runtime (or JS... Not sure if that's accurate),
multiple single step requests can be created when the breakpoint is hit again.  In order to handle this scenario for wasm, we just cancel the existing one.

NOTE: The debugger args addition seemed a better way to handle this than outright canceling in debugger-engine. If there are implications in doing this, I can take it out.