### PR TITLE
Revert "Update ILLinkTasksVersion dependency"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,7 +122,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
-    <ILLinkTasksVersion>0.1.6-prerelease.20078.1</ILLinkTasksVersion>
+    <ILLinkTasksVersion>0.1.6-prerelease.19567.1</ILLinkTasksVersion>
   </PropertyGroup>
   <!-- Package names -->
   <PropertyGroup>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -83,8 +83,6 @@
       <ILLinkArgs>$(ILLinkArgs) --skip-unresolved true</ILLinkArgs>
       <!-- keep interface implementations -->
       <ILLinkArgs>$(ILLinkArgs) --disable-opt unusedinterfaces</ILLinkArgs>
-      <!-- disable optimization to unblock dependencies bump -->
-      <ILLinkArgs>$(ILLinkArgs) --disable-opt ipconstprop</ILLinkArgs>
       <!-- keep PreserveDependencyAttribute unless a project explicitly disables it -->
       <ILLinkArgs Condition="'$(ILLinkKeepDepAttributes)' != 'false'">$(ILLinkArgs) --keep-dep-attributes true</ILLinkArgs>
     </PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/runtime#2334

Reverting to unblock official builds which were failing during signing because illink is stripping out assembly attributes from assemblies.

@safern do you know why we don't do signing dry-runs in non-official builds? Those would have captured the break.

Opened https://github.com/dotnet/runtime/issues/31806 to follow-up on the right fix.

cc @marek-safar 