### PR TITLE
Skip EqualityComparer<TKey>.Default creation in Dictionary .ctor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -79,7 +79,7 @@ namespace System.Collections.Generic
         {
             if (capacity < 0) ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
             if (capacity > 0) Initialize(capacity);
-            if (comparer != EqualityComparer<TKey>.Default)
+            if (comparer != null && comparer != EqualityComparer<TKey>.Default)
             {
                 _comparer = comparer;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -79,7 +79,7 @@ namespace System.Collections.Generic
         {
             if (capacity < 0) ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
             if (capacity > 0) Initialize(capacity);
-            if (comparer != null && comparer != EqualityComparer<TKey>.Default)
+            if (comparer != null && comparer != EqualityComparer<TKey>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
             {
                 _comparer = comparer;
             }


### PR DESCRIPTION
Saw this in startup checking if the comparer is `EqualityComparer<TKey>.Default` for string instantiates the static comparer, however by default the value is `null`; so check against `null` before checking the `static`.

e.g. in `AppContext.Setup` 
```csharp
s_dataStore = new Dictionary<string, object?>(count);
```

Before

![image](https://user-images.githubusercontent.com/1142958/73611504-5b968680-45da-11ea-9785-bd979ffeb97e.png)


After

![image](https://user-images.githubusercontent.com/1142958/73611516-723cdd80-45da-11ea-91ed-a396d87c1178.png)

Note it doesn't use the created comparer as it switches to `NonRandomizedStringEqualityComparer`

/cc @jkotas 