### PR TITLE
Remove AppDomain usage from stack walk and related places

### DIFF
--- a/src/coreclr/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -538,13 +538,6 @@ void DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread                  
             fpCallback(&frameData, pUserData);
         }
 
-        // update the current appdomain if necessary
-        AppDomain * pRetDomain = pFrame->GetReturnDomain();
-        if (pRetDomain != NULL)
-        {
-            pAppDomain = pRetDomain;
-        }
-
         // move on to the next internal frame
         pFrame = pFrame->Next();
     }
@@ -695,8 +688,7 @@ void DacDbiInterfaceImpl::InitFrameData(StackFrameIterator *   pIter,
     // Since we don't have chains anymore, this can always be false.
     pFrameData->quicklyUnwound = false;
 
-    AppDomain * pAppDomain = pCF->GetAppDomain();
-    pFrameData->vmCurrentAppDomainToken.SetHostPtr(pAppDomain);
+    pFrameData->vmCurrentAppDomainToken.SetHostPtr(AppDomain::GetCurrentDomain());
 
     if (ft == kNativeRuntimeUnwindableStackFrame)
     {

--- a/src/coreclr/src/debug/daccess/stack.cpp
+++ b/src/coreclr/src/debug/daccess/stack.cpp
@@ -343,7 +343,7 @@ ClrDataStackWalk::GetFrame(
         RawGetFrameType(&simpleType, &detailedType);
         dataFrame =
             new (nothrow) ClrDataFrame(m_dac, simpleType, detailedType,
-                                       m_frameIter.m_crawl.GetAppDomain(),
+                                       AppDomain::GetCurrentDomain(),
                                        m_frameIter.m_crawl.GetFunction());
         if (!dataFrame)
         {

--- a/src/coreclr/src/debug/ee/frameinfo.cpp
+++ b/src/coreclr/src/debug/ee/frameinfo.cpp
@@ -769,7 +769,7 @@ void FrameInfo::InitFromStubHelper(
     // Method associated w/a stub will never have a JitManager.
     this->pIJM        = NULL;
     this->MethodToken = METHODTOKEN(NULL, 0);
-    this->currentAppDomain      = pCF->GetAppDomain();
+    this->currentAppDomain      = AppDomain::GetCurrentDomain();
     this->exactGenericArgsToken = NULL;
 
     // Stub frames are mutually exclusive with chain markers.
@@ -1545,7 +1545,7 @@ StackWalkAction DebuggerWalkStackProc(CrawlFrame *pCF, void *data)
 
     // Record the appdomain that the thread was in when it
     // was running code for this frame.
-    d->info.currentAppDomain = pCF->GetAppDomain();
+    d->info.currentAppDomain = AppDomain::GetCurrentDomain();
 
     //  Grab all the info from CrawlFrame that we need to
     //  check for "Am I in an exeption code blob?" now.

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -2881,10 +2881,10 @@ public:
     //****************************************************************************************
     // Methods used to get the callers module and hence assembly and app domain.
 
-    static MethodDesc* GetCallersMethod(StackCrawlMark* stackMark, AppDomain **ppAppDomain = NULL);
-    static MethodTable* GetCallersType(StackCrawlMark* stackMark, AppDomain **ppAppDomain = NULL);
-    static Module* GetCallersModule(StackCrawlMark* stackMark, AppDomain **ppAppDomain = NULL);
-    static Assembly* GetCallersAssembly(StackCrawlMark* stackMark, AppDomain **ppAppDomain = NULL);
+    static MethodDesc* GetCallersMethod(StackCrawlMark* stackMark);
+    static MethodTable* GetCallersType(StackCrawlMark* stackMark);
+    static Module* GetCallersModule(StackCrawlMark* stackMark);
+    static Assembly* GetCallersAssembly(StackCrawlMark* stackMark);
 
     static bool IsReflectionInvocationMethod(MethodDesc* pMeth);
 

--- a/src/coreclr/src/vm/assembly.cpp
+++ b/src/coreclr/src/vm/assembly.cpp
@@ -421,8 +421,7 @@ Assembly *Assembly::CreateDynamic(AppDomain *pDomain, CreateDynamicAssemblyArgs 
 
     Assembly *pRetVal = NULL;
 
-    AppDomain  *pCallersDomain;
-    MethodDesc *pmdEmitter = SystemDomain::GetCallersMethod(args->stackMark, &pCallersDomain);
+    MethodDesc *pmdEmitter = SystemDomain::GetCallersMethod(args->stackMark);
 
     // Called either from interop or async delegate invocation. Rejecting because we don't
     // know how to set the correct permission on the new dynamic assembly.

--- a/src/coreclr/src/vm/crossgencompile.cpp
+++ b/src/coreclr/src/vm/crossgencompile.cpp
@@ -304,7 +304,7 @@ PCODE COMDelegate::GetWrapperInvoke(MethodDesc* pMD)
     return (PCODE)(0x12345);
 }
 
-Assembly * SystemDomain::GetCallersAssembly(StackCrawlMark * stackMark, AppDomain ** ppAppDomain)
+Assembly * SystemDomain::GetCallersAssembly(StackCrawlMark * stackMark)
 {
     return NULL;
 }

--- a/src/coreclr/src/vm/debugdebugger.cpp
+++ b/src/coreclr/src/vm/debugdebugger.cpp
@@ -976,11 +976,6 @@ StackWalkAction DebugStackTrace::GetStackFramesCallback(CrawlFrame* pCf, VOID* d
 
     GetStackFramesData* pData = (GetStackFramesData*)data;
 
-    if (pData->pDomain != pCf->GetAppDomain())
-    {
-        return SWA_CONTINUE;
-    }
-
     if (pData->skip > 0)
     {
         pData->skip--;

--- a/src/coreclr/src/vm/debughelp.cpp
+++ b/src/coreclr/src/vm/debughelp.cpp
@@ -792,7 +792,7 @@ void PrintException(OBJECTREF pObjectRef)
 /*******************************************************************/
 /* sends a current stack trace to the debug window */
 
-const char* FormatSig(MethodDesc* pMD, AppDomain *pDomain, AllocMemTracker *pamTracker);
+const char* FormatSig(MethodDesc* pMD, AllocMemTracker *pamTracker);
 
 struct PrintCallbackData {
     BOOL toStdout;
@@ -845,7 +845,7 @@ StackWalkAction PrintStackTraceCallback(CrawlFrame* pCF, VOID* pData)
                       _TRUNCATE,
                       W("%S %S  "),
                       pMD->GetName(),
-                      FormatSig(pMD, pCF->GetAppDomain(), &dummyAmTracker));
+                      FormatSig(pMD, &dummyAmTracker));
 
         dummyAmTracker.SuppressRelease();
         if (buffLen < 0 )

--- a/src/coreclr/src/vm/frames.h
+++ b/src/coreclr/src/vm/frames.h
@@ -488,12 +488,6 @@ public:
         return (ptr != NULL) ? *PTR_PCODE(ptr) : NULL;
     }
 
-    AppDomain *GetReturnDomain()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return NULL;
-    }
-
 #ifndef DACCESS_COMPILE
     virtual Object **GetReturnExecutionContextAddr()
     {

--- a/src/coreclr/src/vm/sigformat.cpp
+++ b/src/coreclr/src/vm/sigformat.cpp
@@ -637,7 +637,7 @@ const char* FormatSig(MethodDesc * pMD, LoaderHeap * pHeap, AllocMemTracker * pa
 }
 
 /*******************************************************************/
-const char* FormatSig(MethodDesc* pMD, AppDomain *pDomain, AllocMemTracker *pamTracker)
+const char* FormatSig(MethodDesc* pMD, AllocMemTracker *pamTracker)
 {
     CONTRACTL
     {
@@ -646,7 +646,7 @@ const char* FormatSig(MethodDesc* pMD, AppDomain *pDomain, AllocMemTracker *pamT
     }
     CONTRACTL_END;
 
-    return FormatSig(pMD,pDomain->GetLowFrequencyHeap(),pamTracker);
+    return FormatSig(pMD,GetAppDomain()->GetLowFrequencyHeap(),pamTracker);
 }
 #endif
 #endif

--- a/src/coreclr/src/vm/stackwalk.cpp
+++ b/src/coreclr/src/vm/stackwalk.cpp
@@ -376,9 +376,6 @@ inline void CrawlFrame::GotoNextFrame()
     // Update app domain if this frame caused a transition
     //
 
-    AppDomain *pRetDomain = pFrame->GetReturnDomain();
-    if (pRetDomain != NULL)
-        pAppDomain = pRetDomain;
     pFrame = pFrame->Next();
 
     if (pFrame != FRAME_TOP)
@@ -1248,7 +1245,6 @@ BOOL StackFrameIterator::Init(Thread *    pThread,
     }
 
     m_crawl.pRD = pRegDisp;
-    m_crawl.pAppDomain = pThread->GetDomain(INDEBUG(flags & PROFILER_DO_STACK_SNAPSHOT));
 
     m_codeManFlags = (ICodeManagerFlags)((flags & QUICKUNWIND) ? 0 : UpdateAllRegs);
     m_scanFlag = ExecutionManager::GetScanFlags();
@@ -1341,9 +1337,6 @@ BOOL StackFrameIterator::ResetRegDisp(PREGDISPLAY pRegDisp,
     }
 
     m_crawl.pRD = pRegDisp;
-
-    // we initialize the appdomain to be the current domain, but this nees to be updated below
-    m_crawl.pAppDomain = m_crawl.pThread->GetDomain(INDEBUG(m_flags & PROFILER_DO_STACK_SNAPSHOT));
 
     m_codeManFlags = (ICodeManagerFlags)((m_flags & QUICKUNWIND) ? 0 : UpdateAllRegs);
 
@@ -2633,16 +2626,6 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             m_crawl.hasFaulted = (uFrameAttribs & Frame::FRAME_ATTR_FAULTED) != 0;
             m_crawl.isIPadjusted = (uFrameAttribs & Frame::FRAME_ATTR_OUT_OF_LINE) != 0;
             _ASSERTE(!m_crawl.hasFaulted || !m_crawl.isIPadjusted); // both cant be set together
-        }
-
-        //
-        // Update app domain if this frame caused a transition.
-        //
-
-        AppDomain *retDomain = m_crawl.pFrame->GetReturnDomain();
-        if (retDomain != NULL)
-        {
-            m_crawl.pAppDomain = retDomain;
         }
 
         PCODE adr = m_crawl.pFrame->GetReturnAddress();

--- a/src/coreclr/src/vm/stackwalk.h
+++ b/src/coreclr/src/vm/stackwalk.h
@@ -312,13 +312,6 @@ public:
         return flags;
     }
 
-    AppDomain *GetAppDomain()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-
-        return pAppDomain;
-    }
-
     /* Is this frame at a safe spot for GC?
      */
     bool IsGcSafe();
@@ -410,6 +403,12 @@ public:
 
     void CheckGSCookies();
 
+    inline Thread* GetThread()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return pThread;
+    }
+
 #if defined(FEATURE_EH_FUNCLETS)
     bool IsFunclet()
     {
@@ -488,7 +487,6 @@ private:
     MethodDesc       *pFunc;
 
     // the rest is only used for "frameless methods"
-    AppDomain        *pAppDomain;
     PREGDISPLAY       pRD; // "thread context"/"virtual register set"
 
     EECodeInfo        codeInfo;

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -8459,6 +8459,11 @@ Thread::EnumMemoryRegionsWorker(CLRDataEnumMemoryFlags flags)
         DacGetThreadContext(this, &context);
     }
 
+    if (flags != CLRDATA_ENUM_MEM_MINI && flags != CLRDATA_ENUM_MEM_TRIAGE)
+    {
+        AppDomain::GetCurrentDomain()->EnumMemoryRegions(flags, true);
+    }
+
     FillRegDisplay(&regDisp, &context);
     frameIter.Init(this, NULL, &regDisp, 0);
     while (frameIter.IsValid())
@@ -8516,14 +8521,6 @@ Thread::EnumMemoryRegionsWorker(CLRDataEnumMemoryFlags flags)
         // Enumerate the code around the call site to help debugger stack walking heuristics
         PCODE callEnd = GetControlPC(&regDisp);
         DacEnumCodeForStackwalk(callEnd);
-
-        if (flags != CLRDATA_ENUM_MEM_MINI && flags != CLRDATA_ENUM_MEM_TRIAGE)
-        {
-            if (frameIter.m_crawl.GetAppDomain())
-            {
-                frameIter.m_crawl.GetAppDomain()->EnumMemoryRegions(flags, true);
-            }
-        }
 
         // To stackwalk through funceval frames, we need to be sure to preserve the
         // DebuggerModule's m_pRuntimeDomainFile.  This is the only case that doesn't use the current


### PR DESCRIPTION
This is yet another cleanup removal of the AppDomain. When working on x86 EH issues last week, I've found that the stack walker still refers to AppDomain at several places.