### PR TITLE
[mono] Enable debugging for netcore configurations by default.

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1610,8 +1610,9 @@ mini_usage (void)
 		"\n"
 		"Development:\n"
 		"    --aot[=<options>]      Compiles the assembly to native code\n"
-#ifndef ENABLE_NETCORE
-		"    --debug=ignore    Disable debugging support, use --help-debug for details\n"
+#ifdef ENABLE_NETCORE
+		"    --debug=ignore    Disable debugging support\n"
+		"    --debug=<options>    Enable debugging support, use --help-debug for details\n"
 #else
 		"    --debug[=<options>]    Enable debugging support, use --help-debug for details\n"
 #endif

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -200,6 +200,7 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
+	opt->enabled = TRUE;
 
 	do {
 		if (!*p) {
@@ -1611,8 +1612,8 @@ mini_usage (void)
 		"Development:\n"
 		"    --aot[=<options>]      Compiles the assembly to native code\n"
 #ifdef ENABLE_NETCORE
-		"    --debug=ignore    Disable debugging support\n"
-		"    --debug=<options>    Enable debugging support, use --help-debug for details\n"
+		"    --debug=ignore         Disable debugging support (on by default)\n"
+		"    --debug=[<options>]    Disable debugging support or enable debugging extras, use --help-debug for details\n"
 #else
 		"    --debug[=<options>]    Enable debugging support, use --help-debug for details\n"
 #endif
@@ -1674,10 +1675,17 @@ mini_debug_usage (void)
 {
 	fprintf (stdout,
 		 "Debugging options:\n"
+#ifdef ENABLE_NETCORE
+		 "   --debug[=OPTIONS]     Disable debugging support or enable debugging extras, optional OPTIONS is a comma\n"
+#else
 		 "   --debug[=OPTIONS]     Enable debugging support, optional OPTIONS is a comma\n"
+#endif
 		 "                         separated list of options\n"
 		 "\n"
 		 "OPTIONS is composed of:\n"
+#ifdef ENABLE_NETCORE
+		 "    ignore               Disable debugging support (on by default).\n"
+#endif
 		 "    casts                Enable more detailed InvalidCastException messages.\n"
 		 "    mdb-optimizations    Disable some JIT optimizations which are normally\n"
 		 "                         disabled when running inside the debugger.\n"
@@ -2339,10 +2347,8 @@ mono_main (int argc, char* argv[])
 			mname = argv [++i];
 			mono_graph_options = MONO_GRAPH_CFG;
 			action = DO_DRAW;
-#ifndef ENABLE_NETCORE
 		} else if (strcmp (argv [i], "--debug") == 0) {
 			enable_debugging = TRUE;
-#endif
 		} else if (strncmp (argv [i], "--debug=", 8) == 0) {
 			enable_debugging = TRUE;
 			if (!parse_debug_options (argv [i] + 8))

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3662,6 +3662,10 @@ mini_parse_debug_option (const char *option)
 
 	if (!strcmp (option, "handle-sigint"))
 		mini_debug_options.handle_sigint = TRUE;
+#ifdef ENABLE_NETCORE
+	else if (!strcmp (option, "ignore"))
+		mini_debug_options.enabled = FALSE;
+#endif
 	else if (!strcmp (option, "keep-delegates"))
 		mini_debug_options.keep_delegates = TRUE;
 	else if (!strcmp (option, "reverse-pinvoke-exceptions"))

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3662,10 +3662,6 @@ mini_parse_debug_option (const char *option)
 
 	if (!strcmp (option, "handle-sigint"))
 		mini_debug_options.handle_sigint = TRUE;
-#ifdef ENABLE_NETCORE
-	else if (!strcmp (option, "ignore"))
-		mini_debug_options.enabled = FALSE;
-#endif
 	else if (!strcmp (option, "keep-delegates"))
 		mini_debug_options.keep_delegates = TRUE;
 	else if (!strcmp (option, "reverse-pinvoke-exceptions"))

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -262,6 +262,8 @@ typedef struct MonoDebugOptions {
 	 * embedding.
 	 */
 	gboolean top_runtime_invoke_unhandled;
+
+	gboolean enabled;
 } MonoDebugOptions;
 
 /*


### PR DESCRIPTION
What this means is:

1. --debug is no longer needed since the default is TRUE
2. --debug=ignore is a new switch to go back to the old mono default

Fixes https://github.com/dotnet/runtime/issues/31662