### PR TITLE
Avoid using a spinlock when WeakReference finalization is called by the GC

### DIFF
--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -23,6 +23,8 @@
 
 bool ThreadSuspend::s_fSuspendRuntimeInProgress = false;
 
+bool ThreadSuspend::s_fSuspended = false;
+
 CLREvent* ThreadSuspend::g_pGCSuspendEvent = NULL;
 
 ThreadSuspend::SUSPEND_REASON ThreadSuspend::m_suspendReason;
@@ -6227,6 +6229,7 @@ void Thread::UnmarkForSuspension(ULONG mask)
 
 void ThreadSuspend::RestartEE(BOOL bFinishedGC, BOOL SuspendSucceded)
 {
+    ThreadSuspend::s_fSuspended = false;
 #ifdef TIME_SUSPEND
     g_SuspendStatistics.StartRestart();
 #endif //TIME_SUSPEND
@@ -6589,6 +6592,7 @@ retry_for_debugger:
 #ifdef TIME_SUSPEND
     g_SuspendStatistics.EndSuspend(reason == SUSPEND_FOR_GC || reason == SUSPEND_FOR_GC_PREP);
 #endif //TIME_SUSPEND
+    ThreadSuspend::s_fSuspended = true;
 }
 
 #if defined(FEATURE_HIJACK) && defined(TARGET_UNIX)

--- a/src/coreclr/src/vm/threadsuspend.h
+++ b/src/coreclr/src/vm/threadsuspend.h
@@ -192,7 +192,6 @@ private:
                                           // that the runtime was suspended
     static Thread* m_pThreadAttemptingSuspendForGC;
 
-private:
     static HRESULT SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason);
     static void    ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded);
 public:

--- a/src/coreclr/src/vm/threadsuspend.h
+++ b/src/coreclr/src/vm/threadsuspend.h
@@ -192,10 +192,10 @@ private:
                                           // that the runtime was suspended
     static Thread* m_pThreadAttemptingSuspendForGC;
 
-public:
+private:
     static HRESULT SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason);
     static void    ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded);
-
+public:
     // Initialize thread suspension support
     static void    Initialize();
 
@@ -229,6 +229,8 @@ private:
     // But there won't be any corruption or AV.  More details on the profiler API scenario in VsWhidbey bug 454936.
     static bool     s_fSuspendRuntimeInProgress;
 
+    static bool     s_fSuspended;
+
     static void SetSuspendRuntimeInProgress();
     static void ResetSuspendRuntimeInProgress();
 
@@ -236,6 +238,7 @@ private:
 
 public:
     static bool SysIsSuspendInProgress() { return s_fSuspendRuntimeInProgress; }
+    static bool SysIsSuspended() { return s_fSuspended; }
 
 public:
     //suspend all threads

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -521,10 +521,7 @@ void FinalizeWeakReference(Object * obj)
     }
 
     // Release the spin lock
-    if (!isRuntimeSuspended)
-    {
-        ReleaseWeakHandleSpinLock(pThis, handle);
-    }
+    ReleaseWeakHandleSpinLock(pThis, handle);
 
     if (handleToDestroy != NULL)
     {

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -500,9 +500,8 @@ void FinalizeWeakReference(Object * obj)
     // We need to revisit the implementation of FinalizeWeakReference() in case of concurrent ScanForFinalization
     // ThreadSuspend::g_pSuspensionThread is set before SuspendRuntime is called, during that time interval, 
     // there could be managed code running calling WeakReferenceNative::SetTarget() and missed the synchronization.
-    bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
 
-    OBJECTHANDLE handle = isRuntimeSuspended ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
+    OBJECTHANDLE handle = ThreadSuspend::SysIsSuspended() ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;
     bool isWeakWinRTHandle = false;
 

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -496,6 +496,7 @@ void FinalizeWeakReference(Object * obj)
 
     WEAKREFERENCEREF pThis((WeakReferenceObject *)(obj));
 
+    // The suspension state of the runtime must be prevented from changing while in this function in order for this to be safe.
     OBJECTHANDLE handle = ThreadSuspend::SysIsSuspended() ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;
     bool isWeakWinRTHandle = false;

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -500,11 +500,7 @@ void FinalizeWeakReference(Object * obj)
     // We need to revisit the implementation of FinalizeWeakReference() in case of concurrent ScanForFinalization
     // ThreadSuspend::g_pSuspensionThread is set before SuspendRuntime is called, during that time interval, 
     // there could be managed code running calling WeakReferenceNative::SetTarget() and missed the synchronization.
-    // bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
-
-    // An alternative solution that should work all the time - as it will be false for the time interval
-    // that we worried about
-    bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() == ::GetThread());
+    bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
 
     OBJECTHANDLE handle = isRuntimeSuspended ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -496,7 +496,15 @@ void FinalizeWeakReference(Object * obj)
 
     WEAKREFERENCEREF pThis((WeakReferenceObject *)(obj));
 
-    bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
+    // Note:
+    // We need to revisit the implementation of FinalizeWeakReference() in case of concurrent ScanForFinalization
+    // ThreadSuspend::g_pSuspensionThread is set before SuspendRuntime is called, during that time interval, 
+    // there could be managed code running calling WeakReferenceNative::SetTarget() and missed the synchronization.
+    // bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
+
+    // An alternative solution that should work all the time - as it will be false for the time interval
+    // that we worried about
+    bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() == ::GetThread());
 
     OBJECTHANDLE handle = isRuntimeSuspended ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -498,7 +498,7 @@ void FinalizeWeakReference(Object * obj)
 
     bool isRuntimeSuspended = (ThreadSuspend::GetSuspensionThread() != nullptr);
 
-    OBJECTHANDLE handle = isRuntimeSuspended ? pThis->m_Handle : AcquireWeakHandleSpinLock(pThis);
+    OBJECTHANDLE handle = isRuntimeSuspended ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;
     bool isWeakWinRTHandle = false;
 

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -496,11 +496,6 @@ void FinalizeWeakReference(Object * obj)
 
     WEAKREFERENCEREF pThis((WeakReferenceObject *)(obj));
 
-    // Note:
-    // We need to revisit the implementation of FinalizeWeakReference() in case of concurrent ScanForFinalization
-    // ThreadSuspend::g_pSuspensionThread is set before SuspendRuntime is called, during that time interval, 
-    // there could be managed code running calling WeakReferenceNative::SetTarget() and missed the synchronization.
-
     OBJECTHANDLE handle = ThreadSuspend::SysIsSuspended() ? pThis->m_Handle.LoadWithoutBarrier() : AcquireWeakHandleSpinLock(pThis);
     OBJECTHANDLE handleToDestroy = NULL;
     bool isWeakWinRTHandle = false;

--- a/src/coreclr/src/vm/weakreferencenative.cpp
+++ b/src/coreclr/src/vm/weakreferencenative.cpp
@@ -519,6 +519,9 @@ void FinalizeWeakReference(Object * obj)
     }
 
     // Release the spin lock
+    // This is necessary even when the spin lock is not acquired
+    // (i.e. When ThreadSuspend::SysIsSuspended() == true)
+    // so that the new handle value is set.
     ReleaseWeakHandleSpinLock(pThis, handle);
 
     if (handleToDestroy != NULL)


### PR DESCRIPTION
Fixes #2274