### PR TITLE
Remove dead code in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -11,8 +11,6 @@ namespace System
     // The idea is to stay with static helper methods and strings
     internal static partial class IPv6AddressHelper
     {
-        // methods
-
         internal static unsafe string ParseCanonicalName(string str, int start, ref bool isLoopback, ref string? scopeId)
         {
             Span<ushort> numbers = stackalloc ushort[NumberOfLabels];

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -206,14 +206,7 @@ namespace System
         //
         internal static bool IriParsingStatic(UriParser? syntax)
         {
-            return (IriParsing && (((syntax != null) && syntax.InFact(UriSyntaxFlags.AllowIriParsing)) ||
-                   (syntax == null)));
-        }
-
-        private bool IsIntranet(string schemeHost)
-        {
-            // .NET Native/CoreCLR behavior difference: all URI/IRIs will be treated as Internet.
-            return false;
+            return syntax is null || syntax.InFact(UriSyntaxFlags.AllowIriParsing);
         }
 
         internal bool UserDrivenParsing
@@ -892,10 +885,6 @@ namespace System
         {
             return syntax.InFact(UriSyntaxFlags.FileLikeUri);
         }
-
-        // Value from config Uri section
-        // On by default in .NET 4.5+ and cannot be disabled by config.
-        private const bool IriParsing = true; // IRI Parsing is always enabled in .NET Native and CoreCLR
 
         private string GetLocalPath()
         {
@@ -4003,7 +3992,7 @@ namespace System
             ushort start = idx;
             newHost = null;
             bool justNormalized = false;
-            bool iriParsing = (IriParsing && IriParsingStatic(syntax)); // perf
+            bool iriParsing = IriParsingStatic(syntax); // perf
             bool hasUnicode = ((flags & Flags.HasUnicode) != 0); // perf
             bool hostNotUnicodeNormalized = ((flags & Flags.HostUnicodeNormalized) == 0); // perf
             UriSyntaxFlags syntaxFlags = syntax.Flags;
@@ -4089,7 +4078,7 @@ namespace System
             {
                 flags |= Flags.IPv6HostType;
 
-                _iriParsing = (IriParsing && IriParsingStatic(syntax));
+                _iriParsing = IriParsingStatic(syntax);
 
                 if (hasUnicode && iriParsing && hostNotUnicodeNormalized)
                 {
@@ -4127,8 +4116,8 @@ namespace System
                     && DomainNameHelper.IsValidByIri(pString, start, ref end, ref dnsNotCanonical,
                                             StaticNotAny(flags, Flags.ImplicitFile)))
             {
-                CheckAuthorityHelperHandleDnsIri(pString, start, end, startInput, iriParsing, hasUnicode, syntax,
-                    userInfoString, ref flags, ref justNormalized, ref newHost, ref err);
+                CheckAuthorityHelperHandleDnsIri(pString, start, end, hasUnicode,
+                    ref flags, ref justNormalized, ref newHost, ref err);
             }
             else if ((syntaxFlags & UriSyntaxFlags.AllowUncHost) != 0)
             {
@@ -4243,7 +4232,7 @@ namespace System
                             break;
                         }
                     }
-                    CheckAuthorityHelperHandleAnyHostIri(pString, startInput, end, iriParsing, hasUnicode, syntax,
+                    CheckAuthorityHelperHandleAnyHostIri(pString, startInput, end, iriParsing, hasUnicode,
                                                             ref flags, ref newHost, ref err);
                 }
                 else
@@ -4307,8 +4296,8 @@ namespace System
             return (ushort)end;
         }
 
-        private unsafe void CheckAuthorityHelperHandleDnsIri(char* pString, ushort start, int end, int startInput,
-            bool iriParsing, bool hasUnicode, UriParser syntax, string? userInfoString, ref Flags flags,
+        private unsafe void CheckAuthorityHelperHandleDnsIri(char* pString, ushort start, int end,
+            bool hasUnicode, ref Flags flags,
             ref bool justNormalized, ref string? newHost, ref ParsingError err)
         {
             // comes here only if host has unicode chars and iri is on or idn is allowed
@@ -4332,7 +4321,7 @@ namespace System
         }
 
         private unsafe void CheckAuthorityHelperHandleAnyHostIri(char* pString, int startInput, int end,
-                                            bool iriParsing, bool hasUnicode, UriParser syntax,
+                                            bool iriParsing, bool hasUnicode,
                                             ref Flags flags, ref string? newHost, ref ParsingError err)
         {
             if (StaticNotAny(flags, Flags.HostUnicodeNormalized) && (iriParsing && hasUnicode))

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3225,7 +3225,7 @@ namespace System
             ushort idx = _info.Offset.Scheme;
             ushort length = (ushort)_string.Length;
             Check result = Check.None;
-            UriSyntaxFlags syntaxFlags = _syntax.Flags;    // perf
+            UriSyntaxFlags syntaxFlags = _syntax.Flags;
 
             // m_Info.Offset values may be parsed twice but we lock only on m_Flags update.
 
@@ -3992,9 +3992,9 @@ namespace System
             ushort start = idx;
             newHost = null;
             bool justNormalized = false;
-            bool iriParsing = IriParsingStatic(syntax); // perf
-            bool hasUnicode = ((flags & Flags.HasUnicode) != 0); // perf
-            bool hostNotUnicodeNormalized = ((flags & Flags.HostUnicodeNormalized) == 0); // perf
+            bool iriParsing = IriParsingStatic(syntax);
+            bool hasUnicode = ((flags & Flags.HasUnicode) != 0);
+            bool hostNotUnicodeNormalized = ((flags & Flags.HostUnicodeNormalized) == 0);
             UriSyntaxFlags syntaxFlags = syntax.Flags;
 
             //Special case is an empty authority

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -81,7 +81,7 @@ namespace System
 
             bool hasUnicode = false;
 
-            _iriParsing = (IriParsing && ((_syntax == null) || _syntax.InFact(UriSyntaxFlags.AllowIriParsing)));
+            _iriParsing = IriParsingStatic(_syntax);
 
             if (_iriParsing &&
                 (CheckForUnicode(_string) || CheckForEscapedUnreserved(_string)))


### PR DESCRIPTION
Similar idea to #696

Removed unused method parameters, always true `IriParsing` and unused `bool IsIntranet(string schemeHost)`.