### PR TITLE
[draft][interp][wasm] Split generate_code into recursive and non-recursive parts.

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -1226,7 +1226,7 @@ fi
 
 AC_SUBST(CXXFLAGS_COMMON)
 
-if test "x$enable_cxx" = "xyes"; then
+#if test "x$enable_cxx" = "xyes"; then
 
 	CXX_ADD_CFLAGS=" -xc++ $CXXFLAGS_COMMON "
 
@@ -1255,7 +1255,7 @@ if test "x$enable_cxx" = "xyes"; then
 				   CXX_REMOVE_CFLAGS="$CXX_REMOVE_CFLAGS -Wno-format-zero-length" ])
 	CXXFLAGS=$ORIG_CXXFLAGS
 	AC_LANG_POP(C++)
-fi
+#fi
 AC_SUBST(CXX_ADD_CFLAGS)
 AC_SUBST(CXX_REMOVE_CFLAGS)
 

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -645,6 +645,16 @@ primitive_type_to_llvm_type (MonoTypeEnum type)
 	}
 }
 
+#if __cplusplus
+
+static LLVMTypeRef
+primitive_type_to_llvm_type (long type)
+{
+	return primitive_type_to_llvm_type ((MonoTypeEnum)type);
+}
+
+#endif
+
 /*
  * type_to_llvm_type:
  *


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18725,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Split generate_code into recursive and non-recursive parts, so that the recursive cost is much less.

This should contribute toward https://github.com/mono/mono/issues/18646 and we'll see later if it is enough to fix it.

This requires C++ but that can be "fixed" if it works,
or is another reason to use C++ -- "easier refactoring through this parameter".