### PR TITLE
Fix createdump DAC segfault

### DIFF
--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -1275,10 +1275,13 @@ void CallCountingManager::DacEnumerateCallCountingStubHeapRanges(CLRDataEnumMemo
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+    if (s_callCountingManagers != PTR_NULL)
     {
-        PTR_CallCountingManager callCountingManager = *it;
-        callCountingManager->m_callCountingStubAllocator.EnumerateHeapRanges(flags);
+        for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+        {
+            PTR_CallCountingManager callCountingManager = *it;
+            callCountingManager->m_callCountingStubAllocator.EnumerateHeapRanges(flags);
+        }
     }
 }
 


### PR DESCRIPTION
Need to check s_callCountingManagers is not null in the CallCountingManager enumerate memory function.