### PR TITLE
[Arm64] Use scalar forms for a destination register in emitDistIns for addv, smaxv, umaxv

### DIFF
--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -11569,10 +11569,31 @@ void emitter::emitDispIns(
             break;
 
         case IF_DV_2A: // DV_2A   .Q.......X...... ......nnnnnddddd      Vd Vn   (fabs, fcvt - vector)
-        case IF_DV_2M: // DV_2M   .Q......XX...... ......nnnnnddddd      Vd Vn   (abs, neg   - vector)
         case IF_DV_2P: // DV_2P   ................ ......nnnnnddddd      Vd Vn   (aes*, sha1su1)
             emitDispVectorReg(id->idReg1(), id->idInsOpt(), true);
             emitDispVectorReg(id->idReg2(), id->idInsOpt(), false);
+            break;
+
+        case IF_DV_2M: // DV_2M   .Q......XX...... ......nnnnnddddd      Vd Vn   (abs, neg - vector)
+            switch (ins)
+            {
+                case INS_addv:
+                case INS_saddlv:
+                case INS_smaxv:
+                case INS_sminv:
+                case INS_uaddlv:
+                case INS_umaxv:
+                case INS_uminv:
+                    elemsize = optGetElemsize(id->idInsOpt());
+                    emitDispReg(id->idReg1(), elemsize, true);
+                    emitDispVectorReg(id->idReg2(), id->idInsOpt(), false);
+                    break;
+
+                default:
+                    emitDispVectorReg(id->idReg1(), id->idInsOpt(), true);
+                    emitDispVectorReg(id->idReg2(), id->idInsOpt(), false);
+                    break;
+            }
             break;
 
         case IF_DV_2N: // DV_2N   .........iiiiiii ......nnnnnddddd      Vd Vn imm   (shift - scalar)


### PR DESCRIPTION
For a destination register use scalar forms (i.e. `Sd`, `Hd`, `Bd`) instead of vector ones (i.e. `Vd.2S`, `Vd.4H`, `Vd.2B`) for instructions that return scalar result (e.g. `addv`, `smaxv`, `umaxv`) in emitDispIns in emitarm64.cpp

**Output before the change:**
```asm
addv    v16.8b, v16.8b
```
**Output after the change:**
```asm
addv    b16, v16.8b
```

@dotnet/jit-contrib PTAL