### PR TITLE
Remove remaining libraries references to string.Copy

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLString.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLString.cs
@@ -174,7 +174,7 @@ namespace System.Data.SqlTypes
             else
             {
                 m_fNotNull = true;
-                m_value = data; // PERF: do not String.Copy
+                m_value = data;
             }
         }
 

--- a/src/libraries/System.Management/src/System/Management/WMIGenerator.cs
+++ b/src/libraries/System.Management/src/System/Management/WMIGenerator.cs
@@ -4727,7 +4727,7 @@ namespace System.Management
             bool bAdd = true;
             if (str.Length == 0)
             {
-                return string.Copy("");
+                return string.Empty;
             }
 
             char[] arrString = str.ToCharArray();


### PR DESCRIPTION
Since `string.Copy` is obsolete, removing remaining code references to this method.