### PR TITLE
[mono] Review [SkipOnTargetFramework(TargetFrameworkMonikers.Mono...] occurrences

### DIFF
--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbCommandTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbCommandTests.cs
@@ -153,8 +153,7 @@ namespace System.Data.Common.Tests
             }
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "GC has different behavior on Mono")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void CanBeFinalized()
         {
             FinalizingCommand.CreateAndRelease();

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbConnectionTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbConnectionTests.cs
@@ -136,8 +136,7 @@ namespace System.Data.Common.Tests
             public static DbProviderFactory Instance = new TestDbProviderFactory();
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "GC has different behavior on Mono")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void CanBeFinalized()
         {
             FinalizingConnection.CreateAndRelease();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1316,8 +1316,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => process.StandardInput);
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "GC has different behavior on Mono")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void CanBeFinalized()
         {
             FinalizingProcess.CreateAndRelease();

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -773,8 +773,7 @@ namespace System.Net.NetworkInformation.Tests
             pingResultValidator(pingResult);
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "GC has different behavior on Mono")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void CanBeFinalized()
         {
             FinalizingPing.CreateAndRelease();

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1148,7 +1148,6 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(EchoServers))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "no exception thrown on mono")]
         public void BeginGetRequestStream_CreatePostRequestThenCallTwice_ThrowsInvalidOperationException(Uri remoteServer)
         {
             HttpWebRequest request = HttpWebRequest.CreateHttp(remoteServer);
@@ -1715,7 +1714,6 @@ namespace System.Net.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/corefx/issues/19083")]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "https://github.com/dotnet/corefx/issues/19083")]
         [Fact]
         public async Task Abort_BeginGetRequestStreamThenAbort_EndGetRequestStreamThrowsWebException()
         {
@@ -1737,7 +1735,6 @@ namespace System.Net.Tests
             });
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "ResponseCallback not called after Abort on mono")]
         [Fact]
         public async Task Abort_BeginGetResponseThenAbort_ResponseCallbackCalledBeforeAbortReturns()
         {

--- a/src/libraries/System.Net.Requests/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.Requests/tests/LoggingTest.cs
@@ -10,7 +10,6 @@ namespace System.Net.Tests
     public class LoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "NetEventSource is only part of .NET Core.")]
         [SkipOnCoreClr("System.Net.Tests are flaky", RuntimeConfiguration.Checked)]
         public void EventSource_ExistsWithCorrectId()
         {

--- a/src/libraries/System.Net.WebHeaderCollection/tests/LoggingTest.cs
+++ b/src/libraries/System.Net.WebHeaderCollection/tests/LoggingTest.cs
@@ -10,7 +10,6 @@ namespace System.Net.Tests
     public class WebHeaderCollectionLoggingTest
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "NetEventSource is only part of .NET Core")]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(WebHeaderCollection).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
+++ b/src/libraries/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
@@ -541,7 +541,6 @@ namespace System.Net.Tests
         private const string CookieInvalid = "helloWorld";
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Does not work in Mono")]
         public void GetValues_MultipleSetCookieHeadersWithExpiresAttribute_Success()
         {
             WebHeaderCollection w = new WebHeaderCollection();
@@ -559,7 +558,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Does not work in Mono")]
         public void GetValues_SingleSetCookieHeaderWithMultipleCookiesWithExpiresAttribute_Success()
         {
             WebHeaderCollection w = new WebHeaderCollection();
@@ -605,7 +603,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "Does not work in Mono")]
         public void GetValues_InvalidSetCookieHeader_Success()
         {
             WebHeaderCollection w = new WebHeaderCollection();

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -321,7 +321,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void CurrentCultureTest_DifferentThread()
         {
             CultureInfo culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
@@ -404,7 +403,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void CurrentPrincipalTest_SkipOnDesktopFramework()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() => Assert.Null(Thread.CurrentPrincipal));
@@ -460,7 +458,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void CurrentPrincipalContextFlowTest_NotFlow()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(async () =>
@@ -527,7 +524,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void ExecutionContextTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(
@@ -705,7 +701,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void AbortSuspendTest()
         {
             var e = new ManualResetEvent(false);
@@ -1079,7 +1074,6 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void MiscellaneousTest()
         {
             Thread.BeginCriticalRegion();

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -149,7 +149,6 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void SetMinMaxThreadsTest_ChangedInDotNetCore()
         {
             int minw, minc, maxw, maxc;

--- a/src/libraries/System.Threading/tests/ExecutionContextTests.cs
+++ b/src/libraries/System.Threading/tests/ExecutionContextTests.cs
@@ -147,7 +147,6 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void CaptureThenSuppressThenRunFlowTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
+++ b/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
@@ -10,7 +10,6 @@ namespace System.Threading.Tests
     public static class SynchronizationContextTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "SynchronizationContext.Wait(IntPtr[], bool, int) is not implemented on Mono")]
         public static void WaitTest()
         {
             var tsc = new TestSynchronizationContext();
@@ -37,14 +36,12 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void WaitTest_ChangedInDotNetCore()
         {
             Assert.Throws<ArgumentNullException>(() => TestSynchronizationContext.WaitHelper(null, false, 0));
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "https://bugzilla.xamarin.com/show_bug.cgi?id=60568")]
         public static void WaitNotificationTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
+++ b/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
@@ -42,6 +42,7 @@ namespace System.Threading.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/31977", TargetFrameworkMonikers.Mono)]
         public static void WaitNotificationTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -315,8 +315,7 @@ namespace System.Threading.Tests
             Assert.Throws<ObjectDisposedException>(() => values = tl.Values);
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "This test requires precise stack scanning")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void RunThreadLocalTest8_Values_NegativeCases()
         {
             // Test that Dispose works and that objects are released on dispose


### PR DESCRIPTION
This PR is to re-exam the existing tests annotated with  `[SkipOnTargetFramework(TargetFrameworkMonikers.Mono...]` attribute since some of them mention old bugzilla bugs or issues in old mono/mono BCL implementation that should no longer apply.
