### PR TITLE
WIP Hack: DAC_TABLE_RVA

### DIFF
--- a/src/coreclr/src/debug/daccess/CMakeLists.txt
+++ b/src/coreclr/src/debug/daccess/CMakeLists.txt
@@ -61,4 +61,6 @@ if(CLR_CMAKE_HOST_UNIX)
   )
 
   add_dependencies(daccess dactablerva_header)
-endif(CLR_CMAKE_HOST_UNIX)
+elseif(CLR_CMAKE_TARGET_UNIX)
+  add_definitions(-DDAC_TABLE_RVA=0x0000000001235cf0)
+endif()

--- a/src/coreclr/src/debug/daccess/daccess.cpp
+++ b/src/coreclr/src/debug/daccess/daccess.cpp
@@ -24,7 +24,7 @@
 #include "dwreport.h"
 #include "primitives.h"
 #include "dbgutil.h"
-#ifdef TARGET_UNIX
+#ifdef HOST_UNIX
 #include <dactablerva.h>
 #endif
 

--- a/src/coreclr/src/debug/daccess/enummem.cpp
+++ b/src/coreclr/src/debug/daccess/enummem.cpp
@@ -21,7 +21,7 @@
 #include "binder.h"
 #include "win32threadpool.h"
 
-#ifdef TARGET_UNIX
+#ifdef HOST_UNIX
 #include <dactablerva.h>
 #endif
 


### PR DESCRIPTION
This is my quick and dirty workaround for locating the Unix `g_dacTable` from a Windows cross OS dac build.

/cc @hoyosjs This and #31901 #31903 #31908 are the remaining pieces to get the cross OS dac to compile. 