### PR TITLE
Fix Receive loop in System.Net.Quic, add test

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -283,8 +283,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                     QuicBuffer nativeBuffer = sourceBuffers[i];
                     int length = Math.Min((int)nativeBuffer.Length, slicedBuffer.Length);
                     new Span<byte>(nativeBuffer.Buffer, length).CopyTo(slicedBuffer);
-                    if (length < slicedBuffer.Length)
+                    if (length < nativeBuffer.Length)
                     {
+                        // The buffer passed in was larger that the received data, return
                         return;
                     }
                     slicedBuffer = slicedBuffer.Slice(length);
@@ -297,6 +298,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 if (_readState == ReadState.IndividualReadComplete)
                 {
+                    _receiveQuicBuffers.Clear();
                     ReceiveComplete(actual);
                     EnableReceive();
                     _readState = ReadState.None;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -327,7 +327,7 @@ namespace System.Net.Quic.Tests
             Assert.Equal(24, res);
         }
 
-        [Theory]
+        [Theory(Skip = "MsQuic not available")]]
         [MemberData(nameof(QuicStream_ReadWrite_Random_Success_Data))]
         public async Task QuicStream_ReadWrite_Random_Success(int readSize, int writeSize)
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Net.Security;
 using System.Text;
 using System.Threading.Tasks;
@@ -324,6 +325,69 @@ namespace System.Net.Quic.Tests
 
             res = await serverStream.ReadAsync(memory);
             Assert.Equal(24, res);
+        }
+
+        [Theory]
+        [MemberData(nameof(QuicStream_ReadWrite_Random_Success_Data))]
+        public async Task QuicStream_ReadWrite_Random_Success(int readSize, int writeSize)
+        {
+            byte[] testBuffer = new byte[8192];
+            new Random().NextBytes(testBuffer);
+
+
+            await Task.WhenAll(DoWrite(), DoRead());
+
+            async Task DoWrite()
+            {
+                using QuicConnection clientConnection = CreateQuicConnection(DefaultListener.ListenEndPoint);
+                await clientConnection.ConnectAsync();
+
+                await using QuicStream clientStream = clientConnection.OpenUnidirectionalStream();
+
+                ReadOnlyMemory<byte> sendBuffer = testBuffer;
+                while (sendBuffer.Length != 0)
+                {
+                    ReadOnlyMemory<byte> chunk = sendBuffer.Slice(0, Math.Min(sendBuffer.Length, writeSize));
+                    await clientStream.WriteAsync(chunk);
+                    sendBuffer = sendBuffer.Slice(chunk.Length);
+                }
+
+                clientStream.Shutdown();
+                await clientStream.ShutdownWriteCompleted();
+            }
+
+            async Task DoRead()
+            {
+                using QuicConnection serverConnection = await DefaultListener.AcceptConnectionAsync();
+                await using QuicStream serverStream = await serverConnection.AcceptStreamAsync();
+
+                byte[] receiveBuffer = new byte[testBuffer.Length];
+                int totalBytesRead = 0;
+
+                while (totalBytesRead != receiveBuffer.Length)
+                {
+                    int bytesRead = await serverStream.ReadAsync(receiveBuffer.AsMemory(totalBytesRead, Math.Min(receiveBuffer.Length - totalBytesRead, readSize)));
+
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    totalBytesRead += bytesRead;
+                }
+
+                Assert.True(receiveBuffer.AsSpan().SequenceEqual(testBuffer));
+            }
+        }
+
+        public static IEnumerable<object[]> QuicStream_ReadWrite_Random_Success_Data()
+        {
+            IEnumerable<int> sizes = Enumerable.Range(1, 8).Append(2048).Append(8192);
+
+            return
+                from readSize in sizes
+                from writeSize in sizes
+                select new object[] { readSize, writeSize };
         }
 
         private static async Task CreateAndTestBidirectionalStream(QuicConnection c1, QuicConnection c2)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -327,7 +327,7 @@ namespace System.Net.Quic.Tests
             Assert.Equal(24, res);
         }
 
-        [Theory(Skip = "MsQuic not available")]]
+        [Theory(Skip = "MsQuic not available")]
         [MemberData(nameof(QuicStream_ReadWrite_Random_Success_Data))]
         public async Task QuicStream_ReadWrite_Random_Success(int readSize, int writeSize)
         {


### PR DESCRIPTION
There were two bugs in the receive loop where receives weren't getting the right data. Most of the time when verifying the response, we were just checking the length rather than the contents. The length was always correct, however, the copying of data wasn't.

