### PR TITLE
Unix: Default to a users-specific temp directory for extracting single-file apps

### DIFF
--- a/src/installer/corehost/cli/apphost/bundle/extractor.cpp
+++ b/src/installer/corehost/cli/apphost/bundle/extractor.cpp
@@ -19,15 +19,13 @@ void extractor_t::determine_extraction_dir()
 {
     if (!pal::getenv(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR"), &m_extraction_dir))
     {
-        if (!pal::get_temp_directory(m_extraction_dir))
+        if (!pal::get_default_bundle_extraction_base_dir(m_extraction_dir))
         {
             trace::error(_X("Failure processing application bundle."));
             trace::error(_X("Failed to determine location for extracting embedded files."));
-            trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and temp-directory doesn't exist or is not readable/writable."));
+            trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write temp-directory couldn't be created."));
             throw StatusCode::BundleExtractionFailure;
         }
-
-        append_path(&m_extraction_dir, _X(".net"));
     }
 
     pal::string_t host_name = strip_executable_ext(get_filename(m_bundle_path));

--- a/src/installer/corehost/cli/hostmisc/pal.h
+++ b/src/installer/corehost/cli/hostmisc/pal.h
@@ -289,6 +289,10 @@ namespace pal
 
     bool get_temp_directory(string_t& tmp_dir);
 
+    // Returns a platform-specific, user-private directory within get_temp_directory()
+    // that can be used for extracting out components of a single-file app.
+    bool get_default_bundle_extraction_base_dir(string_t& extraction_dir);
+
     int xtoi(const char_t* input);
 
     bool get_loaded_library(const char_t *library_name, const char *symbol_name, /*out*/ dll_t *dll, /*out*/ string_t *path);

--- a/src/installer/corehost/cli/hostmisc/pal.windows.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.windows.cpp
@@ -560,8 +560,34 @@ bool pal::get_temp_directory(pal::string_t& tmp_dir)
     assert(len < max_len);
     tmp_dir.assign(temp_path);
 
-    return pal::realpath(&tmp_dir);
+    return realpath(&tmp_dir);
 }
+
+bool pal::get_default_bundle_extraction_base_dir(pal::string_t& extraction_dir)
+{
+    if (!get_temp_directory(extraction_dir))
+    {
+        return false;
+    }
+
+    append_path(&extraction_dir, _X(".net"));
+    // Windows Temp-Path is already user-private.
+
+    if (realpath(&extraction_dir))
+    {
+        return true;
+    }
+
+    // Create the %TEMP%\.net directory
+    if (CreateDirectoryW(extraction_dir.c_str(), NULL) == 0 &&
+        GetLastError() != ERROR_ALREADY_EXISTS)
+    {
+        return false;
+    }
+
+    return realpath(&extraction_dir);
+}
+
 
 static bool wchar_convert_helper(DWORD code_page, const char* cstr, int len, pal::string_t* out)
 {


### PR DESCRIPTION
In .net core 3, single file apps run by extracting the bundled contents to a temp directory.
The extraction directory is machine specific, and can be set through DOTNET_BUNDLE_EXTRACT_BASE_DIR environment variable.

When this setting is not configured, the host tries to use certain default directories.
On windows, extraction is within %TMPDIR%, which is user specific.
On Unix systems $TMPDIR/.net if set, which may be user specific (ex: MAC)
Otherwise, the extraction directory is within /var/tmp/ or /tmp/ which is common to all users, and may be locked by a specific user on first creation.

Therefore, this change fixes this issue by defaulting the extraction base directory in Unix systems to
`<temp-dir>/.net/<user-ID>` , where
`<temp-dir>/.net/` has permission 0777, and
`<temp-dir>/.net/<user-ID>/` has permission 0700.

This fix will be migrated to coreclr/3.1 branch for servicing.

Testing: Manual testing on Unix/Mac systems, since we don't have the setup to add automated tests with multiple users.

Fixes https://github.com/dotnet/core-setup/issues/8882