### PR TITLE
Add clang to the list of requirements needed for building on Ubuntu

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -69,6 +69,7 @@ Install the following packages for the toolchain:
 - cmake
 - llvm-9
 - clang-9
+- clang
 - autoconf
 - automake
 - libtool
@@ -89,6 +90,6 @@ Install the following packages for the toolchain:
 
 A single line to install all packages above:
 
-    ~$ sudo apt-get install cmake llvm-9 clang-9 autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev
+    ~$ sudo apt-get install cmake llvm-9 clang-9 clang autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev
 
 You now have all the required components.


### PR DESCRIPTION
I found this was necessary for building mono