### PR TITLE
Fixed Memory leak in src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.c (#1975)

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_seckey.c
@@ -182,10 +182,18 @@ OSStatus ExportImportKey(SecKeyRef* key, SecExternalItemType type)
                 CFRetain(outItem);
                 *key = (SecKeyRef)CONST_CAST(void *, outItem);
 
-                return noErr;
+                goto cleanup;
             }
         }
     }
 
-    return errSecBadReq;
+    status = errSecBadReq;
+
+cleanup:
+    if (outItems != NULL)
+    {
+        CFRelease(outItems);
+    }
+
+    return status;
 }


### PR DESCRIPTION
Added a cleanup section that releases the CFArray outItems

Fixes #1975.