### PR TITLE
Get tests running for HTTP/3

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
@@ -224,7 +224,7 @@ namespace System.Net.Http.QPack
                     }
                     break;
                 case State.CompressedHeaders:
-                    switch (BitOperations.LeadingZeroCount(b) - 24)
+                    switch (BitOperations.LeadingZeroCount(b) - 24) // byte 'b' is extended to uint, so will have 24 extra 0s.
                     {
                         case 0: // Indexed Header Field
                             prefixInt = IndexedHeaderFieldPrefixMask & b;

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -18,10 +18,7 @@ namespace System.Net.Test.Common
         public abstract GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null);
         public abstract Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null);
 
-        // TODO: just expose a version property.
-        public abstract bool IsHttp11 { get; }
-        public abstract bool IsHttp2 { get; }
-        public abstract bool IsHttp3 { get; }
+        public abstract Version Version { get; }
 
         // Common helper methods
 

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -315,7 +315,7 @@ namespace System.Net.Test.Common
 
         private static (int bytesConsumed, int value) DecodeInteger(ReadOnlySpan<byte> headerBlock, byte prefixMask)
         {
-            return QPackDecoder.DecodeInteger(headerBlock, prefixMask);
+            return QPackTestDecoder.DecodeInteger(headerBlock, prefixMask);
         }
 
         private static (int bytesConsumed, string value) DecodeString(ReadOnlySpan<byte> headerBlock)

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -237,9 +237,7 @@ namespace System.Net.Test.Common
             }
         }
 
-        public override bool IsHttp11 => false;
-        public override bool IsHttp2 => true;
-        public override bool IsHttp3 => false;
+        public override Version Version => HttpVersion.Version20;
     }
 
     public enum ProtocolErrors

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -61,22 +61,22 @@ namespace System.Net.Test.Common
 
         public async Task SendHeadersFrameAsync(ICollection<HttpHeaderData> headers)
         {
-            int bufferLength = QPackEncoder.MaxPrefixLength;
+            int bufferLength = QPackTestEncoder.MaxPrefixLength;
 
             foreach (HttpHeaderData header in headers)
             {
                 // Two varints for length, and double the name/value lengths to account for expanding Huffman coding.
-                bufferLength += QPackEncoder.MaxVarIntLength * 2 + header.Name.Length * 2 + header.Value.Length * 2;
+                bufferLength += QPackTestEncoder.MaxVarIntLength * 2 + header.Name.Length * 2 + header.Value.Length * 2;
             }
 
             var buffer = new byte[bufferLength];
             int bytesWritten = 0;
 
-            bytesWritten += QPackEncoder.EncodePrefix(buffer.AsSpan(bytesWritten), 0, 0);
+            bytesWritten += QPackTestEncoder.EncodePrefix(buffer.AsSpan(bytesWritten), 0, 0);
 
             foreach (HttpHeaderData header in headers)
             {
-                bytesWritten += QPackEncoder.EncodeHeader(buffer.AsSpan(bytesWritten), header.Name, header.Value, header.HuffmanEncoded ? QPackFlags.HuffmanEncode : QPackFlags.None);
+                bytesWritten += QPackTestEncoder.EncodeHeader(buffer.AsSpan(bytesWritten), header.Name, header.Value, header.HuffmanEncoded ? QPackFlags.HuffmanEncode : QPackFlags.None);
             }
 
             await SendFrameAsync(HeadersFrame, buffer.AsMemory(0, bytesWritten)).ConfigureAwait(false);
@@ -100,9 +100,10 @@ namespace System.Net.Test.Common
             await _stream.WriteAsync(framePayload).ConfigureAwait(false);
         }
 
-        public void ShutdownSend()
+        public async Task ShutdownSendAsync()
         {
             _stream.Shutdown();
+            await _stream.ShutdownWriteCompleted().ConfigureAwait(false);
         }
 
         static int EncodeHttpInteger(long longToEncode, Span<byte> buffer)
@@ -176,14 +177,14 @@ namespace System.Net.Test.Common
         {
             HttpRequestData request = new HttpRequestData { RequestId = Http3LoopbackConnection.GetRequestId(_stream) };
 
-            (int prefixLength, int requiredInsertCount, int deltaBase) = QPackDecoder.DecodePrefix(buffer);
+            (int prefixLength, int requiredInsertCount, int deltaBase) = QPackTestDecoder.DecodePrefix(buffer);
             if (requiredInsertCount != 0 || deltaBase != 0) throw new Exception("QPack dynamic table not yet supported.");
 
             buffer = buffer.Slice(prefixLength);
 
             while (!buffer.IsEmpty)
             {
-                (int headerLength, HttpHeaderData header) = QPackDecoder.DecodeHeader(buffer);
+                (int headerLength, HttpHeaderData header) = QPackTestDecoder.DecodeHeader(buffer);
 
                 request.Headers.Add(header);
                 buffer = buffer.Slice(headerLength);
@@ -247,7 +248,6 @@ namespace System.Net.Test.Common
         public async Task<long?> ReadInteger()
         {
             byte[] buffer = new byte[MaximumVarIntBytes];
-            int bufferAvailableOffset = -1;
             int bufferActiveLength = 0;
 
             long integerValue;
@@ -255,14 +255,14 @@ namespace System.Net.Test.Common
 
             do
             {
-                bytesRead = await _stream.ReadAsync(buffer.AsMemory(++bufferAvailableOffset, 1)).ConfigureAwait(false);
+                bytesRead = await _stream.ReadAsync(buffer.AsMemory(bufferActiveLength++, 1)).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
-                    return bufferActiveLength == 0 ? (long?)null : throw new Exception("Unable to read varint; unexpected end of stream.");
+                    return bufferActiveLength == 1 ? (long?)null : throw new Exception("Unable to read varint; unexpected end of stream.");
                 }
                 Debug.Assert(bytesRead == 1);
             }
-            while (!TryDecodeHttpInteger(buffer.AsSpan(0, ++bufferActiveLength), out integerValue, out bytesRead));
+            while (!TryDecodeHttpInteger(buffer.AsSpan(0, bufferActiveLength), out integerValue, out bytesRead));
 
             Debug.Assert(bytesRead == bufferActiveLength);
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -33,9 +33,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true, CancellationMode.Token)]
         public async Task PostAsync_CancelDuringRequestContentSend_TaskCanceledQuickly(bool chunkedTransfer, CancellationMode mode)
         {
-            if (LoopbackServerFactory.IsHttp2 && chunkedTransfer)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && chunkedTransfer)
             {
-                // There is no chunked encoding in HTTP/2
+                // There is no chunked encoding in HTTP/2 and later
                 return;
             }
 
@@ -80,9 +80,9 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(OneBoolAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseHeadersReceived_TaskCanceledQuickly(bool connectionClose, CancellationMode mode)
         {
-            if (LoopbackServerFactory.IsHttp2 && connectionClose)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && connectionClose)
             {
-                // There is no Connection header in HTTP/2
+                // There is no Connection header in HTTP/2 and later
                 return;
             }
 
@@ -130,9 +130,9 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {
-            if (LoopbackServerFactory.IsHttp2 && (chunkedTransfer || connectionClose))
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && (chunkedTransfer || connectionClose))
             {
-                // There is no chunked encoding or connection header in HTTP/2
+                // There is no chunked encoding or connection header in HTTP/2 and later
                 return;
             }
 
@@ -186,9 +186,9 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(ThreeBools))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Unbuffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, bool readOrCopyToAsync)
         {
-            if (LoopbackServerFactory.IsHttp2 && (chunkedTransfer || connectionClose))
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && (chunkedTransfer || connectionClose))
             {
-                // There is no chunked encoding or connection header in HTTP/2
+                // There is no chunked encoding or connection header in HTTP/2 and later
                 return;
             }
 
@@ -312,10 +312,10 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact]
         public async Task MaxConnectionsPerServer_WaitingConnectionsAreCancelable()
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
                 // HTTP/2 does not use connection limits.
-                throw new SkipTestException("Not supported on HTTP/2");
+                throw new SkipTestException("Not supported on HTTP/2 and later");
             }
 
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -182,7 +182,7 @@ namespace System.Net.Http.Functional.Tests
 
         private string GetCookieValue(HttpRequestData request)
         {
-            if (!LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version < HttpVersion.Version20)
             {
                 // HTTP/1.x must have only one value.
                 return request.GetSingleHeaderValue("Cookie");

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -479,9 +479,9 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(SecureAndNonSecure_IPBasedUri_MemberData))]
         public async Task GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(IPAddress address, bool useSsl)
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
-                throw new SkipTestException("Host header is not supported on HTTP/2.");
+                throw new SkipTestException("Host header is not supported on HTTP/2 and later.");
             }
 
             var options = new LoopbackServer.Options { Address = address, UseSsl= useSsl };
@@ -871,9 +871,9 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal("X-Underscore_Name", requestData.GetSingleHeaderValue("X-Underscore_Name"));
                     Assert.Equal("End", requestData.GetSingleHeaderValue("X-End"));
 
-                    if (LoopbackServerFactory.IsHttp2)
+                    if (LoopbackServerFactory.Version >= HttpVersion.Version20)
                     {
-                        // HTTP/2 forbids  certain headers or values.
+                        // HTTP/2 and later forbids certain headers or values.
                         Assert.Equal("trailers", requestData.GetSingleHeaderValue("TE"));
                         Assert.Equal(0, requestData.GetHeaderValueCount("Upgrade"));
                         Assert.Equal(0, requestData.GetHeaderValueCount("Proxy-Connection"));
@@ -904,9 +904,9 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly_MemberData))]
         public async Task GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(string newline, string fold, bool dribble)
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
-                throw new SkipTestException("Folding is not supported on HTTP/2.");
+                throw new SkipTestException("Folding is not supported on HTTP/2 and later.");
             }
 
             // Using examples from https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Response_fields
@@ -1035,9 +1035,9 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact]
         public async Task GetAsync_NonTraditionalChunkSizes_Accepted()
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
-                throw new SkipTestException("Chunking is not supported on HTTP/2.");
+                throw new SkipTestException("Chunking is not supported on HTTP/2 and later.");
             }
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
@@ -1259,9 +1259,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(null)]
         public async Task ReadAsStreamAsync_HandlerProducesWellBehavedResponseStream(bool? chunked)
         {
-            if (LoopbackServerFactory.IsHttp2 && chunked == true)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && chunked == true)
             {
-                throw new SkipTestException("Chunking is not supported on HTTP/2.");
+                throw new SkipTestException("Chunking is not supported on HTTP/2 and later.");
             }
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -2068,9 +2068,9 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
-                throw new SkipTestException("Upgrade is not supported on HTTP/2");
+                throw new SkipTestException("Upgrade is not supported on HTTP/2 and later");
             }
 
             var clientFinished = new TaskCompletionSource<bool>();
@@ -2238,9 +2238,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
         public async Task GetAsync_CallMethod_ExpectedStatusLine(HttpStatusCode statusCode, string reasonPhrase)
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
-                // Custom messages are not supported on HTTP2.
+                // Custom messages are not supported on HTTP2 and later.
                 return;
             }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -34,8 +34,8 @@ namespace System.Net.Http.Functional.Tests
         protected HttpClient CreateHttpClient(HttpMessageHandler handler) =>
             new HttpClient(handler) { DefaultRequestVersion = UseVersion };
 
-        protected static HttpClient CreateHttpClient(string useHttp2String) =>
-            CreateHttpClient(CreateHttpClientHandler(useHttp2String), useHttp2String);
+        protected static HttpClient CreateHttpClient(string useVersionString) =>
+            CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>
             new HttpClient(handler) { DefaultRequestVersion = Version.Parse(useVersionString) };

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -673,7 +673,7 @@ namespace System.Net.Test.Common
                 {
                     if (requestData.GetHeaderValueCount("Content-Length") != 0)
                     {
-                        _contentLength = Int32.Parse(requestData.GetSingleHeaderValue("Content-Length"));
+                        _contentLength = int.Parse(requestData.GetSingleHeaderValue("Content-Length"));
                     }
                     else if (requestData.GetHeaderValueCount("Transfer-Encoding") != 0 && requestData.GetSingleHeaderValue("Transfer-Encoding") == "chunked")
                     {
@@ -897,8 +897,6 @@ namespace System.Net.Test.Common
             return newOptions;
         }
 
-        public override bool IsHttp11 => true;
-        public override bool IsHttp2 => false;
-        public override bool IsHttp3 => false;
+        public override Version Version => HttpVersion.Version11;
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/QPackTestEncoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackTestEncoder.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Net.Test.Common
 {
-    public static class QPackEncoder
+    public static class QPackTestEncoder
     {
         public const int MaxVarIntLength = 6;
         public const int MaxPrefixLength = MaxVarIntLength * 2;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -85,11 +85,11 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackConnection.cs">
       <Link>Common\System\Net\Http\Http2LoopbackConnection.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)System\Net\Http\QPackDecoder.cs">
-      <Link>Common\System\Net\Http\QPackDecoder.cs</Link>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackTestDecoder.cs">
+      <Link>Common\System\Net\Http\QPackTestDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)System\Net\Http\QPackEncoder.cs">
-      <Link>Common\System\Net\Http\QPackEncoder.cs</Link>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackTestEncoder.cs">
+      <Link>Common\System\Net\Http\QPackTestEncoder.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\Http3LoopbackServer.cs">
       <Link>Common\System\Net\Http\Http3LoopbackServer.cs</Link>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -21,12 +21,13 @@ namespace System.Net.Http
     {
         private readonly HttpRequestMessage _request;
         private Http3Connection _connection;
-        private readonly long _streamId;
+        private long _streamId = -1; // A stream does not have an ID until the first I/O against it. This gets set almost immediately following construction.
         private QuicStream _stream;
         private ArrayBuffer _sendBuffer;
         private readonly ReadOnlyMemory<byte>[] _gatheredSendBuffer = new ReadOnlyMemory<byte>[2];
         private ArrayBuffer _recvBuffer;
         private TaskCompletionSource<bool> _expect100ContinueCompletionSource; // True indicates we should send content (e.g. received 100 Continue).
+        private bool _disposed;
 
         private CancellationTokenSource _goawayCancellationSource;
         private CancellationToken _goawayCancellationToken;
@@ -52,12 +53,17 @@ namespace System.Net.Http
         // Keep track of how much is remaining in that frame.
         private long _requestContentLengthRemaining = 0;
 
+        public long StreamId
+        {
+            get => Volatile.Read(ref _streamId);
+            set => Volatile.Write(ref _streamId, value);
+        }
+
         public Http3RequestStream(HttpRequestMessage request, Http3Connection connection, QuicStream stream)
         {
             _request = request;
             _connection = connection;
             _stream = stream;
-            _streamId = stream.StreamId;
             _sendBuffer = new ArrayBuffer(initialSize: 64, usePool: true);
             _recvBuffer = new ArrayBuffer(initialSize: 64, usePool: true);
 
@@ -70,30 +76,29 @@ namespace System.Net.Http
 
         public void Dispose()
         {
-            if (_stream != null)
+            if (!_disposed)
             {
+                _disposed = true;
                 _stream.Dispose();
-                _stream = null;
-
                 DisposeSyncHelper();
             }
         }
 
         public async ValueTask DisposeAsync()
         {
-            if (_stream != null)
+            if (!_disposed)
             {
+                _disposed = true;
                 await _stream.DisposeAsync().ConfigureAwait(false);
-                _stream = null;
-
                 DisposeSyncHelper();
             }
         }
 
         private void DisposeSyncHelper()
         {
-            _connection.RemoveStream(_streamId);
+            _connection.RemoveStream(_stream);
             _connection = null;
+            _stream = null;
 
             _sendBuffer.Dispose();
             _recvBuffer.Dispose();
@@ -780,13 +785,14 @@ namespace System.Net.Http
                     }
                     else
                     {
+                        if (NetEventSource.IsEnabled) Trace($"Server closed response stream before entire header payload could be read. {headersLength:N0} bytes remaining.");
                         throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
                     }
                 }
 
                 int processLength = (int)Math.Min(headersLength, _recvBuffer.ActiveLength);
 
-                _headerDecoder.Decode(_recvBuffer.ActiveSpan.Slice(processLength), this);
+                _headerDecoder.Decode(_recvBuffer.ActiveSpan.Slice(0, processLength), this);
                 _recvBuffer.Discard(processLength);
                 headersLength -= processLength;
             }
@@ -1129,7 +1135,7 @@ namespace System.Net.Http
         }
 
         public void Trace(string message, [CallerMemberName] string memberName = null) =>
-            _connection.Trace(_stream.StreamId, message, memberName);
+            _connection.Trace(StreamId, message, memberName);
 
         // TODO: it may be possible for Http3RequestStream to implement Stream directly and avoid this allocation.
         private sealed class Http3ReadStream : HttpBaseStream
@@ -1164,7 +1170,7 @@ namespace System.Net.Http
                     {
                         // We shouldn't be using a managed instance here, but don't have much choice -- we
                         // need to remove the stream from the connection's GOAWAY collection.
-                        _stream._connection.RemoveStream(_stream._streamId);
+                        _stream._connection.RemoveStream(_stream._stream);
                         _stream._connection = null;
                     }
 
@@ -1209,7 +1215,7 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 
@@ -1235,12 +1241,12 @@ namespace System.Net.Http
 
             public override int Read(Span<byte> buffer)
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http
         /// <summary>The origin authority used to construct the <see cref="HttpConnectionPool"/>.</summary>
         private readonly HttpAuthority _originAuthority;
 
-        /// <summary>Initially set identical to <see cref="_originAuthority"/> (i.e. what came in the request URL), this can be updated based on Alt-Svc.</summary>
+        /// <summary>Initially set to null, this can be set to enable HTTP/3 based on Alt-Svc.</summary>
         private volatile HttpAuthority _http3Authority;
 
         /// <summary>A timer to expire <see cref="_http3Authority"/> and return the pool to <see cref="_originAuthority"/>. Initialized on first use.</summary>
@@ -109,7 +109,11 @@ namespace System.Net.Http
             if (host != null)
             {
                 _originAuthority = new HttpAuthority(host, port);
-                _http3Authority = _originAuthority;
+
+                if (_poolManager.Settings._assumePrenegotiatedHttp3ForTesting)
+                {
+                    _http3Authority = _originAuthority;
+                }
             }
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
@@ -626,7 +630,7 @@ namespace System.Net.Http
             if (http3Connection != null)
             {
                 TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
-                if (http3Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime) && http3Connection.Authority == _http3Authority)
+                if (http3Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime) || http3Connection.Authority != authority)
                 {
                     // Connection expired.
                     http3Connection.Dispose();
@@ -675,11 +679,14 @@ namespace System.Net.Http
 
                 QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(authority.IdnHost, authority.Port, _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
 
+                //TODO: NegotiatedApplicationProtocol not yet implemented.
+#if false
                 if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
                 {
                     BlacklistAuthority(authority);
                     throw new HttpRequestException("QUIC connected but no HTTP/3 indicated via ALPN.", null, RequestRetryType.RetryOnSameOrNextProxy);
                 }
+#endif
 
                 http3Connection = new Http3Connection(this, _originAuthority, authority, quicConnection);
                 _http3Connection = http3Connection;
@@ -790,7 +797,7 @@ namespace System.Net.Http
                     // 'clear' should be the only value present.
                     if (value == AltSvcHeaderValue.Clear)
                     {
-                        _http3Authority = _originAuthority;
+                        ExpireAltSvcAuthority();
                         _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
                         break;
                     }
@@ -849,7 +856,7 @@ namespace System.Net.Http
                             var wr = (WeakReference<HttpConnectionPool>)o;
                             if (wr.TryGetTarget(out HttpConnectionPool @this))
                             {
-                                @this._http3Authority = @this._originAuthority;
+                                @this.ExpireAltSvcAuthority();
                             }
                         }, thisRef, nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
                     }
@@ -862,6 +869,15 @@ namespace System.Net.Http
                     _persistAuthority = nextAuthorityPersist;
                 }
             }
+        }
+
+        /// <summary>
+        /// Expires the current Alt-Svc authority, resetting the connection back to origin.
+        /// </summary>
+        private void ExpireAltSvcAuthority()
+        {
+            // If we ever support prenegotiated HTTP/3, this should be set to origin, not nulled out.
+            _http3Authority = null;
         }
 
         /// <summary>
@@ -915,7 +931,7 @@ namespace System.Net.Http
             {
                 if (_http3Authority == badAuthority)
                 {
-                    _http3Authority = _originAuthority;
+                    ExpireAltSvcAuthority();
                     _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 }
             }
@@ -946,9 +962,9 @@ namespace System.Net.Http
         {
             lock (SyncObj)
             {
-                if (_http3Authority != _originAuthority && _persistAuthority == false)
+                if (_http3Authority != null && _persistAuthority == false)
                 {
-                    _http3Authority = _originAuthority;
+                    ExpireAltSvcAuthority();
                     _authorityExpireTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -48,6 +48,9 @@ namespace System.Net.Http
 
         internal bool _allowUnencryptedHttp2;
 
+        // Used for testing until https://github.com/dotnet/runtime/issues/987
+        internal bool _assumePrenegotiatedHttp3ForTesting;
+
         internal SslClientAuthenticationOptions _sslOptions;
 
         internal IDictionary<string, object> _properties;
@@ -99,6 +102,7 @@ namespace System.Net.Http
                 _useCookies = _useCookies,
                 _useProxy = _useProxy,
                 _allowUnencryptedHttp2 = _allowUnencryptedHttp2,
+                _assumePrenegotiatedHttp3ForTesting = _assumePrenegotiatedHttp3ForTesting
             };
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AltSvc.cs
@@ -16,6 +16,17 @@ namespace System.Net.Http.Functional.Tests
         {
         }
 
+        /// <summary>
+        /// HTTP/3 tests by default use prenegotiated HTTP/3. To test Alt-Svc upgrades, that must be disabled.
+        /// </summary>
+        protected override HttpClient CreateHttpClient()
+        {
+            HttpClientHandler handler = CreateHttpClientHandler(HttpVersion.Version30);
+            SetUsePrenegotiatedHttp3(handler, usePrenegotiatedHttp3: false);
+
+            return CreateHttpClient(handler);
+        }
+
         [Fact]
         public async Task AltSvc_Header_UpgradeFrom11_Success()
         {
@@ -32,7 +43,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using GenericLoopbackServer firstServer = GetFactoryForVersion(fromVersion).CreateServer();
             using Http3LoopbackServer secondServer = new Http3LoopbackServer();
-            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+            using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
 
@@ -52,7 +63,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
             using Http3LoopbackServer secondServer = new Http3LoopbackServer();
-            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+            using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
 
@@ -74,7 +85,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using Http2LoopbackServer firstServer = Http2LoopbackServer.CreateServer();
             using Http3LoopbackServer secondServer = new Http3LoopbackServer();
-            using HttpClient client = CreateHttpClient(CreateHttpClientHandler(HttpVersion.Version30));
+            using HttpClient client = CreateHttpClient();
 
             Task<HttpResponseMessage> firstResponseTask = client.GetAsync(firstServer.Address);
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -273,10 +273,10 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SendAsync_GetWithInvalidHostHeader_ThrowsException()
         {
-            if (LoopbackServerFactory.IsHttp2)
+            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
             {
                 // Only SocketsHttpHandler with HTTP/1.x uses the Host header to influence the SSL auth.
-                // Host header is not used for HTTP2.
+                // Host header is not used for HTTP2 and later.
                 return;
             }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -23,7 +23,22 @@ namespace System.Net.Http.Functional.Tests
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }
 
+            if (useVersion == HttpVersion.Version30)
+            {
+                SetUsePrenegotiatedHttp3(handler, usePrenegotiatedHttp3: true);
+            }
+
             return handler;
+        }
+
+        /// <summary>
+        /// Used to bypass Alt-Svc until https://github.com/dotnet/runtime/issues/987
+        /// </summary>
+        protected static void SetUsePrenegotiatedHttp3(HttpClientHandler handler, bool usePrenegotiatedHttp3)
+        {
+            object socketsHttpHandler = GetUnderlyingSocketsHttpHandler(handler);
+            object settings = socketsHttpHandler.GetType().GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(socketsHttpHandler);
+            settings.GetType().GetField("_assumePrenegotiatedHttp3ForTesting", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(settings, usePrenegotiatedHttp3);
         }
 
         protected static object GetUnderlyingSocketsHttpHandler(HttpClientHandler handler)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -30,8 +31,8 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    // TODO: public to test HTTP/3.
-    internal sealed class SocketsHttpHandler_HttpClientMiniStress_Http3 : HttpClientMiniStress
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandler_HttpClientMiniStress_Http3 : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -149,13 +150,6 @@ namespace System.Net.Http.Functional.Tests
     {
         public SocketsHttpHandler_HttpClientHandler_Finalization_Http2_Test(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version20;
-    }
-
-    // TODO: public to test HTTP/3.
-    internal sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test : HttpClientHandler_Finalization_Test
-    {
-        public SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
     }
 
     public sealed class SocketsHttpHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test
@@ -2148,47 +2142,49 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version20;
     }
 
-    // TODO: public to test HTTP/3.
-    internal sealed class SocketsHttpHandlerTest_Http3 : HttpClientHandlerTest_Http3
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test : HttpClientHandler_Finalization_Test
+    {
+        public SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version30;
+    }
+
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandlerTest_Http3 : HttpClientHandlerTest_Http3
     {
         public SocketsHttpHandlerTest_Http3(ITestOutputHelper output) : base(output) { }
     }
 
-    // TODO: public to test HTTP/3.
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    internal sealed class SocketsHttpHandlerTest_Cookies_Http3 : HttpClientHandlerTest_Cookies
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandlerTest_Cookies_Http3 : HttpClientHandlerTest_Cookies
     {
         public SocketsHttpHandlerTest_Cookies_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    // TODO: public to test HTTP/3.
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    internal sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Http3 : HttpClientHandlerTest
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Http3 : HttpClientHandlerTest
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    // TODO: public to test HTTP/3.
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    internal sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3 : HttpClientHandlerTest_Headers
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3 : HttpClientHandlerTest_Headers
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    // TODO: public to test HTTP/3.
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    internal sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3 : HttpClientHandler_Cancellation_Test
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3 : HttpClientHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    // TODO: public to test HTTP/3.
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    internal sealed class SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3 : HttpClientHandler_AltSvc_Test
+    [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
+    public sealed class SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3 : HttpClientHandler_AltSvc_Test
     {
         public SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -224,11 +224,11 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\HPackEncoder.cs">
       <Link>Common\System\Net\Http\HPackEncoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)System\Net\Http\QPackDecoder.cs">
-      <Link>Common\System\Net\Http\QPackDecoder.cs</Link>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackTestDecoder.cs">
+      <Link>Common\System\Net\Http\QPackTestDecoder.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)System\Net\Http\QPackEncoder.cs">
-      <Link>Common\System\Net\Http\QPackEncoder.cs</Link>
+    <Compile Include="$(CommonTestPath)System\Net\Http\QPackTestEncoder.cs">
+      <Link>Common\System\Net\Http\QPackTestEncoder.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\Http2LoopbackServer.cs">
       <Link>Common\System\Net\Http\Http2LoopbackServer.cs</Link>


### PR DESCRIPTION
This PR gets a minimal set of tests working, but not all of them. It enables all HTTP/3 tests, even the not yet working ones, if you have MsQuic support. Our CI does not have MsQuic support, so the failing tests will not cause CI failures.

- Update generic tests to use a Version rather than boolean IsHttp11/IsHttp20, and update some HTTP/2 to work for HTTP/3.
- Enable tests for HTTP/3, behind a conditional feature test.
- Fix QPackDecoder lzcnt assuming an 8-bit test.
- Rename test QPACK classes from QPackEncoder/QPackDecoder -> QPackTestEncoder/QPackTestDecoder to avoid naming confusion with product code classes.
- Fix QPackTestDecoder bit flag checks.
- Fix a double call to QuicConnection.CloseAsync(). Update to shutdown QuicConnection in a background task.