### PR TITLE
Fix check.* cross compilation linker errors

### DIFF
--- a/src/coreclr/src/inc/check.inl
+++ b/src/coreclr/src/inc/check.inl
@@ -180,7 +180,7 @@ inline CHECK CheckAligned(UINT value, UINT alignment)
     CHECK_OK;
 }
 
-#ifndef TARGET_UNIX
+#ifndef HOST_UNIX
 // For Unix this and the previous function get the same types.
 // So, exclude this one.
 inline CHECK CheckAligned(ULONG value, UINT alignment)
@@ -189,7 +189,7 @@ inline CHECK CheckAligned(ULONG value, UINT alignment)
     CHECK(AlignmentTrim(value, alignment) == 0);
     CHECK_OK;
 }
-#endif // TARGET_UNIX
+#endif // HOST_UNIX
 
 inline CHECK CheckAligned(UINT64 value, UINT alignment)
 {
@@ -270,7 +270,7 @@ inline CHECK CheckUnderflow(UINT value1, UINT value2)
     CHECK_OK;
 }
 
-#ifndef TARGET_UNIX
+#ifndef HOST_UNIX
 // For Unix this and the previous function get the same types.
 // So, exclude this one.
 inline CHECK CheckUnderflow(ULONG value1, ULONG value2)
@@ -279,7 +279,7 @@ inline CHECK CheckUnderflow(ULONG value1, ULONG value2)
 
     CHECK_OK;
 }
-#endif // TARGET_UNIX
+#endif // HOST_UNIX
 
 inline CHECK CheckUnderflow(UINT64 value1, UINT64 value2)
 {


### PR DESCRIPTION
The Windows and Unix linker seem to have different method matching rules.  Fix the check.inl #if to fix Windows linker errors when cross OS compiling the DAC.