### PR TITLE
Move generic_class_init out of line to assist branch prediction.

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -2893,6 +2893,7 @@ emit_class_init (MonoCompile *cfg, MonoClass *klass)
 		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, inited_reg, 0);
 		MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_IBNE_UN, inited_bb);
 
+		cfg->cbb->out_of_line = TRUE;
 		mono_emit_jit_icall (cfg, mono_generic_class_init, &vtable_arg);
 
 		MONO_START_BB (cfg, inited_bb);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18497,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When calling a generic class we need to make sure it has been initilized. This is done by calling generic_class_init. Since the need to check if the method has been executed happens frequently, but will only run once, it should be put out of line, assisting branch predictor, preventing misspredictions (in all places but the first).

Currently this is not the case, since we will generate code like this:

```
0000000000000484: cmp         byte ptr [rcx+2Dh],0
0000000000000488: jne         000000000000048F
000000000000048A: call        p_3_plt_EmptyGame__jit_icall_mono_generic_class_init_llvm
000000000000048F: mov         rax,qword ptr [mono_aot_EmptyGame_llvm_got+0C8h]
```

Where we will always (except for first call) take the forward branch.

Instead we should mark the call to the method as out of line, at least giving the code generator the information so it can move it out of line and preventing a jmp, unless when it needs to init, the slow path. Doing that will generate the following code:

```
0000000000000484: cmp         byte ptr [rcx+2Dh],0
0000000000000488: je          00000000000004C1
000000000000048A: mov         rax,qword ptr [mono_aot_EmptyGame_llvm_got+0C8h]
...
00000000000004C1: call        p_3_plt_EmptyGame__jit_icall_mono_generic_class_init_llvm
00000000000004C6: jmp         000000000000048A

```