### PR TITLE
Disable macOS 10.15 from fullMatrix runs

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -72,7 +72,6 @@ jobs:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
-        - OSX.1015.Amd64.Open
       - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -72,6 +72,9 @@ jobs:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
+        # The 10.15 machines aren't in the same configuration, see
+        # https://github.com/dotnet/runtime/issues/24736
+        #- OSX.1015.Amd64.Open
       - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open


### PR DESCRIPTION
This OS was just enabled a couple of days ago, and isn't testing so hot.

Turning it off until it can come back on in a passing state.

Suppresses the problem from #24736 until the machine configuration can get worked out.