### PR TITLE
Add a fallback condition for musl ldd check

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -138,7 +138,8 @@ initDistroRidGlobal()
         local distroRid=""
 
         # Check for musl-based distros (e.g Alpine Linux, Void Linux).
-        if "${rootfsDir}/usr/bin/ldd" --version 2>&1 | grep -q musl; then
+        if "${rootfsDir}/usr/bin/ldd" --version 2>&1 | grep -q musl ||
+                strings "${rootfsDir}/usr/bin/ldd" 2>&1 | grep -q musl; then
             distroRid="linux-musl-${buildArch}"
         fi
 


### PR DESCRIPTION
If `ldd` fails with `Exec format error`, attempt to locate `musl` token
in the output of `strings /path/ldd`.