### PR TITLE
Enable generation of deps.json for non-VS builds

### DIFF
--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -14,7 +14,7 @@
          the same bits tests expect to see in artifacts/crossgen2. That way we never need to wonder which
          binaries are up to date and which are stale. -->
     <OutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(BinDir)/crossgen2</OutputPath>
-    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <GenerateDependencyFile Condition="'$(BuildingInsideVisualStudio)' == 'true'">false</GenerateDependencyFile>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
This removes the "Cannot use stream for resource" error message that was being emitted at the beginning of compilation.
This also makes SDK-based compilations work now, because without this, the SDK would fail the publishing because of this "Cannot use stream for resource" message, which gets treated as an error regardless of the error code returned by crossgen2.

I did test the VS-based compilation, and it still works and I was able to debug.

cc @dotnet/crossgen-contrib 