### PR TITLE
Disable linux unwinder on Windows

### DIFF
--- a/src/coreclr/src/debug/daccess/dacfn.cpp
+++ b/src/coreclr/src/debug/daccess/dacfn.cpp
@@ -273,7 +273,9 @@ DacVirtualUnwind(ULONG32 threadId, PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_P
 #endif
     {
         SIZE_T baseAddress = DacGlobalBase();
+#ifdef HOST_UNIX
         if (baseAddress == 0 || !PAL_VirtualUnwindOutOfProc(context, contextPointers, baseAddress, DacReadAllAdapter))
+#endif
         {
             hr = E_FAIL;
         }

--- a/src/coreclr/src/inc/clrnt.h
+++ b/src/coreclr/src/inc/clrnt.h
@@ -811,9 +811,9 @@ PEXCEPTION_ROUTINE
     IN OUT PKNONVOLATILE_CONTEXT_POINTERS ContextPointers OPTIONAL
     );
 
-#ifndef TARGET_UNIX
+#ifndef HOST_UNIX
 extern RtlVirtualUnwindFn* RtlVirtualUnwind_Unsafe;
-#else // !TARGET_UNIX
+#else // !HOST_UNIX
 PEXCEPTION_ROUTINE
 RtlVirtualUnwind_Unsafe(
     IN ULONG HandlerType,
@@ -825,7 +825,7 @@ RtlVirtualUnwind_Unsafe(
     OUT PULONG64 EstablisherFrame,
     IN OUT PKNONVOLATILE_CONTEXT_POINTERS ContextPointers OPTIONAL
     );
-#endif // !TARGET_UNIX
+#endif // !HOST_UNIX
 
 #endif // TARGET_AMD64
 

--- a/src/coreclr/src/unwinder/arm/unwinder_arm.cpp
+++ b/src/coreclr/src/unwinder/arm/unwinder_arm.cpp
@@ -1498,7 +1498,7 @@ BOOL DacUnwindStackFrame(T_CONTEXT *pContext, T_KNONVOLATILE_CONTEXT_POINTERS* p
     return res;
 }
 
-#if defined(TARGET_UNIX)
+#if defined(HOST_UNIX)
 PEXCEPTION_ROUTINE RtlVirtualUnwind(
     __in ULONG HandlerType,
     __in ULONG ImageBase,

--- a/src/coreclr/src/unwinder/arm64/unwinder_arm64.cpp
+++ b/src/coreclr/src/unwinder/arm64/unwinder_arm64.cpp
@@ -1609,7 +1609,7 @@ BOOL DacUnwindStackFrame(T_CONTEXT *pContext, T_KNONVOLATILE_CONTEXT_POINTERS* p
     return res;
 }
 
-#if defined(TARGET_UNIX)
+#if defined(HOST_UNIX)
 PEXCEPTION_ROUTINE
 RtlVirtualUnwind(
     IN ULONG HandlerType,


### PR DESCRIPTION
The unwinder does not compile _yet_ for cross OS DAC builds.  Disable it.