### PR TITLE
Publish (bin)logs as pipeline artifacts

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -136,12 +136,11 @@ jobs:
       - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(_BuildConfig) /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj
         displayName: Sign Binaries
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: Publish Signing Logs
         inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
-          PublishLocation: Container
-          ArtifactName: ${{ format('SignLogs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+          targetPath: '$(Build.SourcesDirectory)/artifacts/log/'
+          artifactName: ${{ format('SignLogs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         continueOnError: true
         condition: always()
 
@@ -205,10 +204,10 @@ jobs:
             NUGET_PACKAGES: $(Build.SourcesDirectory)\.packages
 
     # Publish Logs
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/artifacts/log
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
         artifactName: 'BuildLogs_CoreCLR_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/build-test-job.yml
+++ b/eng/pipelines/coreclr/templates/build-test-job.yml
@@ -139,10 +139,10 @@ jobs:
 
 
     # Publish Logs
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/artifacts/log
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
         artifactName: 'TestBuildLogs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
@@ -176,7 +176,7 @@ jobs:
             --diff_dir   %HELIX_WORKITEM_PAYLOAD%\log\$(targetFlavor)
 
     # Publish log
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish log
       inputs:
         pathtoPublish: $(artifactsDirectory)/log

--- a/eng/pipelines/coreclr/templates/run-test-job.yml
+++ b/eng/pipelines/coreclr/templates/run-test-job.yml
@@ -380,10 +380,10 @@ jobs:
           - jitelthookenabled_tiered
 
     # Publish Logs
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/artifacts/log
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
         artifactName: '$(LogNamePrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
@@ -33,10 +33,10 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: Publish BuildLogs
   inputs:
-    PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-    ArtifactName: Installer-Logs-${{ parameters.name }}-$(_BuildConfig)
+    targetPath: '$(Build.StagingDirectory)/BuildLogs'
+    artifactName: Installer-Logs-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: succeededOrFailed()

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -87,10 +87,10 @@ jobs:
         displayName: 'product build'
 
     # Publish Logs
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: Publish Logs
       inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/artifacts/log
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
         ${{ if ne(parameters.llvm, true) }}:
           artifactName: 'BuildLogs_Mono_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
         ${{ if eq(parameters.llvm, true) }}:

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -2,6 +2,7 @@ parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromPlatform: ''
   isOfficialBuild: false
+  logArtifactName: 'Logs-PrepareSignedArtifacts'
 
 jobs:
 - job: PrepareSignedArtifacts
@@ -66,5 +67,5 @@ jobs:
     displayName: Publish BuildLogs
     inputs:
       targetPath: '$(Build.StagingDirectory)\BuildLogs'
-      artifactName: Logs-PrepareSignedArtifacts
+      artifactName: ${{ parameters.logArtifactName }}
     condition: succeededOrFailed()

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -62,9 +62,9 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact BuildLogs
+  - task: PublishPipelineArtifact@1
+    displayName: Publish BuildLogs
     inputs:
-      PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
-      ArtifactName: Logs-PrepareSignedArtifacts
+      targetPath: '$(Build.StagingDirectory)\BuildLogs'
+      artifactName: Logs-PrepareSignedArtifacts
     condition: succeededOrFailed()


### PR DESCRIPTION
Currently we publish logs and binlogs as build artifacts. Pipeline
artifacts are the replacement for build artifacts and enable multi-stage
uploads. This doesn't change upload our build artifacts via the
PublishBuildArtifacts task.

Fixes https://github.com/dotnet/runtime/issues/2289
Follow-up of https://github.com/dotnet/runtime/pull/2292