### PR TITLE
Disable warnAsError from windows libraries builds in official builds to workaround cmake issue

### DIFF
--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -102,6 +102,9 @@ jobs:
         # Windows variables
         - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
           - _runtimeOSArg: /p:RuntimeOS=win10
+          - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+            # Remove when: https://github.com/dotnet/runtime/issues/31888 is fixed.
+            - _warnAsErrorArg: -warnAsError:0
 
         # Non-Windows variables
         - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:


### PR DESCRIPTION
Workaround for: https://github.com/dotnet/runtime/issues/31888

Validated in: https://dev.azure.com/dnceng/internal/_build/results?buildId=510729
cc: @dotnet/runtime-infrastructure 