### PR TITLE
Don't block specific generic types in field marshalling scenarios.

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -340,9 +340,10 @@ namespace Internal.TypeSystem.Interop
                 // * Vector64<T>: Represents the __m64 ABI primitive which requires currently unimplemented handling
                 // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
                 // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
-                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for inteorp scenarios
+                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
+                // We can't block these types for field scenarios for back-compat reasons.
 
-                if (type.HasInstantiation && (!isBlittable
+                if (type.HasInstantiation && !isField && (!isBlittable
                     || InteropTypes.IsSystemByReference(context, type)
                     || InteropTypes.IsSystemNullable(context, type)
                     || InteropTypes.IsSystemRuntimeIntrinsicsVector64T(context, type)

--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -345,6 +345,8 @@ namespace Internal.TypeSystem.Interop
 
                 if (type.HasInstantiation && !isField && (!isBlittable
                     || InteropTypes.IsSystemByReference(context, type)
+                    || InteropTypes.IsSystemSpan(context, type)
+                    || InteropTypes.IsSystemReadOnlySpan(context, type)
                     || InteropTypes.IsSystemNullable(context, type)
                     || InteropTypes.IsSystemRuntimeIntrinsicsVector64T(context, type)
                     || InteropTypes.IsSystemRuntimeIntrinsicsVector128T(context, type)

--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/InteropTypes.cs
@@ -113,6 +113,16 @@ namespace Internal.TypeSystem.Interop
             return IsCoreNamedType(context, type, "System", "ByReference`1");
         }
 
+        public static bool IsSystemSpan(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "Span`1");
+        }
+
+        public static bool IsSystemReadOnlySpan(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "ReadOnlySpan`1");
+        }
+
         public static bool IsSystemNullable(TypeSystemContext context, TypeDesc type)
         {
             return IsCoreNamedType(context, type, "System", "Nullable`1");

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -2786,11 +2786,20 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
                 // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
 
-                if (m_pMT->HasInstantiation() && !IsFieldScenario())
+                if (m_pMT->HasInstantiation())
                 {
-                    if (!m_pMT->IsBlittable()
+                    if (m_pMT->HasSameTypeDefAs(g_pNullableClass))
+                    {
+                        // We need to allow Nullable<T> fields for people who are using Marshal.SizeOf instead of Unsafe.SizeOf
+                        // for back-compat reasons. We want to block it for parameters in case we decide to add special handling later.
+                        if (!IsFieldScenario())
+                        {
+                            m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
+                            IfFailGoto(E_FAIL, lFail);
+                        }
+                    }
+                    else if (!m_pMT->IsBlittable()
                         || (m_pMT->HasSameTypeDefAs(g_pByReferenceClass)
-                            || m_pMT->HasSameTypeDefAs(g_pNullableClass)
                             || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR64T))
                             || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR128T))
                             || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR256T))
@@ -2799,17 +2808,6 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTORT))
 #endif // !CROSSGEN_COMPILE
                         ))
-                    {
-                        m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
-                        IfFailGoto(E_FAIL, lFail);
-                    }
-                }
-                else if (IsFieldScenario())
-                {
-                    // In the field scenario, we used to allow other types such as Nullable<T>, so we need to keep allowing them.
-                    // However, since ByReference<T> has very special handling, we continue to block it from being marshalled even in
-                    // the field scenario.
-                    if (m_pMT->HasSameTypeDefAs(g_pByReferenceClass))
                     {
                         m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
                         IfFailGoto(E_FAIL, lFail);

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -2790,6 +2790,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     && (!m_pMT->IsBlittable()
                         || (m_pMT->HasSameTypeDefAs(g_pNullableClass)
                         || m_pMT->HasSameTypeDefAs(g_pByReferenceClass)
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__SPAN))
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__READONLY_SPAN))
                         || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR64T))
                         || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR128T))
                         || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR256T))

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -2784,22 +2784,25 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 // * Vector64<T>: Represents the __m64 ABI primitive which requires currently unimplemented handling
                 // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
                 // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
-                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for inteorp scenarios
+                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
 
-                if (m_pMT->HasInstantiation() && (!m_pMT->IsBlittable()
-                    || m_pMT->HasSameTypeDefAs(g_pByReferenceClass)
-                    || m_pMT->HasSameTypeDefAs(g_pNullableClass)
-                    || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR64T))
-                    || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR128T))
-                    || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR256T))
-#ifndef CROSSGEN_COMPILE
-                    // Crossgen scenarios block Vector<T> from even being loaded
-                    || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTORT))
-#endif // !CROSSGEN_COMPILE
-                    ))
+                if (m_pMT->HasInstantiation() && !m_pMT->IsBlittable())
                 {
-                    m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
-                    IfFailGoto(E_FAIL, lFail);
+                    if (!IsFieldScenario() &&
+                        (m_pMT->HasSameTypeDefAs(g_pByReferenceClass)
+                        || m_pMT->HasSameTypeDefAs(g_pNullableClass)
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR64T))
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR128T))
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTOR256T))
+#ifndef CROSSGEN_COMPILE
+                        // Crossgen scenarios block Vector<T> from even being loaded
+                        || m_pMT->HasSameTypeDefAs(MscorlibBinder::GetClass(CLASS__VECTORT))
+#endif // !CROSSGEN_COMPILE
+                        ))
+                    {
+                        m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
+                        IfFailGoto(E_FAIL, lFail);
+                    }
                 }
 
                 UINT managedSize = m_pMT->GetAlignedNumInstanceFieldBytes();

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -56,6 +56,8 @@ namespace System.Runtime.InteropServices.Tests
         public void SizeOf_Struct_With_GenericValueTypeField_ReturnsExpected()
         {
             Assert.Equal(8, Marshal.SizeOf<TestStructWithGenericStructField>());
+            Assert.Equal(8, Marshal.SizeOf<TestStructWithNullable>());
+            Assert.Equal(8, Marshal.SizeOf<TestStructWithVector64>());
         }
 
         public static IEnumerable<object[]> SizeOf_InvalidType_TestData()
@@ -122,6 +124,16 @@ namespace System.Runtime.InteropServices.Tests
         public struct TestStructWithGenericStructField
         {
             public GenericStruct<int> i;
+        }
+
+        public struct TestStructWithNullable
+        {
+            public int? i;
+        }
+
+        public struct TestStructWithVector64
+        {
+            public System.Runtime.Intrinsics.Vector64<double> v;
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -52,6 +52,12 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentNullException>("structure", () => Marshal.SizeOf<string>(null));
         }
 
+        [Fact]
+        public void SizeOf_Struct_With_GenericValueTypeField_ReturnsExpected()
+        {
+            Assert.Equal(8, Marshal.SizeOf<TestStructWithGenericStructField>());
+        }
+
         public static IEnumerable<object[]> SizeOf_InvalidType_TestData()
         {
             yield return new object[] { typeof(int).MakeByRefType(), null };
@@ -105,6 +111,17 @@ namespace System.Runtime.InteropServices.Tests
         {
             [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.LPStr, SizeConst = 0)]
             public string[] Arr;
+        }
+
+        public struct GenericStruct<T>
+        {
+            public T t;
+            public bool b;
+        }
+
+        public struct TestStructWithGenericStructField
+        {
+            public GenericStruct<int> i;
         }
     }
 }


### PR DESCRIPTION
Bing is using `Marshal.SizeOf` to calculate the size of structs that contain a `Nullable<T>` field. In the old system, this would unexpectedly work since we apparently allowed using generic structs as fields in interop types (but not generic classes). See the `&& ELEMENT_TYPE_CLASS` at the end of the condition on line 208: https://github.com/dotnet/coreclr/blob/release/3.1/src/vm/fieldmarshaler.cpp#L208-L211

Semantically, the correct function for users to call here would be `Unsafe.SizeOf<T>`, but there's a large number of users who use `Marshal.SizeOf` instead of `Unsafe.SizeOf` for various reasons.

Fixes #31640 