### PR TITLE
[jit] Add a 'top-runtime-invoke-unhandled' option to treat exceptions which reach the top invoke frame as unhandled when embedding.

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1777,7 +1777,7 @@ mono_jit_parse_options (int argc, char * argv[])
 	for (i = 0; i < argc; ++i) {
 		if (argv [i] [0] != '-')
 			break;
- 		if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
+		if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
 			MonoDebugOptions *opt = mini_get_debug_options ();
 
 			sdb_options = g_strdup (argv [i] + 17);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2731,10 +2731,15 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 			if (unhandled)
 				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 			else if (!ji || (jinfo_get_method (ji)->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE)) {
-				if (last_mono_wrapper_runtime_invoke && !mono_thread_internal_current ()->threadpool_thread)
+				if (last_mono_wrapper_runtime_invoke && !mono_thread_internal_current ()->threadpool_thread) {
 					mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
-				else
+					if (mini_get_debug_options ()->top_runtime_invoke_unhandled) {
+						mini_set_abort_threshold (&catch_frame);
+						mono_unhandled_exception_internal (obj);
+					}
+				} else {
 					mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, &ctx_cp, &catch_frame);
+				}
 			}
 			else if (res != MONO_FIRST_PASS_CALLBACK_TO_NATIVE)
 				if (!is_caught_unmanaged)

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3734,6 +3734,8 @@ mini_parse_debug_option (const char *option)
 		mini_debug_options.weak_memory_model = FALSE;
 	else if (!strcmp (option, "weak-memory-model"))
 		mini_debug_options.weak_memory_model = TRUE;
+	else if (!strcmp (option, "top-runtime-invoke-unhandled"))
+		mini_debug_options.top_runtime_invoke_unhandled = TRUE;
 	else if (!strncmp (option, "thread-dump-dir=", 16))
 		mono_set_thread_dump_dir(g_strdup(option + 16));
 	else if (!strncmp (option, "aot-skip=", 9)) {

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -256,8 +256,13 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean aot_skip_set;
 	int aot_skip;
-} MonoDebugOptions;
 
+	/*
+	 * Treat exceptions which reach the topmost runtime invoke as unhandled when
+	 * embedding.
+	 */
+	gboolean top_runtime_invoke_unhandled;
+} MonoDebugOptions;
 
 /*
  * We need to store the image which the token refers to along with the token,


### PR DESCRIPTION
This is not really a MONO_DEBUG option, but easier to implement it this way.