### PR TITLE
Improve resiliency of CertificateValidationRemoteServer_EndToEnd_Ok test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -34,19 +34,19 @@ namespace System.Net.Security.Tests
                     new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.Message}");
                 }
 
-                try
+                using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
                 {
-                    using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
+                    try
                     {
                         await sslStream.AuthenticateAsClientAsync(Configuration.Security.TlsServer.IdnHost);
                     }
-                }
-                catch (IOException ex) when (ex.InnerException is SocketException &&
+                    catch (IOException ex) when (ex.InnerException is SocketException &&
                       ((SocketException)ex.InnerException).SocketErrorCode == SocketError.ConnectionReset)
-                {
-                    // Since we try to verify certificate validation, ignore IO errors
-                    // caused most likely by environmental failures.
-                    new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.InnerException.Message}");
+                    {
+                        // Since we try to verify certificate validation, ignore IO errors
+                        // caused most likely by environmental failures.
+                        new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.InnerException.Message}");
+                    }
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Net.Security.Tests
@@ -19,19 +21,32 @@ namespace System.Net.Security.Tests
         [OuterLoop("Uses external servers")]
         public async Task CertificateValidationRemoteServer_EndToEnd_Ok()
         {
-            if (PlatformDetection.IsWindows7)
-            {
-                // https://github.com/dotnet/corefx/issues/42339
-                return;
-            }
-
             using (var client = new TcpClient(AddressFamily.InterNetwork))
             {
-                await client.ConnectAsync(Configuration.Security.TlsServer.IdnHost, Configuration.Security.TlsServer.Port);
-
-                using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
+                try
                 {
-                    await sslStream.AuthenticateAsClientAsync(Configuration.Security.TlsServer.IdnHost);
+                    await client.ConnectAsync(Configuration.Security.TlsServer.IdnHost, Configuration.Security.TlsServer.Port);
+                }
+                catch (Exception ex)
+                {
+                    // if we cannot connect, skip the test instead of failing.
+                    // This test is not trying to test networking.
+                    new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.Message}");
+                }
+
+                try
+                {
+                    using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
+                    {
+                        await sslStream.AuthenticateAsClientAsync(Configuration.Security.TlsServer.IdnHost);
+                    }
+                }
+                catch (IOException ex) when (ex.InnerException is SocketException &&
+                      ((SocketException)ex.InnerException).SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    // Since we try to verify certificate validation, ignore IO errors
+                    // caused most likely by environmental failures.
+                    new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.InnerException.Message}");
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -33,7 +33,7 @@ namespace System.Net.Security.Tests
                 {
                     // if we cannot connect, skip the test instead of failing.
                     // This test is not trying to test networking.
-                    new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.Message}");
+                    throw new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.Message}");
                 }
 
                 using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
@@ -54,7 +54,7 @@ namespace System.Net.Security.Tests
                     {
                         // Since we try to verify certificate validation, ignore IO errors
                         // caused most likely by environmental failures.
-                        new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.InnerException.Message}");
+                        throw new SkipTestException($"Unable to connect to '{Configuration.Security.TlsServer.IdnHost}': {ex.InnerException.Message}");
                     }
                 }
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -17,9 +17,11 @@ namespace System.Net.Security.Tests
 
     public class CertificateValidationRemoteServer
     {
-        [Fact]
         [OuterLoop("Uses external servers")]
-        public async Task CertificateValidationRemoteServer_EndToEnd_Ok()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CertificateValidationRemoteServer_EndToEnd_Ok(bool useAsync)
         {
             using (var client = new TcpClient(AddressFamily.InterNetwork))
             {
@@ -38,7 +40,14 @@ namespace System.Net.Security.Tests
                 {
                     try
                     {
-                        await sslStream.AuthenticateAsClientAsync(Configuration.Security.TlsServer.IdnHost);
+                        if (useAsync)
+                        {
+                            await sslStream.AuthenticateAsClientAsync(Configuration.Security.TlsServer.IdnHost);
+                        }
+                        else
+                        {
+                            sslStream.AuthenticateAsClient(Configuration.Security.TlsServer.IdnHost);
+                        }
                     }
                     catch (IOException ex) when (ex.InnerException is SocketException &&
                       ((SocketException)ex.InnerException).SocketErrorCode == SocketError.ConnectionReset)


### PR DESCRIPTION
This test connects to Azure endpoint and depends on external services.
Once in a while, we seek a spike of failures. This is not specific to Windows 7 (https://github.com/dotnet/corefx/issues/42339) but more so luck and overall network condition. 

Since this test is trying to verify certificate validation, I made modifications to ignore connect failures as well as cases when we get reset from the remote peer. That is most likely caused by the network infrastructure and not caused by the product. If we mess up handshake we would most likely get AuthenticationException and the test would still fail.

fixes  #2350
contributes to https://github.com/dotnet/corefx/issues/42339