### PR TITLE
set THUMB_CODE bit

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 
 using Internal.Text;
+using Internal.TypeSystem;
 using Internal.ReadyToRunConstants;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
@@ -57,8 +58,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             // This needs to be an empty target pointer since it will be filled in with Module*
             // when loaded by CoreCLR
+            int codeDelta = 0;
+            if (factory.Target.Architecture == TargetArchitecture.ARM)
+            {
+                // THUMB_CODE
+                codeDelta = 1;
+            }
             dataBuilder.EmitReloc(_delayLoadHelper,
-                factory.Target.PointerSize == 4 ? RelocType.IMAGE_REL_BASED_HIGHLOW : RelocType.IMAGE_REL_BASED_DIR64);
+                factory.Target.PointerSize == 4 ? RelocType.IMAGE_REL_BASED_HIGHLOW : RelocType.IMAGE_REL_BASED_DIR64, codeDelta);
         }
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -82,7 +82,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     FrameInfo frameInfo = method.FrameInfos[frameIndex];
 
                     // StartOffset of the runtime function
-                    runtimeFunctionsBuilder.EmitReloc(method, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: frameInfo.StartOffset);
+                    int codeDelta = 0;
+                    if (Target.Architecture == TargetArchitecture.ARM)
+                    {
+                        // THUMB_CODE
+                        codeDelta = 1;
+                    }
+                    runtimeFunctionsBuilder.EmitReloc(method, RelocType.IMAGE_REL_BASED_ADDR32NB, delta: frameInfo.StartOffset + codeDelta);
                     if (!relocsOnly && Target.Architecture == TargetArchitecture.X64)
                     {
                         // On Amd64, the 2nd word contains the EndOffset of the runtime function


### PR DESCRIPTION
There is necessity to conditionally set THUMB_CODE bit (0x00000001) form ARM thumb-2 mode for all values that are used as jump addresses.

One can look at this PR as a part of https://github.com/dotnet/runtime/pull/21072

@jkotas @alpencolt 