### PR TITLE
JsonExtensionData + IgnoreNullValues fix

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -89,6 +89,11 @@ namespace System.Text.Json
                         jsonPropertyInfo.GetDictionaryKeyAndValue(ref state.Current, out key, out value);
                     }
 
+                    if (state.Current.ExtensionDataStatus == ExtensionDataWriteStatus.Writing && value == null && options.IgnoreNullValues)
+                    {
+                        return false;
+                    }
+
                     if (options.DictionaryKeyPolicy != null && state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing)
                     {
                         Debug.Assert(key != null);

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -657,6 +657,32 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(obj2));
         }
 
+        [Fact]
+        public static void NullExtensionPropertyIsIgnoredWhenSerializedAndOptionsConfigured()
+        {
+            ClassWithMultipleDictionaries obj = new ClassWithMultipleDictionaries
+            {
+                MyOverflow = new Dictionary<string, object>
+                {
+                    ["Prop1"] = "valid",
+                    ["Prop2"] = null
+                },
+
+                ActualDictionary = new Dictionary<string, object>
+                {
+                    ["Prop1"] = "valid",
+                    ["Prop2"] = null
+                }
+            };
+
+            string expected = @"{""ActualDictionary"":{""Prop1"":""valid"",""Prop2"":null},""Prop1"":""valid""}";
+            string actual = JsonSerializer.Serialize(obj, new JsonSerializerOptions
+            {
+                IgnoreNullValues = true
+            });
+            Assert.Equal(expected, actual);
+        }
+
         private class ClassWithExtensionPropertyAlreadyInstantiated
         {
             public ClassWithExtensionPropertyAlreadyInstantiated()


### PR DESCRIPTION
Fixed JsonExtensionData items with null values showing up in JSON when serializing and IgnoreNullValues=true.

Resolves #31786.