### PR TITLE
[interp][wasm] Reduce recursion in interpreter (call_vararg, newobj_fast). 

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -9,6 +9,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-internals.h>
 #include "interp.h"
+#include "mintops.h"
 
 #define MINT_TYPE_I1 0
 #define MINT_TYPE_U1 1
@@ -200,6 +201,9 @@ typedef struct {
 	const unsigned short  *ip;
 	GSList *finally_ips;
 	FrameClauseArgs *clause_args;
+	MonoObject* volatile o; // GC hole?
+	MintOpcode opcode;
+	gboolean is_void : 1;
 } InterpState;
 
 struct _InterpFrame {
@@ -209,7 +213,7 @@ struct _InterpFrame {
 	stackval       *stack_args; /* parent */
 	stackval       *stack;
 	/* An address on the native stack associated with the frame, used during EH */
-	gpointer       native_stack_addr;
+	char           *native_stack_addr;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *iframe_frag, *data_frag;
 	/* exception info */


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18670,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is a https://github.com/mono/mono/pull/18669
but with merge conflict resolved and slightly cleaned up.

This removes recursion from call_vararg and newobj_fast.
One or both is implicated in https://github.com/mono/mono/issues/18646
and this has been seen to fix that (which I reproduced many times).

Also fix the type of clause_args. I'll put that in a separate PR.

This *might* introduce a GC hole, as noted within.
The stored value is also passed on, so maybe it is ok.

Also from other PRs:
  Put function names in release WebAssembly callstacks.
 Use per call site functions so it is clear which recursion is occuring.

Note that there remain a few sources of recursion in the interpreter:
  1 transform
  2 newobj_vt_fast
  3 newobj_vtst_fast
  4 vtable initialization

1 is probably difficult to fix
2 and 3 easy
4 not sure