### PR TITLE
Revert "Disable test based on #129 (#130)"

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -351,9 +351,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_26311/GitHub_26311/*">
             <Issue>26311</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/compareexchange/compareexchangedouble/*">
-            <Issue>129</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x86 specific excludes -->


### PR DESCRIPTION
This reverts commit 3a2dc0f8429b922fa254a1ba6f751b79259275b1.

Fixed by https://github.com/dotnet/runtime/pull/1457. Closes https://github.com/dotnet/runtime/issues/129.