### PR TITLE
Annotate System.Net.Primitives for nullable

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
@@ -33,7 +33,7 @@ internal static partial class Interop
             }
 
             // Marshal.PtrToStringAnsi uses UTF8 on Unix.
-            return Marshal.PtrToStringAnsi((IntPtr)name);
+            return Marshal.PtrToStringAnsi((IntPtr)name)!;
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -57,7 +57,7 @@ namespace System.Net
 
             // See if it's an IP Address.
             IPHostEntry ipHostEntry;
-            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress address))
+            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress? address))
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
@@ -158,7 +158,7 @@ namespace System.Net
 
             // See if it's an IP Address.
             IPAddress[] addresses;
-            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress address))
+            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress? address))
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
@@ -210,7 +210,7 @@ namespace System.Net
                 throw new ArgumentNullException(nameof(hostName));
             }
 
-            if (IPAddress.TryParse(hostName, out IPAddress address))
+            if (IPAddress.TryParse(hostName, out IPAddress? address))
             {
                 return CreateHostEntryForAddress(address);
             }
@@ -287,7 +287,7 @@ namespace System.Net
 
             // See if it's an IP Address.
             IPHostEntry ipHostEntry;
-            if (IPAddress.TryParse(hostName, out IPAddress address) &&
+            if (IPAddress.TryParse(hostName, out IPAddress? address) &&
                 (address.AddressFamily != AddressFamily.InterNetworkV6 || SocketProtocolSupportPal.OSSupportsIPv6))
             {
                 try
@@ -441,7 +441,7 @@ namespace System.Net
             }
 
             // See if it's an IP Address.
-            if (IPAddress.TryParse(hostName, out IPAddress ipAddress))
+            if (IPAddress.TryParse(hostName, out IPAddress? ipAddress))
             {
                 if (throwOnIIPAny && (ipAddress.Equals(IPAddress.Any) || ipAddress.Equals(IPAddress.IPv6Any)))
                 {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -208,7 +208,7 @@ namespace System.Net.NetworkInformation
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
 
-            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress address))
+            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress? address))
             {
                 return Send(address, timeout, buffer, options);
             }
@@ -357,7 +357,7 @@ namespace System.Net.NetworkInformation
                 throw new ArgumentNullException(nameof(hostNameOrAddress));
             }
 
-            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress address))
+            if (IPAddress.TryParse(hostNameOrAddress, out IPAddress? address))
             {
                 return SendPingAsync(address, timeout, buffer, options);
             }

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -21,24 +21,30 @@ namespace System.Net
     public sealed partial class Cookie
     {
         public Cookie() { }
-        public Cookie(string name, string value) { }
-        public Cookie(string name, string value, string path) { }
-        public Cookie(string name, string value, string path, string domain) { }
+        public Cookie(string name, string? value) { }
+        public Cookie(string name, string? value, string? path) { }
+        public Cookie(string name, string? value, string? path, string? domain) { }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Comment { get { throw null; } set { } }
-        public System.Uri CommentUri { get { throw null; } set { } }
+        public System.Uri? CommentUri { get { throw null; } set { } }
         public bool Discard { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Domain { get { throw null; } set { } }
         public bool Expired { get { throw null; } set { } }
         public System.DateTime Expires { get { throw null; } set { } }
         public bool HttpOnly { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Name { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Path { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Port { get { throw null; } set { } }
         public bool Secure { get { throw null; } set { } }
         public System.DateTime TimeStamp { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Value { get { throw null; } set { } }
         public int Version { get { throw null; } set { } }
-        public override bool Equals(object comparand) { throw null; }
+        public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
@@ -49,7 +55,7 @@ namespace System.Net
         public bool IsReadOnly { get { throw null; } }
         public bool IsSynchronized { get { throw null; } }
         public System.Net.Cookie this[int index] { get { throw null; } }
-        public System.Net.Cookie this[string name] { get { throw null; } }
+        public System.Net.Cookie? this[string name] { get { throw null; } }
         public object SyncRoot { get { throw null; } }
         public void Add(System.Net.Cookie cookie) { }
         public void Add(System.Net.CookieCollection cookies) { }
@@ -95,11 +101,11 @@ namespace System.Net
         public static System.Net.NetworkCredential DefaultNetworkCredentials { get { throw null; } }
         public void Add(string host, int port, string authenticationType, System.Net.NetworkCredential credential) { }
         public void Add(System.Uri uriPrefix, string authType, System.Net.NetworkCredential cred) { }
-        public System.Net.NetworkCredential GetCredential(string host, int port, string authenticationType) { throw null; }
-        public System.Net.NetworkCredential GetCredential(System.Uri uriPrefix, string authType) { throw null; }
+        public System.Net.NetworkCredential? GetCredential(string host, int port, string authenticationType) { throw null; }
+        public System.Net.NetworkCredential? GetCredential(System.Uri uriPrefix, string authType) { throw null; }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public void Remove(string host, int port, string authenticationType) { }
-        public void Remove(System.Uri uriPrefix, string authType) { }
+        public void Remove(string? host, int port, string? authenticationType) { }
+        public void Remove(System.Uri? uriPrefix, string? authType) { }
     }
     [System.FlagsAttribute]
     public enum DecompressionMethods
@@ -117,7 +123,7 @@ namespace System.Net
         public override System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public string Host { get { throw null; } }
         public int Port { get { throw null; } }
-        public override bool Equals(object comparand) { throw null; }
+        public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
@@ -207,11 +213,11 @@ namespace System.Net
     }
     public partial interface ICredentials
     {
-        System.Net.NetworkCredential GetCredential(System.Uri uri, string authType);
+        System.Net.NetworkCredential? GetCredential(System.Uri uri, string authType);
     }
     public partial interface ICredentialsByHost
     {
-        System.Net.NetworkCredential GetCredential(string host, int port, string authenticationType);
+        System.Net.NetworkCredential? GetCredential(string host, int port, string authenticationType);
     }
     public partial class IPAddress
     {
@@ -236,7 +242,7 @@ namespace System.Net
         public bool IsIPv6SiteLocal { get { throw null; } }
         public bool IsIPv6Teredo { get { throw null; } }
         public long ScopeId { get { throw null; } set { } }
-        public override bool Equals(object comparand) { throw null; }
+        public override bool Equals(object? comparand) { throw null; }
         public byte[] GetAddressBytes() { throw null; }
         public override int GetHashCode() { throw null; }
         public static short HostToNetworkOrder(short host) { throw null; }
@@ -252,8 +258,8 @@ namespace System.Net
         public static System.Net.IPAddress Parse(string ipString) { throw null; }
         public override string ToString() { throw null; }
         public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> ipString, out System.Net.IPAddress address) { throw null; }
-        public static bool TryParse(string ipString, out System.Net.IPAddress address) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> ipString, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Net.IPAddress? address) { throw null; }
+        public static bool TryParse(string? ipString, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Net.IPAddress? address) { throw null; }
         public bool TryWriteBytes(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public partial class IPEndPoint : System.Net.EndPoint
@@ -266,18 +272,18 @@ namespace System.Net
         public override System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public int Port { get { throw null; } set { } }
         public override System.Net.EndPoint Create(System.Net.SocketAddress socketAddress) { throw null; }
-        public override bool Equals(object comparand) { throw null; }
+        public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public static System.Net.IPEndPoint Parse(System.ReadOnlySpan<char> s) { throw null; }
         public static System.Net.IPEndPoint Parse(string s) { throw null; }
         public override System.Net.SocketAddress Serialize() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(System.ReadOnlySpan<char> s, out System.Net.IPEndPoint result) { throw null; }
-        public static bool TryParse(string s, out System.Net.IPEndPoint result) { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<char> s, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Net.IPEndPoint result) { throw null; }
+        public static bool TryParse(string s, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out System.Net.IPEndPoint? result) { throw null; }
     }
     public partial interface IWebProxy
     {
-        System.Net.ICredentials Credentials { get; set; }
+        System.Net.ICredentials? Credentials { get; set; }
         System.Uri GetProxy(System.Uri destination);
         bool IsBypassed(System.Uri host);
     }
@@ -285,18 +291,22 @@ namespace System.Net
     {
         public NetworkCredential() { }
         [System.CLSCompliantAttribute(false)]
-        public NetworkCredential(string userName, System.Security.SecureString password) { }
+        public NetworkCredential(string? userName, System.Security.SecureString? password) { }
         [System.CLSCompliantAttribute(false)]
-        public NetworkCredential(string userName, System.Security.SecureString password, string domain) { }
-        public NetworkCredential(string userName, string password) { }
-        public NetworkCredential(string userName, string password, string domain) { }
+        public NetworkCredential(string? userName, System.Security.SecureString? password, string? domain) { }
+        public NetworkCredential(string? userName, string? password) { }
+        public NetworkCredential(string? userName, string? password, string? domain) { }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Domain { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Password { get { throw null; } set { } }
         [System.CLSCompliantAttribute(false)]
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Security.SecureString SecurePassword { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string UserName { get { throw null; } set { } }
-        public System.Net.NetworkCredential GetCredential(string host, int port, string authenticationType) { throw null; }
-        public System.Net.NetworkCredential GetCredential(System.Uri uri, string authType) { throw null; }
+        public System.Net.NetworkCredential GetCredential(string? host, int port, string? authenticationType) { throw null; }
+        public System.Net.NetworkCredential GetCredential(System.Uri? uri, string? authType) { throw null; }
     }
     public partial class SocketAddress
     {
@@ -305,14 +315,14 @@ namespace System.Net
         public System.Net.Sockets.AddressFamily Family { get { throw null; } }
         public byte this[int offset] { get { throw null; } set { } }
         public int Size { get { throw null; } }
-        public override bool Equals(object comparand) { throw null; }
+        public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }
     public abstract partial class TransportContext
     {
         protected TransportContext() { }
-        public abstract System.Security.Authentication.ExtendedProtection.ChannelBinding GetChannelBinding(System.Security.Authentication.ExtendedProtection.ChannelBindingKind kind);
+        public abstract System.Security.Authentication.ExtendedProtection.ChannelBinding? GetChannelBinding(System.Security.Authentication.ExtendedProtection.ChannelBindingKind kind);
     }
 }
 namespace System.Net.Cache

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.csproj
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Primitives.cs" />

--- a/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ILLinkKeepDepAttributes>false</ILLinkKeepDepAttributes> <!-- See comments in Cookie.cs -->
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
     <!-- SYSTEM_NET_PRIMITIVES_DLL is required to allow source-level code sharing for types defined within the

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -46,7 +48,7 @@ namespace System.Net
         internal static readonly char[] ReservedToValue = new char[] { ';', ',' };
 
         private string m_comment = string.Empty; // Do not rename (binary serialization)
-        private Uri m_commentUri = null; // Do not rename (binary serialization)
+        private Uri? m_commentUri = null; // Do not rename (binary serialization)
         private CookieVariant m_cookieVariant = CookieVariant.Plain; // Do not rename (binary serialization)
         private bool m_discard = false; // Do not rename (binary serialization)
         private string m_domain = string.Empty; // Do not rename (binary serialization)
@@ -57,7 +59,7 @@ namespace System.Net
         private bool m_path_implicit = true; // Do not rename (binary serialization)
         private string m_port = string.Empty; // Do not rename (binary serialization)
         private bool m_port_implicit = true; // Do not rename (binary serialization)
-        private int[] m_port_list = null; // Do not rename (binary serialization)
+        private int[]? m_port_list = null; // Do not rename (binary serialization)
         private bool m_secure = false; // Do not rename (binary serialization)
         [System.Runtime.Serialization.OptionalField]
         private bool m_httpOnly = false; // Do not rename (binary serialization)
@@ -96,24 +98,25 @@ namespace System.Net
         }
 
         [PreserveDependency("ToServerString")] // Workaround for https://github.com/dotnet/runtime/issues/19348
-        public Cookie(string name, string value)
+        public Cookie(string name, string? value)
         {
             Name = name;
             Value = value;
         }
 
-        public Cookie(string name, string value, string path)
+        public Cookie(string name, string? value, string? path)
             : this(name, value)
         {
             Path = path;
         }
 
-        public Cookie(string name, string value, string path, string domain)
+        public Cookie(string name, string? value, string? path, string? domain)
             : this(name, value, path)
         {
             Domain = domain;
         }
 
+        [AllowNull]
         public string Comment
         {
             get
@@ -126,7 +129,7 @@ namespace System.Net
             }
         }
 
-        public Uri CommentUri
+        public Uri? CommentUri
         {
             get
             {
@@ -164,6 +167,7 @@ namespace System.Net
             }
         }
 
+        [AllowNull]
         public string Domain
         {
             get
@@ -231,7 +235,7 @@ namespace System.Net
                 }
             }
         }
-        internal bool InternalSetName(string value)
+        internal bool InternalSetName(string? value)
         {
             if (string.IsNullOrEmpty(value) || value[0] == '$' || value.IndexOfAny(ReservedToName) != -1 || value[0] == ' ' || value[value.Length - 1] == ' ')
             {
@@ -242,6 +246,7 @@ namespace System.Net
             return true;
         }
 
+        [AllowNull]
         public string Path
         {
             get
@@ -530,7 +535,7 @@ namespace System.Net
             {
                 // Port must match against the one from the uri.
                 valid = false;
-                foreach (int p in m_port_list)
+                foreach (int p in m_port_list!)
                 {
                     if (p == port)
                     {
@@ -573,6 +578,7 @@ namespace System.Net
             return true;
         }
 
+        [AllowNull]
         public string Port
         {
             get
@@ -627,7 +633,7 @@ namespace System.Net
         }
 
 
-        internal int[] PortList
+        internal int[]? PortList
         {
             get
             {
@@ -656,6 +662,7 @@ namespace System.Net
             }
         }
 
+        [AllowNull]
         public string Value
         {
             get
@@ -707,9 +714,9 @@ namespace System.Net
             }
         }
 
-        public override bool Equals(object comparand)
+        public override bool Equals(object? comparand)
         {
-            Cookie other = comparand as Cookie;
+            Cookie? other = comparand as Cookie;
 
             return other != null
                     && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
@@ -787,7 +794,7 @@ namespace System.Net
             }
         }
 
-        internal string ToServerString()
+        internal string? ToServerString()
         {
             string result = Name + EqualsLiteral + Value;
             if (m_comment != null && m_comment.Length > 0)

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -41,17 +42,17 @@ namespace System.Net
                 {
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
-                return m_list[index] as Cookie;
+                return (m_list[index] as Cookie)!;
             }
         }
 
-        public Cookie this[string name]
+        public Cookie? this[string name]
         {
             get
             {
-                foreach (Cookie c in m_list)
+                foreach (Cookie? c in m_list)
                 {
-                    if (string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(c!.Name, name, StringComparison.OrdinalIgnoreCase))
                     {
                         return c;
                     }
@@ -89,9 +90,9 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(cookies));
             }
-            foreach (Cookie cookie in cookies.m_list)
+            foreach (Cookie? cookie in cookies.m_list)
             {
-                Add(cookie);
+                Add(cookie!);
             }
         }
 
@@ -203,13 +204,13 @@ namespace System.Net
                 int listCount = m_list.Count;
                 for (int i = 0; i < listCount; i++)
                 {
-                    Cookie c = (Cookie)m_list[i];
+                    Cookie c = (Cookie)m_list[i]!;
                     if (CookieComparer.Compare(cookie, c) == 0)
                     {
                         ret = 0; // Will replace or reject
 
                         // Cookie2 spec requires that new Variant cookie overwrite the old one.
-                        if (c.Variant <= cookie.Variant)
+                        if (c!.Variant <= cookie.Variant)
                         {
                             m_list[idx] = cookie;
                         }
@@ -236,9 +237,9 @@ namespace System.Net
         internal int IndexOf(Cookie cookie)
         {
             int idx = 0;
-            foreach (Cookie c in m_list)
+            foreach (Cookie? c in m_list)
             {
-                if (CookieComparer.Compare(cookie, c) == 0)
+                if (CookieComparer.Compare(cookie, c!) == 0)
                 {
                     return idx;
                 }
@@ -254,9 +255,9 @@ namespace System.Net
 
         IEnumerator<Cookie> IEnumerable<Cookie>.GetEnumerator()
         {
-            foreach (Cookie cookie in m_list)
+            foreach (Cookie? cookie in m_list)
             {
-                yield return cookie;
+                yield return cookie!;
             }
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieException.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieException.cs
@@ -14,11 +14,11 @@ namespace System.Net
         {
         }
 
-        internal CookieException(string message) : base(message)
+        internal CookieException(string? message) : base(message)
         {
         }
 
-        internal CookieException(string message, Exception inner) : base(message, inner)
+        internal CookieException(string? message, Exception? inner) : base(message, inner)
         {
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
@@ -43,9 +43,9 @@ namespace System.Net
             _family = addressFamily;
         }
 
-        public override bool Equals(object comparand)
+        public override bool Equals(object? comparand)
         {
-            DnsEndPoint dnsComparand = comparand as DnsEndPoint;
+            DnsEndPoint? dnsComparand = comparand as DnsEndPoint;
 
             if (dnsComparand == null)
             {

--- a/src/libraries/System.Net.Primitives/src/System/Net/ICredentials.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/ICredentials.cs
@@ -20,6 +20,6 @@ namespace System.Net
         ///     is available for the specified host and realm.
         ///   </para>
         /// </devdoc>
-        NetworkCredential GetCredential(Uri uri, string authType);
+        NetworkCredential? GetCredential(Uri uri, string authType);
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/ICredentialsByHost.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/ICredentialsByHost.cs
@@ -20,6 +20,6 @@ namespace System.Net
         ///     is available for the specified host and realm.
         ///   </para>
         /// </devdoc>
-        NetworkCredential GetCredential(string host, int port, string authenticationType);
+        NetworkCredential? GetCredential(string host, int port, string authenticationType);
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -40,12 +42,12 @@ namespace System.Net
         /// <summary>
         /// This field is only used for IPv6 addresses. A null value indicates that this instance is an IPv4 address.
         /// </summary>
-        private readonly ushort[] _numbers;
+        private readonly ushort[]? _numbers;
 
         /// <summary>
         /// A lazily initialized cache of the result of calling <see cref="ToString"/>.
         /// </summary>
-        private string _toString;
+        private string? _toString;
 
         /// <summary>
         /// A lazily initialized cache of the <see cref="GetHashCode"/> value.
@@ -213,7 +215,7 @@ namespace System.Net
         ///     Converts an IP address string to an <see cref='System.Net.IPAddress'/> instance.
         ///   </para>
         /// </devdoc>
-        public static bool TryParse(string ipString, out IPAddress address)
+        public static bool TryParse(string? ipString, [NotNullWhen(true)] out IPAddress? address)
         {
             if (ipString == null)
             {
@@ -225,7 +227,7 @@ namespace System.Net
             return (address != null);
         }
 
-        public static bool TryParse(ReadOnlySpan<char> ipSpan, out IPAddress address)
+        public static bool TryParse(ReadOnlySpan<char> ipSpan, [NotNullWhen(true)] out IPAddress? address)
         {
             address = IPAddressParser.Parse(ipSpan, tryParse: true);
             return (address != null);
@@ -238,12 +240,12 @@ namespace System.Net
                 throw new ArgumentNullException(nameof(ipString));
             }
 
-            return IPAddressParser.Parse(ipString.AsSpan(), tryParse: false);
+            return IPAddressParser.Parse(ipString.AsSpan(), tryParse: false)!;
         }
 
         public static IPAddress Parse(ReadOnlySpan<char> ipSpan)
         {
-            return IPAddressParser.Parse(ipSpan, tryParse: false);
+            return IPAddressParser.Parse(ipSpan, tryParse: false)!;
         }
 
         public bool TryWriteBytes(Span<byte> destination, out int bytesWritten)
@@ -374,7 +376,7 @@ namespace System.Net
             {
                 _toString = IsIPv4 ?
                     IPAddressParser.IPv4AddressToString(PrivateAddress) :
-                    IPAddressParser.IPv6AddressToString(_numbers, PrivateScopeId);
+                    IPAddressParser.IPv6AddressToString(_numbers!, PrivateScopeId);
             }
 
             return _toString;
@@ -384,7 +386,7 @@ namespace System.Net
         {
             return IsIPv4 ?
                 IPAddressParser.IPv4AddressToString(PrivateAddress, destination, out charsWritten) :
-                IPAddressParser.IPv6AddressToString(_numbers, PrivateScopeId, destination, out charsWritten);
+                IPAddressParser.IPv6AddressToString(_numbers!, PrivateScopeId, destination, out charsWritten);
         }
 
         public static long HostToNetworkOrder(long host)
@@ -444,7 +446,7 @@ namespace System.Net
         {
             get
             {
-                return IsIPv6 && ((_numbers[0] & 0xFF00) == 0xFF00);
+                return IsIPv6 && ((_numbers![0] & 0xFF00) == 0xFF00);
             }
         }
 
@@ -457,7 +459,7 @@ namespace System.Net
         {
             get
             {
-                return IsIPv6 && ((_numbers[0] & 0xFFC0) == 0xFE80);
+                return IsIPv6 && ((_numbers![0] & 0xFFC0) == 0xFE80);
             }
         }
 
@@ -470,7 +472,7 @@ namespace System.Net
         {
             get
             {
-                return IsIPv6 && ((_numbers[0] & 0xFFC0) == 0xFEC0);
+                return IsIPv6 && ((_numbers![0] & 0xFFC0) == 0xFEC0);
             }
         }
 
@@ -479,8 +481,8 @@ namespace System.Net
             get
             {
                 return IsIPv6 &&
-                       (_numbers[0] == 0x2001) &&
-                       (_numbers[1] == 0);
+                       (_numbers![0] == 0x2001) &&
+                       (_numbers![1] == 0);
             }
         }
 
@@ -495,12 +497,12 @@ namespace System.Net
                 }
                 for (int i = 0; i < 5; i++)
                 {
-                    if (_numbers[i] != 0)
+                    if (_numbers![i] != 0)
                     {
                         return false;
                     }
                 }
-                return (_numbers[5] == 0xFFFF);
+                return (_numbers![5] == 0xFFFF);
             }
         }
 
@@ -545,7 +547,7 @@ namespace System.Net
         }
 
         /// <summary>Compares two IP addresses.</summary>
-        public override bool Equals(object comparand)
+        public override bool Equals(object? comparand)
         {
             return comparand is IPAddress address && Equals(address);
         }
@@ -642,12 +644,13 @@ namespace System.Net
             // Cast the ushort values to a uint and mask with unsigned literal before bit shifting.
             // Otherwise, we can end up getting a negative value for any IPv4 address that ends with
             // a byte higher than 127 due to sign extension of the most significant 1 bit.
-            long address = ((((uint)_numbers[6] & 0x0000FF00u) >> 8) | (((uint)_numbers[6] & 0x000000FFu) << 8)) |
+            long address = ((((uint)_numbers![6] & 0x0000FF00u) >> 8) | (((uint)_numbers[6] & 0x000000FFu) << 8)) |
                     (((((uint)_numbers[7] & 0x0000FF00u) >> 8) | (((uint)_numbers[7] & 0x000000FFu) << 8)) << 16);
 
             return new IPAddress(address);
         }
 
+        [DoesNotReturn]
         private static byte[] ThrowAddressNullException() => throw new ArgumentNullException("address");
 
         private sealed class ReadOnlyIPAddress : IPAddress

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -16,7 +18,7 @@ namespace System.Net
     {
         private const int MaxIPv4StringLength = 15; // 4 numbers separated by 3 periods, with up to 3 digits per number
 
-        internal static IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
+        internal static IPAddress? Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
         {
             if (ipSpan.Contains(':'))
             {
@@ -209,7 +211,7 @@ namespace System.Net
             }
             if (isValid || (end != ipSpan.Length))
             {
-                string scopeId = null;
+                string? scopeId = null;
                 IPv6AddressHelper.Parse(ipSpan, numbers, 0, ref scopeId);
 
                 if (scopeId?.Length > 1)

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Sockets;
 
@@ -85,12 +87,12 @@ namespace System.Net
             }
         }
 
-        public static bool TryParse(string s, out IPEndPoint result)
+        public static bool TryParse(string s, [NotNullWhen(true)] out IPEndPoint? result)
         {
             return TryParse(s.AsSpan(), out result);
         }
 
-        public static bool TryParse(ReadOnlySpan<char> s, out IPEndPoint result)
+        public static bool TryParse(ReadOnlySpan<char> s, [NotNullWhen(true)] out IPEndPoint? result)
         {
             int addressLength = s.Length;  // If there's no port then send the entire string to the address parser
             int lastColonPos = s.LastIndexOf(':');
@@ -109,7 +111,7 @@ namespace System.Net
                 }
             }
 
-            if (IPAddress.TryParse(s.Slice(0, addressLength), out IPAddress address))
+            if (IPAddress.TryParse(s.Slice(0, addressLength), out IPAddress? address))
             {
                 uint port = 0;
                 if (addressLength == s.Length ||
@@ -137,7 +139,7 @@ namespace System.Net
 
         public static IPEndPoint Parse(ReadOnlySpan<char> s)
         {
-            if (TryParse(s, out IPEndPoint result))
+            if (TryParse(s, out IPEndPoint? result))
             {
                 return result;
             }
@@ -173,7 +175,7 @@ namespace System.Net
             return socketAddress.GetIPEndPoint();
         }
 
-        public override bool Equals(object comparand)
+        public override bool Equals(object? comparand)
         {
             return comparand is IPEndPoint other && other._address.Equals(_address) && other._port == _port;
         }

--- a/src/libraries/System.Net.Primitives/src/System/Net/IWebProxy.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IWebProxy.cs
@@ -14,6 +14,6 @@ namespace System.Net
     {
         Uri GetProxy(Uri destination);
         bool IsBypassed(Uri host);
-        ICredentials Credentials { get; set; }
+        ICredentials? Credentials { get; set; }
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/NetworkCredential.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/NetworkCredential.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -15,9 +16,9 @@ namespace System.Net
     /// </devdoc>
     public class NetworkCredential : ICredentials, ICredentialsByHost
     {
-        private string _domain;
-        private string _userName;
-        private object _password;
+        private string _domain = null!;
+        private string _userName = string.Empty;
+        private object? _password;
 
         public NetworkCredential()
             : this(string.Empty, string.Empty, string.Empty)
@@ -30,7 +31,7 @@ namespace System.Net
         ///       class with name and password set as specified.
         ///    </para>
         /// </devdoc>
-        public NetworkCredential(string userName, string password)
+        public NetworkCredential(string? userName, string? password)
         : this(userName, password, string.Empty)
         {
         }
@@ -41,7 +42,7 @@ namespace System.Net
         ///       class with name, password and domain set as specified.
         ///    </para>
         /// </devdoc>
-        public NetworkCredential(string userName, string password, string domain)
+        public NetworkCredential(string? userName, string? password, string? domain)
         {
             UserName = userName;
             Password = password;
@@ -49,13 +50,13 @@ namespace System.Net
         }
 
         [CLSCompliant(false)]
-        public NetworkCredential(string userName, SecureString password)
+        public NetworkCredential(string? userName, SecureString? password)
         : this(userName, password, string.Empty)
         {
         }
 
         [CLSCompliant(false)]
-        public NetworkCredential(string userName, SecureString password, string domain)
+        public NetworkCredential(string? userName, SecureString? password, string? domain)
         {
             UserName = userName;
             SecurePassword = password;
@@ -67,6 +68,7 @@ namespace System.Net
         ///       The user name associated with this credential.
         ///    </para>
         /// </devdoc>
+        [AllowNull]
         public string UserName
         {
             get { return _userName; }
@@ -78,41 +80,43 @@ namespace System.Net
         ///       The password for the user name.
         ///    </para>
         /// </devdoc>
+        [AllowNull]
         public string Password
         {
             get
             {
-                SecureString sstr = _password as SecureString;
+                SecureString? sstr = _password as SecureString;
                 if (sstr != null)
                 {
                     return MarshalToString(sstr);
                 }
-                return (string)_password ?? string.Empty;
+                return (string?)_password ?? string.Empty;
             }
             set
             {
-                SecureString old = _password as SecureString;
+                SecureString? old = _password as SecureString;
                 _password = value;
                 old?.Dispose();
             }
         }
 
         [CLSCompliant(false)]
+        [AllowNull]
         public SecureString SecurePassword
         {
             get
             {
-                string str = _password as string;
+                string? str = _password as string;
                 if (str != null)
                 {
                     return MarshalToSecureString(str);
                 }
-                SecureString sstr = _password as SecureString;
+                SecureString? sstr = _password as SecureString;
                 return sstr != null ? sstr.Copy() : new SecureString();
             }
             set
             {
-                SecureString old = _password as SecureString;
+                SecureString? old = _password as SecureString;
                 _password = value?.Copy();
                 old?.Dispose();
             }
@@ -124,6 +128,7 @@ namespace System.Net
         ///       the credentials. Usually this is the host machine.
         ///    </para>
         /// </devdoc>
+        [AllowNull]
         public string Domain
         {
             get { return _domain; }
@@ -136,12 +141,12 @@ namespace System.Net
         ///       authentication type.
         ///    </para>
         /// </devdoc>
-        public NetworkCredential GetCredential(Uri uri, string authenticationType)
+        public NetworkCredential GetCredential(Uri? uri, string? authenticationType)
         {
             return this;
         }
 
-        public NetworkCredential GetCredential(string host, int port, string authenticationType)
+        public NetworkCredential GetCredential(string? host, int port, string? authenticationType)
         {
             return this;
         }
@@ -158,7 +163,7 @@ namespace System.Net
             try
             {
                 ptr = Marshal.SecureStringToGlobalAllocUnicode(sstr);
-                result = Marshal.PtrToStringUni(ptr);
+                result = Marshal.PtrToStringUni(ptr)!;
             }
             finally
             {

--- a/src/libraries/System.Net.Primitives/src/System/Net/TransportContext.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/TransportContext.cs
@@ -8,6 +8,6 @@ namespace System.Net
 {
     public abstract class TransportContext
     {
-        public abstract ChannelBinding GetChannelBinding(ChannelBindingKind kind);
+        public abstract ChannelBinding? GetChannelBinding(ChannelBindingKind kind);
     }
 }

--- a/src/libraries/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
+++ b/src/libraries/System.Net.ServicePoint/src/System/Net/ServicePointManager.cs
@@ -176,7 +176,7 @@ namespace System.Net
             {
                 try
                 {
-                    Uri proxyAddress = proxy.GetProxy(address);
+                    Uri? proxyAddress = proxy.GetProxy(address);
                     if (proxyAddress != null)
                     {
                         if (proxyAddress.Scheme != Uri.UriSchemeHttp)


### PR DESCRIPTION
Contributes to #2339

- Should IWebProxy be nullable?
- Should `public virtual SocketAddress Serialize()` in EndPoint.cs be nullable?
- Some files are shared with System.Net.HttpListener which is not annotated - how resolve this?
- There is 3 compile errors - looks like a side bug:
```
System\Net\CredentialCache.cs(319,88): error CS8714: The type 'TKey' cannot be used as type parameter 'TKey' in the generic type or method 'Dictionary<TKey, TValue>'. Nullability of type argument 'TKey' doesn't match 'notnull' constraint. [src\libraries\System.Net.Primitives\src\System.Net.Primitives.csproj]
System\Net\CredentialCache.cs(321,115): error CS8714: The type 'TKey' cannot be used as type parameter 'TKey' in the generic type or method 'Dictionary<TKey, TValue>'. Nullability of type argument 'TKey' doesn't match 'notnull' constraint. [src\libraries\System.Net.Primitives\src\System.Net.Primitives.csproj]
System\Net\CredentialCache.cs(383,117): error CS8714: The type 'TKey' cannot be used as type parameter 'TKey' in the generic type or method 'Dictionary<TKey, TValue>'. Nullability of type argument 'TKey' doesn't match 'notnull' constraint. [src\libraries\System.Net.Primitives\src\System.Net.Primitives.csproj]
```