### PR TITLE
Disable cross OS compilation

### DIFF
--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -8,6 +8,9 @@ if (CLR_CMAKE_HOST_OS STREQUAL CLR_CMAKE_TARGET_OS)
     set (CLR_CROSS_COMPONENTS_LIST
         crossgen
         clrjit
+        dactablegen
+        GenClrDebugResource
+        InjectResource
     )
 endif()
 

--- a/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
@@ -12,7 +12,7 @@ set(DACTABLEGEN_SOURCES
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "")
 
 set(CMAKE_CSharp_FLAGS "/platform:anycpu32bitpreferred")
-add_executable(dactablegen ${DACTABLEGEN_SOURCES})
+add_executable_clr(dactablegen ${DACTABLEGEN_SOURCES})
 
 set_target_properties(dactablegen PROPERTIES VS_DOTNET_REFERENCES "System")
 set_target_properties(dactablegen PROPERTIES VS_DOTNET_REFERENCE_DIALib ${CMAKE_CURRENT_SOURCE_DIR}/DIALib.dll)

--- a/src/coreclr/src/tools/GenClrDebugResource/CMakeLists.txt
+++ b/src/coreclr/src/tools/GenClrDebugResource/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_definitions(-MT)
-add_executable(GenClrDebugResource GenClrDebugResource.cpp)
+add_executable_clr(GenClrDebugResource GenClrDebugResource.cpp)
 
 target_link_libraries(GenClrDebugResource
     ${STATIC_MT_CRT_LIB}
     ${STATIC_MT_VCRT_LIB}
 )
 
-install(TARGETS GenClrDebugResource EXPORT dactabletools DESTINATION dactabletools)
+install_clr(TARGETS GenClrDebugResource EXPORT dactabletools DESTINATION dactabletools)

--- a/src/coreclr/src/tools/InjectResource/CMakeLists.txt
+++ b/src/coreclr/src/tools/InjectResource/CMakeLists.txt
@@ -2,11 +2,11 @@ remove_definitions(-DUNICODE)
 remove_definitions(-D_UNICODE)
 add_definitions(-MT)
 
-add_executable(InjectResource InjectResource.cpp)
+add_executable_clr(InjectResource InjectResource.cpp)
 
 target_link_libraries(InjectResource
     ${STATIC_MT_CRT_LIB}
     ${STATIC_MT_VCRT_LIB}
 )
 
-install(TARGETS InjectResource EXPORT dactabletools DESTINATION dactabletools)
+install_clr(TARGETS InjectResource EXPORT dactabletools DESTINATION dactabletools)


### PR DESCRIPTION
Disable compilation and instsallation of miscellaneous executables during cross
compilation.

The `add_executable_clr` and `install_clr` add checks to see if we are doing cross compilation, and whether the component is desired for the type of cross compilation we are doing. Only if desisered call the underlying `add_executable` and `install` functions respectively.