### PR TITLE
Remove popped trees more aggressively.

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -13043,12 +13043,16 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         op1 = op1->AsOp()->gtOp1;
                     }
 
-                    // If 'op1' is an expression, create an assignment node.
-                    // Helps analyses (like CSE) to work fine.
-
                     if (op1->gtOper != GT_CALL)
                     {
-                        op1 = gtUnusedValNode(op1);
+                        if ((op1->gtFlags & GTF_SIDE_EFFECT) != 0)
+                        {
+                            op1 = gtUnusedValNode(op1);
+                        }
+                        else
+                        {
+                            op1->gtBashToNOP();
+                        }
                     }
 
                     /* Append the value to the tree list */


### PR DESCRIPTION
When processing CEE_POP the importer sometimes created trees
like
ASG(tmp1, expr)
followed by
COMMA(ADDR(tmp1), NOP))
and that was causing some CQ issues.

LocalAddressVisitor was then marking tmp1 as address-exposed,
morph adds a GTF_GLOB_REF flag for all address-exposed locals,
and we never get rid of the dead ASG(tmp1, expr). What's worse, we
then were adding a zero-initialization for tmp1 in the prolog.

The fix here is to create a NOP instead of a COMMA if there are
no side effects in the first operand of the COMMA.

This addresses the first example in #2325.