### PR TITLE
[interp] Cleanup native_stack_addr.

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -205,7 +205,7 @@ struct _InterpFrame {
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
 	/* An address on the native stack associated with the frame, used during EH */
-	gpointer       native_stack_addr;
+	char           *native_stack_addr;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *iframe_frag, *data_frag;
 	/* exception info */


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18666,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Consolidate native_stack_addr and dummy. Their addresses are taken anyway.
Change type to reduce casting.
Use native_stack_addr, even in the recursive cases,
instead of other locals. At least one of these recursive
cases needs fixing soon anyway (call_varargs).