### PR TITLE
Fix unused variable warning

### DIFF
--- a/src/coreclr/src/utilcode/regutil.cpp
+++ b/src/coreclr/src/utilcode/regutil.cpp
@@ -201,8 +201,6 @@ HRESULT REGUTIL::GetConfigInteger(LPCWSTR name, ULONGLONG defValue, __out ULONGL
     ULONGLONG rtn;
     ULONGLONG ret = 0;
     DWORD type = 0;
-    HKEY userKey;
-    HKEY machineKey;
     DWORD size = 4;
 
     FAULT_NOT_FATAL(); // We don't report OOM errors here, we return a default value.
@@ -250,7 +248,7 @@ HRESULT REGUTIL::GetConfigInteger(LPCWSTR name, ULONGLONG defValue, __out ULONGL
         {
             LONG retVal = ERROR_SUCCESS;
             BOOL bCloseHandle = FALSE;
-            userKey = s_hUserFrameworkKey;
+            HKEY userKey = s_hUserFrameworkKey;
 
             if (userKey == INVALID_HANDLE_VALUE)
             {
@@ -281,7 +279,7 @@ HRESULT REGUTIL::GetConfigInteger(LPCWSTR name, ULONGLONG defValue, __out ULONGL
         {
             LONG retVal = ERROR_SUCCESS;
             BOOL bCloseHandle = FALSE;
-            machineKey = s_hMachineFrameworkKey;
+            HKEY machineKey = s_hMachineFrameworkKey;
 
             if (machineKey == INVALID_HANDLE_VALUE)
             {


### PR DESCRIPTION
When cross compiling this file on Window the unused variable cause a warning which is treated as an error.  Fix the warning to allow cross compilation.