### PR TITLE
Add runtime flavor to test run name for libraries outerloop runs

### DIFF
--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -48,6 +48,7 @@ jobs:
         - _testScopeArg: ''
         - _extraHelixArguments: ''
         - _crossBuildPropertyArg: ''
+        - _testRunNamePrefixSuffix: ''
 
         - librariesBuildArtifactName: ${{ format('libraries_bin_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 
@@ -92,6 +93,7 @@ jobs:
           - _runtimeDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/${{ parameters.runtimeFlavor }}'
           - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
           - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
+          - _testRunNamePrefixSuffix: $(runtimeFlavorName)_${{ parameters.liveRuntimeBuildConfig }}
 
           # WebAssembly uses linux implementation detail
           - ${{ if eq(parameters.osGroup, 'WebAssembly') }}:

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -184,4 +184,5 @@ jobs:
               testScope: ${{ parameters.testScope }}
               creator: dotnet-bot
               helixToken: ''
+              testRunNamePrefixSuffix: $(_testRunNamePrefixSuffix)
               extraHelixArguments: $(_extraHelixArguments)

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -72,7 +72,7 @@ jobs:
         buildConfig: Debug
         platforms:
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
-          - Windows_NT_x86
+          - Windows_NT_x64
         - ${{ if eq(variables['includeLinuxOuterloop'], true) }}:
           - Linux_x64
           - Linux_musl_x64

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -52,9 +52,6 @@ jobs:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.dependsOnTestArchitecture, parameters.dependsOnTestBuildConfiguration) }}
         - _archiveTestsParameter: /p:ArchiveTests=true
         - _skipTestRestoreArg: /p:SkipTestRestore=false
-        - _testRunNamePrefixSuffix: ''
-        - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
-          - _testRunNamePrefixSuffix: $(runtimeFlavorName)_${{ parameters.liveRuntimeBuildConfig }}
         - ${{ parameters.variables }}
 
       steps:


### PR DESCRIPTION
I noticed in: https://github.com/dotnet/runtime/issues/2198 that the outerloop runs since they send to helix via `build-job.yml` and not `test-run-job.yml` the test runs doesn't include the runtime flavor and configuration and since people are used to the PR and CI results having it, it seems to confuse people.

cc: @stephentoub 