### PR TITLE
Update SkipOnCoreClr in RunContinueWithStressTestsNoState test

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
@@ -42,7 +42,7 @@ namespace System.Threading.Tasks.Tests
 
         // Stresses on multiple continuations from a single antecedent
         [Fact]
-        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271")]
+        [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", RuntimeTestModes.CheckedRuntime)]
         public static void RunContinueWithStressTestsNoState()
         {
             int numIterations = 3;


### PR DESCRIPTION
Didn't make it to update it in the arcade update PR. Updating it so that it is only skipped on a checked coreclr.

cc: @jkotas @stephentoub 