### PR TITLE
[WIP] Reduce ThreadLocal<T>.LinkedSlot creation by 64 fold

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -177,8 +177,8 @@ namespace System.Threading
             lock (s_idManager)
             {
                 id = ~_idComplement;
-                int slotId = id / valuePerSlot;
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId;
+                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
                 _idComplement = 0;
 
                 if (id < 0 || !_initialized)
@@ -198,7 +198,6 @@ namespace System.Threading
                     created |= linkedSlot._created;
                 }
 
-                // Experiment show that if I return the id, whether or not I free the array, the test case still repros.
                 if (created == 0)
                 {
                     for (LinkedSlot? linkedSlot = _linkedSlot._next; linkedSlot != null; linkedSlot = linkedSlot._next)
@@ -225,7 +224,6 @@ namespace System.Threading
                 }
             }
             _linkedSlot = null;
-            // Experiment show that if I never return the id, the test case failure will not repro.
             s_idManager.ReturnId(id);
         }
 
@@ -276,8 +274,8 @@ namespace System.Threading
                 LinkedSlotVolatile[]? slotArray = ts_slotArray;
                 LinkedSlot? slot;
                 int id = ~_idComplement;
-                int slotId = id / valuePerSlot;
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId;
+                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
                 //
                 // Attempt to get the value using the fast path
@@ -305,8 +303,8 @@ namespace System.Threading
                 LinkedSlotVolatile[]? slotArray = ts_slotArray;
                 LinkedSlot? slot;
                 int id = ~_idComplement;
-                int slotId = id / valuePerSlot;
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId;
+                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
                 // Attempt to set the value using the fast path
                 if (slotArray != null   // Has the slot array been initialized?
@@ -367,8 +365,8 @@ namespace System.Threading
         private void SetValueSlow(T value, LinkedSlotVolatile[]? slotArray)
         {
             int id = ~_idComplement;
-            int slotId = id / valuePerSlot;
-            int withinSlotId = id % valuePerSlot;
+            int withinSlotId;
+            int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
             // If the object has been disposed, id will be -1.
             if (id < 0)
@@ -426,8 +424,8 @@ namespace System.Threading
         /// </summary>
         private void CreateLinkedSlot(LinkedSlotVolatile[] slotArray, int id, T value)
         {
-            int slotId = id / valuePerSlot;
-            int withinSlotId = id % valuePerSlot;
+            int withinSlotId;
+            int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
             // Create a LinkedSlot
             var linkedSlot = new LinkedSlot(slotArray);
@@ -565,8 +563,8 @@ namespace System.Threading
                 {
                     throw new ObjectDisposedException(SR.ThreadLocal_Disposed);
                 }
-                int slotId = id / valuePerSlot;
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId;
+                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
                 LinkedSlotVolatile[]? slotArray = ts_slotArray;
                 return slotArray != null && slotId < slotArray.Length && slotArray[slotId].Value != null && (slotArray[slotId].Value!._created & (1L << withinSlotId)) != 0;
@@ -584,8 +582,8 @@ namespace System.Threading
                 LinkedSlotVolatile[]? slotArray = ts_slotArray;
                 int id = ~_idComplement;
                 // This is potentially already wrong? What if the instance is disposed?
-                int slotId = id / valuePerSlot;
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId;
+                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
 
                 LinkedSlot? slot;
                 if (slotArray == null || slotId >= slotArray.Length || (slot = slotArray[slotId].Value) == null || (slotArray[slotId].Value!._created & (1L << withinSlotId)) == 0 || !_initialized)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -178,7 +178,7 @@ namespace System.Threading
             {
                 id = ~_idComplement;
                 int withinSlotId;
-                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+                int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
                 _idComplement = 0;
 
                 if (id < 0 || !_initialized)
@@ -215,7 +215,7 @@ namespace System.Threading
 
                         // And clear the references from the slot table to the linked slot and the value so that
                         // both can get garbage collected.
-                        for (int i = 0; i < valuePerSlot; i++)
+                        for (int i = 0; i < ValuePerSlot; i++)
                         {
                             slotArray[slotId].Value!._value![i] = default!;
                         }
@@ -275,7 +275,7 @@ namespace System.Threading
                 LinkedSlot? slot;
                 int id = ~_idComplement;
                 int withinSlotId;
-                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+                int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
                 //
                 // Attempt to get the value using the fast path
@@ -304,7 +304,7 @@ namespace System.Threading
                 LinkedSlot? slot;
                 int id = ~_idComplement;
                 int withinSlotId;
-                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+                int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
                 // Attempt to set the value using the fast path
                 if (slotArray != null   // Has the slot array been initialized?
@@ -366,7 +366,7 @@ namespace System.Threading
         {
             int id = ~_idComplement;
             int withinSlotId;
-            int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+            int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
             // If the object has been disposed, id will be -1.
             if (id < 0)
@@ -425,7 +425,7 @@ namespace System.Threading
         private void CreateLinkedSlot(LinkedSlotVolatile[] slotArray, int id, T value)
         {
             int withinSlotId;
-            int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+            int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
             // Create a LinkedSlot
             var linkedSlot = new LinkedSlot(slotArray);
@@ -489,7 +489,7 @@ namespace System.Threading
         {
             LinkedSlot? linkedSlot = _linkedSlot;
             int id = ~_idComplement;
-            int withinSlotId = id % valuePerSlot;
+            int withinSlotId = id % ValuePerSlot;
             if (id == -1 || linkedSlot == null)
             {
                 return null;
@@ -522,7 +522,7 @@ namespace System.Threading
                 {
                     throw new ObjectDisposedException(SR.ThreadLocal_Disposed);
                 }
-                int withinSlotId = id % valuePerSlot;
+                int withinSlotId = id % ValuePerSlot;
 
                 // Walk over the linked list of slots and gather the values associated with this ThreadLocal instance.
                 for (linkedSlot = linkedSlot._next; linkedSlot != null; linkedSlot = linkedSlot._next)
@@ -564,7 +564,7 @@ namespace System.Threading
                     throw new ObjectDisposedException(SR.ThreadLocal_Disposed);
                 }
                 int withinSlotId;
-                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+                int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
                 LinkedSlotVolatile[]? slotArray = ts_slotArray;
                 return slotArray != null && slotId < slotArray.Length && slotArray[slotId].Value != null && (slotArray[slotId].Value!._created & (1L << withinSlotId)) != 0;
@@ -583,7 +583,7 @@ namespace System.Threading
                 int id = ~_idComplement;
                 // This is potentially already wrong? What if the instance is disposed?
                 int withinSlotId;
-                int slotId = Math.DivRem(id, valuePerSlot, out withinSlotId);
+                int slotId = Math.DivRem(id, ValuePerSlot, out withinSlotId);
 
                 LinkedSlot? slot;
                 if (slotArray == null || slotId >= slotArray.Length || (slot = slotArray[slotId].Value) == null || (slotArray[slotId].Value!._created & (1L << withinSlotId)) == 0 || !_initialized)
@@ -701,7 +701,7 @@ namespace System.Threading
                 _slotArray = slotArray;
                 if (slotArray != null)
                 {
-                    _value = new T[valuePerSlot];
+                    _value = new T[ValuePerSlot];
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -311,6 +311,7 @@ namespace System.Threading
                     && slotId >= 0   // Is the ID non-negative (i.e., instance is not disposed)?
                     && slotId < slotArray.Length   // Is the table large enough?
                     && (slot = slotArray[slotId].Value) != null   // Has a LinkedSlot object has been allocated for this ID?
+                    && (slotArray[slotId].Value!._created & (1L << withinSlotId)) != 0 // Has the slot been created?
                     && _linkedSlot!._next != null // We already linked the instance with the slot array
                     && _initialized // Has the instance *still* not been disposed (important for a race condition with Dispose)?
                     )

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -27,7 +27,7 @@ namespace System.Threading
     [DebuggerDisplay("IsValueCreated={IsValueCreated}, Value={ValueForDebugDisplay}, Count={ValuesCountForDebugDisplay}")]
     public class ThreadLocal<T> : IDisposable
     {
-        private const int valuePerSlot = 64;
+        private const int ValuePerSlot = 64;
 
         // a delegate that returns the created value, if null the created value will be default(T)
         private Func<T>? _valueFactory;


### PR DESCRIPTION
This PR is meant to reduce allocation by limiting the number of LinkedSlot object instances.

Before the change, per instance of ThreadLocal, per thread accessed it, there will be an instance of a  LinkedSlot object that holds the slot.

For scenarios like https://github.com/dotnet/runtime/issues/2382, there will be a lot of LinkedSlot objects, and increased GC latency significantly.

After the change, we reduced that by 64 fold. The idea is to use a single object to host 64 slots, and we used some simple arithmetic to determine which spot to use and used a simple bitmask to determine if the spot is used so that we can reclaim the whole LinkedSlot when it is no longer used by anyone.

It took me a good while to figure out the bitmask operations are non-atomic. After fixing that, I am hoping this is good to go. Unfortunately, I cannot spend more time on this. Just in case if it doesn't work out, it would be great if this can be picked up and completed.