### PR TITLE
Allow null IV for Create{Encryptor,Decryptor}.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/ref/System.Security.Cryptography.Primitives.cs
@@ -231,9 +231,9 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.SymmetricAlgorithm Create() { throw null; }
         public static System.Security.Cryptography.SymmetricAlgorithm? Create(string algName) { throw null; }
         public virtual System.Security.Cryptography.ICryptoTransform CreateDecryptor() { throw null; }
-        public abstract System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV);
+        public abstract System.Security.Cryptography.ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[]? rgbIV);
         public virtual System.Security.Cryptography.ICryptoTransform CreateEncryptor() { throw null; }
-        public abstract System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV);
+        public abstract System.Security.Cryptography.ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[]? rgbIV);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public abstract void GenerateIV();

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -173,14 +173,14 @@ namespace System.Security.Cryptography
             return CreateDecryptor(Key, IV);
         }
 
-        public abstract ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV);
+        public abstract ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[]? rgbIV);
 
         public virtual ICryptoTransform CreateEncryptor()
         {
             return CreateEncryptor(Key, IV);
         }
 
-        public abstract ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV);
+        public abstract ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[]? rgbIV);
 
         public void Dispose()
         {


### PR DESCRIPTION
The IV is permitted to be null for most ciphers when in ECB mode.

The derived types are not yet done, or are in-progress at https://github.com/dotnet/runtime/pull/2375.

Fixes #31631

@bartonjs @buyaa-n.