### PR TITLE
Reduce the number of platforms that run JIT stress pipelines

### DIFF
--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -20,7 +20,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     jobParameters:
       testGroup: jitstress
 
@@ -28,7 +36,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -21,6 +21,8 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -39,6 +39,8 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -20,7 +20,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     jobParameters:
       testGroup: jitstress2-jitstressregs
 
@@ -28,7 +36,15 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -21,6 +21,8 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -39,6 +39,8 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -20,24 +20,31 @@ jobs:
   parameters:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     jobParameters:
       testGroup: jitstressregs
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
-    platformGroup: all
-    jobParameters:
-      testGroup: jitstressregs
-      liveLibrariesBuildConfig: Release
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/run-test-job.yml
-    buildConfig: checked
-    platformGroup: all
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    # Currently no Windows arm32, Windows arm64 hardware in Helix. https://github.com/dotnet/runtime/issues/1097
+    #- Windows_NT_arm
+    #- Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -21,6 +21,8 @@ jobs:
     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -39,6 +39,8 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/test-job.yml
     buildConfig: checked
     platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
     - Linux_arm
     - Linux_arm64
     - Linux_x64


### PR DESCRIPTION
The current set of platforms is overkill for JIT stress purposes.
This should reduce resource consumption and improve reliability.

Fixes #2100