### PR TITLE
Disable System.Net.* tests on Mono that are also disabled on CoreCLR

### DIFF
--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderAttributedOverrideUnitTests.cs
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderAttributedOverrideUnitTests.cs
@@ -8,10 +8,12 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 using Xunit.Sdk;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
     [SkipOnCoreClr("Test failures on stress tests")]
+    [SkipOnMono("Test failures on stress tests")]
     public class RegistrationBuilderAttributedOverrideUnitTests
     {
         public interface IContractA { }

--- a/src/libraries/System.Data.SqlClient/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Data.SqlClient/tests/FunctionalTests/AssemblyInfo.cs
@@ -3,5 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 [assembly: SkipOnCoreClr("Timeout in stress tests on Linux/arm32", TestPlatforms.Linux)]
+[assembly: SkipOnMono("Timeout in stress tests on Linux/arm32", TestPlatforms.Linux)]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
@@ -3,5 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 [assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
+[assembly: SkipOnMono("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -10,10 +10,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests are inestable")]
+    [SkipOnCoreClr("System.Net.Tests are flaky")]
+    [SkipOnMono("System.Net.Tests are flaky")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerAuthenticationTests : IDisposable
     {

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -11,10 +11,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests are inestable")]
+    [SkipOnCoreClr("System.Net.Tests are flaky")]
+    [SkipOnMono("System.Net.Tests are flaky")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerContextTests : IDisposable
     {

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.Cookies.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Tests
 {
-    [SkipOnCoreClr("System.Net.Tests are inestable")]
+    [SkipOnCoreClr("System.Net.Tests are flaky")]
+    [SkipOnMono("System.Net.Tests are flaky")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerResponseCookiesTests : HttpListenerResponseTestBase
     {

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Tests
 {
@@ -57,7 +58,8 @@ namespace System.Net.Tests
         }
     }
 
-    [SkipOnCoreClr("System.Net.Tests are inestable")]
+    [SkipOnCoreClr("System.Net.Tests are flaky")]
+    [SkipOnMono("System.Net.Tests are flaky")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // httpsys component missing in Nano.
     public class HttpListenerResponseTests : HttpListenerResponseTestBase
     {
@@ -113,7 +115,8 @@ namespace System.Net.Tests
         [InlineData(" \r \t \n", 123)]
         [InlineData("http://microsoft.com", 155)]
         [InlineData("  http://microsoft.com  ", 155)]
-        [SkipOnCoreClr("System.Net.Tests are inestable")]
+        [SkipOnCoreClr("System.Net.Tests are flaky")]
+        [SkipOnMono("System.Net.Tests are flaky")]
         public async Task Redirect_Invoke_SetsRedirectionProperties(string url, int expectedNumberOfBytes)
         {
             string expectedUrl = url?.Trim() ?? "";

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Systen.Net.Mail.Tests;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Mail.Tests
 {
@@ -340,6 +341,7 @@ namespace System.Net.Mail.Tests
         [InlineData("")]
         [InlineData(null)]
         [SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
+        [SkipOnMono("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
         public async Task TestMailDeliveryAsync(string body)
         {
             using var server = new LoopbackSmtpServer();
@@ -358,6 +360,7 @@ namespace System.Net.Mail.Tests
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // NTLM support required, see https://github.com/dotnet/corefx/issues/28961
         [SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
+        [SkipOnMono("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
         public async Task TestCredentialsCopyInAsyncContext()
         {
             using var server = new LoopbackSmtpServer();

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.Tracing;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Tests
 {
@@ -11,7 +12,8 @@ namespace System.Net.Tests
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "NetEventSource is only part of .NET Core.")]
-        [SkipOnCoreClr("System.Net.Tests are inestable")]
+        [SkipOnCoreClr("System.Net.Tests are flaky")]
+        [SkipOnMono("System.Net.Tests are flaky")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebRequest).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 namespace System.Net.Security.Tests
 {
@@ -138,6 +139,7 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
+        [SkipOnMono("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
         public async Task SslStream_NoSniFromClient_CallbackReturnsNull()
         {
             await WithVirtualConnection(async (server, client) =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
@@ -3,5 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions.Attributes;
 
 [assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]
+[assembly: SkipOnMono("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131")]


### PR DESCRIPTION
Should help with https://github.com/dotnet/runtime/issues/2316