### PR TITLE
[interp] Make call_vararg non-recursive.

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -200,6 +200,7 @@ typedef struct {
 	const unsigned short  *ip;
 	GSList *finally_ips;
 	FrameClauseArgs *clause_args;
+	gboolean is_void : 1;
 } InterpState;
 
 struct _InterpFrame {


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18697,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>[interp] Remove recursion from call_vararg.

This contributes to https://github.com/mono/mono/issues/18646 but is not enough to fix it. The interpreter still recurses a lot.