### PR TITLE
Update alpine arm64 image

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -119,7 +119,7 @@ jobs:
       archType: arm64
       platform: Linux_musl_arm64
       container:
-        image: ubuntu-16.04-cross-arm64-alpine-406629a-20200121150126
+        image: ubuntu-16.04-cross-arm64-alpine-406629a-20200127195039
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -40,11 +40,10 @@ jobs:
         - (Alpine.310.Amd64.Open)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.10-helix-3043688-20190918214010
         - (Alpine.311.Amd64.Open)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.11-helix-08e8e40-20200107182408
 
-    # Issue tracking this being re-enabled https://github.com/dotnet/runtime/issues/1723
     # Linux musl arm64
-    #- ${{ if eq(parameters.platform, 'Linux_musl_arm64') }}:
-    #  - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-    #    - (Alpine.38.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
+    - ${{ if eq(parameters.platform, 'Linux_musl_arm64') }}:
+      - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
+        - (Alpine.38.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-a45aeeb-20190620184035
 
     # Linux x64
     - ${{ if eq(parameters.platform, 'Linux_x64') }}:


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/1723

Once we get an official build with these changes, we can update the host version we use for testing and the issue will be fixed.