### PR TITLE
Disable ThrowStatementDoesNotResetExceptionStackLineOtherMethod in arm64

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ExceptionTests.cs
@@ -108,7 +108,7 @@ namespace System.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(https://github.com/dotnet/runtime/issues/1871)] can't use ActiveIssue for archs
         public static void ThrowStatementDoesNotResetExceptionStackLineOtherMethod()
         {
             (string, string, int) rethrownExceptionStackFrame = (null, null, 0);


### PR DESCRIPTION
Disable test failing on Rolling CI builds to get them clean: https://github.com/dotnet/runtime/issues/1871

I queued a manual build to prove this change: https://dev.azure.com/dnceng/public/_build/results?buildId=507212