### PR TITLE
Fix package testing run name prefix

### DIFF
--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -36,6 +36,7 @@
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
 
+    <TestRunNamePrefix>packaging-</TestRunNamePrefix>
     <GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</GlobalJsonContent>
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($(GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</DotNetCliVersion>
   </PropertyGroup>


### PR DESCRIPTION
This was a regression introduced in: https://github.com/dotnet/runtime/pull/1841

Since now we don't use `TargetGroup=allConfigurations` for package testing, the Test Run Prefix is netcoreapp which is confusing.