### PR TITLE
Use char.GetUnicodeCategory in RegexCompiler for single Unicode categories

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -744,6 +744,44 @@ namespace System.Text.RegularExpressions
             !IsSubtraction(set) &&
             (set[SetStartIndex] == LastChar || set[SetStartIndex] + 1 == set[SetStartIndex + 1]);
 
+        /// <summary>Gets whether the set contains nothing other than a single UnicodeCategory (it may be negated).</summary>
+        /// <param name="set">The set to examine.</param>
+        /// <param name="category">The single category if there was one.</param>
+        /// <param name="negated">true if the single category is a not match.</param>
+        /// <returns>true if a single category could be obtained; otherwise, false.</returns>
+        public static bool TryGetSingleUnicodeCategory(string set, out UnicodeCategory category, out bool negated)
+        {
+            if (set[CategoryLengthIndex] == 1 &&
+                set[SetLengthIndex] == 0 &&
+                !IsSubtraction(set))
+            {
+                short c = (short)set[SetStartIndex];
+
+                if (c > 0)
+                {
+                    if (c != SpaceConst)
+                    {
+                        category = (UnicodeCategory)(c - 1);
+                        negated = IsNegated(set);
+                        return true;
+                    }
+                }
+                else if (c < 0)
+                {
+                    if (c != NotSpaceConst)
+                    {
+                        category = (UnicodeCategory)(-1 - c);
+                        negated = !IsNegated(set);
+                        return true;
+                    }
+                }
+            }
+
+            category = default;
+            negated = false;
+            return false;
+        }
+
         /// <summary>Attempts to get a single range stored in the set.</summary>
         /// <param name="set">The set.</param>
         /// <param name="lowInclusive">The inclusive lower-bound of the range, if available.</param>

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCharacterSetTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Xunit;
 using Xunit.Sdk;
 
@@ -292,6 +293,54 @@ namespace System.Text.RegularExpressions.Tests
 
             ValidateSet($"[{set}]", RegexOptions.None, included, null);
             ValidateSet($"[^{set}]", RegexOptions.None, null, included);
+        }
+
+        [Theory]
+        [InlineData("Cc", UnicodeCategory.Control)]
+        [InlineData("Cf", UnicodeCategory.Format)]
+        [InlineData("Cn", UnicodeCategory.OtherNotAssigned)]
+        [InlineData("Co", UnicodeCategory.PrivateUse)]
+        [InlineData("Cs", UnicodeCategory.Surrogate)]
+        [InlineData("Ll", UnicodeCategory.LowercaseLetter)]
+        [InlineData("Lm", UnicodeCategory.ModifierLetter)]
+        [InlineData("Lo", UnicodeCategory.OtherLetter)]
+        [InlineData("Lt", UnicodeCategory.TitlecaseLetter)]
+        [InlineData("Lu", UnicodeCategory.UppercaseLetter)]
+        [InlineData("Mc", UnicodeCategory.SpacingCombiningMark)]
+        [InlineData("Me", UnicodeCategory.EnclosingMark)]
+        [InlineData("Mn", UnicodeCategory.NonSpacingMark)]
+        [InlineData("Nd", UnicodeCategory.DecimalDigitNumber)]
+        [InlineData("Nl", UnicodeCategory.LetterNumber)]
+        [InlineData("No", UnicodeCategory.OtherNumber)]
+        [InlineData("Pc", UnicodeCategory.ConnectorPunctuation)]
+        [InlineData("Pd", UnicodeCategory.DashPunctuation)]
+        [InlineData("Pe", UnicodeCategory.ClosePunctuation)]
+        [InlineData("Po", UnicodeCategory.OtherPunctuation)]
+        [InlineData("Ps", UnicodeCategory.OpenPunctuation)]
+        [InlineData("Pf", UnicodeCategory.FinalQuotePunctuation)]
+        [InlineData("Pi", UnicodeCategory.InitialQuotePunctuation)]
+        [InlineData("Sc", UnicodeCategory.CurrencySymbol)]
+        [InlineData("Sk", UnicodeCategory.ModifierSymbol)]
+        [InlineData("Sm", UnicodeCategory.MathSymbol)]
+        [InlineData("So", UnicodeCategory.OtherSymbol)]
+        [InlineData("Zl", UnicodeCategory.LineSeparator)]
+        [InlineData("Zp", UnicodeCategory.ParagraphSeparator)]
+        [InlineData("Zs", UnicodeCategory.SpaceSeparator)]
+        public void UnicodeCategoriesInclusionsExpected(string generalCategory, UnicodeCategory unicodeCategory)
+        {
+            foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled })
+            {
+                Regex r;
+                char[] allChars = Enumerable.Range(0, char.MaxValue + 1).Select(i => (char)i).ToArray();
+                int expectedInCategory = allChars.Count(c => char.GetUnicodeCategory(c) == unicodeCategory);
+                int expectedNotInCategory = allChars.Length - expectedInCategory;
+
+                r = new Regex(@$"\p{{{generalCategory}}}");
+                Assert.Equal(expectedInCategory, r.Matches(string.Concat(allChars)).Count);
+
+                r = new Regex(@$"\P{{{generalCategory}}}");
+                Assert.Equal(expectedNotInCategory, r.Matches(string.Concat(allChars)).Count);
+            }
         }
 
         private static HashSet<char> ComputeIncludedSet(Func<char, bool> func)


### PR DESCRIPTION
When `\p{..}` or `\p{..}` is used to specify a Unicode category, we will now generate a call to `char.GetUnicodeCategory` rather than generating our own ASCII lookup table and fallback call to CharInClass.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

public class Program
{
    public static void Main(string[] args)
    {
        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
    }

    private string _input = new string('s', 100);
    private Regex _r = new Regex(@"\p{Cc}", RegexOptions.Compiled);

    [Benchmark]
    public bool IsMatch() => _r.IsMatch(_input);
}
```

```
|  Method |               Toolchain |     Mean |   Error |   StdDev | Ratio | RatioSD |
|-------- |------------------------ |---------:|--------:|---------:|------:|--------:|
| IsMatch | \coreclrnew\CoreRun.exe | 161.2 ns | 6.14 ns | 17.03 ns |  0.79 |    0.09 |
| IsMatch | \coreclrold\corerun.exe | 210.4 ns | 4.21 ns |  7.60 ns |  1.00 |    0.00 |
```

Contributes to https://github.com/dotnet/runtime/issues/1349
cc: @danmosemsft, @eerhardt, @ViktorHofer, @GrabYourPitchforks, @tarekgh 