### PR TITLE
Remove unused locals in System.ServiceModel.Syndication

### DIFF
--- a/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
+++ b/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/Atom10FeedFormatter.cs
@@ -595,8 +595,6 @@ namespace System.ServiceModel.Syndication
                 }
             }
             reader.MoveToElement();
-            string localName = reader.LocalName;
-            string nameSpace = reader.NamespaceURI;
             string val = (kind == TextSyndicationContentKind.XHtml) ? reader.ReadInnerXml() : reader.ReadElementString();
             TextSyndicationContent result = new TextSyndicationContent(val, kind);
             if (attrs != null)


### PR DESCRIPTION
Contributes to #30457

Only attributes' names are checked here.