### PR TITLE
improve Connection_UnderDifferentUsers_BehavesAsExpected test

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.IO.Pipes.Tests
 {
@@ -16,6 +17,13 @@ namespace System.IO.Pipes.Tests
     /// </summary>
     public class NamedPipeTest_CurrentUserOnly_Unix
     {
+        private readonly ITestOutputHelper _output;
+
+        public NamedPipeTest_CurrentUserOnly_Unix(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [ConditionalTheory]
         [OuterLoop("Needs sudo access")]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
@@ -26,15 +34,14 @@ namespace System.IO.Pipes.Tests
         public async Task Connection_UnderDifferentUsers_BehavesAsExpected(
             PipeOptions serverPipeOptions, PipeOptions clientPipeOptions)
         {
-            if (PlatformDetection.IsFedora)
-            {
-                // [ActiveIssue("https://github.com/dotnet/corefx/issues/38834")]
-                throw new SkipTestException("Failing on Fedora by not throwing expected exception");
-            }
 
             // Use an absolute path, otherwise, the test can fail if the remote invoker and test runner have
             // different working and/or temp directories.
             string pipeName = "/tmp/" + Path.GetRandomFileName();
+            bool isRoot = String.CompareOrdinal(Environment.UserName, "root") == 0;
+
+            _output.WriteLine("Starting as {0} on '{1}'", Environment.UserName, pipeName);
+
             using (var server = new NamedPipeServerStream(
                 pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, serverPipeOptions | PipeOptions.Asynchronous))
             {
@@ -43,12 +50,12 @@ namespace System.IO.Pipes.Tests
                 using (RemoteExecutor.Invoke(
                     new Action<string, string>(ConnectClientFromRemoteInvoker),
                     pipeName,
-                    clientPipeOptions == PipeOptions.CurrentUserOnly ? "true" : "false",
+                    clientPipeOptions == PipeOptions.CurrentUserOnly && !isRoot ? "true" : "false",
                     new RemoteInvokeOptions { RunAsSudo = true }))
                 {
                 }
 
-                if (serverPipeOptions == PipeOptions.CurrentUserOnly)
+                if (serverPipeOptions == PipeOptions.CurrentUserOnly && !isRoot)
                     await Assert.ThrowsAsync<UnauthorizedAccessException>(() => serverTask);
                 else
                     await serverTask;

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Unix.cs
@@ -38,7 +38,7 @@ namespace System.IO.Pipes.Tests
             // Use an absolute path, otherwise, the test can fail if the remote invoker and test runner have
             // different working and/or temp directories.
             string pipeName = "/tmp/" + Path.GetRandomFileName();
-            bool isRoot = String.CompareOrdinal(Environment.UserName, "root") == 0;
+            bool isRoot = Environment.UserName == "root";
 
             _output.WriteLine("Starting as {0} on '{1}'", Environment.UserName, pipeName);
 


### PR DESCRIPTION
I can get same failure as described in https://github.com/dotnet/corefx/issues/38834 on Ubuntu when running tests as `root` or elevated via `sudo`. Based on the discussion that is how we used to run on Fedora. In that case, both test processes have the same user and `Expected: typeof(System.UnauthorizedAccessException)`  will not happen. 

While touching this test, I also add little instrumentation to get more info if this fails ever again. 
Fedora now runs as contained instead of hand-crafted VM and the test should be executed as `helixbot`. 

```
furt@Ubuntu16:~/github/wfurt-runtime$ ./eng/common/msbuild.sh src/libraries/sendtohelix.proj /t:test /p:WaitForWorkItemCompletion=true /p:HelixSource=furt /p:Creator=furt '/p:HelixTargetQueues=(Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249'
  Using Queues: (Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249
  Using Queues: (Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249
  Uploading payloads for Job on (Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249...
  Finished uploading payloads for Job on (Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249...
  Sending Job to (Fedora.29.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-09ca40b-20190508143249...
  Sent Helix Job e8d8741c-ad3f-48ac-9178-f86059b55f58
  Waiting for completion of job e8d8741c-ad3f-48ac-9178-f86059b55f58
  Job e8d8741c-ad3f-48ac-9178-f86059b55f58 is completed with 2 finished work items.

Build succeeded.
```

fixes https://github.com/dotnet/corefx/issues/38834