### PR TITLE
Fix arm cross OS DAC compilation

### DIFF
--- a/src/coreclr/src/inc/clrnt.h
+++ b/src/coreclr/src/inc/clrnt.h
@@ -945,7 +945,7 @@ RtlUnwindEx (
     __in_opt PEXCEPTION_RECORD ExceptionRecord,
     __in PVOID ReturnValue,
     __in PT_CONTEXT ContextRecord,
-    __in_opt PUNWIND_HISTORY_TABLE HistoryTable
+    __in_opt PVOID HistoryTable
     );
 
 EXTERN_C

--- a/src/coreclr/src/inc/clrnt.h
+++ b/src/coreclr/src/inc/clrnt.h
@@ -956,7 +956,7 @@ RtlVirtualUnwind (
     __in DWORD HandlerType,
     __in DWORD ImageBase,
     __in DWORD ControlPc,
-    __in PRUNTIME_FUNCTION FunctionEntry,
+    __in PT_RUNTIME_FUNCTION FunctionEntry,
     __inout PT_CONTEXT ContextRecord,
     __out PVOID *HandlerData,
     __out PDWORD EstablisherFrame,

--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -196,7 +196,7 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PUCHAR NonVolatileRegisters;
 } T_DISPATCHER_CONTEXT, *PT_DISPATCHER_CONTEXT;
 
-#if defined(HOST_WINDOWS) && defined(HOST_X86)
+#if defined(HOST_WINDOWS) && !defined(HOST_X86)
 typedef struct _T_RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;

--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -113,8 +113,7 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
 // each frame function.
 //
 
-#ifndef HOST_UNIX
-#ifdef HOST_X86
+#if defined(HOST_WINDOWS) && defined(HOST_X86)
 typedef struct _RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;
@@ -141,8 +140,7 @@ typedef struct _UNWIND_HISTORY_TABLE {
     DWORD HighAddress;
     UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
 } UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
-#endif // HOST_X86
-#endif // !HOST_UNIX
+#endif // defined(HOST_WINDOWS) && defined(HOST_X86)
 
 
 //
@@ -198,14 +196,14 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PUCHAR NonVolatileRegisters;
 } T_DISPATCHER_CONTEXT, *PT_DISPATCHER_CONTEXT;
 
-#if defined(HOST_UNIX) || defined(HOST_X86)
-#define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
-#define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
-#else
+#if defined(HOST_WINDOWS) && defined(HOST_X86)
 typedef struct _T_RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;
 } T_RUNTIME_FUNCTION, *PT_RUNTIME_FUNCTION;
+#else
+#define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
+#define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
 #endif
 
 #elif defined(HOST_AMD64) && defined(TARGET_ARM64)  // Host amd64 managing ARM64 related code

--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -113,7 +113,7 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
 // each frame function.
 //
 
-#ifndef TARGET_UNIX
+#ifndef HOST_UNIX
 #ifdef HOST_X86
 typedef struct _RUNTIME_FUNCTION {
     DWORD BeginAddress;
@@ -142,7 +142,7 @@ typedef struct _UNWIND_HISTORY_TABLE {
     UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
 } UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
 #endif // HOST_X86
-#endif // !TARGET_UNIX
+#endif // !HOST_UNIX
 
 
 //
@@ -198,7 +198,7 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PUCHAR NonVolatileRegisters;
 } T_DISPATCHER_CONTEXT, *PT_DISPATCHER_CONTEXT;
 
-#if defined(TARGET_UNIX) || defined(HOST_X86)
+#if defined(HOST_UNIX) || defined(HOST_X86)
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
 #else

--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -113,12 +113,13 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
 // each frame function.
 //
 
-#if defined(HOST_WINDOWS) && defined(HOST_X86)
-typedef struct _RUNTIME_FUNCTION {
+#if defined(HOST_WINDOWS)
+typedef struct _T_RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;
-} RUNTIME_FUNCTION, *PRUNTIME_FUNCTION;
+} T_RUNTIME_FUNCTION, *PT_RUNTIME_FUNCTION;
 
+#if defined(HOST_X86)
 //
 // Define unwind history table structure.
 //
@@ -127,7 +128,7 @@ typedef struct _RUNTIME_FUNCTION {
 
 typedef struct _UNWIND_HISTORY_TABLE_ENTRY {
     DWORD ImageBase;
-    PRUNTIME_FUNCTION FunctionEntry;
+    PT_RUNTIME_FUNCTION FunctionEntry;
 } UNWIND_HISTORY_TABLE_ENTRY, *PUNWIND_HISTORY_TABLE_ENTRY;
 
 typedef struct _UNWIND_HISTORY_TABLE {
@@ -140,8 +141,11 @@ typedef struct _UNWIND_HISTORY_TABLE {
     DWORD HighAddress;
     UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
 } UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
-#endif // defined(HOST_WINDOWS) && defined(HOST_X86)
-
+#endif // HOST_X86
+#else // HOST_WINDOWS
+#define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
+#define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
+#endif // HOST_WINDOWS
 
 //
 // Nonvolatile context pointer record.
@@ -175,7 +179,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 //
 
 typedef
-PRUNTIME_FUNCTION
+PT_RUNTIME_FUNCTION
 (*PGET_RUNTIME_FUNCTION_CALLBACK) (
     IN DWORD64 ControlPc,
     IN PVOID Context
@@ -184,7 +188,7 @@ PRUNTIME_FUNCTION
 typedef struct _T_DISPATCHER_CONTEXT {
     ULONG ControlPc;
     ULONG ImageBase;
-    PRUNTIME_FUNCTION FunctionEntry;
+    PT_RUNTIME_FUNCTION FunctionEntry;
     ULONG EstablisherFrame;
     ULONG TargetPc;
     PT_CONTEXT ContextRecord;
@@ -196,15 +200,6 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PUCHAR NonVolatileRegisters;
 } T_DISPATCHER_CONTEXT, *PT_DISPATCHER_CONTEXT;
 
-#if defined(HOST_WINDOWS) && !defined(HOST_X86)
-typedef struct _T_RUNTIME_FUNCTION {
-    DWORD BeginAddress;
-    DWORD UnwindData;
-} T_RUNTIME_FUNCTION, *PT_RUNTIME_FUNCTION;
-#else
-#define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
-#define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
-#endif
 
 #elif defined(HOST_AMD64) && defined(TARGET_ARM64)  // Host amd64 managing ARM64 related code
 

--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -118,30 +118,6 @@ typedef struct _T_RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;
 } T_RUNTIME_FUNCTION, *PT_RUNTIME_FUNCTION;
-
-#if defined(HOST_X86)
-//
-// Define unwind history table structure.
-//
-
-#define UNWIND_HISTORY_TABLE_SIZE 12
-
-typedef struct _UNWIND_HISTORY_TABLE_ENTRY {
-    DWORD ImageBase;
-    PT_RUNTIME_FUNCTION FunctionEntry;
-} UNWIND_HISTORY_TABLE_ENTRY, *PUNWIND_HISTORY_TABLE_ENTRY;
-
-typedef struct _UNWIND_HISTORY_TABLE {
-    DWORD Count;
-    BYTE  LocalHint;
-    BYTE  GlobalHint;
-    BYTE  Search;
-    BYTE  Once;
-    DWORD LowAddress;
-    DWORD HighAddress;
-    UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
-} UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
-#endif // HOST_X86
 #else // HOST_WINDOWS
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
@@ -194,7 +170,7 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PT_CONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
     ULONG ScopeIndex;
     BOOLEAN ControlPcIsUnwound;
     PUCHAR NonVolatileRegisters;
@@ -332,7 +308,7 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
     DWORD ScopeIndex;
     BOOLEAN ControlPcIsUnwound;
     PBYTE  NonVolatileRegisters;

--- a/src/coreclr/src/pal/inc/rt/palrt.h
+++ b/src/coreclr/src/pal/inc/rt/palrt.h
@@ -1173,37 +1173,6 @@ typedef OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK *POUT_OF_PROCESS_FUNCTION_TABLE_C
 #define OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK_EXPORT_NAME \
     "OutOfProcessFunctionTableCallback"
 
-// #if !defined(TARGET_OSX)
-// typedef LONG (*PEXCEPTION_ROUTINE)(
-    // IN PEXCEPTION_POINTERS pExceptionPointers,
-    // IN LPVOID lpvParam);
-
-// #define DISPATCHER_CONTEXT    LPVOID
-
-// #else // defined(TARGET_OSX)
-
-//
-// Define unwind history table structure.
-//
-
-#define UNWIND_HISTORY_TABLE_SIZE 12
-
-typedef struct _UNWIND_HISTORY_TABLE_ENTRY {
-    DWORD64 ImageBase;
-    PRUNTIME_FUNCTION FunctionEntry;
-} UNWIND_HISTORY_TABLE_ENTRY, *PUNWIND_HISTORY_TABLE_ENTRY;
-
-typedef struct _UNWIND_HISTORY_TABLE {
-    DWORD Count;
-    BYTE  LocalHint;
-    BYTE  GlobalHint;
-    BYTE  Search;
-    BYTE  Once;
-    DWORD64 LowAddress;
-    DWORD64 HighAddress;
-    UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
-} UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
-
 typedef
 EXCEPTION_DISPOSITION
 (*PEXCEPTION_ROUTINE) (
@@ -1224,7 +1193,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
     DWORD ScopeIndex;
     BOOLEAN ControlPcIsUnwound;
     PBYTE  NonVolatileRegisters;
@@ -1242,7 +1211,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
     ULONG64 ScopeIndex;
     BOOLEAN ControlPcIsUnwound;
     PBYTE  NonVolatileRegisters;
@@ -1260,7 +1229,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 
 #elif defined(HOST_X86)
@@ -1275,7 +1244,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;
-    PUNWIND_HISTORY_TABLE HistoryTable;
+    PVOID HistoryTable;
     BOOLEAN ControlPcIsUnwound;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 


### PR DESCRIPTION
This fixes the cross OS DAC build for arm.  It adds the missing data structures needed to make arm target code compile on a Windows X86 host compiler.