### PR TITLE
Avoid keeping runtext alive in Regex cache

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
@@ -24,7 +24,7 @@ namespace System.Text.RegularExpressions
         public int Length { get; private protected set; }
 
         /// <summary>The original string</summary>
-        internal string Text { get; private protected set; }
+        internal string Text { get; set; }
 
         /// <summary>
         /// Returns the value of this Regex Capture.


### PR DESCRIPTION
Null out any references to the string in case the Regex object is kept alive in a cache and the string object is very large.

Fixes https://github.com/dotnet/runtime/issues/27453
cc: @danmosemsft, @eerhardt, @ViktorHofer 