### PR TITLE
Managed Renames for consistency

### DIFF
--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+        <FeatureCoreCLR>true</FeatureCoreCLR>
         <FeatureCollectibleALC>true</FeatureCollectibleALC>
         <FeatureEventTrace>true</FeatureEventTrace>
         <FeatureHardwareIntrinsics>true</FeatureHardwareIntrinsics>

--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -14,7 +14,6 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
-        <FeaturePal>true</FeaturePal>
         <FeatureXplatEventSource>true</FeatureXplatEventSource>
 
         <FeatureArrayStubAsIL>true</FeatureArrayStubAsIL>
@@ -60,7 +59,6 @@
         <DefineConstants Condition="'$(FeatureCominteropWinRTManagedActivation)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION</DefineConstants>
         <DefineConstants Condition="'$(FeatureManagedEtw)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW</DefineConstants>
         <DefineConstants Condition="'$(FeatureManagedEtwChannels)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW_CHANNELS</DefineConstants>
-        <DefineConstants Condition="'$(FeaturePal)' == 'true'">$(DefineConstants);FEATURE_PAL</DefineConstants>
         <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">$(DefineConstants);FEATURE_PERFTRACING</DefineConstants>
         <DefineConstants Condition="'$(FeatureXplatEventSource)' == 'true'">$(DefineConstants);FEATURE_EVENTSOURCE_XPLAT</DefineConstants>
         <DefineConstants Condition="'$(FeatureWin32Registry)' == 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
@@ -73,8 +71,8 @@
         <DefineConstants Condition="'$(ProfilingSupportedBuild)' == 'true'">$(DefineConstants);PROFILING_SUPPORTED</DefineConstants>
         <DefineConstants Condition="'$(FeatureProfAttach)' == 'true'">$(DefineConstants);FEATURE_PROFAPI_ATTACH_DETACH</DefineConstants>
 
-        <DefineConstants Condition="'$(TargetsUnix)' == 'true'">$(DefineConstants);PLATFORM_UNIX</DefineConstants>
-        <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);PLATFORM_WINDOWS</DefineConstants>
-        <DefineConstants Condition="'$(TargetsOSX)' == 'true'">$(DefineConstants);PLATFORM_OSX</DefineConstants>
+        <DefineConstants Condition="'$(TargetsUnix)' == 'true'">$(DefineConstants);TARGET_UNIX</DefineConstants>
+        <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);TARGET_WINDOWS</DefineConstants>
+        <DefineConstants Condition="'$(TargetsOSX)' == 'true'">$(DefineConstants);TARGET_OSX</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -68,19 +68,19 @@
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>BIT64;AMD64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_64BIT;TARGET_AMD64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <PlatformTarget>x86</PlatformTarget>
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm'">
     <PlatformTarget>arm</PlatformTarget>
-    <DefineConstants>BIT32;ARM;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;TARGET_ARM;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm64'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>BIT64;ARM64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_64BIT;TARGET_ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <FeatureCoreCLR>true</FeatureCoreCLR>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <FeatureCoreCLR>true</FeatureCoreCLR>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>

--- a/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -25,7 +25,7 @@ namespace Internal.Runtime.InteropServices
                 throw new ArgumentNullException(argName);
             }
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             string? result = Marshal.PtrToStringUni(arg);
 #else
             string? result = Marshal.PtrToStringUTF8(arg);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -25,7 +25,7 @@ namespace System
         private IntPtr ArgPtr;                  // Pointer to remaining args.
         private int RemainingArgs;           // # of remaining args.
 
-#if PLATFORM_WINDOWS // Native Varargs are not supported on Unix
+#if TARGET_WINDOWS // Native Varargs are not supported on Unix
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
 
@@ -178,6 +178,6 @@ namespace System
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 using nint = System.UInt64;
 #else

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Object.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Object.CoreCLR.cs
@@ -5,7 +5,7 @@
 using System.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -509,11 +509,8 @@ namespace System.Reflection
             {
                 string s = GetFullyQualifiedName();
 
-#if TARGET_WINDOWS
-                int i = s.LastIndexOf('\\');
-#else
                 int i = s.LastIndexOf(System.IO.Path.DirectorySeparatorChar);
-#endif
+
                 if (i == -1)
                     return s;
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -509,7 +509,7 @@ namespace System.Reflection
             {
                 string s = GetFullyQualifiedName();
 
-#if !TARGET_UNIX
+#if TARGET_WINDOWS
                 int i = s.LastIndexOf('\\');
 #else
                 int i = s.LastIndexOf(System.IO.Path.DirectorySeparatorChar);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -509,7 +509,7 @@ namespace System.Reflection
             {
                 string s = GetFullyQualifiedName();
 
-#if !FEATURE_PAL
+#if !TARGET_UNIX
                 int i = s.LastIndexOf('\\');
 #else
                 int i = s.LastIndexOf(System.IO.Path.DirectorySeparatorChar);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -10,7 +10,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -53,7 +53,7 @@ namespace System.Runtime.CompilerServices
             // then we use fibonacci hashing to reduce the value to desired size.
 
             int hashShift = HashShift(table);
-#if BIT64
+#if TARGET_64BIT
             ulong hash = (((ulong)source << 32) | ((ulong)source >> 32)) ^ (ulong)target;
             return (int)((hash * 11400714819323198485ul) >> hashShift);
 #else

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -125,11 +125,11 @@ namespace System.Runtime.CompilerServices
                 // after the sync block, so don't count that.
                 // This property allows C#'s fixed statement to work on Strings.
                 // On 64 bit platforms, this should be 12 (8+4) and on 32 bit 8 (4+4).
-#if BIT64
+#if TARGET_64BIT
                 12;
 #else // 32
                 8;
-#endif // BIT64
+#endif // TARGET_64BIT
 
         }
 
@@ -285,7 +285,7 @@ namespace System.Runtime.CompilerServices
     internal class RawArrayData
     {
         public uint Length; // Array._numComponents padded to IntPtr
-#if BIT64
+#if TARGET_64BIT
         public uint Padding;
 #endif
         public byte Data;
@@ -323,7 +323,7 @@ namespace System.Runtime.CompilerServices
 #endif
         ;
 
-#if BIT64
+#if TARGET_64BIT
         private const int InterfaceMapOffset = 0x38
 #else
         private const int InterfaceMapOffset = 0x24

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -257,7 +257,7 @@ namespace System.Runtime.InteropServices
             // though I couldn't reproduce that.  In either case, that means we should continue
             // throwing an OOM instead of an ArgumentOutOfRangeException for "negative" amounts of memory.
             UIntPtr numBytes;
-#if BIT64
+#if TARGET_64BIT
             numBytes = new UIntPtr(unchecked((ulong)cb.ToInt64()));
 #else // 32
             numBytes = new UIntPtr(unchecked((uint)cb.ToInt32()));

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/NativeMethods.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/NativeMethods.cs
@@ -4,7 +4,7 @@
 
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
-#if BIT64
+#if TARGET_64BIT
     [StructLayout(LayoutKind.Explicit, Size = 24)]
 #else
     [StructLayout(LayoutKind.Explicit, Size = 20)]

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -205,7 +205,7 @@ namespace System.Runtime.Loader
             }
         }
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
         private const CharSet HostpolicyCharSet = CharSet.Unicode;
 #else
         private const CharSet HostpolicyCharSet = CharSet.Ansi;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -67,7 +67,7 @@ namespace System.Runtime.Loader
             return loadedAssembly!;
         }
 
-#if !TARGET_UNIX
+#if TARGET_WINDOWS
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadFromInMemoryModuleInternal(IntPtr ptrNativeAssemblyLoadContext, IntPtr hModule, ObjectHandleOnStack retAssembly);
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -67,7 +67,7 @@ namespace System.Runtime.Loader
             return loadedAssembly!;
         }
 
-#if !FEATURE_PAL
+#if !TARGET_UNIX
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadFromInMemoryModuleInternal(IntPtr ptrNativeAssemblyLoadContext, IntPtr hModule, ObjectHandleOnStack retAssembly);
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -149,7 +149,7 @@ namespace System.StubHelpers
 
             fixed (char* pwzChar = strManaged)
             {
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
                 cbWritten = Interop.Kernel32.WideCharToMultiByte(
                     Interop.Kernel32.CP_ACP,
                     bestFit ? 0 : Interop.Kernel32.WC_NO_BEST_FIT_CHARS,
@@ -1565,7 +1565,7 @@ namespace System.StubHelpers
         // but on ARM it will allow us to correctly determine the layout of native argument lists containing
         // VARIANTs). Note that the field names here don't matter: none of the code refers to these fields,
         // the structure just exists to provide size information to the IL marshaler.
-#if BIT64
+#if TARGET_64BIT
         private IntPtr data1;
         private IntPtr data2;
 #else
@@ -1857,10 +1857,10 @@ namespace System.StubHelpers
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern IntPtr GetStubContext();
 
-#if BIT64
+#if TARGET_64BIT
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern IntPtr GetStubContextAddr();
-#endif // BIT64
+#endif // TARGET_64BIT
 
 #if FEATURE_ARRAYSTUB_AS_IL
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -83,7 +83,7 @@ namespace System.Text
                 // Both MultiByteToWideChar and the UTF8Encoding instance used on Unix-like
                 // platforms default to replacing invalid characters with the Unicode replacement
                 // character U+FFFD.
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
                 convertedChars = Interop.Kernel32.MultiByteToWideChar(
                     Interop.Kernel32.CP_ACP,
                     Interop.Kernel32.MB_PRECOMPOSED,

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Text/Utf8Span.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Text/Utf8Span.cs
@@ -13,7 +13,7 @@ using Internal.Runtime.CompilerServices;
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'Utf8Span.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
 #else

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Utf8Extensions.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Utf8Extensions.cs
@@ -78,7 +78,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -164,7 +164,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -256,7 +256,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -358,7 +358,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.Enumeration.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.Enumeration.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 using System.Text;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
 #else

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.Manipulation.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.Manipulation.cs
@@ -345,7 +345,7 @@ namespace System
         [StackTraceHidden]
         private void ValidateStartIndexAndLength(int startIndex, int length)
         {
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)startIndex + (ulong)(uint)length > (ulong)(uint)this.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Utf8String.cs
@@ -12,7 +12,7 @@ using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
 #else

--- a/src/coreclr/src/ToolBox/SOS/DacTableGen/main.cs
+++ b/src/coreclr/src/ToolBox/SOS/DacTableGen/main.cs
@@ -7,10 +7,10 @@ using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 
-#if !FEATURE_PAL
+#if !TARGET_UNIX
 using Dia;
 using Dia.Util;
-#endif // !FEATURE_PAL
+#endif // !TARGET_UNIX
 using System.Globalization;
 
 /******************************************************************************
@@ -31,7 +31,7 @@ public abstract class SymbolProvider
                                         String keyBaseName);
 }
 
-#if !FEATURE_PAL
+#if !TARGET_UNIX
 public class PdbSymbolProvider : SymbolProvider
 {
     public PdbSymbolProvider(String symbolFilename, String dllFilename)
@@ -149,7 +149,7 @@ public class PdbSymbolProvider : SymbolProvider
     FileInfo fPDB = null;
     DiaFile df = null;
 }
-#endif // !FEATURE_PAL
+#endif // !TARGET_UNIX
 
 public class Shell
 {
@@ -295,7 +295,7 @@ Required:
 
         if (pdbFile != null)
         {
-#if FEATURE_PAL
+#if TARGET_UNIX
             throw new InvalidOperationException("PDBs are only supported on Windows.");
 #else
             PdbSymbolProvider pdbSymProvider = new PdbSymbolProvider(pdbFile, dllFile);

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1344,7 +1344,7 @@ namespace Internal.JitInterface
         CORJIT_FLAG_RELATIVE_CODE_RELOCS = 41, // JIT should generate PC-relative address computations instead of EE relocation records
         CORJIT_FLAG_NO_INLINING = 42, // JIT should not inline any called method into this method
 
-#region ARM64
+#region TARGET_ARM64
         CORJIT_FLAG_HAS_ARM64_AES           = 43, // ID_AA64ISAR0_EL1.AES is 1 or better
         CORJIT_FLAG_HAS_ARM64_ATOMICS       = 44, // ID_AA64ISAR0_EL1.Atomic is 2 or better
         CORJIT_FLAG_HAS_ARM64_CRC32         = 45, // ID_AA64ISAR0_EL1.CRC32 is 1 or better

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.cs
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.cs
@@ -13,7 +13,7 @@ class Test
     private const string PathEnvSubdirectoryName = "Subdirectory";
     private const string PathEnvFileName = "MovedNativeLib";
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
     private const string RelativePath1 = @".\RelativeNative\..\DllImportPath_Relative";
     private const string RelativePath3 = @"..\DllImportPathTest\DllImportPath_Relative";
 #else

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.cs
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.cs
@@ -97,7 +97,7 @@ class ExactSpellingTest
         Console.WriteLine("Method Auto.Marshal_Int_InOut: ExactSpelling = false. Verify CharSet.Auto behavior per-platform.");
         int int9 = intManaged;
         int intRet9 = Auto.Marshal_Int_InOut2(int9);
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
         failures += Verify(intReturnUnicode, intManaged, intRet9, int9);
 #else
         failures += Verify(intReturnAnsi, intManaged, intRet9, int9);

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 // It required GCStress=0xc and GcStressOnDirectCalls=1 to hit issues. The issues were with saving GC pointers in the return registers.
 // The GC infra has to correctly mark registers with pointers as alive and must not report registers without pointers.
 
-#if BIT32
+#if TARGET_32BIT
 using nint = System.Int32;
 #else
 using nint = System.Int64;

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -4,7 +4,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(PointerSize)' == '32' ">
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert.cs
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert.cs
@@ -613,9 +613,9 @@ partial class VectorTest
         if (!jitLog.Check("System.Numerics.Vector:ConvertToInt32(struct):struct")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector:ConvertToSingle(struct):struct")) returnVal = Fail;
         // SIMD Conversion to Int64 is not supported on x86
-#if !BIT32
+#if !TARGET_32BIT
         if (!jitLog.Check("System.Numerics.Vector:ConvertToInt64(struct):struct")) returnVal = Fail;
-#endif // !BIT32
+#endif // !TARGET_32BIT
         if (!jitLog.Check("System.Numerics.Vector:ConvertToDouble(struct):struct")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector:Narrow(struct,struct):struct")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector:Widen(struct,byref,byref)")) returnVal = Fail;

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildArch)' == 'x86'">
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildArch)' == 'x86'">
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/libraries/Microsoft.Diagnostics.Tracing.EventSource.Redist/src/Microsoft.Diagnostics.Tracing.EventSource.Redist.csproj
+++ b/src/libraries/Microsoft.Diagnostics.Tracing.EventSource.Redist/src/Microsoft.Diagnostics.Tracing.EventSource.Redist.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.Diagnostics.Tracing.EventSource</AssemblyName>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
-    <DefineConstants>$(DefineConstants);NO_EVENTCOMMANDEXECUTED_SUPPORT;ES_BUILD_STANDALONE;FEATURE_MANAGED_ETW;PLATFORM_WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_EVENTCOMMANDEXECUTED_SUPPORT;ES_BUILD_STANDALONE;FEATURE_MANAGED_ETW;TARGET_WINDOWS</DefineConstants>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;$(NetFrameworkCurrent)-Windows_NT-Debug;$(NetFrameworkCurrent)-Windows_NT-Release</Configurations>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
@@ -10,7 +10,7 @@
     <OptionCompare>Binary</OptionCompare>
     <WarningsNotAsErrors>42025</WarningsNotAsErrors>
     <DefineConstants>$(DefineConstants),LATEBINDING=True</DefineConstants>
-    <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants),PLATFORM_WINDOWS=True</DefineConstants>
+    <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants),TARGET_WINDOWS=True</DefineConstants>
     <NoWarn Condition="'$(TargetsWindows)' != 'true'">$(NoWarn);CA1823</NoWarn> <!-- Avoid unused fields warnings in Unix build -->
     <AssemblyName>Microsoft.VisualBasic.Core</AssemblyName>
     <NoStdLib>true</NoStdLib>

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/Utils.vb
@@ -21,7 +21,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
 
         <Diagnostics.DebuggerHiddenAttribute()>
         Friend Shared Sub SetTime(ByVal dtTime As DateTime)
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Dim systime As New NativeTypes.SystemTime
 
             SafeNativeMethods.GetLocalTime(systime)
@@ -45,7 +45,7 @@ Namespace Global.Microsoft.VisualBasic.CompilerServices
 
         <Diagnostics.DebuggerHiddenAttribute()>
         Friend Shared Sub SetDate(ByVal vDate As DateTime)
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Dim systime As New NativeTypes.SystemTime
 
             SafeNativeMethods.GetLocalTime(systime)

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Conversion.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Conversion.vb
@@ -933,7 +933,7 @@ NextOctCharacter:
         <ResourceExposure(ResourceScope.None)>
         <ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)>
         Friend Function ParseInputField(ByVal Value As Object, ByVal vtInput As VariantType) As Object
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Dim numprsPtr() As Byte
             Dim vtSuffix As Integer
             Dim cDecMax As Integer

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/DateAndTime.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/DateAndTime.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.VisualBasic
         End Property
 
         Private Function IsDBCSCulture() As Boolean
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             'This function is apparently trying to determine a different default for East Asian systems.
             If System.Runtime.InteropServices.Marshal.SystemMaxDBCSCharSize = 1 Then
                 Return False

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
@@ -14,7 +14,7 @@ Imports System.Security
 Imports System.Text
 
 Imports Microsoft.VisualBasic.CompilerServices
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
 Imports Microsoft.VisualBasic.CompilerServices.NativeMethods
 Imports Microsoft.VisualBasic.CompilerServices.NativeTypes
 #End If
@@ -1141,7 +1141,7 @@ Namespace Microsoft.VisualBasic.FileIO
                     ' but have write permission / ACL thus cannot see but can delete / overwrite destination.
 
                     If Environment.OSVersion.Platform = PlatformID.Win32NT Then ' Platforms supporting MoveFileEx.
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
                         Try
                             Dim succeed As Boolean = NativeMethods.MoveFileEx(
                                     sourceFileFullPath, destinationFileFullPath, m_MOVEFILEEX_FLAGS)
@@ -1606,7 +1606,7 @@ Namespace Microsoft.VisualBasic.FileIO
             Debug.Assert(FullTargetPath <> "" And IO.Path.IsPathRooted(FullTargetPath), "Invalid FullTargetPath")
             Debug.Assert(ShowUI <> UIOptionInternal.NoUI, "Why call ShellDelete if ShowUI is NoUI???")
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             ' Set operation type.
             Dim OperationType As SHFileOperationType
             If Operation = CopyOrMove.Copy Then
@@ -1670,7 +1670,7 @@ Namespace Microsoft.VisualBasic.FileIO
             Debug.Assert(FullPath <> "" And IO.Path.IsPathRooted(FullPath), "FullPath must be a full path")
             Debug.Assert(ShowUI <> UIOptionInternal.NoUI, "Why call ShellDelete if ShowUI is NoUI???")
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             ' Set fFlags to control the operation details.
             Dim OperationFlags As ShFileOperationFlags = GetOperationFlags(ShowUI)
             If (recycle = RecycleOption.SendToRecycleBin) Then
@@ -1683,7 +1683,7 @@ Namespace Microsoft.VisualBasic.FileIO
 #End If
         End Sub
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
         ''' <summary>
         ''' Calls NativeMethods.SHFileOperation with the given SHFILEOPSTRUCT, notifies the shell of change,
         ''' and throw exceptions if needed.
@@ -1855,7 +1855,7 @@ Namespace Microsoft.VisualBasic.FileIO
             End If
         End Sub
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
         ''' <summary>
         ''' Given an error code from winerror.h, throw the appropriate exception.
         ''' </summary>
@@ -1965,7 +1965,7 @@ Namespace Microsoft.VisualBasic.FileIO
             Throw New InvalidEnumArgumentException(argName, argValue, GetType(UICancelOption))
         End Sub
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
         ' Base operation flags used in shell IO operation.
         ' - DON'T move connected files as a group.
         ' - DON'T confirm directory creation - our silent copy / move do not.

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.VisualBasic
                 "Methods in Microsoft.VisualBasic should not call FileSystem public method.")
 
             If Attributes = FileAttribute.Volume Then
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
                 Dim Result As Integer
                 Dim VolumeName As StringBuilder = New StringBuilder(256)
                 Dim RootName As String = Nothing
@@ -469,7 +469,7 @@ Namespace Microsoft.VisualBasic
 
         'IMPORTANT: This call provides sensitive information whether a device exists and should be used with extreme care
         Private Function UnsafeValidDrive(ByVal cDrive As Char) As Boolean 'Return of True means not a valid drive
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Dim iDrive As Integer = AscW(cDrive) - AscW(chLetterA)
             Return (CLng(UnsafeNativeMethods.GetLogicalDrives()) And CLng(&H2 ^ iDrive)) <> 0
 #Else
@@ -1170,7 +1170,7 @@ Namespace Microsoft.VisualBasic
             OldPath = VB6CheckPathname(oAssemblyData, OldPath, CType(OpenModeTypes.Any, OpenMode))
             NewPath = VB6CheckPathname(oAssemblyData, NewPath, CType(OpenModeTypes.Any, OpenMode))
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Dim Result As Integer
             Dim ErrCode As Integer
 

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Interaction.vb
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualBasic
         '============================================================================
 
         Public Sub Beep()
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             UnsafeNativeMethods.MessageBeep(0)
 #Else
             Throw New PlatformNotSupportedException()

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Strings.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Strings.vb
@@ -2008,7 +2008,7 @@ RedimAndExit:
         End Function
 
         Public Function StrConv(ByVal [str] As String, ByVal Conversion As VbStrConv, Optional ByVal LocaleID As Integer = 0) As String
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
             Try
                 Const LANG_CHINESE As Integer = &H4I
                 Const LANG_JAPANESE As Integer = &H11I
@@ -2147,7 +2147,7 @@ RedimAndExit:
 #End If
         End Function
 
-#If PLATFORM_WINDOWS Then
+#If TARGET_WINDOWS Then
         Friend Function ValidLCID(ByVal LocaleID As Integer) As Boolean
             Try
                 Dim loc As CultureInfo = New CultureInfo(LocaleID)

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
@@ -6,12 +6,12 @@ namespace System
 {
     internal static class ExternDll
     {
-#if FEATURE_PAL && !SILVERLIGHT
+#if TARGET_UNIX && !SILVERLIGHT
 
-#if !PLATFORM_UNIX
+#if !TARGET_UNIX
         internal const String DLLPREFIX = "";
         internal const String DLLSUFFIX = ".dll";
-#else // !PLATFORM_UNIX
+#else // !TARGET_UNIX
 #if __APPLE__
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".dylib";
@@ -25,13 +25,13 @@ namespace System
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".so";
 #endif
-#endif // !PLATFORM_UNIX
+#endif // !TARGET_UNIX
 
         public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string Mscoree  = DLLPREFIX + "sscoree" + DLLSUFFIX;
 
-#elif FEATURE_PAL && SILVERLIGHT
+#elif TARGET_UNIX && SILVERLIGHT
 
         public const string Kernel32 = "coreclr";
         public const string User32 = "coreclr";
@@ -78,6 +78,6 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //!FEATURE_PAL
+#endif //!TARGET_UNIX
     }
 }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
@@ -6,37 +6,6 @@ namespace System
 {
     internal static class ExternDll
     {
-#if TARGET_UNIX && !SILVERLIGHT
-
-#if TARGET_WINDOWS
-        internal const String DLLPREFIX = "";
-        internal const String DLLSUFFIX = ".dll";
-#else // TARGET_WINDOWS
-#if __APPLE__
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".dylib";
-#elif _AIX
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".a";
-#elif __hppa__ || IA64
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".sl";
-#else
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".so";
-#endif
-#endif // TARGET_WINDOWS
-
-        public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
-        public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
-        public const string Mscoree  = DLLPREFIX + "sscoree" + DLLSUFFIX;
-
-#elif TARGET_UNIX && SILVERLIGHT
-
-        public const string Kernel32 = "coreclr";
-        public const string User32 = "coreclr";
-
-#else
         public const string Activeds = "activeds.dll";
         public const string Advapi32 = "advapi32.dll";
         public const string Comctl32 = "comctl32.dll";
@@ -78,6 +47,5 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //TARGET_WINDOWS
     }
 }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/ExternDll.cs
@@ -8,10 +8,10 @@ namespace System
     {
 #if TARGET_UNIX && !SILVERLIGHT
 
-#if !TARGET_UNIX
+#if TARGET_WINDOWS
         internal const String DLLPREFIX = "";
         internal const String DLLSUFFIX = ".dll";
-#else // !TARGET_UNIX
+#else // TARGET_WINDOWS
 #if __APPLE__
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".dylib";
@@ -25,7 +25,7 @@ namespace System
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".so";
 #endif
-#endif // !TARGET_UNIX
+#endif // TARGET_WINDOWS
 
         public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
@@ -78,6 +78,6 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //!TARGET_UNIX
+#endif //TARGET_WINDOWS
     }
 }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
@@ -6,12 +6,12 @@ namespace System
 {
     internal static class ExternDll
     {
-#if FEATURE_PAL && !SILVERLIGHT
+#if TARGET_UNIX && !SILVERLIGHT
 
-#if !PLATFORM_UNIX
+#if !TARGET_UNIX
         internal const String DLLPREFIX = "";
         internal const String DLLSUFFIX = ".dll";
-#else // !PLATFORM_UNIX
+#else // !TARGET_UNIX
 #if __APPLE__
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".dylib";
@@ -25,13 +25,13 @@ namespace System
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".so";
 #endif
-#endif // !PLATFORM_UNIX
+#endif // !TARGET_UNIX
 
         public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string Mscoree  = DLLPREFIX + "sscoree" + DLLSUFFIX;
 
-#elif FEATURE_PAL && SILVERLIGHT
+#elif TARGET_UNIX && SILVERLIGHT
 
         public const string Kernel32 = "coreclr";
         public const string User32 = "coreclr";
@@ -78,6 +78,6 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //!FEATURE_PAL
+#endif //!TARGET_UNIX
     }
 }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
@@ -6,37 +6,6 @@ namespace System
 {
     internal static class ExternDll
     {
-#if TARGET_UNIX && !SILVERLIGHT
-
-#if TARGET_WINDOWS
-        internal const String DLLPREFIX = "";
-        internal const String DLLSUFFIX = ".dll";
-#else // TARGET_WINDOWS
-#if __APPLE__
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".dylib";
-#elif _AIX
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".a";
-#elif __hppa__ || IA64
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".sl";
-#else
-        internal const String DLLPREFIX = "lib";
-        internal const String DLLSUFFIX = ".so";
-#endif
-#endif // TARGET_WINDOWS
-
-        public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
-        public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
-        public const string Mscoree  = DLLPREFIX + "sscoree" + DLLSUFFIX;
-
-#elif TARGET_UNIX && SILVERLIGHT
-
-        public const string Kernel32 = "coreclr";
-        public const string User32 = "coreclr";
-
-#else
         public const string Activeds = "activeds.dll";
         public const string Advapi32 = "advapi32.dll";
         public const string Comctl32 = "comctl32.dll";
@@ -78,6 +47,5 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //TARGET_WINDOWS
     }
 }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ExternDll.cs
@@ -8,10 +8,10 @@ namespace System
     {
 #if TARGET_UNIX && !SILVERLIGHT
 
-#if !TARGET_UNIX
+#if TARGET_WINDOWS
         internal const String DLLPREFIX = "";
         internal const String DLLSUFFIX = ".dll";
-#else // !TARGET_UNIX
+#else // TARGET_WINDOWS
 #if __APPLE__
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".dylib";
@@ -25,7 +25,7 @@ namespace System
         internal const String DLLPREFIX = "lib";
         internal const String DLLSUFFIX = ".so";
 #endif
-#endif // !TARGET_UNIX
+#endif // TARGET_WINDOWS
 
         public const string Kernel32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
         public const string User32 = DLLPREFIX + "rotor_pal" + DLLSUFFIX;
@@ -78,6 +78,6 @@ namespace System
         // system.data.oracleclient specific
         internal const string OciDll = "oci.dll";
         internal const string OraMtsDll = "oramts.dll";
-#endif //!TARGET_UNIX
+#endif //TARGET_WINDOWS
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -145,7 +145,7 @@ namespace System.Drawing.Imaging
             return _guid.GetHashCode();
         }
 
-#if !TARGET_UNIX
+#if TARGET_WINDOWS
         // Find any random encoder which supports this format
         internal ImageCodecInfo FindEncoder()
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -145,7 +145,6 @@ namespace System.Drawing.Imaging
             return _guid.GetHashCode();
         }
 
-#if TARGET_WINDOWS
         // Find any random encoder which supports this format
         internal ImageCodecInfo FindEncoder()
         {
@@ -157,7 +156,6 @@ namespace System.Drawing.Imaging
             }
             return null;
         }
-#endif
 
         /// <summary>
         /// Converts this <see cref='System.Drawing.Imaging.ImageFormat'/> to a human-readable string.

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -145,7 +145,7 @@ namespace System.Drawing.Imaging
             return _guid.GetHashCode();
         }
 
-#if !FEATURE_PAL
+#if !TARGET_UNIX
         // Find any random encoder which supports this format
         internal ImageCodecInfo FindEncoder()
         {

--- a/src/libraries/System.Private.CoreLib/src/Internal/Padding.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Padding.cs
@@ -10,7 +10,7 @@ namespace Internal
     internal static class PaddingHelpers
     {
         /// <summary>A size greater than or equal to the size of the most common CPU cache lines.</summary>
-#if ARM64
+#if TARGET_ARM64
         internal const int CACHE_LINE_SIZE = 128;
 #else
         internal const int CACHE_LINE_SIZE = 64;

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 using nint = System.Int64;
 #else
@@ -145,7 +145,7 @@ namespace Internal.Runtime.CompilerServices
 #endif
         }
 
-#if BIT64
+#if TARGET_64BIT
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1446,7 +1446,7 @@
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\WindowsRuntime\EventRegistrationToken.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(TargetsUnix)'=='true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(FeatureCoreCLR)'=='true'">
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs">

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1446,7 +1446,7 @@
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\WindowsRuntime\EventRegistrationToken.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(FeaturePal)'=='true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(TargetsUnix)'=='true'">
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs">

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1446,6 +1446,7 @@
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\WindowsRuntime\EventRegistrationToken.cs" />
   </ItemGroup>
+  <!-- CoreCLR uses PAL layer that emulates Windows API on Unix. This is bridge for that PAL layer. See issue dotnet/runtime/#31721. -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(FeatureCoreCLR)'=='true'">
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1021,7 +1021,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if !BIT64
+#if !TARGET_64BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1029,7 +1029,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-#if BIT64
+#if TARGET_64BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1251,7 +1251,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if !BIT64
+#if !TARGET_64BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1259,7 +1259,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-#if BIT64
+#if TARGET_64BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1460,7 +1460,7 @@ namespace System
                     return;
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
-#if !BIT64
+#if !TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_I:
                 case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1469,7 +1469,7 @@ namespace System
                     return;
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
-#if BIT64
+#if TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_I:
                 case CorElementType.ELEMENT_TYPE_U:
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1021,7 +1021,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if !TARGET_64BIT
+#if TARGET_32BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1251,7 +1251,7 @@ namespace System
                             break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-#if !TARGET_64BIT
+#if TARGET_32BIT
                         case CorElementType.ELEMENT_TYPE_I:
                         case CorElementType.ELEMENT_TYPE_U:
 #endif
@@ -1460,7 +1460,7 @@ namespace System
                     return;
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
-#if !TARGET_64BIT
+#if TARGET_32BIT
                 case CorElementType.ELEMENT_TYPE_I:
                 case CorElementType.ELEMENT_TYPE_U:
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.Unix.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -13,12 +13,12 @@ namespace System
 {
     public static partial class Buffer
     {
-#if ARM64
+#if TARGET_ARM64
             // Managed code is currently faster than glibc unoptimized memmove
             // TODO-ARM64-UNIX-OPT revisit when glibc optimized memmove is in Linux distros
             // https://github.com/dotnet/coreclr/issues/13844
             private const nuint MemmoveNativeThreshold = ulong.MaxValue;
-#elif ARM
+#elif TARGET_ARM
             private const nuint MemmoveNativeThreshold = 512;
 #else
             private const nuint MemmoveNativeThreshold = 2048;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.Windows.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -13,7 +13,7 @@ namespace System
 {
     public static partial class Buffer
     {
-#if ARM64
+#if TARGET_ARM64
         // Determine optimal value for Windows.
         // https://github.com/dotnet/coreclr/issues/13843
         private const nuint MemmoveNativeThreshold = ulong.MaxValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if AMD64 || ARM64 || (BIT32 && !ARM)
+#if TARGET_AMD64 || TARGET_ARM64 || (TARGET_32BIT && !TARGET_ARM)
 #define HAS_CUSTOM_BLOCKS
 #endif
 
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
 #else
@@ -166,7 +166,7 @@ namespace System
             Debug.Assert(len > 16 && len <= 64);
 #if HAS_CUSTOM_BLOCKS
             *(Block16*)dest = *(Block16*)src;                   // [0,16]
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)dest = *(long*)src;
             *(long*)(dest + 8) = *(long*)(src + 8);             // [0,16]
 #else
@@ -178,7 +178,7 @@ namespace System
             if (len <= 32) goto MCPY01;
 #if HAS_CUSTOM_BLOCKS
             *(Block16*)(dest + 16) = *(Block16*)(src + 16);     // [0,32]
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)(dest + 16) = *(long*)(src + 16);
             *(long*)(dest + 24) = *(long*)(src + 24);           // [0,32]
 #else
@@ -190,7 +190,7 @@ namespace System
             if (len <= 48) goto MCPY01;
 #if HAS_CUSTOM_BLOCKS
             *(Block16*)(dest + 32) = *(Block16*)(src + 32);     // [0,48]
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)(dest + 32) = *(long*)(src + 32);
             *(long*)(dest + 40) = *(long*)(src + 40);           // [0,48]
 #else
@@ -205,7 +205,7 @@ namespace System
             Debug.Assert(len > 16 && len <= 64);
 #if HAS_CUSTOM_BLOCKS
             *(Block16*)(destEnd - 16) = *(Block16*)(srcEnd - 16);
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)(destEnd - 16) = *(long*)(srcEnd - 16);
             *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
 #else
@@ -220,7 +220,7 @@ namespace System
             // Copy the first 8 bytes and then unconditionally copy the last 8 bytes and return.
             if ((len & 24) == 0) goto MCPY03;
             Debug.Assert(len >= 8 && len <= 16);
-#if BIT64
+#if TARGET_64BIT
             *(long*)dest = *(long*)src;
             *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
 #else
@@ -263,7 +263,7 @@ namespace System
         MCPY06:
 #if HAS_CUSTOM_BLOCKS
             *(Block64*)dest = *(Block64*)src;
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)dest = *(long*)src;
             *(long*)(dest + 8) = *(long*)(src + 8);
             *(long*)(dest + 16) = *(long*)(src + 16);
@@ -299,7 +299,7 @@ namespace System
             if (len > 16) goto MCPY00;
 #if HAS_CUSTOM_BLOCKS
             *(Block16*)(destEnd - 16) = *(Block16*)(srcEnd - 16);
-#elif BIT64
+#elif TARGET_64BIT
             *(long*)(destEnd - 16) = *(long*)(srcEnd - 16);
             *(long*)(destEnd - 8) = *(long*)(srcEnd - 8);
 #else
@@ -361,7 +361,7 @@ namespace System
             Debug.Assert(len > 16 && len <= 64);
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block16>(ref dest) = Unsafe.As<byte, Block16>(ref src); // [0,16]
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref dest) = Unsafe.As<byte, long>(ref src);
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 8)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 8)); // [0,16]
 #else
@@ -374,7 +374,7 @@ namespace System
                 goto MCPY01;
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block16>(ref Unsafe.Add(ref dest, 16)) = Unsafe.As<byte, Block16>(ref Unsafe.Add(ref src, 16)); // [0,32]
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 16)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 16));
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 24)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 24)); // [0,32]
 #else
@@ -387,7 +387,7 @@ namespace System
                 goto MCPY01;
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block16>(ref Unsafe.Add(ref dest, 32)) = Unsafe.As<byte, Block16>(ref Unsafe.Add(ref src, 32)); // [0,48]
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 32)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 32));
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 40)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 40)); // [0,48]
 #else
@@ -402,7 +402,7 @@ namespace System
             Debug.Assert(len > 16 && len <= 64);
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block16>(ref Unsafe.Add(ref destEnd, -16)) = Unsafe.As<byte, Block16>(ref Unsafe.Add(ref srcEnd, -16));
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref Unsafe.Add(ref destEnd, -16)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref srcEnd, -16));
             Unsafe.As<byte, long>(ref Unsafe.Add(ref destEnd, -8)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref srcEnd, -8));
 #else
@@ -418,7 +418,7 @@ namespace System
             if ((len & 24) == 0)
                 goto MCPY03;
             Debug.Assert(len >= 8 && len <= 16);
-#if BIT64
+#if TARGET_64BIT
             Unsafe.As<byte, long>(ref dest) = Unsafe.As<byte, long>(ref src);
             Unsafe.As<byte, long>(ref Unsafe.Add(ref destEnd, -8)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref srcEnd, -8));
 #else
@@ -464,7 +464,7 @@ namespace System
         MCPY06:
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block64>(ref dest) = Unsafe.As<byte, Block64>(ref src);
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref dest) = Unsafe.As<byte, long>(ref src);
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 8)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 8));
             Unsafe.As<byte, long>(ref Unsafe.Add(ref dest, 16)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref src, 16));
@@ -502,7 +502,7 @@ namespace System
                 goto MCPY00;
 #if HAS_CUSTOM_BLOCKS
             Unsafe.As<byte, Block16>(ref Unsafe.Add(ref destEnd, -16)) = Unsafe.As<byte, Block16>(ref Unsafe.Add(ref srcEnd, -16));
-#elif BIT64
+#elif TARGET_64BIT
             Unsafe.As<byte, long>(ref Unsafe.Add(ref destEnd, -16)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref srcEnd, -16));
             Unsafe.As<byte, long>(ref Unsafe.Add(ref destEnd, -8)) = Unsafe.As<byte, long>(ref Unsafe.Add(ref srcEnd, -8));
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -51,7 +51,7 @@ namespace System.Collections.Generic
 
         private int[]? _buckets;
         private Entry[]? _entries;
-#if BIT64
+#if TARGET_64BIT
         private ulong _fastModMultiplier;
 #endif
         private int _count;
@@ -460,7 +460,7 @@ namespace System.Collections.Generic
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _freeList = -1;
-#if BIT64
+#if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
 #endif
             _buckets = buckets;
@@ -743,7 +743,7 @@ namespace System.Collections.Generic
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new int[newSize];
-#if BIT64
+#if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
 #endif
             for (int i = 0; i < count; i++)
@@ -1166,7 +1166,7 @@ namespace System.Collections.Generic
         private ref int GetBucket(uint hashCode)
         {
             int[] buckets = _buckets!;
-#if BIT64
+#if TARGET_64BIT
             return ref buckets[HashHelpers.FastMod(hashCode, (uint)buckets.Length, _fastModMultiplier)];
 #else
             return ref buckets[hashCode % (uint)buckets.Length];

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -89,7 +89,7 @@ namespace System.Collections
             return GetPrime(newSize);
         }
 
-#if BIT64
+#if TARGET_64BIT
         // Returns approximate reciprocal of the divisor: ceil(2**64 / divisor)
         public static ulong GetFastModMultiplier(uint divisor)
             => ulong.MaxValue / divisor + 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -249,7 +249,7 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static bool Div96ByConst(ref ulong high64, ref uint low, uint pow)
             {
-#if BIT64
+#if TARGET_64BIT
                 ulong div64 = high64 / pow;
                 uint div = (uint)((((high64 - div64 * pow) << 32) + low) / pow);
                 if (low == div * pow)
@@ -323,7 +323,7 @@ namespace System
                 // Since 10 = 2 * 5, there must be a factor of 2 for every power of 10 we can extract.
                 // We use this as a quick test on whether to try a given power.
 
-#if BIT64
+#if TARGET_64BIT
                 while ((byte)low == 0 && scale >= 8 && Div96ByConst(ref high64, ref low, 100000000))
                     scale -= 8;
 
@@ -613,7 +613,7 @@ PosRem:
                             case 4:
                                 power = DivByConst(result, hiRes, out quotient, out remainder, 10000);
                                 break;
-#if BIT64
+#if TARGET_64BIT
                             case 5:
                                 power = DivByConst(result, hiRes, out quotient, out remainder, 100000);
                                 break;
@@ -640,7 +640,7 @@ PosRem:
                         if (quotient == 0 && hiRes != 0)
                             hiRes--;
 
-#if BIT64
+#if TARGET_64BIT
                         newScale -= MaxInt32Scale;
 #else
                         newScale -= 4;
@@ -706,7 +706,7 @@ ThrowOverflow:
                 remainder = high - (quotient = high / power) * power;
                 for (uint i = hiRes - 1; (int)i >= 0; i--)
                 {
-#if BIT64
+#if TARGET_64BIT
                     ulong num = result[i] + ((ulong)remainder << 32);
                     remainder = (uint)num - (result[i] = (uint)(num / power)) * power;
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using System.Runtime.InteropServices;
-#if CORECLR && PLATFORM_WINDOWS
+#if CORECLR && TARGET_WINDOWS
 using Internal.Win32;
 #endif
 #if ES_BUILD_AGAINST_DOTNET_V35
@@ -121,7 +121,7 @@ namespace System.Diagnostics.Tracing
         {
             m_eventProvider = providerType switch
             {
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
                 EventProviderType.ETW => new EtwEventProvider(),
 #endif
 #if FEATURE_PERFTRACING
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tracing
             status = EventRegister(eventSource, m_etwCallback);
             if (status != 0)
             {
-#if PLATFORM_WINDOWS && !ES_BUILD_STANDALONE
+#if TARGET_WINDOWS && !ES_BUILD_STANDALONE
                 throw new ArgumentException(Interop.Kernel32.GetMessage(unchecked((int)status)));
 #else
                 throw new ArgumentException(Convert.ToString(unchecked((int)status)));
@@ -467,7 +467,7 @@ namespace System.Diagnostics.Tracing
 
             // However the framework version of EventSource DOES have ES_SESSION_INFO defined and thus
             // does not have this issue.
-#if (PLATFORM_WINDOWS && (ES_SESSION_INFO || !ES_BUILD_STANDALONE))
+#if (TARGET_WINDOWS && (ES_SESSION_INFO || !ES_BUILD_STANDALONE))
             int buffSize = 256;     // An initial guess that probably works most of the time.
             byte* buffer;
             while (true)
@@ -507,7 +507,7 @@ namespace System.Diagnostics.Tracing
                 providerInstance = (Interop.Advapi32.TRACE_PROVIDER_INSTANCE_INFO*)&structBase[providerInstance->NextOffset];
             }
 #else
-#if !ES_BUILD_PCL && PLATFORM_WINDOWS  // TODO command arguments don't work on PCL builds...
+#if !ES_BUILD_PCL && TARGET_WINDOWS  // TODO command arguments don't work on PCL builds...
             // This code is only used in the Nuget Package Version of EventSource.  because
             // the code above is using APIs baned from UWP apps.
             //
@@ -595,7 +595,7 @@ namespace System.Diagnostics.Tracing
             dataStart = 0;
             if (filterData == null)
             {
-#if (!ES_BUILD_PCL && !ES_BUILD_PN && PLATFORM_WINDOWS)
+#if (!ES_BUILD_PCL && !ES_BUILD_PN && TARGET_WINDOWS)
                 string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
                 if (IntPtr.Size == 8)
                     regKey = @"Software\Wow6432Node" + regKey;
@@ -1214,7 +1214,7 @@ namespace System.Diagnostics.Tracing
         private void EventUnregister(long registrationHandle) =>
             m_eventProvider.EventUnregister(registrationHandle);
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
         private static bool m_setInformationMissing;
 
         internal unsafe int SetInformation(
@@ -1245,7 +1245,7 @@ namespace System.Diagnostics.Tracing
 #endif
     }
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
 
     // A wrapper around the ETW-specific API calls.
     internal sealed class EtwEventProvider : IEventProvider

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -518,12 +518,12 @@ namespace System.Diagnostics.Tracing
                 (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                 ref activityId);
 #endif // FEATURE_PERFTRACING
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             // Set the activity id via ETW.
             Interop.Advapi32.EventActivityIdControl(
                 Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                 ref activityId);
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW
         }
 
@@ -538,7 +538,7 @@ namespace System.Diagnostics.Tracing
                 // errors. Note we can't access m_throwOnWrites because this is a static method.
                 Guid retVal = default;
 #if FEATURE_MANAGED_ETW
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
                 Interop.Advapi32.EventActivityIdControl(
                     Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
                     ref retVal);
@@ -546,7 +546,7 @@ namespace System.Diagnostics.Tracing
                 EventPipeInternal.EventActivityIdControl(
                     (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
                     ref retVal);
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW
                 return retVal;
             }
@@ -578,7 +578,7 @@ namespace System.Diagnostics.Tracing
             // We ignore errors to keep with the convention that EventSources do not throw errors.
             // Note we can't access m_throwOnWrites because this is a static method.
 
-#if FEATURE_PERFTRACING && PLATFORM_WINDOWS
+#if FEATURE_PERFTRACING && TARGET_WINDOWS
             EventPipeInternal.EventActivityIdControl(
                 (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                     ref oldActivityThatWillContinue);
@@ -586,13 +586,13 @@ namespace System.Diagnostics.Tracing
             EventPipeInternal.EventActivityIdControl(
                 (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
                     ref oldActivityThatWillContinue);
-#endif // FEATURE_PERFTRACING && PLATFORM_WINDOWS
+#endif // FEATURE_PERFTRACING && TARGET_WINDOWS
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             Interop.Advapi32.EventActivityIdControl(
                 Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
                     ref oldActivityThatWillContinue);
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW
 
             // We don't call the activityDying callback here because the caller has declared that
@@ -1469,7 +1469,7 @@ namespace System.Diagnostics.Tracing
                 // Set m_provider, which allows this.
                 m_etwProvider = etwProvider;
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
 #if (!ES_BUILD_STANDALONE && !ES_BUILD_PN)
                 // API available on OS >= Win 8 and patched Win 7.
                 // Disable only for FrameworkEventSource to avoid recursion inside exception handling.
@@ -1488,7 +1488,7 @@ namespace System.Diagnostics.Tracing
 
                     metadataHandle.Free();
                 }
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW
 
 #if FEATURE_PERFTRACING

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -5,9 +5,9 @@
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
 #define FEATURE_MANAGED_ETW
-#endif // PLATFORM_WINDOWS
+#endif // TARGET_WINDOWS
 
 #if ES_BUILD_STANDALONE
 #define FEATURE_MANAGED_ETW_CHANNELS

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -934,12 +934,12 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_CHAR:
                     return Unsafe.As<byte, ushort>(ref pThisValue).CompareTo(Unsafe.As<byte, ushort>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_I4:
-#if !TARGET_64BIT
+#if TARGET_32BIT
                 case CorElementType.ELEMENT_TYPE_I:
 #endif
                     return Unsafe.As<byte, int>(ref pThisValue).CompareTo(Unsafe.As<byte, int>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_U4:
-#if !TARGET_64BIT
+#if TARGET_32BIT
                 case CorElementType.ELEMENT_TYPE_U:
 #endif
                     return Unsafe.As<byte, uint>(ref pThisValue).CompareTo(Unsafe.As<byte, uint>(ref pTargetValue));

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -934,22 +934,22 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_CHAR:
                     return Unsafe.As<byte, ushort>(ref pThisValue).CompareTo(Unsafe.As<byte, ushort>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_I4:
-#if !BIT64
+#if !TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_I:
 #endif
                     return Unsafe.As<byte, int>(ref pThisValue).CompareTo(Unsafe.As<byte, int>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_U4:
-#if !BIT64
+#if !TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_U:
 #endif
                     return Unsafe.As<byte, uint>(ref pThisValue).CompareTo(Unsafe.As<byte, uint>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_I8:
-#if BIT64
+#if TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_I:
 #endif
                     return Unsafe.As<byte, long>(ref pThisValue).CompareTo(Unsafe.As<byte, long>(ref pTargetValue));
                 case CorElementType.ELEMENT_TYPE_U8:
-#if BIT64
+#if TARGET_64BIT
                 case CorElementType.ELEMENT_TYPE_U:
 #endif
                     return Unsafe.As<byte, ulong>(ref pThisValue).CompareTo(Unsafe.As<byte, ulong>(ref pTargetValue));

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -96,7 +96,7 @@ namespace System
             {
                 case SpecialFolder.CommonApplicationData: return "/usr/share";
                 case SpecialFolder.CommonTemplates: return "/usr/share/templates";
-#if PLATFORM_OSX
+#if TARGET_OSX
                 case SpecialFolder.ProgramFiles: return "/Applications";
                 case SpecialFolder.System: return "/System";
 #endif
@@ -152,7 +152,7 @@ namespace System
                 case SpecialFolder.MyVideos:
                     return ReadXdgDirectory(home, "XDG_VIDEOS_DIR", "Videos");
 
-#if PLATFORM_OSX
+#if TARGET_OSX
                 case SpecialFolder.MyMusic:
                     return Path.Combine(home, "Music");
                 case SpecialFolder.MyPictures:

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -10,7 +10,7 @@ using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -545,7 +545,7 @@ namespace System.Globalization
         {
             IntPtr byteOffset = IntPtr.Zero;
 
-#if BIT64
+#if TARGET_64BIT
             // Read 4 chars (64 bits) at a time from each string
             while ((uint)length >= 4)
             {
@@ -577,7 +577,7 @@ namespace System.Globalization
 #endif
 
             // Read 2 chars (32 bits) at a time from each string
-#if BIT64
+#if TARGET_64BIT
             if ((uint)length >= 2)
 #else
             while ((uint)length >= 2)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -11,11 +11,11 @@ using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System.Globalization
 {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -137,7 +137,7 @@ namespace System.IO
         {
             get
             {
-                #if PLATFORM_OSX
+                #if TARGET_OSX
                     return false;
                 #else
                     return true;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 #else
 using nint = System.Int32;
@@ -38,7 +38,7 @@ namespace System
         [NonVersionable]
         public unsafe IntPtr(long value)
         {
-#if BIT64
+#if TARGET_64BIT
             _value = (void*)value;
 #else
             _value = (void*)checked((int)value);
@@ -79,7 +79,7 @@ namespace System
 
         public override unsafe int GetHashCode()
         {
-#if BIT64
+#if TARGET_64BIT
             long l = (long)_value;
             return unchecked((int)l) ^ (int)(l >> 32);
 #else
@@ -90,7 +90,7 @@ namespace System
         [NonVersionable]
         public unsafe int ToInt32()
         {
-#if BIT64
+#if TARGET_64BIT
             long l = (long)_value;
             return checked((int)l);
 #else
@@ -123,7 +123,7 @@ namespace System
         [NonVersionable]
         public static unsafe explicit operator int(IntPtr value)
         {
-#if BIT64
+#if TARGET_64BIT
             long l = (long)value._value;
             return checked((int)l);
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
@@ -9,7 +9,7 @@ using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -13,11 +13,11 @@ using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System
 {
@@ -105,7 +105,7 @@ namespace System
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
@@ -267,7 +267,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<T> Slice(int start, int length)
         {
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
@@ -357,7 +357,7 @@ namespace System
                     nuint desiredStartIndex = (uint)_index & (uint)ReadOnlyMemory<T>.RemoveFlagsBitMask;
                     int desiredLength = _length;
 
-#if BIT64
+#if TARGET_64BIT
                     // See comment in Span<T>.Slice for how this works.
                     if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -9,11 +9,11 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System
 {
@@ -149,7 +149,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -231,7 +231,7 @@ namespace System
                 return default;
             }
 
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -222,7 +222,7 @@ namespace System.Numerics
                 return (int)Popcnt.X64.PopCount(value);
             }
 
-#if BIT32
+#if TARGET_32BIT
             return PopCount((uint)value) // lo
                 + PopCount((uint)(value >> 32)); // hi
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
@@ -11,7 +11,7 @@ using System.Text;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 #else
 using nint = System.Int32;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.tt
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.tt
@@ -16,7 +16,7 @@ using System.Text;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 #else
 using nint = System.Int32;

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -13,11 +13,11 @@ using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System
 {
@@ -83,7 +83,7 @@ namespace System
                 this = default;
                 return; // returns default
             }
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
@@ -196,7 +196,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyMemory<T> Slice(int start, int length)
         {
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
@@ -279,7 +279,7 @@ namespace System
                     nuint desiredStartIndex = (uint)_index & (uint)RemoveFlagsBitMask;
                     int desiredLength = _length;
 
-#if BIT64
+#if TARGET_64BIT
                     // See comment in Span<T>.Slice for how this works.
                     if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -14,7 +14,7 @@ using Internal.Runtime.CompilerServices;
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -75,7 +75,7 @@ namespace System
                 this = default;
                 return; // returns default
             }
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
@@ -364,7 +364,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<T> Slice(int start, int length)
         {
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ArrayWithOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ArrayWithOffset.cs
@@ -5,7 +5,7 @@
 using System.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 #else
 using nint = System.Int32;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -11,7 +11,7 @@ using Internal.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -350,7 +350,7 @@ namespace System.Runtime.InteropServices
 
         public static IntPtr ReadIntPtr(object ptr, int ofs)
         {
-#if BIT64
+#if TARGET_64BIT
             return (IntPtr)ReadInt64(ptr, ofs);
 #else // 32
             return (IntPtr)ReadInt32(ptr, ofs);
@@ -359,7 +359,7 @@ namespace System.Runtime.InteropServices
 
         public static IntPtr ReadIntPtr(IntPtr ptr, int ofs)
         {
-#if BIT64
+#if TARGET_64BIT
             return (IntPtr)ReadInt64(ptr, ofs);
 #else // 32
             return (IntPtr)ReadInt32(ptr, ofs);
@@ -464,7 +464,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteIntPtr(IntPtr ptr, int ofs, IntPtr val)
         {
-#if BIT64
+#if TARGET_64BIT
             WriteInt64(ptr, ofs, (long)val);
 #else // 32
             WriteInt32(ptr, ofs, (int)val);
@@ -473,7 +473,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteIntPtr(object ptr, int ofs, IntPtr val)
         {
-#if BIT64
+#if TARGET_64BIT
             WriteInt64(ptr, ofs, (long)val);
 #else // 32
             WriteInt32(ptr, ofs, (int)val);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.Loader
     internal partial struct LibraryNameVariation
     {
         private const string LibraryNamePrefix = "lib";
-#if PLATFORM_OSX
+#if TARGET_OSX
         private const string LibraryNameSuffix = ".dylib";
 #else
         private const string LibraryNameSuffix = ".so";

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -14,7 +14,7 @@ using Internal.Runtime.CompilerServices;
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -81,7 +81,7 @@ namespace System
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
-#if BIT64
+#if TARGET_64BIT
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
@@ -444,7 +444,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
-#if BIT64
+#if TARGET_64BIT
             // Since start and length are both 32-bit, their sum can be computed across a 64-bit domain
             // without loss of fidelity. The cast to uint before the cast to ulong ensures that the
             // extension from 32- to 64-bit is zero-extending rather than sign-extending. The end result

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -11,11 +11,11 @@ using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -11,7 +11,7 @@ using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 using nint = System.Int64;
 #else
@@ -107,7 +107,7 @@ namespace System
                 }
             }
 
-#if BIT64
+#if TARGET_64BIT
             if ((byte*)minLength >= (byte*)(i + sizeof(int) / sizeof(char)))
             {
                 if (Unsafe.ReadUnaligned<int>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref first, i))) ==

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -22,7 +22,7 @@ namespace System
             if (byteLength == 0)
                 return;
 
-#if AMD64 || ARM64
+#if TARGET_AMD64 || TARGET_ARM64
             // The exact matrix on when ZeroMemory is faster than InitBlockUnaligned is very complex. The factors to consider include
             // type of hardware and memory aligment. This threshold was chosen as a good balance accross different configurations.
             if (byteLength > 768)
@@ -66,7 +66,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 6) = 0;
                     return;
                 case 8:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -74,7 +74,7 @@ namespace System
 #endif
                     return;
                 case 9:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -83,7 +83,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 8) = 0;
                     return;
                 case 10:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -92,7 +92,7 @@ namespace System
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     return;
                 case 11:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -102,7 +102,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 10) = 0;
                     return;
                 case 12:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -111,7 +111,7 @@ namespace System
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     return;
                 case 13:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -121,7 +121,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 12) = 0;
                     return;
                 case 14:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -131,7 +131,7 @@ namespace System
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
                     return;
                 case 15:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
 #else
                     Unsafe.As<byte, int>(ref b) = 0;
@@ -142,7 +142,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 14) = 0;
                     return;
                 case 16:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -153,7 +153,7 @@ namespace System
 #endif
                     return;
                 case 17:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -165,7 +165,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 16) = 0;
                     return;
                 case 18:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -177,7 +177,7 @@ namespace System
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     return;
                 case 19:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -190,7 +190,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 18) = 0;
                     return;
                 case 20:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -202,7 +202,7 @@ namespace System
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     return;
                 case 21:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -215,7 +215,7 @@ namespace System
                     Unsafe.Add<byte>(ref b, 20) = 0;
                     return;
                 case 22:
-#if BIT64
+#if TARGET_64BIT
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
 #else
@@ -287,7 +287,7 @@ namespace System
                 // So the only cost is a bit of code size, which is made up for by the fact that
                 // we save on writes to b.
 
-#if BIT64
+#if TARGET_64BIT
                 Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i + 8)) = 0;
 #else
@@ -306,7 +306,7 @@ namespace System
 
             if ((byteLength & 8) != 0)
             {
-#if BIT64
+#if TARGET_64BIT
                 Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
 #else
                 Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -106,7 +106,7 @@ namespace System
                 length -= 2; a += 2; b += 2;
 
                 // unroll the loop
-#if BIT64
+#if TARGET_64BIT
                 while (length >= 12)
                 {
                     if (*(long*)a != *(long*)b) goto DiffOffset0;
@@ -114,7 +114,7 @@ namespace System
                     if (*(long*)(a + 8) != *(long*)(b + 8)) goto DiffOffset8;
                     length -= 12; a += 12; b += 12;
                 }
-#else // BIT64
+#else // TARGET_64BIT
                 while (length >= 10)
                 {
                     if (*(int*)a != *(int*)b) goto DiffOffset0;
@@ -124,7 +124,7 @@ namespace System
                     if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
                     length -= 10; a += 10; b += 10;
                 }
-#endif // BIT64
+#endif // TARGET_64BIT
 
                 // Fallback loop:
                 // go back to slower code path and do comparison on 4 bytes at a time.
@@ -144,10 +144,10 @@ namespace System
                 // The longer string will be larger.
                 return strA.Length - strB.Length;
 
-#if BIT64
+#if TARGET_64BIT
             DiffOffset8: a += 4; b += 4;
             DiffOffset4: a += 4; b += 4;
-#else // BIT64
+#else // TARGET_64BIT
                 // Use jumps instead of falling through, since
                 // otherwise going to DiffOffset8 will involve
                 // 8 add instructions before getting to DiffNextInt
@@ -155,16 +155,16 @@ namespace System
                 DiffOffset6: a += 6; b += 6; goto DiffOffset0;
                 DiffOffset4: a += 2; b += 2;
                 DiffOffset2: a += 2; b += 2;
-#endif // BIT64
+#endif // TARGET_64BIT
 
             DiffOffset0:
                 // If we reached here, we already see a difference in the unrolled loop above
-#if BIT64
+#if TARGET_64BIT
                 if (*(int*)a == *(int*)b)
                 {
                     a += 2; b += 2;
                 }
-#endif // BIT64
+#endif // TARGET_64BIT
 
             DiffNextInt:
                 if (*a != *b) return *a - *b;

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -217,7 +217,7 @@ namespace System
             if (numBytes == 0)
                 return Empty;
 
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             int numCharsRequired = Interop.Kernel32.MultiByteToWideChar(Interop.Kernel32.CP_ACP, Interop.Kernel32.MB_PRECOMPOSED, pb, numBytes, (char*)null, 0);
             if (numCharsRequired == 0)
                 throw new ArgumentException(SR.Arg_InvalidANSIString);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -10,13 +10,13 @@ using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nint = System.Int32;
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System.Text
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -9,13 +9,13 @@ using System.Numerics;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nint = System.Int32;
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System.Text.Unicode
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -10,13 +10,13 @@ using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nint = System.Int32;
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System.Text.Unicode
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -8,13 +8,13 @@ using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else // BIT64
+#else // TARGET_64BIT
 using nint = System.Int32;
 using nuint = System.UInt32;
-#endif // BIT64
+#endif // TARGET_64BIT
 
 namespace System.Text.Unicode
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.WhiteSpace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.WhiteSpace.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nint = System.Int64;
 using nuint = System.UInt64;
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -405,7 +405,7 @@ namespace System.Text
 #if FASTLOOP
                     // If endianess is backwards then each pair of bytes would be backwards.
                     if ((bigEndian ^ BitConverter.IsLittleEndian) &&
-#if BIT64
+#if TARGET_64BIT
                         (unchecked((long)chars) & 7) == 0 &&
 #else
                         (unchecked((int)chars) & 3) == 0 &&
@@ -692,7 +692,7 @@ namespace System.Text
 #if FASTLOOP
                     // If endianess is backwards then each pair of bytes would be backwards.
                     if ((bigEndian ^ BitConverter.IsLittleEndian) &&
-#if BIT64
+#if TARGET_64BIT
                         (unchecked((long)chars) & 7) == 0 &&
 #else
                         (unchecked((int)chars) & 3) == 0 &&
@@ -1044,11 +1044,11 @@ namespace System.Text
                 // That'll hurt if we're unaligned because we'll always test but never be aligned
 #if FASTLOOP
                 if ((bigEndian ^ BitConverter.IsLittleEndian) &&
-#if BIT64
+#if TARGET_64BIT
                     (unchecked((long)bytes) & 7) == 0 &&
 #else
                     (unchecked((int)bytes) & 3) == 0 &&
-#endif // BIT64
+#endif // TARGET_64BIT
                     lastByte == -1 && lastChar == 0)
                 {
                     // Need -1 to check 2 at a time.  If we have an even #, longBytes will go
@@ -1365,7 +1365,7 @@ namespace System.Text
                 // That'll hurt if we're unaligned because we'll always test but never be aligned
 #if FASTLOOP
                 if ((bigEndian ^ BitConverter.IsLittleEndian) &&
-#if BIT64
+#if TARGET_64BIT
                     (unchecked((long)chars) & 7) == 0 &&
 #else
                     (unchecked((int)chars) & 3) == 0 &&

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
@@ -19,7 +19,7 @@ namespace System.Threading
 
         private void CreateEventCore(bool initialState, EventResetMode mode, string? name, out bool createdNew)
         {
-#if !TARGET_WINDOWS
+#if TARGET_UNIX
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
@@ -19,7 +19,7 @@ namespace System.Threading
 
         private void CreateEventCore(bool initialState, EventResetMode mode, string? name, out bool createdNew)
         {
-#if !PLATFORM_WINDOWS
+#if !TARGET_WINDOWS
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 #endif
@@ -44,7 +44,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out EventWaitHandle? result)
         {
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
             if (name.Length == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
@@ -25,7 +25,7 @@ namespace System.Threading
             if (mutexHandle.IsInvalid)
             {
                 mutexHandle.SetHandleAsInvalid();
-#if !PLATFORM_WINDOWS
+#if !TARGET_WINDOWS
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
                     throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
@@ -62,7 +62,7 @@ namespace System.Threading
             if (myHandle.IsInvalid)
             {
                 int errorCode = Marshal.GetLastWin32Error();
-#if !PLATFORM_WINDOWS
+#if !TARGET_WINDOWS
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                 {
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
@@ -25,7 +25,7 @@ namespace System.Threading
             if (mutexHandle.IsInvalid)
             {
                 mutexHandle.SetHandleAsInvalid();
-#if !TARGET_WINDOWS
+#if TARGET_UNIX
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
                     throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
@@ -62,7 +62,7 @@ namespace System.Threading
             if (myHandle.IsInvalid)
             {
                 int errorCode = Marshal.GetLastWin32Error();
-#if !TARGET_WINDOWS
+#if TARGET_UNIX
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                 {
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
@@ -18,9 +18,9 @@ namespace System.Threading
 
         private const int ThreadPoolThreadTimeoutMs = 20 * 1000; // If you change this make sure to change the timeout times in the tests.
 
-#if BIT64
+#if TARGET_64BIT
         private const short MaxPossibleThreadCount = short.MaxValue;
-#elif BIT32
+#elif TARGET_32BIT
         private const short MaxPossibleThreadCount = 1023;
 #else
         #error Unknown platform
@@ -40,7 +40,7 @@ namespace System.Threading
         [StructLayout(LayoutKind.Explicit, Size = CacheLineSize * 5)]
         private struct CacheLineSeparated
         {
-#if ARM64
+#if TARGET_ARM64
             private const int CacheLineSize = 128;
 #else
             private const int CacheLineSize = 64;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
@@ -24,7 +24,7 @@ namespace System.Threading
             Debug.Assert(maximumCount >= 1);
             Debug.Assert(initialCount <= maximumCount);
 
-#if !TARGET_WINDOWS
+#if TARGET_UNIX
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
@@ -24,7 +24,7 @@ namespace System.Threading
             Debug.Assert(maximumCount >= 1);
             Debug.Assert(initialCount <= maximumCount);
 
-#if !PLATFORM_WINDOWS
+#if !TARGET_WINDOWS
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 #endif
@@ -45,7 +45,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out Semaphore? result)
         {
-#if PLATFORM_WINDOWS
+#if TARGET_WINDOWS
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
             if (name.Length == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -90,7 +90,7 @@ namespace System.Threading
         [Intrinsic]
         [NonVersionable]
         public static long Read(ref long location) =>
-#if BIT64
+#if TARGET_64BIT
             (long)Unsafe.As<long, VolatileIntPtr>(ref location).Value;
 #else
             // On 32-bit machines, we use Interlocked, since an ordinary volatile read would not be atomic.
@@ -100,7 +100,7 @@ namespace System.Threading
         [Intrinsic]
         [NonVersionable]
         public static void Write(ref long location, long value) =>
-#if BIT64
+#if TARGET_64BIT
             Unsafe.As<long, VolatileIntPtr>(ref location).Value = (IntPtr)value;
 #else
             // On 32-bit, we use Interlocked, since an ordinary volatile write would not be atomic.

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;
@@ -35,7 +35,7 @@ namespace System
         [NonVersionable]
         public unsafe UIntPtr(ulong value)
         {
-#if BIT64
+#if TARGET_64BIT
             _value = (void*)value;
 #else
             _value = (void*)checked((uint)value);
@@ -80,7 +80,7 @@ namespace System
 
         public override unsafe int GetHashCode()
         {
-#if BIT64
+#if TARGET_64BIT
             ulong l = (ulong)_value;
             return unchecked((int)l) ^ (int)(l >> 32);
 #else
@@ -91,7 +91,7 @@ namespace System
         [NonVersionable]
         public unsafe uint ToUInt32()
         {
-#if BIT64
+#if TARGET_64BIT
             return checked((uint)_value);
 #else
             return (uint)_value;
@@ -119,7 +119,7 @@ namespace System
 
         [NonVersionable]
         public static unsafe explicit operator uint(UIntPtr value) =>
-#if BIT64
+#if TARGET_64BIT
             checked((uint)value._value);
 #else
             (uint)value._value;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CodeGenerator.cs
@@ -1461,17 +1461,14 @@ namespace System.Runtime.Serialization
         }
 
 
-        [Conditional("NOT_SILVERLIGHT")]
         internal void EmitSourceInstruction(string line)
         {
         }
 
-        [Conditional("NOT_SILVERLIGHT")]
         internal void EmitSourceLabel(string line)
         {
         }
 
-        [Conditional("NOT_SILVERLIGHT")]
         internal void EmitSourceComment(string comment)
         {
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -43,9 +43,9 @@ namespace System.Xml.Xsl.XsltOld
     internal enum ScriptingLanguage
     {
         JScript,
-#if !FEATURE_PAL // visualbasic
+#if !TARGET_UNIX // visualbasic
         VisualBasic,
-#endif // !FEATURE_PAL
+#endif // !TARGET_UNIX
         CSharp
     }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -43,9 +43,9 @@ namespace System.Xml.Xsl.XsltOld
     internal enum ScriptingLanguage
     {
         JScript,
-#if !TARGET_UNIX // visualbasic
+#if TARGET_WINDOWS // visualbasic
         VisualBasic,
-#endif // !TARGET_UNIX
+#endif // TARGET_WINDOWS
         CSharp
     }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -43,9 +43,7 @@ namespace System.Xml.Xsl.XsltOld
     internal enum ScriptingLanguage
     {
         JScript,
-#if TARGET_WINDOWS // visualbasic
         VisualBasic,
-#endif // TARGET_WINDOWS
         CSharp
     }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
@@ -918,7 +918,7 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.CSharp;
                         }
-#if !FEATURE_PAL // visualbasic
+#if !TARGET_UNIX // visualbasic
                         else if (
                             string.Equals(langName, "vb", StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(langName, "visualbasic", StringComparison.OrdinalIgnoreCase)
@@ -926,7 +926,7 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.VisualBasic;
                         }
-#endif // !FEATURE_PAL
+#endif // !TARGET_UNIX
                         else
                         {
                             throw XsltException.Create(SR.Xslt_ScriptInvalidLanguage, langName);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
@@ -918,7 +918,7 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.CSharp;
                         }
-#if !TARGET_UNIX // visualbasic
+#if TARGET_WINDOWS // visualbasic
                         else if (
                             string.Equals(langName, "vb", StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(langName, "visualbasic", StringComparison.OrdinalIgnoreCase)
@@ -926,7 +926,7 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.VisualBasic;
                         }
-#endif // !TARGET_UNIX
+#endif // TARGET_WINDOWS
                         else
                         {
                             throw XsltException.Create(SR.Xslt_ScriptInvalidLanguage, langName);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/ContainerAction.cs
@@ -918,7 +918,6 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.CSharp;
                         }
-#if TARGET_WINDOWS // visualbasic
                         else if (
                             string.Equals(langName, "vb", StringComparison.OrdinalIgnoreCase) ||
                             string.Equals(langName, "visualbasic", StringComparison.OrdinalIgnoreCase)
@@ -926,7 +925,6 @@ namespace System.Xml.Xsl.XsltOld
                         {
                             lang = ScriptingLanguage.VisualBasic;
                         }
-#endif // TARGET_WINDOWS
                         else
                         {
                             throw XsltException.Create(SR.Xslt_ScriptInvalidLanguage, langName);

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -67,23 +67,23 @@
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>BIT64;AMD64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_64BIT;TARGET_AMD64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <PlatformTarget>x86</PlatformTarget>
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm'">
     <PlatformTarget>arm</PlatformTarget>
-    <DefineConstants>BIT32;ARM;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;TARGET_ARM;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm64'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>BIT64;ARM64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_64BIT;TARGET_ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'wasm32'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_32BIT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->
@@ -97,7 +97,7 @@
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsOSX)' == 'true'">
-    <DefineConstants>PLATFORM_OSX;$(DefineConstants)</DefineConstants>
+    <DefineConstants>TARGET_OSX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Assembly attributes -->

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Array.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Array.Mono.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Mono;
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Buffer.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Buffer.Mono.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.CompilerServices;
 
-#if BIT64
+#if TARGET_64BIT
 using nuint = System.UInt64;
 #else
 using nuint = System.UInt32;


### PR DESCRIPTION
Rename coreclr managed conditional compilation macros to match CoreCLR native concepts

    BIT64                   -> TARGET_64BIT
    BIT32                   -> TARGET_32BIT
    FEATURE_PAL             -> TARGET_UNIX
    PLATFORM_UNIX           -> TARGET_UNIX
    PLATFORM_WINDOWS        -> TARGET_WINDOWS
    PLATFORM_OSX            -> TARGET_OSX

Remove obsolete logic and obsolete define: FeaturePal