### PR TITLE
Update ActiveIssue URLs for Newtonsoft tests for immutable collections

### DIFF
--- a/src/libraries/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -87,7 +87,6 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region Array
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeArray()
         {
@@ -106,7 +105,6 @@ namespace System.Text.Json.Tests
 ]", json);
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void DeserializeArray()
         {
@@ -124,7 +122,6 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", data[2]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
         [Fact]
         public void SerializeDefaultArray()
         {
@@ -330,7 +327,7 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region Dictionary
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40120")]
         [Fact]
         public void SerializeDictionary()
         {
@@ -349,7 +346,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", (string)a[3]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40120")]
         [Fact]
         public void DeserializeDictionary()
         {
@@ -367,7 +364,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("3", data[3]);
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40120")]
         [Fact]
         public void DeserializeDictionaryInterface()
         {
@@ -387,7 +384,7 @@ namespace System.Text.Json.Tests
         #endregion
 
         #region SortedDictionary
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40120")]
         [Fact]
         public void SerializeSortedDictionary()
         {
@@ -406,7 +403,7 @@ namespace System.Text.Json.Tests
 }", json);
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/36643")]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/40120")]
         [Fact]
         public void DeserializeSortedDictionary()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36643#issuecomment-577501482

- Support for `ImmutableArray<T>` was added in https://github.com/dotnet/corefx/pull/39493
- Support for immutable dictionaries was added in https://github.com/dotnet/corefx/pull/37710
    - Dictionaries with non-string keys are not supported, so the active issue URLs for these tests were replaced with issues to the [tracking issue for that feature](https://github.com/dotnet/corefx/issues/40120).

Further tests for immutable collections:
- dictionaries: https://github.com/dotnet/runtime/blob/10717887317beb824e57cdb29417663615211e99/src/libraries/System.Text.Json/tests/Serialization/DictionaryTests.cs
- non-dictionaries: 
    - https://github.com/dotnet/runtime/blob/10717887317beb824e57cdb29417663615211e99/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ImmutableCollections.cs
    - https://github.com/dotnet/runtime/blob/10717887317beb824e57cdb29417663615211e99/src/libraries/System.Text.Json/tests/Serialization/Value.WriteTests.ImmutableCollections.cs

cc @stephentoub 