### PR TITLE
Hide redundant members from debugger views

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/KeyValuePair.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/KeyValuePair.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Text;
 
 namespace System.Collections.Generic
@@ -50,7 +51,9 @@ namespace System.Collections.Generic
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct KeyValuePair<TKey, TValue>
     {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly TKey key; // Do not rename (binary serialization)
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly TValue value; // Do not rename (binary serialization)
 
         public KeyValuePair(TKey key, TValue value)


### PR DESCRIPTION
When looking at a `KeyValuePair<K,V>` in the debugger (often as part of a dictionary), both the key and the value are shown twice:

![image](https://user-images.githubusercontent.com/3548/73398564-f7ef1f00-42a2-11ea-980c-3395fceeffce.png)

These attributes will prevent the `key` and `value` fields from showing up, leaving just the two meaningful properties.