### PR TITLE
configure.ac: checks for libunwind

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -2357,6 +2357,11 @@ if test x$host_win32 = xno; then
 	dnl *****************************
 	AC_CHECK_LIB(socket, socket, LIBS="$LIBS -lsocket")
 
+	dnl *****************************
+	dnl *** Checks for libunwind  ***
+	dnl *****************************
+	AC_CHECK_LIB(unwind, _Unwind_GetIP, LIBS="$LIBS -lunwind")
+
 	case "$host" in
 		*-*-*freebsd*)
 			dnl *****************************


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18648,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>_Unwind_GetIP is used in build_stack_trace however this function can be
provided by libunwind so check for it to avoid the following build
failure:

```
/home/buildroot/autobuild/run/instance-1/output/host/lib/gcc/arm-buildroot-linux-musleabihf/7.4.0/../../../../arm-buildroot-linux-musleabihf/bin/ld: ./.libs/libmini.a(libmini_la-mini-exceptions.o): in function `build_stack_trace':
/home/buildroot/autobuild/run/instance-1/output/build/mono-5.20.1.27/mono/mini/mini-exceptions.c:365: undefined reference to `_Unwind_GetIP'
collect2: error: ld returned 1 exit status
```

Fixes:
 - http://autobuild.buildroot.net/results/dbd64c89815d393a4e28b312d74fd80ee6de92da

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>