### PR TITLE
Optimize CheckIriUnicodeRange

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -29,7 +29,8 @@ namespace System
         {
             Debug.Assert(char.IsHighSurrogate(highSurr));
 
-            if (isSurrogatePair = char.IsLowSurrogate(lowSurr))
+            isSurrogatePair = char.IsLowSurrogate(lowSurr);
+            if (isSurrogatePair)
             {
                 uint utf32 = (uint)char.ConvertToUtf32(highSurr, lowSurr);
 

--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -29,9 +29,9 @@ namespace System
         {
             Debug.Assert(char.IsHighSurrogate(highSurr));
 
-            isSurrogatePair = char.IsLowSurrogate(lowSurr);
-            if (isSurrogatePair)
+            if (char.IsLowSurrogate(lowSurr))
             {
+                isSurrogatePair = true;
                 uint utf32 = (uint)char.ConvertToUtf32(highSurr, lowSurr);
 
                 return ((utf32 - 0x10000) <= (0x1FFFD - 0x10000) ||
@@ -52,6 +52,8 @@ namespace System
                         ((utf32 - 0xF0000) <= (0xFFFFD - 0xF0000) ||
                         (utf32 - 0x100000) <= (0x10FFFD - 0x100000))));
             }
+
+            isSurrogatePair = false;
             return false;
         }
 

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4435,8 +4435,7 @@ namespace System
                         {
                             if ((i + 1) < end)
                             {
-                                bool surrPair = false;
-                                valid = IriHelper.CheckIriUnicodeRange(c, str[i + 1], ref surrPair, true);
+                                valid = IriHelper.CheckIriUnicodeRange(c, str[i + 1], out _, true);
                             }
                         }
                         else

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -575,12 +575,12 @@ namespace System
                     if (iriParsing)
                     {
                         if (!isHighSurr)
+                        {
                             inIriRange = IriHelper.CheckIriUnicodeRange(unescapedChars[j], isQuery);
+                        }
                         else
                         {
-                            bool surrPair = false;
-                            inIriRange = IriHelper.CheckIriUnicodeRange(unescapedChars[j], unescapedChars[j + 1],
-                                                                   ref surrPair, isQuery);
+                            inIriRange = IriHelper.CheckIriUnicodeRange(unescapedChars[j], unescapedChars[j + 1], out _, isQuery);
                         }
                     }
 


### PR DESCRIPTION
Avoid using an intermediate string to do range comparisons, behavior remains the same for all inputs.

Perf for that method alone is ~10-15x,

Perf for `"scheme:" + { '\ud83f', '\udffe' } * 1000`

| Method |         Toolchain |     Mean | Ratio |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------- |------------------ |---------:|------:|--------:|--------:|------:|----------:|
| NewUr1 | clean\CoreRun.exe | 345.1 us |  1.31 | 69.3359 | 13.6719 |     - | 285.44 KB |
| NewUr1 |   new\CoreRun.exe | 270.0 us |  1.00 | 62.0117 | 12.2070 |     - | 254.19 KB |