### PR TITLE
Add UTF8NoBOM property to `System.Text.Encoding` class

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -1019,6 +1019,11 @@ namespace System.Text
 
         public static Encoding UTF8 => UTF8Encoding.s_default;
 
+        // Returns an encoding for the UTF-8 format without BOM. The returned encoding will be
+        // an instance of the UTF8Encoding class.
+
+        public static Encoding UTF8NoBOM => UTF8Encoding.s_noBom;
+
         // Returns an encoding for the UTF-32 format. The returned encoding will be
         // an instance of the UTF32Encoding class.
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -61,6 +61,10 @@ namespace System.Text
         // The initialization code will not be run until a static member of the class is referenced
         internal static readonly UTF8EncodingSealed s_default = new UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: true);
 
+        // Used by Encoding.UTF8NoBOM for lazy initialization
+        // The initialization code will not be run until a static member of the class is referenced
+        internal static readonly UTF8EncodingSealed s_noBom = new UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: false);
+
         internal static ReadOnlySpan<byte> PreambleSpan => new byte[3] { 0xEF, 0xBB, 0xBF }; // uses C# compiler's optimization for static byte[] data
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into


### PR DESCRIPTION
This PR adds a new property to the `System.Text.Encoding` class called `UTF8NoBOM` with an instance of the `UTF8Encoding` class configured to _not_ include the [byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark).

I opted to use the name `UTF8NoBOM` because it's the name used in the internal [`EncodingCache`](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Private.CoreLib/src/System/IO/EncodingCache.cs#L11) class that is referenced in several places throughout the codebase.

For consistency with other properties of the `Encoding` class such as `UTF8` for example, The argument `throwOnInvalidBytes` is not set on the constructor and it will use the default (`false`). This means we wouldn't be able to replace references to [`EncodingCache.UTF8NoBOM`](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Private.CoreLib/src/System/IO/EncodingCache.cs#L11) with references to `Encoding.UTF8NoBOM` as they have different behavior.

Resolves #2136 if we want to stop here for now, unless we want to also add other similar properties together such as `UnicodeNoBOM` and `UTF32NoBOM`, etc. as [suggested in #2136](https://github.com/dotnet/runtime/issues/2136#issuecomment-578340678).