### PR TITLE
Set scan-build in init-compiler

### DIFF
--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -32,9 +32,8 @@ source "$scriptroot/init-compiler.sh" "$build_arch" "$compiler" "$majorVersion" 
 
 CCC_CC="$CC"
 CCC_CXX="$CXX"
-SCAN_BUILD_COMMAND="$(command -v "scan-build$desired_version")"
 
-export CCC_CC CCC_CXX SCAN_BUILD_COMMAND
+export CCC_CC CCC_CXX
 
 buildtype=DEBUG
 code_coverage=OFF

--- a/eng/native/init-compiler.sh
+++ b/eng/native/init-compiler.sh
@@ -19,6 +19,10 @@ cxxCompiler="$compiler++"
 majorVersion="$3"
 minorVersion="$4"
 
+# clear the existing CC and CXX from environment
+CC=
+CXX=
+
 if [[ "$compiler" == "gcc" ]]; then cxxCompiler="g++"; fi
 
 check_version_exists() {
@@ -102,4 +106,6 @@ if [[ -z "$CC" ]]; then
     exit 1
 fi
 
-export CC CXX
+SCAN_BUILD_COMMAND="$(command -v "scan-build$desired_version")"
+
+export CC CXX SCAN_BUILD_COMMAND


### PR DESCRIPTION
`desired_version` lives in `init-compiler.sh`.

Also clear the existing CC and CXX preset by environment to avoid unexpected overriding. (the only way to override compiler tools is using CLR_* vars: CLR_CC, CLR_CXX, CLR_AR and so on)