### PR TITLE
Fix incorrect early exit in SortKey.Compare and seal type

### DIFF
--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -182,8 +182,14 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\u30FC", "\u2010", ignoreKanaIgnoreWidthIgnoreCase, 1 };
 
             yield return new object[] { s_invariantCompare, "/", "\uFF0F", ignoreKanaIgnoreWidthIgnoreCase, 0 };
-            yield return new object[] { s_invariantCompare, "'", "\uFF07", ignoreKanaIgnoreWidthIgnoreCase, PlatformDetection.IsWindows7 ? -1 : 0};
             yield return new object[] { s_invariantCompare, "\"", "\uFF02", ignoreKanaIgnoreWidthIgnoreCase, 0 };
+
+            if (!PlatformDetection.IsWindows7)
+            {
+                // For the below string, LCMapStringEx and CompareStringEx on Windows 7 return inconsistent results.
+                // We'll only run this test case on Win8+ or on non-Windows machines.
+                yield return new object[] { s_invariantCompare, "'", "\uFF07", ignoreKanaIgnoreWidthIgnoreCase, 0 };
+            }
 
             yield return new object[] { s_invariantCompare, "\u3042", "\u30A1", CompareOptions.None, s_expectedHiraganaToKatakanaCompare };
             yield return new object[] { s_invariantCompare, "\u3042", "\u30A2", CompareOptions.None, s_expectedHiraganaToKatakanaCompare };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -71,7 +71,7 @@ namespace System.Globalization.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode(null, CompareOptions.None));
 
-            AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test", CompareOptions.StringSort));
+            AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test", CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreCase));
             AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test", CompareOptions.Ordinal | CompareOptions.IgnoreSymbols));
             AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test", (CompareOptions)(-1)));
         }
@@ -471,7 +471,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void GetHashCode_Span_Invalid()
         {
-            AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test".AsSpan(), CompareOptions.StringSort));
+            AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test".AsSpan(), CompareOptions.OrdinalIgnoreCase | CompareOptions.IgnoreCase));
             AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test".AsSpan(), CompareOptions.Ordinal | CompareOptions.IgnoreSymbols));
             AssertExtensions.Throws<ArgumentException>("options", () => CultureInfo.InvariantCulture.CompareInfo.GetHashCode("Test".AsSpan(), (CompareOptions)(-1)));
         }

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -349,12 +349,18 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(SortKey_TestData))]
-        public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
+        public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expectedSign)
         {
             SortKey sk1 = compareInfo.GetSortKey(string1, options);
             SortKey sk2 = compareInfo.GetSortKey(string2, options);
 
-            Assert.Equal(expected, SortKey.Compare(sk1, sk2));
+            Assert.Equal(expectedSign, Math.Sign(SortKey.Compare(sk1, sk2)));
+            Assert.Equal(expectedSign == 0, sk1.Equals(sk2));
+            Assert.Equal(Math.Sign(compareInfo.Compare(string1, string2, options)), Math.Sign(SortKey.Compare(sk1, sk2)));
+
+            Assert.Equal(compareInfo.GetHashCode(string1, options), sk1.GetHashCode());
+            Assert.Equal(compareInfo.GetHashCode(string2, options), sk2.GetHashCode());
+
             Assert.Equal(string1, sk1.OriginalString);
             Assert.Equal(string2, sk2.OriginalString);
         }
@@ -388,6 +394,9 @@ namespace System.Globalization.Tests
             Assert.Equal(sk4, sk5);
             Assert.Equal(sk4.GetHashCode(), sk5.GetHashCode());
             Assert.Equal(sk4.KeyData, sk5.KeyData);
+
+            Assert.False(sk1.Equals(null));
+            Assert.True(sk1.Equals(sk1));
 
             AssertExtensions.Throws<ArgumentNullException>("source", () => ci.GetSortKey(null));
             AssertExtensions.Throws<ArgumentException>("options", () => ci.GetSortKey(s1, CompareOptions.Ordinal));

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -646,6 +646,7 @@ namespace System.Globalization.Tests
         [InlineData("hello", "hello", 0)]
         [InlineData("prefix", "prefix-with-more-data", -1)]
         [InlineData("prefix-with-more-data", "prefix", 1)]
+        [InlineData("e", "\u0115", -1)] // U+0115 = LATIN SMALL LETTER E WITH BREVE, tests endianness handling
         public void TestSortKey_Compare_And_Equals(string value1, string value2, int expectedSign)
         {
             // These tests are in the "invariant" unit test project because we rely on Invariant mode

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -639,6 +639,24 @@ namespace System.Globalization.Tests
             Assert.NotEqual(0, SortKey.Compare(sortKeyForEmptyString, sortKeyForZeroWidthJoiner));
         }
 
+        [Theory]
+        [InlineData("", "", 0)]
+        [InlineData("", "not-empty", -1)]
+        [InlineData("not-empty", "", 1)]
+        [InlineData("hello", "hello", 0)]
+        [InlineData("prefix", "prefix-with-more-data", -1)]
+        [InlineData("prefix-with-more-data", "prefix", 1)]
+        public void TestSortKey_Compare_And_Equals(string value1, string value2, int expectedSign)
+        {
+            // These tests are in the "invariant" unit test project because we rely on Invariant mode
+            // copying the input data directly into the sort key.
+
+            SortKey sortKey1 = CultureInfo.InvariantCulture.CompareInfo.GetSortKey(value1);
+            SortKey sortKey2 = CultureInfo.InvariantCulture.CompareInfo.GetSortKey(value2);
+
+            Assert.Equal(expectedSign, Math.Sign(SortKey.Compare(sortKey1, sortKey2)));
+            Assert.Equal(expectedSign == 0, sortKey1.Equals(sortKey2));
+        }
 
         private static StringComparison GetStringComparison(CompareOptions options)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -816,7 +816,7 @@ namespace System.Globalization
 
             if (source==null) { throw new ArgumentNullException(nameof(source)); }
 
-            if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
+            if ((options & ValidCompareMaskOffFlags) != 0)
             {
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -505,7 +505,7 @@ namespace System.Globalization
 
             if (source == null) { throw new ArgumentNullException(nameof(source)); }
 
-            if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
+            if ((options & ValidCompareMaskOffFlags) != 0)
             {
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -24,18 +24,8 @@ namespace System.Globalization
             ~(CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols | CompareOptions.IgnoreNonSpace |
               CompareOptions.IgnoreWidth | CompareOptions.IgnoreKanaType);
 
-        // Mask used to check if Compare() has the right flags.
+        // Mask used to check if Compare() / GetHashCode(string) / GetSortKey has the right flags.
         private const CompareOptions ValidCompareMaskOffFlags =
-            ~(CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols | CompareOptions.IgnoreNonSpace |
-              CompareOptions.IgnoreWidth | CompareOptions.IgnoreKanaType | CompareOptions.StringSort);
-
-        // Mask used to check if GetHashCode(string) has the right flags.
-        private const CompareOptions ValidHashCodeOfStringMaskOffFlags =
-            ~(CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols | CompareOptions.IgnoreNonSpace |
-              CompareOptions.IgnoreWidth | CompareOptions.IgnoreKanaType);
-
-        // Mask used to check if we have the right flags.
-        private const CompareOptions ValidSortkeyCtorMaskOffFlags =
             ~(CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols | CompareOptions.IgnoreNonSpace |
               CompareOptions.IgnoreWidth | CompareOptions.IgnoreKanaType | CompareOptions.StringSort);
 
@@ -1399,7 +1389,7 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(source));
             }
-            if ((options & ValidHashCodeOfStringMaskOffFlags) == 0)
+            if ((options & ValidCompareMaskOffFlags) == 0)
             {
                 // No unsupported flags are set - continue on with the regular logic
                 if (GlobalizationMode.Invariant)
@@ -1428,7 +1418,7 @@ namespace System.Globalization
 
         public int GetHashCode(ReadOnlySpan<char> source, CompareOptions options)
         {
-            if ((options & ValidHashCodeOfStringMaskOffFlags) == 0)
+            if ((options & ValidCompareMaskOffFlags) == 0)
             {
                 // No unsupported flags are set - continue on with the regular logic
                 if (GlobalizationMode.Invariant)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
@@ -9,7 +9,7 @@ namespace System.Globalization
     /// <summary>
     /// This class implements a set of methods for retrieving
     /// </summary>
-    public partial class SortKey
+    public sealed partial class SortKey
     {
         private readonly string _localeName;
         private readonly CompareOptions _options;
@@ -32,13 +32,13 @@ namespace System.Globalization
         /// Returns the original string used to create the current instance
         /// of SortKey.
         /// </summary>
-        public virtual string OriginalString => _string;
+        public string OriginalString => _string;
 
         /// <summary>
         /// Returns a byte array representing the current instance of the
         /// sort key.
         /// </summary>
-        public virtual byte[] KeyData => (byte[])_keyData.Clone();
+        public byte[] KeyData => (byte[])_keyData.Clone();
 
         /// <summary>
         /// Compares the two sort keys.  Returns 0 if the two sort keys are
@@ -62,44 +62,34 @@ namespace System.Globalization
             Debug.Assert(key1Data != null, "key1Data != null");
             Debug.Assert(key2Data != null, "key2Data != null");
 
-            if (key1Data.Length == 0)
-            {
-                if (key2Data.Length == 0)
-                {
-                    return 0;
-                }
+            // SortKey comparisons are done as an ordinal comparison by the raw sort key bytes.
+            // We go byte-by-byte through both buffers until we find the first difference, then
+            // we report the comparison based on that single byte. If one buffer is a strict
+            // prefix of the other, the shorter buffer sorts first.
 
-                return -1;
-            }
-            if (key2Data.Length == 0)
-            {
-                return 1;
-            }
-
-            int compLen = (key1Data.Length < key2Data.Length) ? key1Data.Length : key2Data.Length;
+            int compLen = Math.Min(key1Data.Length, key2Data.Length);
             for (int i = 0; i < compLen; i++)
             {
-                if (key1Data[i] > key2Data[i])
+                int diff = key1Data[i] - key2Data[i];
+                if (diff != 0)
                 {
-                    return 1;
-                }
-                if (key1Data[i] < key2Data[i])
-                {
-                    return -1;
+                    return diff;
                 }
             }
 
-            return 0;
+            return key1Data.Length - key2Data.Length;
         }
 
         public override bool Equals(object? value)
         {
-            return value is SortKey otherSortKey && Compare(this, otherSortKey) == 0;
+            return value is SortKey other
+                && new ReadOnlySpan<byte>(this._keyData).SequenceEqual(other._keyData);
         }
 
         public override int GetHashCode()
         {
-            return CompareInfo.GetCompareInfo(_localeName).GetHashCodeOfString(_string, _options);
+            // keep this in sync with CompareInfo.GetHashCodeOfString
+            return Marvin.ComputeHash32(_keyData, Marvin.DefaultSeed);
         }
 
         public override string ToString()

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
@@ -63,27 +63,14 @@ namespace System.Globalization
             Debug.Assert(key2Data != null, "key2Data != null");
 
             // SortKey comparisons are done as an ordinal comparison by the raw sort key bytes.
-            // We go byte-by-byte through both buffers until we find the first difference, then
-            // we report the comparison based on that single byte. If one buffer is a strict
-            // prefix of the other, the shorter buffer sorts first.
 
-            int compLen = Math.Min(key1Data.Length, key2Data.Length);
-            for (int i = 0; i < compLen; i++)
-            {
-                int diff = key1Data[i] - key2Data[i];
-                if (diff != 0)
-                {
-                    return diff;
-                }
-            }
-
-            return key1Data.Length - key2Data.Length;
+            return new ReadOnlySpan<byte>(key1Data).SequenceCompareTo(key2Data);
         }
 
         public override bool Equals(object? value)
         {
             return value is SortKey other
-                && new ReadOnlySpan<byte>(this._keyData).SequenceEqual(other._keyData);
+                && new ReadOnlySpan<byte>(_keyData).SequenceEqual(other._keyData);
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5086,11 +5086,11 @@ namespace System.Globalization
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class SortKey
+    public sealed partial class SortKey
     {
         internal SortKey() { }
-        public virtual byte[] KeyData { get { throw null; } }
-        public virtual string OriginalString { get { throw null; } }
+        public byte[] KeyData { get { throw null; } }
+        public string OriginalString { get { throw null; } }
         public static int Compare(System.Globalization.SortKey sortkey1, System.Globalization.SortKey sortkey2) { throw null; }
         public override bool Equals(object? value) { throw null; }
         public override int GetHashCode() { throw null; }


### PR DESCRIPTION
The method `SortKey.Compare` contains an early incorrect exit which can cause it to return __0__ if all of the below conditions hold:

 * The application is using the invariant globalization mode, __and__
 * Neither `sortKey1` nor `sortKey2` represents the empty string, __and__
 * `sortKey1` is a prefix of `sortKey2` (or vice versa).

In a nutshell, this means that under the invariant globalization mode, the expression `compareInfo.GetSortKey("he").Equals(compareInfo.GetSortKey("hello!"))` incorrectly returns _true_.

There may also be some inputs under the non-invariant mode which trigger this incorrect output, but I didn't attempt this since it would be highly dependent on how the active version of NLS or ICU produces sort keys. It's far easier to trigger this bug under the invariant mode.

This PR addresses that issue in `SortKey.Compare`. Additionally, there are some performance optimizations made to `SortKey.Equals` and `SortKey.GetHashCode`. This also builds on https://github.com/dotnet/runtime/pull/31761 by sealing the `SortKey` type and devirtualizing the methods.