### PR TITLE
Update delegate return value to nullable

### DIFF
--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.cs
@@ -332,7 +332,7 @@ namespace System.Security.AccessControl
         protected void Persist(System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections, object? exceptionContext) { }
         protected sealed override void Persist(string name, System.Security.AccessControl.AccessControlSections includeSections) { }
         protected void Persist(string name, System.Security.AccessControl.AccessControlSections includeSections, object? exceptionContext) { }
-        protected internal delegate System.Exception ExceptionFromErrorCode(int errorCode, string? name, System.Runtime.InteropServices.SafeHandle? handle, object? context);
+        protected internal delegate System.Exception? ExceptionFromErrorCode(int errorCode, string? name, System.Runtime.InteropServices.SafeHandle? handle, object? context);
     }
     public abstract partial class ObjectAccessRule : System.Security.AccessControl.AccessRule
     {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -40,7 +40,7 @@ namespace System.Security.AccessControl
 
         #region Delegates
 
-        protected internal delegate System.Exception ExceptionFromErrorCode(int errorCode, string? name, SafeHandle? handle, object? context);
+        protected internal delegate System.Exception? ExceptionFromErrorCode(int errorCode, string? name, SafeHandle? handle, object? context);
 
         #endregion
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/31780, the delegate return value need to be nullable