### PR TITLE
Add PreserveDependency to CreateProperty

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -46,6 +46,7 @@ namespace System.Text.Json
         }
 
         [PreserveDependency(".ctor()", "System.Text.Json.JsonPropertyInfoNullable`2")]
+        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.JsonPropertyInfoNotNullable`4")]
         [PreserveDependency(".ctor()", "System.Text.Json.Serialization.JsonPropertyInfoNotNullableContravariant`4")]
         internal static JsonPropertyInfo CreateProperty(
             Type declaredPropertyType,


### PR DESCRIPTION
The method body depends on this ctor, but right now we're lucking out because this ctor is statically referenced from elsewhere.