### PR TITLE
Avoid mutating string instances from libraries code

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3977,11 +3977,14 @@ namespace System
             }
 
             // Then look up the syntax in a string-based table.
-            string str = new string('\0', span.Length);
-            fixed (char* ptr = str)
+            string str;
+            fixed (char* pSpan = span)
             {
-                int charsWritten = span.ToLowerInvariant(new Span<char>(ptr, str.Length));
-                Debug.Assert(charsWritten == str.Length);
+                str = string.Create(span.Length, (ip: (IntPtr)pSpan, length: span.Length), (buffer, state) =>
+                {
+                    int charsWritten = new ReadOnlySpan<char>((char*)state.ip, state.length).ToLowerInvariant(buffer);
+                    Debug.Assert(charsWritten == buffer.Length);
+                });
             }
             syntax = UriParser.FindOrFetchAsUnknownV1Syntax(str);
             return ParsingError.None;


### PR DESCRIPTION
Found two places in the libraries code base that were mutating `string` instances: one in `System.Net.HttpListener`, and one in `System.Private.Uri`. This PR changes the call sites so that they go through the public `string.Create` factory method and do not mutate the `string` instance once it has been instantiated.