### PR TITLE
Account for UpperVector saves in minRegs

### DIFF
--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -1627,6 +1627,12 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
                 {
                     minRegCount++;
                 }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                else if (newRefPosition->refType == RefTypeUpperVectorSave)
+                {
+                    minRegCount++;
+                }
+#endif
                 if (newRefPosition->getInterval()->isSpecialPutArg)
                 {
                     minRegCount++;


### PR DESCRIPTION
When we use a jitStressRegs mode that limits the number of registers, we need to account for the UpperVectorSave.

Fix #31727