### PR TITLE
Remove unused locals in System.ServiceProcess.ServiceController

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -474,7 +474,7 @@ namespace System.ServiceProcess
             try
             {
                 PowerBroadcastStatus status = (PowerBroadcastStatus)eventType;
-                bool statusResult = OnPowerEvent(status);
+                _ = OnPowerEvent(status);
 
                 WriteLogEntry(SR.PowerEventOK);
             }

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -473,8 +473,7 @@ namespace System.ServiceProcess
             // already been freed.
             try
             {
-                PowerBroadcastStatus status = (PowerBroadcastStatus)eventType;
-                _ = OnPowerEvent(status);
+                _ = OnPowerEvent((PowerBroadcastStatus)eventType);
 
                 WriteLogEntry(SR.PowerEventOK);
             }

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -473,7 +473,7 @@ namespace System.ServiceProcess
             // already been freed.
             try
             {
-                _ = OnPowerEvent((PowerBroadcastStatus)eventType);
+                OnPowerEvent((PowerBroadcastStatus)eventType);
 
                 WriteLogEntry(SR.PowerEventOK);
             }


### PR DESCRIPTION
Contributes to #30457

> When implemented in a derived class, the needs of your application determine what value to return. For example, if a `QuerySuspend` broadcast status is passed, you could cause your application to reject the query by returning `false`.