### PR TITLE
Disable Regex long pattern string test on .NET Framework

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -386,6 +386,7 @@ namespace System.Text.RegularExpressions.Tests
             VerifyMatch(r.Match(input, beginning, length), expectedSuccess, expectedValue);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Takes several minutes on .NET Framework")]
         [Theory]
         [InlineData(RegexOptions.None)]
         [InlineData(RegexOptions.Compiled)]


### PR DESCRIPTION
cc: @ViktorHofer 