### PR TITLE
Remove --buildXUnitWrappers from runtest.cmd/runtest.sh

### DIFF
--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -31,7 +31,6 @@ set __IlasmRoundTrip=
 set __CollectDumps=
 set __DoCrossgen=
 set __CrossgenAltJit=
-set __BuildXUnitWrappers=
 set __PrintLastResultsOnly=
 set RunInUnloadableContext=
 
@@ -71,7 +70,6 @@ if /i "%1" == "jitforcerelocs"                          (set COMPlus_ForceRelocs
 if /i "%1" == "jitdisasm"                               (set __JitDisasm=1&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 
-if /i "%1" == "buildxunitwrappers"                      (set __BuildXunitWrappers=1&shift&goto Arg_Loop)
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"                        (set RunCrossGen=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=true&shift&goto Arg_Loop)
@@ -151,10 +149,6 @@ if defined __TestEnv (
 
 if defined __Sequential (
     set __RuntestPyArgs=%__RuntestPyArgs% --sequential
-)
-
-if defined __BuildXUnitWrappers (
-    set __RuntestPyArgs=%__RuntestPyArgs% --build_xunit_test_wrappers
 )
 
 if defined RunCrossGen (

--- a/src/coreclr/tests/runtest.sh
+++ b/src/coreclr/tests/runtest.sh
@@ -39,7 +39,6 @@ function print_usage {
     echo '  --tieredcompilation              : Runs the tests with COMPlus_TieredCompilation=1'
     echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --xunitOutputPath=<path>         : Create xUnit XML report at the specifed path (default: <test root>/coreclrtests.xml)'
-    echo '  --buildXUnitWrappers             : Force creating the xunit wrappers, this is useful if there have been changes to issues.targets'
     echo '  --printLastResultsOnly           : Print the results of the last run'
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
     echo ''
@@ -218,7 +217,6 @@ verbose=0
 doCrossgen=0
 jitdisasm=0
 ilasmroundtrip=
-buildXUnitWrappers=
 printLastResultsOnly=
 runSequential=0
 runincontext=0
@@ -253,9 +251,6 @@ do
             ;;
         release|Release)
             buildConfiguration="Release"
-            ;;
-        --buildXUnitWrappers)
-            buildXUnitWrappers=1
             ;;
         --printLastResultsOnly)
             printLastResultsOnly=1
@@ -502,13 +497,6 @@ fi
 if [ ! -z "$ilasmroundtrip" ]; then
     echo "Running Ilasm round trip"
     runtestPyArguments+=("--ilasmroundtrip")
-fi
-
-if [ ! -z "$buildXUnitWrappers" ]; then
-    runtestPyArguments+=("--build_xunit_test_wrappers")
-else
-    echo "Skipping xunit wrapper build. If build-test was called on a different"
-    echo "host_os or arch the test run will most likely have failures."
 fi
 
 if (($verbose!=0)); then


### PR DESCRIPTION
It looks unused, it forwards `--build_xunit_test_wrappers` to `runtests.py` which is not handled there (see https://github.com/dotnet/runtime/blob/master/src/coreclr/tests/runtest.py)

so `buildxunitwrappers` passed to build.sh/cmd simply fails with `unknown parameter --build_xunit_test_wrappers` in the python script.