### PR TITLE
Reduce PAL DAC exports

### DIFF
--- a/src/coreclr/src/dlls/mscordac/mscordac.src
+++ b/src/coreclr/src/dlls/mscordac/mscordac.src
@@ -3,11 +3,11 @@
 ; See the LICENSE file in the project root for more information.
 
 EXPORTS
-    OutOfProcessFunctionTableCallback
-    OutOfProcessFunctionTableCallbackEx
     DacDbiInterfaceInstance
 
 #ifndef TARGET_UNIX
+    OutOfProcessFunctionTableCallback
+    OutOfProcessFunctionTableCallbackEx
     OutOfProcessExceptionEventCallback
     OutOfProcessExceptionEventSignatureCallback
 #endif // TARGET_UNIX


### PR DESCRIPTION
`OutOfProcessFunctionTableCallback*` is currently only functionally defined for `WINDOWS` `X86`.  The comments on it seem to indicate it is a legacy debugger interface.  It is not clear it is even needed.

In this case it is not needed for a cross OS DAC build.  Moving it out of the exports for TARGET_UNIX solves the cross OS linker error.

One other option would be to remove this code all together....

/cc @dotnet/dotnet-diag 