### PR TITLE
JIT: remove assert from postorder return value optimizations

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -22617,18 +22617,8 @@ Compiler::fgWalkResult Compiler::fgLateDevirtualization(GenTree** pTree, fgWalkD
             JITDUMP(" ... found foldable jtrue at [%06u] in BB%02u\n", dspTreeID(tree), block->bbNum);
             noway_assert((block->bbNext->countOfInEdges() > 0) && (block->bbJumpDest->countOfInEdges() > 0));
 
-            // It would be nice to assert that "tree" is side-effect
-            // free, before we bash it.
-            //
-            // But we expect to see the GTF_CALL flag set, because
-            // this tree is an ancestor of an inline return
-            // value placeholder, and those always have GTF_CALL set,
-            // since if inlining fails we'd swap the call back in
-            // place.
-            //
-            // So, check that at least everything else is clear.
-            assert((tree->gtFlags & (GTF_SIDE_EFFECT & ~GTF_CALL)) == 0);
-
+            // Had hoped to assert here that we are not losing any
+            // side effects, but can't find a way to express it properly.
             tree->gtBashToNOP();
 
             BasicBlock* bTaken    = nullptr;

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -44,12 +44,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/muldimjagary/muldimjagary/*">
             <Issue>3392</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_conv/*">
-            <Issue>31665</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_conv/*">
-            <Issue>31665</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408/*">
             <Issue>11408</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_conv.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_conv.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
We were trying to assert that we weren't losing side effects when folding
return value trees. But this seems to be more trouble than it is worth as
the set of side effects can also change.

Also re-enable the disabled tests, and make one of them Pri0.

Fixes #31665.