### PR TITLE
Make more Regex loops atomic automatically

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
@@ -78,7 +78,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Fact]
         public static void Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException()
         {
-            RegularExpressionAttribute attribute = new RegularExpressionAttribute("(a+)+$") { MatchTimeoutInMilliseconds = 1 };
+            RegularExpressionAttribute attribute = new RegularExpressionAttribute("(a[ab]+)+$") { MatchTimeoutInMilliseconds = 1 };
             Assert.Throws<RegexMatchTimeoutException>(() => attribute.Validate("aaaaaaaaaaaaaaaaaaaaaaaaaaaa>", new ValidationContext(new object())));
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -341,7 +341,7 @@ namespace System.Text.RegularExpressions
 #if DEBUG
         /// <summary>Used when dumping for debugging.</summary>
         [ExcludeFromCodeCoverage]
-        public override string ToString() => Pattern;
+        public override string ToString() => Dump(string.Empty);
 
         [ExcludeFromCodeCoverage]
         public string Dump(string indent)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -15,7 +15,6 @@
 // Strings and sets are indices into a string table.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -395,7 +394,10 @@ namespace System.Text.RegularExpressions
         }
 
         [ExcludeFromCodeCoverage]
-        public void Dump()
+        public void Dump() => Debug.WriteLine(ToString());
+
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
         {
             var sb = new StringBuilder();
 
@@ -426,7 +428,7 @@ namespace System.Text.RegularExpressions
             }
             sb.AppendLine();
 
-            Debug.WriteLine(sb.ToString());
+            return sb.ToString();
         }
 #endif
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -38,6 +38,9 @@ namespace System.Text.RegularExpressions
         public void Dump() => Root.Dump();
 
         [ExcludeFromCodeCoverage]
+        public override string ToString() => Root.ToString();
+
+        [ExcludeFromCodeCoverage]
         public bool Debug => (Options & RegexOptions.Debug) != 0;
 #endif
     }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -730,6 +730,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(?:a{2}?){3}?", "aaaaaaaaa", RegexOptions.None, new string[] { "aaaaaa" } };
             yield return new object[] { null, @"(?:(?:[ab]c[de]f){3}){2}", "acdfbcdfacefbcefbcefbcdfacdef", RegexOptions.None, new string[] { "acdfbcdfacefbcefbcefbcdf" } };
             yield return new object[] { null, @"(?:(?:[ab]c[de]f){3}hello){2}", "aaaaaacdfbcdfacefhellobcefbcefbcdfhellooooo", RegexOptions.None, new string[] { "acdfbcdfacefhellobcefbcefbcdfhello" } };
+            // Nested atomic
+            yield return new object[] { null, @"(?>abc[def]gh(i*))", "123abceghiii456", RegexOptions.None, new string[] { "abceghiii", "iii" } };
 
             // Anchoring loops beginning with .* / .+
             yield return new object[] { null, @".*", "", RegexOptions.None, new string[] { "" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -997,6 +997,17 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => r.IsMatch("input", 6));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // take too long due to backtracking
+        [Theory]
+        [InlineData(@"(\w*)+\.", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)]
+        [InlineData(@"(a+)+b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false)]
+        [InlineData(@"(x+x+)+y", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", false)]
+        public void IsMatch_SucceedQuicklyDueToAutoAtomicity(string regex, string input, bool expected)
+        {
+            Assert.Equal(expected, Regex.IsMatch(input, regex, RegexOptions.None));
+            Assert.Equal(expected, Regex.IsMatch(input, regex, RegexOptions.Compiled));
+        }
+
         [Fact]
         public void Synchronized()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
@@ -272,6 +272,16 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("[0-9][0-9]{1,3}?", "[0-9]{2,4}?")]
         // Set and set
         [InlineData("[ace][ace]", "[ace]{2}")]
+        // Set and one
+        [InlineData("[a]", "a")]
+        [InlineData("[a]*", "a*")]
+        [InlineData("(?>[a]*)", "(?>a*)")]
+        [InlineData("[a]*?", "a*?")]
+        // Set and notone
+        [InlineData("[^\n]", ".")]
+        [InlineData("[^\n]*", ".*")]
+        [InlineData("(?>[^\n]*)", "(?>.*)")]
+        [InlineData("[^\n]*?", ".*?")]
         // Large loop patterns
         [InlineData("a*a*a*a*a*a*a*b*b*?a+a*", "a*b*b*?a+")]
         [InlineData("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "a{0,30}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
@@ -282,6 +292,8 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?:a*)+", "a*")]
         [InlineData("(?:a+){4}", "a{4,}")]
         [InlineData("(?:a{1,2}){4}", "a{4,8}")]
+        // Nested atomic
+        [InlineData("(?>(?>(?>(?>abc*))))", "(?>ab(?>c*))")]
         // Alternation reduction
         [InlineData("a|b", "[ab]")]
         [InlineData("a|b|c|d|e|g|h|z", "[a-eghz]")]
@@ -427,6 +439,11 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"a*a*a*a*a*a*a*b*", 0)]
         [InlineData(@"((a{1,2}){4}){3,7}", 12)]
         [InlineData(@"\b\w{4}\b", 4)]
+        // we stop computing after a certain depth; if that logic changes in the future, these tests can be updated
+        [InlineData(@"((((((((((((((((((((((((((((((ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ)", 0)]
+        [InlineData(@"(YZ+|(WX+|(UV+|(ST+|(QR+|(OP+|(MN+|(KL+|(IJ+|(GH+|(EF+|(CD+|(AB+|(89+|(67+|(45+|(23+|(01+|(yz+|(wx+|(uv+|(st+|(qr+|(op+|(mn+|(kl+|(ij+|(gh+|(ef+|(de+|(a|bc+)))))))))))))))))))))))))))))))", 0)]
+        [InlineData(@"a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ+)", 3)]
+        [InlineData(@"(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((a)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", 0)]
         public void MinRequiredLengthIsCorrect(string pattern, int expectedLength)
         {
             var r = new Regex(pattern);


### PR DESCRIPTION
For example, given an expression like "(abcd*)*e", the inner d* loop will now be converted to be atomic, e.g. "(abc(?>d*))*e)".  We're careful not to convert an expression like "(abca*)*e)", where the inner loop has no overlap with what comes immediately after the loop but does with the start of the loop.

I also fixed what appears to be a long-standing bug in how character classes are canonicalized.  An attempt was made to avoid running the canonlicalization routine, but we almost always need to do it, and we were not doing it in some cases, resulting in character classes that were correct but not as optimized as they should have been, e.g. two abutting ranges when one would suffice, leading to poorer code gen.  It's part of this PR because I caught when changing the reduction tests to validate the full code tree including strings rather than just the codes list.

Fixes https://github.com/dotnet/runtime/issues/27402
cc: @danmosemsft, @eerhardt, @ViktorHofer 