### PR TITLE
Emit DebugDirectory section and all DebugDirectory entries

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -193,6 +193,14 @@ namespace ILCompiler
             }
         }
 
+        public string GetFilePathForLoadedModule(EcmaModule module)
+        {
+            ModuleData moduleData;
+            if (!_moduleHashtable.TryGetValue(module, out moduleData))
+                return null;
+            return moduleData.FilePath;
+        }
+
         private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding)
         {
             MemoryMappedViewAccessor mappedViewAccessor = null;

--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -193,14 +193,6 @@ namespace ILCompiler
             }
         }
 
-        public string GetFilePathForLoadedModule(EcmaModule module)
-        {
-            ModuleData moduleData;
-            if (!_moduleHashtable.TryGetValue(module, out moduleData))
-                return null;
-            return moduleData.FilePath;
-        }
-
         private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding)
         {
             MemoryMappedViewAccessor mappedViewAccessor = null;

--- a/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -290,6 +290,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_ABSOLUTE:
                 case RelocType.IMAGE_REL_BASED_HIGHLOW:
                 case RelocType.IMAGE_REL_SECREL:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     EmitInt(delta);

--- a/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -21,10 +21,11 @@ namespace ILCompiler.DependencyAnalysis
                                                     // for relative pointer (used to make NGen relocation 
                                                     // section smaller)    
         IMAGE_REL_SECREL                = 0x80,     // 32 bit offset from base of section containing target
+        IMAGE_REL_FILE_ABSOLUTE         = 0x81,     // 32 bit offset from begining of image
 
-        IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x81,   // ADRP
-        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x82,   // ADD/ADDS (immediate) with zero shift, for page offset
-        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L = 0x83,   // LDR (indexed, unsigned immediate), for page offset
+        IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x82,   // ADRP
+        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x83,   // ADD/ADDS (immediate) with zero shift, for page offset
+        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L = 0x84,   // LDR (indexed, unsigned immediate), for page offset
 
         //
         // Relocations for R2R image production
@@ -272,6 +273,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                     *(int*)location = (int)value;
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:
@@ -305,6 +307,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_RELPTR32:
                 case RelocType.IMAGE_REL_SECREL:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     return *(int*)location;
                 case RelocType.IMAGE_REL_BASED_DIR64:

--- a/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -21,16 +21,16 @@ namespace ILCompiler.DependencyAnalysis
                                                     // for relative pointer (used to make NGen relocation 
                                                     // section smaller)    
         IMAGE_REL_SECREL                = 0x80,     // 32 bit offset from base of section containing target
-        IMAGE_REL_FILE_ABSOLUTE         = 0x81,     // 32 bit offset from begining of image
 
-        IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x82,   // ADRP
-        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x83,   // ADD/ADDS (immediate) with zero shift, for page offset
-        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L = 0x84,   // LDR (indexed, unsigned immediate), for page offset
+        IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x81,   // ADRP
+        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x82,   // ADD/ADDS (immediate) with zero shift, for page offset
+        IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L = 0x83,   // LDR (indexed, unsigned immediate), for page offset
 
         //
         // Relocations for R2R image production
         //
-        IMAGE_REL_SYMBOL_SIZE = 0x1000,             // The size of data in the image represented by the target symbol node
+        IMAGE_REL_SYMBOL_SIZE           = 0x1000,   // The size of data in the image represented by the target symbol node
+        IMAGE_REL_FILE_ABSOLUTE         = 0x1001,   // 32 bit offset from begining of image
     }
 
     public struct Relocation

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -14,6 +14,7 @@ using ILCompiler.PEWriter;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 using Internal.TypeSystem;
+using System.Security.Cryptography;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -83,6 +84,8 @@ namespace ILCompiler.DependencyAnalysis
                     _inputPeReader,
                     GetRuntimeFunctionsTable);
 
+                NativeDebugDirectoryEntryNode nativeDebugDirectoryEntryNode = null;
+
                 int nodeIndex = -1;
                 foreach (var depNode in _nodes)
                 {
@@ -98,6 +101,15 @@ namespace ILCompiler.DependencyAnalysis
                         continue;
 
                     ObjectData nodeContents = node.GetData(_nodeFactory);
+
+                    if (node is NativeDebugDirectoryEntryNode nddeNode)
+                    {
+                        // There should is only one NativeDebugDirectoryEntry.
+                        // This assert will need to be revisited when we implement the composite R2R format, where we'll need to figure
+                        // out how native symbols will be emitted, and verify that the DiaSymReader library is able to consume them.
+                        Debug.Assert(nativeDebugDirectoryEntryNode == null);
+                        nativeDebugDirectoryEntryNode = nddeNode;
+                    }
 
                     string name = null;
 
@@ -120,6 +132,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 r2rPeBuilder.SetCorHeader(_nodeFactory.CopiedCorHeaderNode, _nodeFactory.CopiedCorHeaderNode.Size);
+                r2rPeBuilder.SetDebugDirectory(_nodeFactory.DebugDirectoryNode, _nodeFactory.DebugDirectoryNode.Size);
 
                 if (_nodeFactory.Win32ResourcesNode != null)
                 {
@@ -127,9 +140,23 @@ namespace ILCompiler.DependencyAnalysis
                     r2rPeBuilder.SetWin32Resources(_nodeFactory.Win32ResourcesNode, _nodeFactory.Win32ResourcesNode.Size);
                 }
 
+                var memStream = new MemoryStream();
+                r2rPeBuilder.Write(memStream);
+                byte[] objectFileData = memStream.ToArray();
+
+                // Compute MD5 hash of the output image and store that in the native DebugDirectory entry
+                using (var md5Hash = MD5.Create())
+                {
+                    byte[] hash = md5Hash.ComputeHash(objectFileData);
+                    byte[] rsdsEntry = nativeDebugDirectoryEntryNode.GenerateRSDSEntryData(hash);
+
+                    int offsetToUpdate = r2rPeBuilder.GetSymbolFilePosition(nativeDebugDirectoryEntryNode);
+                    Array.Copy(rsdsEntry, 0, objectFileData, offsetToUpdate, rsdsEntry.Length);
+                }
+
                 using (var peStream = File.Create(_objectFilePath))
                 {
-                    r2rPeBuilder.Write(peStream);
+                    peStream.Write(objectFileData, 0, objectFileData.Length);
                 }
 
                 if (mapFile != null)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Text;
+using System.Diagnostics;
+using System.Reflection.PortableExecutable;
+
+using Internal.Text;
+using Internal.TypeSystem.Ecma;
+using System.IO;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public abstract class DebugDirectoryEntryNode : ObjectNode, ISymbolDefinitionNode
+    {
+        protected readonly EcmaModule _module;
+
+        public DebugDirectoryEntryNode(EcmaModule module)
+        {
+            _module = module;
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
+
+        public override bool IsShareable => false;
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            return _module.CompareTo(((DebugDirectoryEntryNode)other)._module);
+        }
+    }
+
+    public class NativeDebugDirectoryEntryNode : DebugDirectoryEntryNode
+    {
+        const int RSDSSize =
+            sizeof(int) +   // Magic
+            16 +            // Signature (guid)
+            sizeof(int) +   // Age
+            260;            // FileName
+
+        public override int ClassCode => 119958401;
+
+        public unsafe int Size => RSDSSize;
+
+        public NativeDebugDirectoryEntryNode(EcmaModule sourceModule)
+            : base(sourceModule)
+        { }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($"__NativeRvaBlob_{_module.Assembly.GetName().Name}");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
+
+            // Emit empty entry. This will be filled with data after the output image is emitted
+            builder.EmitZeros(RSDSSize);
+
+            return builder.ToObjectData();
+        }
+
+        public unsafe byte[] GenerateRSDSEntryData(byte[] md5Hash)
+        {
+            byte[] rsdsEntry = new byte[RSDSSize];
+
+            fixed (byte* pData = rsdsEntry)
+            {
+                byte* pSignature = pData + 4;
+                byte* pAge = pSignature + 16;
+                byte* pFileName = pAge + 4;
+
+                *(uint*)pData = 0x53445352;     // Magic "RSDS"
+                *(uint*)pAge = 1;
+
+                // our PDB signature will be the same as our NGEN signature.
+                // However we want the printed version of the GUID to be the same as the
+                // byte dump of the signature so we swap bytes to make this work.
+                Debug.Assert(md5Hash.Length == 16);
+                *(uint*)pSignature = (uint)((md5Hash[0] * 256 + md5Hash[1]) * 256 + md5Hash[2]) * 256 + md5Hash[3];
+                pSignature += 4;
+                *(ushort*)pSignature = (ushort)(md5Hash[4] * 256 + md5Hash[5]);
+                pSignature += 2;
+                *(ushort*)pSignature = (ushort)(md5Hash[6] * 256 + md5Hash[7]);
+                Array.Copy(md5Hash, 8, rsdsEntry, 12, 8);
+
+                string moduleFilePath = ((CompilerTypeSystemContext)_module.Context).GetFilePathForLoadedModule(_module);
+                Debug.Assert(!String.IsNullOrEmpty(moduleFilePath));
+                string pdbFileName = Path.GetFileNameWithoutExtension(moduleFilePath) + ".ni.pdb";
+                Debug.Assert(pdbFileName.Length < 260);
+
+                byte[] pdbFileNameBytes = Encoding.ASCII.GetBytes(pdbFileName);
+                Array.Copy(Encoding.ASCII.GetBytes(pdbFileName), 0, rsdsEntry, (pFileName - pData), pdbFileNameBytes.Length);
+            }
+
+            return rsdsEntry;
+        }
+    }
+
+    public class CopiedDebugDirectoryEntryNode : DebugDirectoryEntryNode
+    {
+        private readonly DebugDirectoryEntry _sourceDebugEntry;
+
+        public override int ClassCode => 1558397;
+
+        public CopiedDebugDirectoryEntryNode(EcmaModule sourceModule, DebugDirectoryEntry sourceEntry)
+            : base(sourceModule)
+        {
+            Debug.Assert(sourceEntry.DataRelativeVirtualAddress > 0 && sourceEntry.DataSize > 0);
+            _sourceDebugEntry = sourceEntry;
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($"__CopiedDebugEntryNode_{_sourceDebugEntry.DataRelativeVirtualAddress}_{_module.Assembly.GetName().Name}");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            if (relocsOnly)
+            {
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+            }
+
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
+
+            PEMemoryBlock block = _module.PEReader.GetSectionData(_sourceDebugEntry.DataRelativeVirtualAddress);
+            byte[] result = new byte[_sourceDebugEntry.DataSize];
+            block.GetContent(0, _sourceDebugEntry.DataSize).CopyTo(result);
+            builder.EmitBytes(result);
+
+            return builder.ToObjectData();
+        }
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            int moduleComp = base.CompareToImpl(other, comparer);
+            if (moduleComp != 0)
+                return moduleComp;
+
+            return _sourceDebugEntry.DataRelativeVirtualAddress - ((CopiedDebugDirectoryEntryNode)other)._sourceDebugEntry.DataRelativeVirtualAddress;
+        }
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
@@ -135,10 +135,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
             }
 
-            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
-            builder.RequireInitialPointerAlignment();
-            builder.AddSymbol(this);
-
             ImmutableArray<DebugDirectoryEntry> entries = _module.PEReader.ReadDebugDirectory();
             Debug.Assert(entries != null && _debugEntryIndex < entries.Length);
 
@@ -147,9 +143,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             PEMemoryBlock block = _module.PEReader.GetSectionData(sourceDebugEntry.DataRelativeVirtualAddress);
             byte[] result = new byte[sourceDebugEntry.DataSize];
             block.GetContent(0, sourceDebugEntry.DataSize).CopyTo(result);
-            builder.EmitBytes(result);
 
-            return builder.ToObjectData();
+            return new ObjectData(result, Array.Empty<Relocation>(), _module.Context.Target.PointerSize, new ISymbolDefinitionNode[] { this });
         }
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+using Internal.Text;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class DebugDirectoryNode : ObjectNode, ISymbolDefinitionNode
+    {
+        const int ImageDebugDirectorySize =
+            sizeof(int) +   // Characteristics
+            sizeof(int) +   // TimeDateStamp
+            sizeof(short) + // MajorVersion:
+            sizeof(short) + // MinorVersion
+            sizeof(int) +   // Type
+            sizeof(int) +   // SizeOfData:
+            sizeof(int) +   // AddressOfRawData:
+            sizeof(int);    // PointerToRawData
+
+        private EcmaModule _module;
+
+        public DebugDirectoryNode(EcmaModule sourceModule)
+        {
+            _module = sourceModule;
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
+
+        public override bool IsShareable => false;
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int ClassCode => 315358387;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public int Size => (GetNumDebugDirectoryEntriesInModule() + 1) * ImageDebugDirectorySize;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append($"__DebugDirectory_{_module.Assembly.GetName().Name}");
+        }
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        int GetNumDebugDirectoryEntriesInModule()
+        {
+            ImmutableArray<DebugDirectoryEntry> entries = _module.PEReader.ReadDebugDirectory();
+            return entries == null ? 0 : entries.Length;
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.RequireInitialPointerAlignment();
+            builder.AddSymbol(this);
+
+            ImmutableArray<DebugDirectoryEntry> entries = _module.PEReader.ReadDebugDirectory();
+            int numEntries = GetNumDebugDirectoryEntriesInModule();
+
+            // First, write the native debug directory entry
+            {
+                var entry = (NativeDebugDirectoryEntryNode)factory.DebugDirectoryEntry(_module, default);
+
+                builder.EmitUInt(0 /* Characteristics */);
+                if (numEntries > 0)
+                {
+                    builder.EmitUInt(entries[0].Stamp);
+                    builder.EmitUShort(entries[0].MajorVersion);
+                }
+                else
+                {
+                    builder.EmitUInt(0);
+                    builder.EmitUShort(0);
+                }
+                // Make sure the "is portable pdb" indicator (MinorVersion == 0x504d) is clear
+                // for the NGen debug directory entry since this debug directory can be copied
+                // from an existing entry which could be a portable pdb.
+                builder.EmitUShort(0 /* MinorVersion */);
+                builder.EmitInt((int)DebugDirectoryEntryType.CodeView);
+                builder.EmitInt(entry.Size);
+                builder.EmitReloc(entry, RelocType.IMAGE_REL_BASED_ADDR32NB);
+                builder.EmitReloc(entry, RelocType.IMAGE_REL_FILE_ABSOLUTE);
+            }
+
+            // Second, copy existing entries from input module
+            for(int i = 0; i < numEntries; i++)
+            {
+                builder.EmitUInt(0 /* Characteristics */);
+                builder.EmitUInt(entries[i].Stamp);
+                builder.EmitUShort(entries[i].MajorVersion);
+                builder.EmitUShort(entries[i].MinorVersion);
+                builder.EmitInt((int)entries[i].Type);
+                builder.EmitInt(entries[i].DataSize);
+                if (entries[i].DataSize == 0)
+                {
+                    builder.EmitUInt(0);
+                    builder.EmitUInt(0);
+                }
+                else
+                {
+                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, entries[i]), RelocType.IMAGE_REL_BASED_ADDR32NB);
+                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, entries[i]), RelocType.IMAGE_REL_FILE_ABSOLUTE);
+                }
+            }
+
+            return builder.ToObjectData();
+        }
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            return _module.CompareTo(((DebugDirectoryNode)other)._module);
+        }
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 using Internal.Text;
 using Internal.TypeSystem.Ecma;
@@ -112,6 +113,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     builder.EmitReloc(factory.DebugDirectoryEntry(_module, i), RelocType.IMAGE_REL_FILE_ABSOLUTE);
                 }
             }
+
+            Debug.Assert(builder.CountBytes == Size);
 
             return builder.ToObjectData();
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
@@ -69,7 +69,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // First, write the native debug directory entry
             {
-                var entry = (NativeDebugDirectoryEntryNode)factory.DebugDirectoryEntry(_module, default);
+                var entry = (NativeDebugDirectoryEntryNode)factory.DebugDirectoryEntry(_module, -1);
 
                 builder.EmitUInt(0 /* Characteristics */);
                 if (numEntries > 0)
@@ -108,8 +108,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
                 else
                 {
-                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, entries[i]), RelocType.IMAGE_REL_BASED_ADDR32NB);
-                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, entries[i]), RelocType.IMAGE_REL_FILE_ABSOLUTE);
+                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, i), RelocType.IMAGE_REL_BASED_ADDR32NB);
+                    builder.EmitReloc(factory.DebugDirectoryEntry(_module, i), RelocType.IMAGE_REL_FILE_ABSOLUTE);
                 }
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -17,7 +17,6 @@ using Internal.Text;
 using Internal.TypeSystem.Ecma;
 using Internal.CorConstants;
 using Internal.ReadyToRunConstants;
-using System.Reflection.PortableExecutable;
 
 namespace ILCompiler.DependencyAnalysis
 {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -114,7 +114,8 @@ namespace ILCompiler
             SignatureContext signatureContext = new SignatureContext(_inputModule, moduleTokenResolver);
             CopiedCorHeaderNode corHeaderNode = new CopiedCorHeaderNode(_inputModule);
             AttributePresenceFilterNode attributePresenceFilterNode = null;
-            
+            DebugDirectoryNode debugDirectoryNode = new DebugDirectoryNode(_inputModule);
+
             // Core library attributes are checked FAR more often than other dlls
             // attributes, so produce a highly efficient table for determining if they are
             // present. Other assemblies *MAY* benefit from this feature, but it doesn't show
@@ -148,6 +149,7 @@ namespace ILCompiler
                 moduleTokenResolver,
                 signatureContext,
                 corHeaderNode,
+                debugDirectoryNode,
                 win32Resources,
                 attributePresenceFilterNode);
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -108,6 +108,8 @@
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedPointerIndirectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ArgIterator.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\AttributePresenceFilterNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DebugDirectoryEntryNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DebugDirectoryNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedFieldRvaNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedManagedResourcesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedMetadataBlobNode.cs" />

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -217,6 +217,11 @@ namespace ILCompiler.PEWriter
             _sectionBuilder.SetCorHeader(symbol, headerSize);
         }
 
+        public void SetDebugDirectory(ISymbolNode symbol, int size)
+        {
+            _sectionBuilder.SetDebugDirectory(symbol, size);
+        }
+
         public void SetWin32Resources(ISymbolNode symbol, int resourcesSize)
         {
             _sectionBuilder.SetWin32Resources(symbol, resourcesSize);
@@ -254,6 +259,11 @@ namespace ILCompiler.PEWriter
             }
 
             _sectionBuilder.AddObjectData(objectData, targetSectionIndex, name, mapFile);
+        }
+
+        public int GetSymbolFilePosition(ISymbolNode symbol)
+        {
+            return _sectionBuilder.GetSymbolFilePosition(symbol);
         }
 
         /// <summary>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -284,6 +284,8 @@ namespace ILCompiler.PEWriter
 
             ApplyMachineOSOverride(outputStream);
 
+            CopyTimeStampFromInputImage(outputStream);
+
             _written = true;
         }
 
@@ -398,6 +400,23 @@ namespace ILCompiler.PEWriter
 
             outputStream.Seek(DosHeaderSize + PESignatureSize, SeekOrigin.Begin);
             outputStream.Write(patchedTargetMachine, 0, patchedTargetMachine.Length);
+        }
+
+        /// <summary>
+        /// Copy over the timestamp from IL image for determinism.
+        /// </summary>
+        /// <param name="outputStream">Output stream representing the R2R PE executable</param>
+        private void CopyTimeStampFromInputImage(Stream outputStream)
+        {
+            byte[] patchedTimestamp = BitConverter.GetBytes(_peReader.PEHeaders.CoffHeader.TimeDateStamp);
+            int seekSize =
+                DosHeaderSize +
+                PESignatureSize +
+                sizeof(short) +     // Machine
+                sizeof(short);      //NumberOfSections
+
+            outputStream.Seek(seekSize, SeekOrigin.Begin);
+            outputStream.Write(patchedTimestamp, 0, patchedTimestamp.Length);
         }
 
         /// <summary>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -136,7 +136,7 @@ namespace ILCompiler.PEWriter
         /// <param name="relocationType">Relocation type to process</param>
         /// <param name="sourceRVA">RVA representing the address to relocate</param>
         /// <param name="targetRVA">RVA representing the relocation target</param>
-        public void ProcessRelocation(RelocType relocationType, int sourceRVA, int targetRVA)
+        public void ProcessRelocation(RelocType relocationType, int sourceRVA, int targetRVA, int filePosWhenPlaced)
         {
             int relocationLength = 0;
             long delta = 0;
@@ -201,6 +201,13 @@ namespace ILCompiler.PEWriter
                     {
                         relocationLength = 4;
                         delta = targetRVA & 0xfff;
+                        break;
+                    }
+
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
+                    {
+                        relocationLength = 4;
+                        delta = filePosWhenPlaced;
                         break;
                     }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -255,6 +255,16 @@ namespace ILCompiler.PEWriter
         int _corHeaderSize;
 
         /// <summary>
+        /// Symbol representing the debug directory.
+        /// </summary>
+        ISymbolNode _debugDirectorySymbol;
+
+        /// <summary>
+        /// Size of the debug directory in bytes.
+        /// </summary>
+        int _debugDirectorySize;
+
+        /// <summary>
         /// Symbol representing the start of the win32 resources
         /// </summary>
         ISymbolNode _win32ResourcesSymbol;
@@ -348,6 +358,19 @@ namespace ILCompiler.PEWriter
         }
 
         /// <summary>
+        /// Look up final file position for a given symbol. This assumes the section have already been placed.
+        /// </summary>
+        /// <param name="symbol">Symbol to look up</param>
+        /// <returns>File position of the symbol, from the begining of the emitted image</returns>
+        public int GetSymbolFilePosition(ISymbolNode symbol)
+        {
+            SymbolTarget symbolTarget = _symbolMap[symbol];
+            Section section = _sections[symbolTarget.SectionIndex];
+            Debug.Assert(section.RVAWhenPlaced != 0);
+            return section.FilePosWhenPlaced + symbolTarget.Offset;
+        }
+
+        /// <summary>
         /// Attach an export symbol to the output PE file.
         /// </summary>
         /// <param name="name">Export symbol identifier</param>
@@ -383,6 +406,12 @@ namespace ILCompiler.PEWriter
         {
             _corHeaderSymbol = symbol;
             _corHeaderSize = headerSize;
+        }
+
+        public void SetDebugDirectory(ISymbolNode symbol, int size)
+        {
+            _debugDirectorySymbol = symbol;
+            _debugDirectorySize = size;
         }
 
         public void SetWin32Resources(ISymbolNode symbol, int resourcesSize)
@@ -788,6 +817,14 @@ namespace ILCompiler.PEWriter
                 Debug.Assert(section.RVAWhenPlaced != 0);
                 directoriesBuilder.AddressOfEntryPoint = section.RVAWhenPlaced + symbolTarget.Offset;
             }
+
+            if (_debugDirectorySymbol != null)
+            {
+                SymbolTarget symbolTarget = _symbolMap[_debugDirectorySymbol];
+                Section section = _sections[symbolTarget.SectionIndex];
+                Debug.Assert(section.RVAWhenPlaced != 0);
+                directoriesBuilder.DebugTable = new DirectoryEntry(section.RVAWhenPlaced + symbolTarget.Offset, _debugDirectorySize);
+            }
         }
 
         /// <summary>
@@ -824,6 +861,7 @@ namespace ILCompiler.PEWriter
                         SymbolTarget relocationTarget = _symbolMap[relocation.Target];
                         Section targetSection = _sections[relocationTarget.SectionIndex];
                         int targetRVA = targetSection.RVAWhenPlaced + relocationTarget.Offset;
+                        int filePosWhenPlaced = targetSection.FilePosWhenPlaced + relocationTarget.Offset;
 
                         // If relocating to a node's size, switch out the target RVA with data length
                         if (relocation.RelocType == RelocType.IMAGE_REL_SYMBOL_SIZE)
@@ -832,7 +870,7 @@ namespace ILCompiler.PEWriter
                         }
 
                         // Apply the relocation
-                        relocationHelper.ProcessRelocation(relocation.RelocType, relocationRVA, targetRVA);
+                        relocationHelper.ProcessRelocation(relocation.RelocType, relocationRVA, targetRVA, filePosWhenPlaced);
                     }
                 }
             }

--- a/src/coreclr/tests/src/readytorun/determinism/Program.cs
+++ b/src/coreclr/tests/src/readytorun/determinism/Program.cs
@@ -7,11 +7,6 @@ using System.IO;
 
 internal class Program
 {
-    public static bool IsTimestampByte(int i)
-    {
-        return i >= 136 && i < 140;
-    }
-
     public static int Main()
     {
         byte[] file1 = File.ReadAllBytes("crossgen2smoke1.ildll");
@@ -24,9 +19,9 @@ internal class Program
 
         for (int i = 0; i < file1.Length; ++i)
         {
-            if (file1[i] != file2[i] && !IsTimestampByte(i))
+            if (file1[i] != file2[i])
             {
-                Console.WriteLine($"Difference at non-timestamp byte {i}");
+                Console.WriteLine($"Difference at byte {i}");
                 return 1;
             }
         }

--- a/src/coreclr/tests/src/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/determinism/crossgen2determinism.csproj
@@ -18,16 +18,16 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set CoreRT_DeterminismSeed=1
-%Core_Root%\crossgen2\crossgen2 -r:%Core_Root%\*.dll -o:crossgen2smoke1.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
+%Core_Root%\crossgen2\crossgen2 --map -r:%Core_Root%\*.dll -o:crossgen2smoke1.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
 set CoreRT_DeterminismSeed=2
-%Core_Root%\crossgen2\crossgen2 -r:%Core_Root%\*.dll -o:crossgen2smoke2.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
+%Core_Root%\crossgen2\crossgen2 --map -r:%Core_Root%\*.dll -o:crossgen2smoke2.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.ildll
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 export CoreRT_DeterminismSeed=1
-$CORE_ROOT/crossgen2/crossgen2 -r:$CORE_ROOT/*.dll -o:crossgen2smoke1.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
+$CORE_ROOT/crossgen2/crossgen2 --map -r:$CORE_ROOT/*.dll -o:crossgen2smoke1.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
 export CoreRT_DeterminismSeed=2
-$CORE_ROOT/crossgen2/crossgen2 -r:$CORE_ROOT/*.dll -o:crossgen2smoke2.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
+$CORE_ROOT/crossgen2/crossgen2 --map -r:$CORE_ROOT/*.dll -o:crossgen2smoke2.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.ildll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These changes ensure that the emitted R2R images can get processed by the DiaSymReader for native symbol emission.

@dotnet/crossgen-contrib 