### PR TITLE
Make sure original Utf8JsonReader options are honored when re-creating the reader.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -306,7 +306,9 @@ namespace System.Text.Json
                     valueSpan.CopyTo(rentedSpan);
                 }
 
-                var newReader = new Utf8JsonReader(rentedSpan, isFinalBlock: true, state: default);
+                JsonReaderOptions originalReaderOptions = state.Options;
+
+                var newReader = new Utf8JsonReader(rentedSpan, originalReaderOptions);
 
                 ReadCore(options, ref newReader, ref readStack);
 

--- a/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Text.Encodings.Web;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -67,6 +68,240 @@ namespace System.Text.Json.Serialization.Tests
             string json = Encoding.UTF8.GetString(memoryStream.ToArray());
 
             Assert.Equal(normalizedString, json);
+        }
+
+        [Fact]
+        public static void WriterOptionsWinIndented()
+        {
+            var input = new int[3] { 1, 2, 3 };
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[1, 2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[1, 2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                {
+                    JsonSerializer.Serialize(writer, input);
+                }
+                Assert.Equal("[1, 2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        [Fact]
+        public static void WriterOptionsWinEncoder()
+        {
+            string input = "abcd+<>&";
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("abcd+<>&", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Encoder = JavaScriptEncoder.Default }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("abcd+<>&", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }))
+                {
+                    JsonSerializer.Serialize(writer, input);
+                }
+                Assert.Equal("abcd+<>&", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        [Fact]
+        public static void WriterOptionsSkipValidation()
+        {
+            var input = new int[3] { 1, 2, 3 };
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Converters = { new InvalidArrayConverter() },
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize(writer, input, serializerOptions));
+                }
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[}", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        public class InvalidArrayConverter : JsonConverter<int[]>
+        {
+            public override int[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, int[] value, JsonSerializerOptions options)
+            {
+                writer.WriteStartArray();
+                writer.WriteEndObject();
+            }
+        }
+
+        [Fact]
+        public static void OptionsFollowToConverter()
+        {
+            string json = "{\"type\":\"array\",\"array\":[1]}";
+            string jsonFormatted =
+@"{
+  ""type"": ""array"",
+  ""array"": [1]
+}";
+
+            var tempOptions = new JsonSerializerOptions();
+            tempOptions.Converters.Add(new CustomConverter());
+            DeepArray direct = JsonSerializer.Deserialize<DeepArray>(json, tempOptions);
+            IContent custom = JsonSerializer.Deserialize<IContent>(json, tempOptions);
+
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new CustomConverter());
+
+                Assert.Equal(json, JsonSerializer.Serialize(direct, options));
+                Assert.Equal(json, JsonSerializer.Serialize(custom, options));
+            }
+
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new CustomConverter());
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream))
+                    {
+                        JsonSerializer.Serialize(writer, direct, options);
+                    }
+                    Assert.Equal(json, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream))
+                    {
+                        JsonSerializer.Serialize(writer, custom, options);
+                    }
+                    Assert.Equal(json, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+            }
+
+            {
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                options.Converters.Add(new CustomConverter());
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+                    {
+                        JsonSerializer.Serialize(writer, direct, options);
+                    }
+                    Assert.Equal(json, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+                    {
+                        JsonSerializer.Serialize(writer, custom, options);
+                    }
+                    Assert.Equal(json, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+            }
+
+            {
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                options.Converters.Add(new CustomConverter());
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream))
+                    {
+                        JsonSerializer.Serialize(writer, direct, options);
+                    }
+                    Assert.Equal(jsonFormatted, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream))
+                    {
+                        JsonSerializer.Serialize(writer, custom, options);
+                    }
+                    Assert.Equal(jsonFormatted, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+            }
+
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new CustomConverter());
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                    {
+                        JsonSerializer.Serialize(writer, direct, options);
+                    }
+                    Assert.Equal(jsonFormatted, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                    {
+                        JsonSerializer.Serialize(writer, custom, options);
+                    }
+                    Assert.Equal(jsonFormatted, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -234,26 +234,40 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             {
-                var options = new JsonSerializerOptions();
+                var options = new JsonSerializerOptions
+                {
+                    Converters = { new CustomConverter() }
+                };
                 WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions: default);
                 WriteAndValidate(custom, typeof(IContent), json, options, writerOptions: default);
             }
 
             {
-                var options = new JsonSerializerOptions { WriteIndented = true };
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { new CustomConverter() }
+                };
                 var writerOptions = new JsonWriterOptions { Indented = false };
                 WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions);
                 WriteAndValidate(custom, typeof(IContent), json, options, writerOptions);
             }
 
             {
-                var options = new JsonSerializerOptions { WriteIndented = true };
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { new CustomConverter() }
+                };
                 WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions: default);
                 WriteAndValidate(custom, typeof(IContent), json, options, writerOptions: default);
             }
 
             {
-                var options = new JsonSerializerOptions();
+                var options = new JsonSerializerOptions
+                {
+                    Converters = { new CustomConverter() }
+                };
                 var writerOptions = new JsonWriterOptions { Indented = true };
                 WriteAndValidate(direct, typeof(DeepArray), $"{{{Environment.NewLine}  \"array\": [{Environment.NewLine}    1{Environment.NewLine}  ]{Environment.NewLine}}}", options, writerOptions);
                 WriteAndValidate(custom, typeof(IContent), jsonFormatted, options, writerOptions);
@@ -261,7 +275,6 @@ namespace System.Text.Json.Serialization.Tests
 
             static void WriteAndValidate(object input, Type type, string expected, JsonSerializerOptions options, JsonWriterOptions writerOptions)
             {
-                options.Converters.Add(new CustomConverter());
                 using (var stream = new MemoryStream())
                 {
                     using (var writer = new Utf8JsonWriter(stream, writerOptions))


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/882 for master (.NET 5.0).

The fix for the bug is only a couple of lines and only affects the read/deserialize, but I wanted to make sure we add tests to exercise the various options for both read and write.

The writer tests are only there for completeness and fill a gap from when the `JsonSerializer` APIs that accept a writer were originally added (see https://github.com/dotnet/corefx/pull/38700#issuecomment-503763061). Those tests pass in master and 3.1 already with no source changes.
