### PR TITLE
Referred GC Benchmarking Infra in the GC Performance testing docs

### DIFF
--- a/docs/project/garbage-collector-guidelines.md
+++ b/docs/project/garbage-collector-guidelines.md
@@ -62,4 +62,6 @@ due to poor interactions with the Linux OOM killer. However, they have proven to
 ```
 
 ## Performance Testing ##
-Performance tests can be run using the GC Benchmarking Infrastructure hosted within the [benchmarks section](https://github.com/dotnet/performance/tree/master/src/benchmarks/gc) of the _performance_ repo. This tool allows you to run the tests capturing traces through PerfView, and later analyze such traces for detailed results on GC's, heaps, and related behaviors.
+Performance tests can be run using the GC Benchmarking Infrastructure hosted within the [benchmarks section](https://github.com/dotnet/performance/tree/master/src/benchmarks/gc) of the _performance_ repo. This tool allows you to run the tests capturing traces through PerfView, and later analyze such traces for detailed results on GC's, heaps, and related behaviors. These tests also allow you to directly compare behaviors and metrics between different .NET builds and machines.
+
+The _README.md_ located at the link mentioned above contains detailed instructions on how to setup and use the tool. Additionally, there is a _docs_ section with all the information to perform further analysis on the traces.

--- a/docs/project/garbage-collector-guidelines.md
+++ b/docs/project/garbage-collector-guidelines.md
@@ -62,4 +62,4 @@ due to poor interactions with the Linux OOM killer. However, they have proven to
 ```
 
 ## Performance Testing ##
-Coming soon.
+Performance tests can be run using the GC Benchmarking Infrastructure hosted within the [benchmarks section](https://github.com/dotnet/performance/tree/master/src/benchmarks/gc) of the _performance_ repo. This tool allows you to run the tests capturing traces through PerfView, and later analyze such traces for detailed results on GC's, heaps, and related behaviors.


### PR DESCRIPTION
This PR adds an overview and link on the GC Benchmarking Infrastructure hosted in the _performance_ repo. This tool was designed and created to run GC performance tests and these docs would benefit of having the reference to it.