### PR TITLE
Remove GetRecycleMemoryInfo from DAC builds

### DIFF
--- a/src/coreclr/src/vm/win32threadpool.h
+++ b/src/coreclr/src/vm/win32threadpool.h
@@ -733,6 +733,7 @@ public:
             return pRecycledListPerProcessor != NULL;
         }
 
+#ifndef DACCESS_COMPILE
     	FORCEINLINE RecycledListInfo& GetRecycleMemoryInfo( enum MemType memType )
         {
             LIMITED_METHOD_CONTRACT;
@@ -756,6 +757,7 @@ public:
 #endif // !TARGET_UNIX
             return pRecycledListPerProcessor[processorNumber][memType];
     	}
+#endif // DACCESS_COMPILE
     };
 
 #define GATE_THREAD_STATUS_NOT_RUNNING         0 // There is no gate thread


### PR DESCRIPTION
I am hoping we can safely remove `ThreadPoolMgr::GetRecycleMemoryInfo` from all DAC builds because it doesn't cross OS compile...

/cc @dotnet/dotnet-diag 