### PR TITLE
Move libraries internal restore before repo restore, produce a restore binlog and increase verbosity

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -7,7 +7,7 @@ steps:
       displayName: Install dotnet ${{ parameters.dotnetVersion }}
       inputs:
         packageType: sdk
-        version: 3.1.200
+        useGlobalJson: true
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: NuGetAuthenticate@0

--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -7,7 +7,7 @@ steps:
       displayName: Install dotnet ${{ parameters.dotnetVersion }}
       inputs:
         packageType: sdk
-        useGlobalJson: true
+        version: 3.1.200
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - task: NuGetAuthenticate@0
@@ -24,4 +24,4 @@ steps:
       projects: 'eng/common/internal/Tools.csproj'
       nugetConfigPath: 'eng/internal/NuGet.config'
       restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-      verbosityRestore: 'normal'
+      verbosityRestore: 'diagnostic'

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -85,13 +85,13 @@ jobs:
               ./emsdk activate --embedded ${EMSCRIPTEN_VERSION}-upstream
             displayName: Install Emscripten
 
-        - script: $(_buildScript) -restore $(_buildArguments) $(_skipTestRestoreArg)
-          displayName: Restore
-
         - ${{ if eq(parameters.isOfficialBuild, true) }}:
           - template: /eng/pipelines/common/restore-internal-tools.yml
             parameters:
-              installDotnet: false
+              installDotnet: true
+
+        - script: $(_buildScript) -restore $(_buildArguments) $(_skipTestRestoreArg) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Restore.binlog
+          displayName: Restore
 
         - script: $(_buildScript)
                 $(_buildAction)


### PR DESCRIPTION
We're tracking the issues here: https://github.com/dotnet/arcade/issues/4704

An attempt is to do the internal restore first with the machine-wide SDK, as it seems like the repo restore been done first is messing with the nugetauth plugin

Also, I bumped the version to 3.1.200 of the SDK used to restore internal tools, since that is the SDK which contains the fixes, per: https://github.com/dotnet/arcade/issues/4704#issuecomment-579469529

Also, generate a binlog for the repo restore step with a custom name since that one is overriden by the build step. 

cc: @dotnet/runtime-infrastructure @JohnTortugo @riarenas 