### PR TITLE
Initial Crossgen2 fixes for composite R2R support

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -89,7 +89,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (result != 0)
                 return result;
 
-            result = _targetMethod.CompareToImpl(otherNode._targetMethod, comparer);
+            result = comparer.Compare(_targetMethod, otherNode._targetMethod);
             if (result != 0)
                 return result;
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -15,8 +15,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly IMethodNode _targetMethod;
 
-        private readonly bool _isInstantiatingStub;
-
         private readonly ModuleToken _methodToken;
 
         private readonly SignatureContext _signatureContext;
@@ -24,13 +22,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public DelegateCtorSignature(
             TypeDesc delegateType,
             IMethodNode targetMethod,
-            bool isInstantiatingStub,
             ModuleToken methodToken,
             SignatureContext signatureContext)
         {
             _delegateType = delegateType;
             _targetMethod = targetMethod;
-            _isInstantiatingStub = isInstantiatingStub;
             _methodToken = methodToken;
             _signatureContext = signatureContext;
 
@@ -81,10 +77,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append(nameMangler.GetMangledTypeName(_delegateType));
             sb.Append(" -> ");
             _targetMethod.AppendMangledName(nameMangler, sb);
-            if (_isInstantiatingStub)
-            {
-                sb.Append(" [INST]");
-            }
             sb.Append("; ");
             sb.Append(_methodToken.ToString());
             sb.Append(")");

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -15,6 +15,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly IMethodNode _targetMethod;
 
+        private readonly bool _isInstantiatingStub;
+
         private readonly ModuleToken _methodToken;
 
         private readonly SignatureContext _signatureContext;
@@ -22,11 +24,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public DelegateCtorSignature(
             TypeDesc delegateType,
             IMethodNode targetMethod,
+            bool isInstantiatingStub,
             ModuleToken methodToken,
             SignatureContext signatureContext)
         {
             _delegateType = delegateType;
             _targetMethod = targetMethod;
+            _isInstantiatingStub = isInstantiatingStub;
             _methodToken = methodToken;
             _signatureContext = signatureContext;
 
@@ -76,7 +80,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append($@"DelegateCtor(");
             sb.Append(nameMangler.GetMangledTypeName(_delegateType));
             sb.Append(" -> ");
-            sb.Append(nameMangler.GetMangledMethodName(_targetMethod.Method));
+            _targetMethod.AppendMangledName(nameMangler, sb);
+            if (_isInstantiatingStub)
+            {
+                sb.Append(" [INST]");
+            }
             sb.Append("; ");
             sb.Append(_methodToken.ToString());
             sb.Append(")");
@@ -89,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (result != 0)
                 return result;
 
-            result = comparer.Compare(_targetMethod.Method, otherNode._targetMethod.Method);
+            result = _targetMethod.CompareToImpl(otherNode._targetMethod, comparer);
             if (result != 0)
                 return result;
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -402,7 +402,7 @@ namespace ILCompiler.DependencyAnalysis
                         this,
                         ReadyToRunFixupKind.MethodEntry,
                         method,
-                        CreateMethodEntrypointNodeHelper(method, isUnboxingStub, isInstantiatingStub, signatureContext),
+                        CreateMethodEntrypointNodeHelper(method, signatureContext),
                         isUnboxingStub,
                         isInstantiatingStub,
                         signatureContext);
@@ -413,7 +413,7 @@ namespace ILCompiler.DependencyAnalysis
                         this,
                         ReadyToRunFixupKind.MethodEntry,
                         method,
-                        CreateMethodEntrypointNodeHelper(method, isUnboxingStub, isInstantiatingStub, signatureContext),
+                        CreateMethodEntrypointNodeHelper(method, signatureContext),
                         isUnboxingStub,
                         isInstantiatingStub,
                         signatureContext);
@@ -445,7 +445,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private NodeCache<TypeAndMethod, MethodWithGCInfo> _localMethodCache = new NodeCache<TypeAndMethod, MethodWithGCInfo>();
 
-        private MethodWithGCInfo CreateMethodEntrypointNodeHelper(MethodWithToken targetMethod, bool isUnboxingStub, bool isInstantiatingStub, SignatureContext signatureContext)
+        private MethodWithGCInfo CreateMethodEntrypointNodeHelper(MethodWithToken targetMethod, SignatureContext signatureContext)
         {
             Debug.Assert(CompilationModuleGroup.ContainsMethodBody(targetMethod.Method, false));
 
@@ -817,11 +817,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 // TODO: cross-bubble RVA field
                 throw new NotSupportedException($"{ecmaField} ... {ecmaField.Module.Assembly}");
-            }
-            if (TypeSystemContext.InputFilePaths.Count > 1)
-            {
-                // TODO: RVA fields in merged multi-file compilation
-                throw new NotSupportedException($"{ecmaField} ... {string.Join("; ", TypeSystemContext.InputFilePaths.Keys)}");
             }
 
             return _copiedFieldRvas.GetOrAdd(new ModuleAndIntValueKey(ecmaField.GetFieldRvaValue(), ecmaField.Module));

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -110,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory,
                     _codegenNodeFactory.HelperImports,
                     ReadyToRunHelper.DelayLoad_Helper_ObjObj,
-                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Token, signatureContext));
+                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Method.HasInstantiation, ctorKey.Method.Token, signatureContext));
             });
 
             _genericLookupHelpers = new NodeCache<GenericLookupKey, ISymbolNode>(key =>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -110,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory,
                     _codegenNodeFactory.HelperImports,
                     ReadyToRunHelper.DelayLoad_Helper_ObjObj,
-                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Method.HasInstantiation, ctorKey.Method.Token, signatureContext));
+                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Token, signatureContext));
             });
 
             _genericLookupHelpers = new NodeCache<GenericLookupKey, ISymbolNode>(key =>


### PR DESCRIPTION
With initial local changes to enable composite R2R I have finally
been able to compile a CoreCLR unit test in this mode. It doesn't
yet work at runtime, these changes just fix initial compiler issues
I hit during the build:

1) Delegate constructor signature was missing some comparison logic
that ended up asserting in the node comparer in the composite
build.

2) I have removed two seeminly superfluous parameters to
CreateMethodEntrypointNodeHelper.

3) I have removed an assertion related to multi-file RVA fields
that I believe to be no longer relevant after the refactorings
to copy the RVA fields around properly.

Thanks

Tomas