### PR TITLE
[llvm] Enable jump threading with LLVM JIT.

### DIFF
--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -300,7 +300,7 @@ public:
 		// FIXME: find optimal mono specific order of passes
 		// see https://llvm.org/docs/Frontend/PerformanceTips.html#pass-ordering
 		// the following order is based on a stripped version of "OPT -O2"
-		const char *default_opts = " -simplifycfg -sroa -lower-expect -instcombine -loop-rotate -licm -simplifycfg -lcssa -loop-idiom -indvars -loop-deletion -gvn -memcpyopt -sccp -bdce -instcombine -dse -simplifycfg -enable-implicit-null-checks";
+		const char *default_opts = " -simplifycfg -sroa -lower-expect -instcombine -jump-threading -loop-rotate -licm -simplifycfg -lcssa -loop-idiom -indvars -loop-deletion -gvn -memcpyopt -sccp -bdce -instcombine -dse -simplifycfg -enable-implicit-null-checks";
 		const char *opts = g_getenv ("MONO_LLVM_OPT");
 		if (opts == NULL)
 			opts = default_opts;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18655,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>See https://github.com/mono/mono/issues/16243. This will allow elision of redundant bounds checks. This pass is already used during AOT (as part of opt -O2).

Here's `FirstOrDefault` (from mono/mono#16243) with this change:
```
0000000000000000 <gram_FirstOrDefault__int___>:
<BB>:1
   0:	31 c0                	xor    %eax,%eax
   2:	48 85 ff             	test   %rdi,%rdi
   5:	74 09                	je     10 <gram_FirstOrDefault__int___+0x10>
   7:	83 7f 18 01          	cmpl   $0x1,0x18(%rdi)
   b:	7e 03                	jle    10 <gram_FirstOrDefault__int___+0x10>
   d:	8b 47 24             	mov    0x24(%rdi),%eax
  10:	c3                   	retq   
***
```