### PR TITLE
[jit] Avoid calling mono_aot_direct_icalls_enabled_for_method () in non-aot mode, it might be a stub if aot is disabled.

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -2175,7 +2175,7 @@ direct_icalls_enabled (MonoCompile *cfg, MonoMethod *method)
 	if (cfg->gen_sdb_seq_points || cfg->disable_direct_icalls)
 		return FALSE;
 
-	if (method && mono_aot_direct_icalls_enabled_for_method (cfg, method))
+	if (method && cfg->compile_aot && mono_aot_direct_icalls_enabled_for_method (cfg, method))
 		return TRUE;
 
 	/* LLVM on amd64 can't handle calls to non-32 bit addresses */


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18707,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>