### PR TITLE
Change Dynamic header underlying data type from byte[] to string

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/DynamicTable.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/DynamicTable.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http.HPack
 
         public int MaxSize => _maxSize;
 
-        public HeaderField this[int index]
+        public ref HeaderField this[int index]
         {
             get
             {
@@ -42,11 +42,11 @@ namespace System.Net.Http.HPack
                     index += _buffer.Length;
                 }
 
-                return _buffer[index];
+                return ref _buffer[index];
             }
         }
 
-        public void Insert(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public void Insert(string name, string value)
         {
             int entryLength = HeaderField.GetLength(name.Length, value.Length);
             EnsureAvailable(entryLength);

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/H2StaticTable.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/H2StaticTable.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.HPack
 
         public static int Count => s_staticDecoderTable.Length;
 
-        public static HeaderField Get(int index) => s_staticDecoderTable[index];
+        public static ref HeaderField Get(int index) => ref s_staticDecoderTable[index];
 
         public static IReadOnlyDictionary<int, int> StatusIndex => s_statusIndex;
 
@@ -96,9 +96,7 @@ namespace System.Net.Http.HPack
         // Tackle as part of header table allocation strategy in general (see note in HeaderField constructor).
 
         private static HeaderField CreateHeaderField(string name, string value) =>
-            new HeaderField(
-                Encoding.ASCII.GetBytes(name),
-                value.Length != 0 ? Encoding.ASCII.GetBytes(value) : Array.Empty<byte>());
+            new HeaderField(name, value);
 
         // Values for encoding.
         // Unused values are omitted.

--- a/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HeaderField.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/Hpack/HeaderField.cs
@@ -3,7 +3,6 @@
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
 using System.Diagnostics;
-using System.Text;
 
 namespace System.Net.Http.HPack
 {
@@ -12,40 +11,23 @@ namespace System.Net.Http.HPack
         // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
         public const int RfcOverhead = 32;
 
-        public HeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public HeaderField(string name, string value)
         {
             Debug.Assert(name.Length > 0);
 
-            // TODO: We're allocating here on every new table entry.
-            // That means a poorly-behaved server could cause us to allocate repeatedly.
-            // We should revisit our allocation strategy here so we don't need to allocate per entry
-            // and we have a cap to how much allocation can happen per dynamic table
-            // (without limiting the number of table entries a server can provide within the table size limit).
-            Name = new byte[name.Length];
-            name.CopyTo(Name);
-
-            Value = new byte[value.Length];
-            value.CopyTo(Value);
+            Name = name;
+            Value = value;
         }
 
-        public byte[] Name { get; }
+        public string Name { get; }
 
-        public byte[] Value { get; }
+        public string Value { get; }
 
         public int Length => GetLength(Name.Length, Value.Length);
 
         public static int GetLength(int nameLength, int valueLength) => nameLength + valueLength + RfcOverhead;
 
-        public override string ToString()
-        {
-            if (Name != null)
-            {
-                return Encoding.ASCII.GetString(Name) + ": " + Encoding.ASCII.GetString(Value);
-            }
-            else
-            {
-                return "<empty>";
-            }
-        }
+        public override string ToString() => $"{Name ?? "<empty>"}: {Value ?? "<empty>"}";
+
     }
 }

--- a/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http2/IHttpHeadersHandler.cs
@@ -18,8 +18,8 @@ namespace System.Net.Http
     interface IHttpHeadersHandler
     {
         void OnStaticIndexedHeader(int index);
-        void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value);
-        void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
+        void OnStaticIndexedHeader(int index, string value);
+        void OnHeader(string name, string value);
         void OnHeadersComplete(bool endStream);
     }
 }

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/H3StaticTable.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/H3StaticTable.cs
@@ -157,7 +157,7 @@ namespace System.Net.Http.QPack
         };
 
         private static HeaderField CreateHeaderField(string name, string value)
-            => new HeaderField(Encoding.ASCII.GetBytes(name), Encoding.ASCII.GetBytes(value));
+            => new HeaderField(name, value);
 
         public const int Authority = 0;
         public const int PathSlash = 1;

--- a/src/libraries/Common/src/System/Net/Http/Http3/QPack/HeaderField.cs
+++ b/src/libraries/Common/src/System/Net/Http/Http3/QPack/HeaderField.cs
@@ -6,15 +6,15 @@ namespace System.Net.Http.QPack
 {
     internal readonly struct HeaderField
     {
-        public HeaderField(byte[] name, byte[] value)
+        public HeaderField(string name, string value)
         {
-            Name = new byte[name.Length];
-            Value = new byte[value.Length];
+            Name = name;
+            Value = value;
         }
 
-        public byte[] Name { get; }
+        public string Name { get; }
 
-        public byte[] Value { get; }
+        public string Value { get; }
 
         public int Length => Name.Length + Value.Length;
     }

--- a/src/libraries/Common/tests/Common.Tests.csproj
+++ b/src/libraries/Common/tests/Common.Tests.csproj
@@ -54,6 +54,9 @@
     <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)System\Net\WebHeaderEncoding.cs">
+      <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\Http2\IHttpHeadersHandler.cs">
       <Link>Common\System\Net\Http\Http2\IHttpHeadersHandler.cs</Link>
     </Compile>

--- a/src/libraries/Common/tests/Tests/System/Net/Http2/DynamicTableTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/Http2/DynamicTableTest.cs
@@ -14,8 +14,8 @@ namespace System.Net.Http.Unit.Tests.HPack
 {
     public class DynamicTableTest
     {
-        private readonly HeaderField _header1 = new HeaderField(Encoding.ASCII.GetBytes("header-1"), Encoding.ASCII.GetBytes("value1"));
-        private readonly HeaderField _header2 = new HeaderField(Encoding.ASCII.GetBytes("header-02"), Encoding.ASCII.GetBytes("value_2"));
+        private readonly HeaderField _header1 = new HeaderField("header-1", "value1");
+        private readonly HeaderField _header2 = new HeaderField("header-02", "value_2");
 
         [Fact]
         public void DynamicTable_IsInitiallyEmpty()
@@ -104,7 +104,7 @@ namespace System.Net.Http.Unit.Tests.HPack
         {
             FieldInfo insertIndexField = typeof(DynamicTable).GetField("_insertIndex", BindingFlags.NonPublic | BindingFlags.Instance);
             DynamicTable table = new DynamicTable(maxSize: 256);
-            Stack<byte[]> insertedHeaders = new Stack<byte[]>();
+            Stack<string> insertedHeaders = new Stack<string>();
 
             // Insert into dynamic table until its insert index into its ring buffer loops back to 0.
             do
@@ -121,7 +121,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             void InsertOne()
             {
-                byte[] data = Encoding.ASCII.GetBytes($"header-{insertedHeaders.Count}");
+                string data = $"header-{insertedHeaders.Count}";
 
                 insertedHeaders.Push(data);
                 table.Insert(data, data);
@@ -135,10 +135,10 @@ namespace System.Net.Http.Unit.Tests.HPack
             for (int i = 0; i < table.Count; ++i)
             {
                 HeaderField dynamicField = table[i];
-                byte[] expectedData = insertedHeaders.Pop();
+                string expectedData = insertedHeaders.Pop();
 
-                Assert.True(expectedData.AsSpan().SequenceEqual(dynamicField.Name));
-                Assert.True(expectedData.AsSpan().SequenceEqual(dynamicField.Value));
+                Assert.Equal(expectedData, dynamicField.Name);
+                Assert.Equal(expectedData, dynamicField.Value);
             }
         }
 
@@ -154,7 +154,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             while (insertedSize != insertSize)
             {
-                byte[] data = Encoding.ASCII.GetBytes($"header-{dynamicTable.Size}".PadRight(16, ' '));
+                string data = $"header-{dynamicTable.Size}".PadRight(16, ' ');
                 Debug.Assert(data.Length == 16);
 
                 dynamicTable.Insert(data, data);
@@ -244,10 +244,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             {
                 HeaderField headerField = dynamicTable[i];
 
-                Assert.NotSame(entries[i].Name, headerField.Name);
                 Assert.Equal(entries[i].Name, headerField.Name);
 
-                Assert.NotSame(entries[i].Value, headerField.Value);
                 Assert.Equal(entries[i].Value, headerField.Value);
             }
         }

--- a/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/Http2/HPackDecoderTest.cs
@@ -98,12 +98,9 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder = new HPackDecoder(DynamicTableInitialMaxSize, MaxHeaderFieldSize, _dynamicTable);
         }
 
-        void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        void IHttpHeadersHandler.OnHeader(string name, string value)
         {
-            string headerName = Encoding.ASCII.GetString(name);
-            string headerValue = Encoding.ASCII.GetString(value);
-
-            _decodedHeaders[headerName] = headerValue;
+             _decodedHeaders[name] = value;
         }
 
         void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
@@ -112,7 +109,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             throw new NotImplementedException();
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, string value)
         {
             // Not yet implemented for HPACK.
             throw new NotImplementedException();
@@ -131,7 +128,7 @@ namespace System.Net.Http.Unit.Tests.HPack
         public void DecodesIndexedHeaderField_DynamicTable()
         {
             // Add the header to the dynamic table
-            _dynamicTable.Insert(_headerNameBytes, _headerValueBytes);
+            _dynamicTable.Insert(_headerNameString, _headerValueString);
 
             // Index it
             _decoder.Decode(_indexedHeaderDynamic, endHeaders: true, handler: this);
@@ -629,8 +626,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             if (expectDynamicTableEntry)
             {
                 Assert.Equal(1, _dynamicTable.Count);
-                Assert.Equal(expectedHeaderName, Encoding.ASCII.GetString(_dynamicTable[0].Name));
-                Assert.Equal(expectedHeaderValue, Encoding.ASCII.GetString(_dynamicTable[0].Value));
+                Assert.Equal(expectedHeaderName, _dynamicTable[0].Name);
+                Assert.Equal(expectedHeaderValue, _dynamicTable[0].Value);
                 Assert.Equal(expectedHeaderName.Length + expectedHeaderValue.Length + 32, _dynamicTable.Size);
             }
             else

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -169,6 +169,9 @@
     <Compile Include="$(CommonPath)System\Net\ContextFlagsPal.cs">
       <Link>Common\System\Net\ContextFlagsPal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)System\Net\WebHeaderEncoding.cs">
+      <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\Http2\IHttpHeadersHandler.cs">
       <Link>Common\System\Net\Http\Http2\IHttpHeadersHandler.cs</Link>
     </Compile>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http
                 1024;
 #endif
 
-            private static readonly byte[] s_statusHeaderName = Encoding.ASCII.GetBytes(":status");
+            private const string s_statusHeaderName = ":status";
 
             private readonly Http2Connection _connection;
             private readonly int _streamId;
@@ -402,15 +402,15 @@ namespace System.Net.Http
                 Debug.Fail("Currently unused by HPACK, this should never be called.");
             }
 
-            void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+            void IHttpHeadersHandler.OnStaticIndexedHeader(int index, string value)
             {
                 // TODO: https://github.com/dotnet/runtime/issues/1505
                 Debug.Fail("Currently unused by HPACK, this should never be called.");
             }
 
-            public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+            public void OnHeader(string name, string value)
             {
-                if (NetEventSource.IsEnabled) Trace($"{Encoding.ASCII.GetString(name)}: {Encoding.ASCII.GetString(value)}");
+                if (NetEventSource.IsEnabled) Trace($"{name}: {value}");
                 Debug.Assert(name != null && name.Length > 0);
 
                 _headerBudgetRemaining -= name.Length + value.Length;
@@ -428,7 +428,7 @@ namespace System.Net.Http
                         return;
                     }
 
-                    if (name[0] == (byte)':')
+                    if (name[0] == ':')
                     {
                         if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingStatus)
                         {
@@ -437,7 +437,7 @@ namespace System.Net.Http
                             throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
-                        if (name.SequenceEqual(s_statusHeaderName))
+                        if (name.Equals(s_statusHeaderName))
                         {
                             if (_responseProtocolState != ResponseProtocolState.ExpectingStatus)
                             {
@@ -482,7 +482,7 @@ namespace System.Net.Http
                         }
                         else
                         {
-                            if (NetEventSource.IsEnabled) Trace($"Invalid response pseudo-header '{Encoding.ASCII.GetString(name)}'.");
+                            if (NetEventSource.IsEnabled) Trace($"Invalid response pseudo-header '{name}'.");
                             throw new HttpRequestException(SR.net_http_invalid_response);
                         }
                     }
@@ -503,7 +503,7 @@ namespace System.Net.Http
                         if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
                         {
                             // Invalid header name
-                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, name));
                         }
 
                         string headerValue = descriptor.GetHeaderValue(value);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -794,13 +794,13 @@ namespace System.Net.Http
 
         private static ReadOnlySpan<byte> StatusHeaderNameBytes => new byte[] { (byte)'s', (byte)'t', (byte)'a', (byte)'t', (byte)'u', (byte)'s' };
 
-        void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        void IHttpHeadersHandler.OnHeader(string name, string value)
         {
             Debug.Assert(name.Length > 0);
             if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
             {
                 // Invalid header name
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, name));
             }
             OnHeader(staticIndex: null, descriptor, staticValue: default, literalValue: value);
         }
@@ -811,7 +811,7 @@ namespace System.Net.Http
             OnHeader(index, descriptor, knownValue, literalValue: default);
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, string value)
         {
             GetStaticQPackHeader(index, out HeaderDescriptor descriptor, knownValue: out _);
             OnHeader(index, descriptor, staticValue: null, literalValue: value);
@@ -831,7 +831,7 @@ namespace System.Net.Http
         /// <param name="staticValue">The static indexed value, if any.</param>
         /// <param name="literalValue">The literal ASCII value, if any.</param>
         /// <remarks>One of <paramref name="staticValue"/> or <paramref name="literalValue"/> will be set.</remarks>
-        private void OnHeader(int? staticIndex, HeaderDescriptor descriptor, string staticValue, ReadOnlySpan<byte> literalValue)
+        private void OnHeader(int? staticIndex, HeaderDescriptor descriptor, string staticValue, string literalValue)
         {
             if (descriptor.Name[0] == ':')
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -58,18 +58,21 @@ namespace System.Net.Http
 
         internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';
 
-        internal static int ParseStatusCode(ReadOnlySpan<byte> value)
+        internal static int ParseStatusCode(string value)
         {
-            byte status1, status2, status3;
+            char status1, status2, status3;
             if (value.Length != 3 ||
                 !IsDigit(status1 = value[0]) ||
                 !IsDigit(status2 = value[1]) ||
                 !IsDigit(status3 = value[2]))
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, System.Text.Encoding.ASCII.GetString(value)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, value));
             }
 
             return 100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0');
+
+            static bool IsDigit(char c) => (c - '0') <= '9' - '0';
+
         }
 
         /// <summary>Awaits a task, ignoring any resulting exceptions.</summary>

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -146,11 +146,11 @@ namespace System.Net.Http.Unit.Tests.HPack
                 _headers = headers;
             }
 
-            public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+            public void OnHeader(string name, string value)
             {
                 if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
                 {
-                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, name));
                 }
 
                 string headerValue = descriptor.GetHeaderValue(value);
@@ -168,7 +168,7 @@ namespace System.Net.Http.Unit.Tests.HPack
                 throw new NotImplementedException();
             }
 
-            public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+            public void OnStaticIndexedHeader(int index, string value)
             {
                 throw new NotImplementedException();
             }

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -456,6 +456,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\WinHttp\Interop.winhttp_types.cs">
       <Link>ProductionCode\Common\Interop\Windows\WinHttp\Interop.winhttp_types.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)System\Net\WebHeaderEncoding.cs">
+      <Link>Common\System\Net\WebHeaderEncoding.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)System\Net\Http\WinInetProxyHelper.cs">
       <Link>Common\System\Net\Http\WinInetProxyHelper.cs</Link>
     </Compile>


### PR DESCRIPTION
# Perf results:

## Dynamic table
Insertion into dynamic table:

### Before:

| Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|------:|------:|------:|----------:|
| Insert | **1.459 us** | 0.0700 us | 0.1974 us |     - |     - |     - |      **88 B** |

### After:

| Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| Insert | **234.7 ns** | 12.73 ns | 37.35 ns |     - |     - |     - |      **48 B** |

## HeaderField constructor

There was removed the main allocation issue

### Before:
| Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
|    Ctr | **336.0 ns** | 6.66 ns | 7.13 ns | 0.1121 |     - |     - |     **704 B** |
### After:
| Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|------:|------:|------:|----------:|
|    Ctr | **21.86 ns** | 0.107 ns | 0.101 ns |     - |     - |     - |         **-** |

##HeaderDescriptor

I added new string overload for *GetHeaderValue* method as the original with byte[] is used by HTTP2 and there was a performance penalty to convert the value to string before.

As you can see there is a significant performance hit for Location headers, however, this path is not used in HTTP2. I would like to discuss this in the PR.

### Before:
|                             Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
|       GetHeaderValue_Bytes_Unknown |  **34.96 ns** | 0.355 ns | 0.315 ns | 0.0114 |     - |     - |      **72 B** |
|         GetHeaderValue_Bytes_Known |  **46.35 ns** | 0.296 ns | 0.247 ns | 0.0114 |     - |     - |      **72 B** |
|      GetHeaderValue_Bytes_Location |  **87.41 ns** | 0.995 ns | 0.931 ns | 0.0114 |     - |     - |      **!!** *72 B* |
| GetHeaderValue_Bytes_Location_utf8 | **109.67 ns** | 2.222 ns | 5.366 ns | 0.0114 |     - |     - |  **!!**    *72 B* |
### After:
|                              Method |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------ |-----------:|----------:|----------:|-------:|------:|------:|----------:|
|       GetHeaderValue_String_Unknown |   **3.719 ns** | 0.0983 ns | 0.1009 ns |      - |     - |     - |         **-** |
|         GetHeaderValue_String_Known |   **4.268 ns** | 0.0332 ns | 0.0294 ns |      - |     - |     - |         **-** |
|      GetHeaderValue_String_Location | **!! 208.229 ns** | 3.1741 ns | 2.8138 ns | 0.0203 |     - |     - |     **!!**    *128 B* |
| GetHeaderValue_String_Location_utf8 | **!! 242.598 ns** | 2.5850 ns | 2.2916 ns | 0.0200 |     - |     - |     **!!**    *128 B* |

## HpackDecoder

It is visible that the decoder doesn't allocate in case of dynamic/static headers at all

### Before:

|                                 Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| DecodesIndexedHeaderField_DynamicTable | **81.19 ns** | 1.149 ns | 1.075 ns | 0.0153 |     - |     - |      **96 B **|
|  DecodesIndexedHeaderField_StaticTable | **76.35 ns** | 1.746 ns | 2.331 ns | 0.0114 |     - |     - |      **72 B** |

### After:

|                                 Method |     Mean |    Error |   StdDev |   Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| DecodesIndexedHeaderField_DynamicTable | **14.61 ns** | 0.501 ns | 0.419 ns | 14.45 ns |     - |     - |     - |         **-** |
|  DecodesIndexedHeaderField_StaticTable | **13.42 ns** | 0.313 ns | 0.808 ns | 13.10 ns |     - |     - |     - |         **-** |

## Http client

The main improvement is in simple get with an empty body (*Get*) as Kestrel sends value from the static table. Another requests with custom headers are equal as this change is not related to encoding (*GetWithHeaders*) and the Kestrel don't send dynamic headers in the response (*GetWithHeaders_Echo*)

### Before:

|              Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|                 Get | **449.6 us** | 10.03 us | 28.13 us | 0.4883 |     - |     - |   **4.58 KB** |
|      GetWithHeaders | 467.2 us | 10.36 us | 30.55 us |      - |     - |     - |   5.11 KB |
| GetWithHeaders_Echo | 469.3 us |  9.25 us | 13.84 us | 0.9766 |     - |     - |   6.53 KB |

### After:

|              Method |     Mean |   Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|---------:|-------:|------:|------:|----------:|
|                 Get | **344.2 us** | 7.69 us |  9.44 us | 0.4883 |     - |     - |   **3.76 KB** |
|      GetWithHeaders | 431.6 us | 8.55 us |  9.50 us | 0.4883 |     - |     - |   5.12 KB |
| GetWithHeaders_Echo | 468.8 us | 9.19 us | 12.58 us | 0.9766 |     - |     - |   6.53 KB |

Fixes #31861