### PR TITLE
Fix EventWrittenEventArgs.Keywords on EventSource error event

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -268,32 +268,29 @@ namespace BasicEventSourceTests
         /// </summary>
         internal class EventListenerEvent : Event
         {
-            private readonly EventWrittenEventArgs _data;
+            internal EventWrittenEventArgs Data { get; }
+
+            internal EventListenerEvent(EventWrittenEventArgs data) => Data = data;
 
             public override bool IsEventListener { get { return true; } }
 
-            public override string ProviderName { get { return _data.EventSource.Name; } }
+            public override string ProviderName { get { return Data.EventSource.Name; } }
 
-            public override string EventName { get { return _data.EventName; } }
+            public override string EventName { get { return Data.EventName; } }
 
-            public override IList<string> PayloadNames { get { return _data.PayloadNames; } }
+            public override IList<string> PayloadNames { get { return Data.PayloadNames; } }
 
             public override int PayloadCount
             {
-                get { return _data.Payload?.Count ?? 0; }
-            }
-
-            internal EventListenerEvent(EventWrittenEventArgs data)
-            {
-                _data = data;
+                get { return Data.Payload?.Count ?? 0; }
             }
 
             public override object PayloadValue(int propertyIndex, string propertyName)
             {
                 if (propertyName != null)
-                    Assert.Equal(propertyName, _data.PayloadNames[propertyIndex]);
+                    Assert.Equal(propertyName, Data.PayloadNames[propertyIndex]);
 
-                return _data.Payload[propertyIndex];
+                return Data.Payload[propertyIndex];
             }
         }
 

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsUserErrors.cs
@@ -127,6 +127,29 @@ namespace BasicEventSourceTests
             // expected message: "ERROR: Exception in Command Processing for EventSource BadEventSource_MismatchedIds: Event Event2 was assigned event ID 2 but 1 was passed to WriteEvent. "
             if (!PlatformDetection.IsNetFramework) // .NET Framework has typo
                 Assert.Matches("Event Event2 was assigned event ID 2 but 1 was passed to WriteEvent", message);
+
+            // Validate the details of the EventWrittenEventArgs object
+            if (_event is EventListenerListener.EventListenerEvent elEvent)
+            {
+                EventWrittenEventArgs ea = elEvent.Data;
+                Assert.NotNull(ea);
+                Assert.Equal(Guid.Empty, ea.ActivityId);
+                Assert.Equal(EventChannel.None, ea.Channel);
+                Assert.Equal(0, ea.EventId);
+                Assert.Equal("EventSourceMessage", ea.EventName);
+                Assert.NotNull(ea.EventSource);
+                Assert.Equal(EventKeywords.None, ea.Keywords);
+                Assert.Equal(EventLevel.LogAlways, ea.Level);
+                Assert.Equal((EventOpcode)0, ea.Opcode);
+                Assert.NotNull(ea.Payload);
+                Assert.NotNull(ea.PayloadNames);
+                Assert.Equal(ea.PayloadNames.Count, ea.Payload.Count);
+                Assert.Equal(Guid.Empty, ea.RelatedActivityId);
+                Assert.Equal(EventTags.None, ea.Tags);
+                Assert.Equal(EventTask.None, ea.Task);
+                Assert.InRange(ea.TimeStamp, DateTime.MinValue, DateTime.MaxValue);
+                Assert.Equal(0, ea.Version);
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4700,7 +4700,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return m_keywords;
 
                 Debug.Assert(m_eventSource.m_eventData != null);


### PR DESCRIPTION
When EventSource encounters an error, it emits an event with ID == 0.  The EventWrittenEventArgs.Keywords property is incorrectly trying to find keyword data for this event, resulting in a null ref when accessing the property on an error event.

Contributes to https://github.com/dotnet/runtime/issues/2198
cc: @noahfalk, @brianrob, @jaredpar, @ViktorHofer, @billwert 