### PR TITLE
Nullability: RuntimeHelpers.GetHashCode should accept null obj input

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -107,7 +107,7 @@ namespace System.Runtime.CompilerServices
         public static extern void PrepareDelegate(Delegate d);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern int GetHashCode(object o);
+        public static extern int GetHashCode(object? o);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern new bool Equals(object? o1, object? o2);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7273,7 +7273,7 @@ namespace System.Runtime.CompilerServices
         public static void EnsureSufficientExecutionStack() { }
         public static new bool Equals(object? o1, object? o2) { throw null; }
         public static void ExecuteCodeWithGuaranteedCleanup(System.Runtime.CompilerServices.RuntimeHelpers.TryCode code, System.Runtime.CompilerServices.RuntimeHelpers.CleanupCode backoutCode, object? userData) { }
-        public static int GetHashCode(object o) { throw null; }
+        public static int GetHashCode(object? o) { throw null; }
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("obj")]
         public static object? GetObjectValue(object? obj) { throw null; }
         public static T[] GetSubArray<T>(T[] array, System.Range range) { throw null; }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -20,9 +20,9 @@ namespace System.Runtime.CompilerServices
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern int InternalGetHashCode (object o);
+		static extern int InternalGetHashCode (object? o);
 
-		public static int GetHashCode (object o)
+		public static int GetHashCode (object? o)
 		{
 			return InternalGetHashCode (o);
 		}


### PR DESCRIPTION
Changes `RuntimeHelpers.GetHashCode(object)` to `RuntimeHelpers.GetHashCode(object?)`. Both coreclr and mono already support passing _null_ as an argument to this method.

https://github.com/dotnet/runtime/blob/cd622cd50c7104fc14a25fb199f8377472920f2e/src/mono/mono/metadata/monitor.c#L565-L573

https://github.com/dotnet/runtime/blob/8e603859f140d6dd5612f3d21a1aabe07e31ead3/src/coreclr/src/classlibnative/bcltype/objectnative.cpp#L85-L99

And we already have a unit test for it.

https://github.com/dotnet/runtime/blob/8e603859f140d6dd5612f3d21a1aabe07e31ead3/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs#L35-L36