### PR TITLE
Convert AppDomainNative::CreateDynamicAssembly to QCall

### DIFF
--- a/src/coreclr/src/vm/appdomainnative.hpp
+++ b/src/coreclr/src/vm/appdomainnative.hpp
@@ -20,7 +20,7 @@
 class AppDomainNative
 {
 public:
-    static FCDECL3(Object*, CreateDynamicAssembly, AssemblyNameBaseObject* assemblyNameUNSAFE, StackCrawlMark* stackMark, INT32 access);
+    static void QCALLTYPE CreateDynamicAssembly(QCall::ObjectHandleOnStack assemblyName, QCall::StackCrawlMarkHandle stackMark, INT32 access, QCall::ObjectHandleOnStack retAssembly);
     static FCDECL0(Object*, GetLoadedAssemblies);
     static FCDECL1(Object*, GetOrInternString, StringObject* pStringUNSAFE);
     static FCDECL1(Object*, IsStringInterned, StringObject* pString);

--- a/src/coreclr/src/vm/ecalllist.h
+++ b/src/coreclr/src/vm/ecalllist.h
@@ -536,7 +536,7 @@ FCFuncStart(gAssemblyFuncs)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyBuilderFuncs)
-    FCFuncElement("nCreateDynamicAssembly", AppDomainNative::CreateDynamicAssembly)
+    QCFuncElement("CreateDynamicAssembly", AppDomainNative::CreateDynamicAssembly)
     FCFuncElement("GetInMemoryAssemblyModule", AssemblyNative::GetInMemoryAssemblyModule)
 FCFuncEnd()
 


### PR DESCRIPTION
- Get rid of the libunwind overhead by converting to QCall