### PR TITLE
Add missing nullability annotation to string ctor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -47,7 +47,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [PreserveDependency("Ctor(System.Char[])", "System.String")]
-        public extern String(char[] value);
+        public extern String(char[]? value);
 
 #if !CORECLR
         static

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2304,7 +2304,7 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public unsafe String(char* value, int startIndex, int length) { }
         public String(char c, int count) { }
-        public String(char[] value) { }
+        public String(char[]? value) { }
         public String(char[] value, int startIndex, int length) { }
         public String(System.ReadOnlySpan<char> value) { }
         [System.CLSCompliantAttribute(false)]


### PR DESCRIPTION
The constructor `string(char[] value)` allows null as an input. We forgot to put the `?` annotation on the parameter. There's already a unit test validating that we allow null inputs, as shown below.

https://github.com/dotnet/runtime/blob/b9f6f5f8c76a25e978d80c72e589fd7cd481d6b2/src/libraries/Common/tests/Tests/System/StringTests.cs#L150-L157