### PR TITLE
Tweaking the joined_condemned_reason implementation

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -15560,7 +15560,7 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
         else
         {
             dprintf (GTC_LOG, ("reducing gen in PM: %d->%d->%d", initial_gen, n, (max_generation - 1)));
-            gc_data_global.gen_to_condemn_reasons.set_condition(gen_joined_last_gen2_fragmented);
+            gc_data_global.gen_to_condemn_reasons.set_condition(gen_joined_gen1_in_pm);
             n = max_generation - 1;
         }
     }
@@ -15601,8 +15601,11 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
                 // If there's not much fragmentation but it looks like it'll be productive to
                 // collect LOH, do that.
                 size_t est_loh_reclaim = get_total_gen_estimated_reclaim (loh_generation);
-                gc_data_global.gen_to_condemn_reasons.set_condition(gen_joined_limit_loh_reclaim);
-                full_compact_gc_p = ((est_loh_reclaim * 8) >= heap_hard_limit);
+                if ((est_loh_reclaim * 8) >= heap_hard_limit)
+                {
+                    gc_data_global.gen_to_condemn_reasons.set_condition(gen_joined_limit_loh_reclaim);
+                    full_compact_gc_p = true;
+                }
                 dprintf (GTC_LOG, ("loh est reclaim: %Id, 1/8 of limit %Id", est_loh_reclaim, (heap_hard_limit / 8)));
             }
         }

--- a/src/coreclr/src/gc/gcrecord.h
+++ b/src/coreclr/src/gc/gcrecord.h
@@ -61,19 +61,19 @@ enum gc_condemn_reason_condition
     gen_induced_noforce_p = 14,
     gen_before_bgc = 15,
     gen_almost_max_alloc = 16,
-    gen_joined_avoid_unproductive = 17,    /* This happens when the GC detects previous attempts to do a full compacting GC is not making progress and therefore reduce its generation */
-    gen_joined_pm_induced_fullgc_p = 18,   /* This happens when a full gc is induced under provisional mode */
-    gen_joined_pm_alloc_loh = 19,          /* This happens when a large object heap allocation is requested under provisional mode */
-    gen_joined_last_gen2_fragmented = 20,  /* This happens when we had a high memory and high fragmentation detected after the last full blocking GC, indicating we have lot of pinned objects in gen 2, so reducing its generation */
-    gen_joined_limit_before_oom = 21,      /* This happens when the last gc was oom */
-    gen_joined_limit_loh_frag = 22,        /* This happens when we had a heap limit and the fragmentation is reaching 1/8 of it */
-    gen_joined_limit_loh_reclaim = 23,     /* This happens when we had a heap limit and we could reclaim 1/8 of it */
-    gen_joined_servo_initial = 24,         /* This happen when the servo tuning is trying to get some initial data */
-    gen_joined_servo_ngc = 25,             /* This happen when the servo tuning decides a background gc is appropriate */
-    gen_joined_servo_bgc = 26,             /* This happen when the servo tuning decides a background gc is appropriate */
-    gen_joined_servo_postpone = 27,        /* This happen when the servo tuning decides a gen2 gc should be postponed */
-    gen_joined_stress_mix = 28,            /* This happen in GCStress mix mode, every 10th GC is gen2  */
-    gen_joined_stress = 29,                /* This happen in GCStress, every GC is gen2  */
+    gen_joined_avoid_unproductive = 17,
+    gen_joined_pm_induced_fullgc_p = 18,
+    gen_joined_pm_alloc_loh = 19,
+    gen_joined_gen1_in_pm = 20,
+    gen_joined_limit_before_oom = 21,
+    gen_joined_limit_loh_frag = 22,
+    gen_joined_limit_loh_reclaim = 23,
+    gen_joined_servo_initial = 24,
+    gen_joined_servo_ngc = 25,
+    gen_joined_servo_bgc = 26,
+    gen_joined_servo_postpone = 27,
+    gen_joined_stress_mix = 28,
+    gen_joined_stress = 29,
     gcrc_max = 30
 };
 


### PR DESCRIPTION
Renaming `gen_joined_last_gen2_fragmented` to `gen_joined_gen1_in_pm` to more accurately describe what is actually happening at that point.

Set the `gen_joined_limit_loh_reclaim` reason only when we change our compacting decision.

Eliminating the comments describing the reasons, an improved version of them will be available as tooltip texts on PerfView.