### PR TITLE
Fix FreeBSD native build

### DIFF
--- a/src/coreclr/src/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/src/pal/src/misc/sysinfo.cpp
@@ -37,6 +37,10 @@ Revision History:
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 
+#if HAVE_SYSCTLBYNAME
+#include <sys/sysctl.h>
+#endif
+
 #if HAVE_SYSINFO
 #include <sys/sysinfo.h>
 #endif

--- a/src/libraries/Native/Unix/System.Native/pal_networkchange.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkchange.c
@@ -162,10 +162,8 @@ void SystemNative_ReadEvents(int32_t sock, NetworkChangeEvent onNetworkChange)
             case RTM_ADD:
             case RTM_DELETE:
             case RTM_REDIRECT:
-            {
                 onNetworkChange(sock, AvailabilityChanged);
                 return;
-            }
             default:
                 break;
         }


### PR DESCRIPTION
FreeBSD requires sys/sysctl.h in sysinfo.cpp.