### PR TITLE
Add config knob to the jit to control total_physical_memory

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -36219,7 +36219,11 @@ HRESULT GCHeap::Initialize()
 #endif //TRACE_GC
 
     bool is_restricted;
-    gc_heap::total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted);
+    gc_heap::total_physical_mem = (size_t)GCConfig::GetGCTotalPhysicalMemory();
+    if (!(gc_heap::total_physical_mem))
+    {
+        gc_heap::total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted);
+    }
 
 #ifdef HOST_64BIT
     gc_heap::heap_hard_limit = (size_t)GCConfig::GetGCHeapHardLimit();

--- a/src/coreclr/src/gc/gcconfig.h
+++ b/src/coreclr/src/gc/gcconfig.h
@@ -121,6 +121,8 @@ public:
         "Specifies a hard limit for the GC heap")                                                \
     INT_CONFIG(GCHeapHardLimitPercent, "GCHeapHardLimitPercent", 0,                              \
         "Specifies the GC heap usage as a percentage of the total memory")                       \
+    INT_CONFIG(GCTotalPhysicalMemory, "GCTotalPhysicalMemory", 0,                                \
+        "Specifies what the GC should consider to be total physical memory")                     \
     STRING_CONFIG(LogFile,    "GCLogFile",    "Specifies the name of the GC log file")           \
     STRING_CONFIG(ConfigLogFile, "GCConfigLogFile",                                              \
         "Specifies the name of the GC config log file")                                          \


### PR DESCRIPTION
- The GC relies on the VM to compute this number normally, but the runtime uses heuristics which may be wrong (especially inside of a Windows Job object)
- This knob provides a way for the customer to override the heuristics