### PR TITLE
Key should be non null

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography
         protected HMAC() { }
         protected int BlockSizeValue { get { throw null; } set { } }
         public string HashName { get { throw null; } set { } }
-        public override byte[]? Key { get { throw null; } set { } }
+        public override byte[] Key { get { throw null; } set { } }
         public static new System.Security.Cryptography.HMAC Create() { throw null; }
         public static new System.Security.Cryptography.HMAC? Create(string algorithmName) { throw null; }
         protected override void Dispose(bool disposing) { }
@@ -171,7 +171,7 @@ namespace System.Security.Cryptography
     {
         protected byte[] KeyValue;
         protected KeyedHashAlgorithm() { }
-        public virtual byte[]? Key { get { throw null; } set { } }
+        public virtual byte[] Key { get { throw null; } set { } }
         public static new System.Security.Cryptography.KeyedHashAlgorithm Create() { throw null; }
         public static new System.Security.Cryptography.KeyedHashAlgorithm? Create(string algName) { throw null; }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/HMAC.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        public override byte[]? Key
+        public override byte[] Key
         {
             get => base.Key;
             set => base.Key = value;

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/KeyedHashAlgorithm.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography
         public static new KeyedHashAlgorithm? Create(string algName) =>
             (KeyedHashAlgorithm?)CryptoConfigForwarder.CreateFromName(algName);
 
-        public virtual byte[]? Key
+        public virtual byte[] Key
         {
             get
             {
@@ -38,11 +38,11 @@ namespace System.Security.Cryptography
                 {
                     Array.Clear(KeyValue, 0, KeyValue.Length);
                 }
-                KeyValue = null;
+                KeyValue = null!;
             }
             base.Dispose(disposing);
         }
 
-        protected byte[]? KeyValue = null;
+        protected byte[] KeyValue = null!;
     }
 }


### PR DESCRIPTION
As per discussion in https://github.com/dotnet/runtime/pull/2375#discussion_r372714143 `Key` expected to be set by derived concrete classes, not expected to be null