### PR TITLE
Mark class ctors as preserved for dependencies of System.SR

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -46,6 +46,7 @@ namespace System
         private static int _infinitelyRecursingCount;
         private static bool _resourceManagerInited = false;
 
+        [PreserveDependency(".cctor()", "System.Resources.ResourceManager")]
         private static string? InternalGetResourceString(string? key)
         {
             if (string.IsNullOrEmpty(key))


### PR DESCRIPTION
The System.SR.InternalGetResourceString calls RuntimeHelpers.RunClassConstructor on several classes. This is a dependency the ILLinker won't be able to figure out, so explicit PreserveDependency is needed.