### PR TITLE
Fix OverflowException from IntPtr casting

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -628,7 +628,7 @@ namespace System.Diagnostics.Tracing
                 if (filterData->Ptr != 0 && 0 < filterData->Size && filterData->Size <= 100*1024)
                 {
                     data = new byte[filterData->Size];
-                    Marshal.Copy((IntPtr)filterData->Ptr, data, 0, data.Length);
+                    Marshal.Copy((IntPtr)(void*)filterData->Ptr, data, 0, data.Length);
                 }
                 command = (ControllerCommand)filterData->Type;
                 return true;


### PR DESCRIPTION
The direct casting from `long` to `IntPtr` leads to OverflowException on 32bit systems.

cc @jkotas @alpencolt