### PR TITLE
Revert "[interp] Remove recursion from call_vararg. (#18697)"

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -200,7 +200,6 @@ typedef struct {
 	const unsigned short  *ip;
 	GSList *finally_ips;
 	FrameClauseArgs *clause_args;
-	gboolean is_void : 1;
 } InterpState;
 
 struct _InterpFrame {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -292,6 +292,14 @@ static gboolean interp_init_done = FALSE;
 static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error);
 
 static MONO_NEVER_INLINE void
+interp_exec_method_call_vararg (InterpFrame *frame, ThreadContext *context, MonoError *error)
+// This function makes WebAsssembly stacks clearer, so you can see which recursion
+// is occuring, in the absence of line numbers in the debugger.
+{
+	interp_exec_method_full (frame, context, NULL, error);
+}
+
+static MONO_NEVER_INLINE void
 interp_exec_method_newobj_fast (InterpFrame *frame, ThreadContext *context, MonoError *error)
 // This function makes WebAsssembly stacks clearer, so you can see which recursion
 // is occuring, in the absence of line numbers in the debugger.
@@ -3237,8 +3245,6 @@ mono_interp_newobj_vt (
 	memset (&valuetype_this, 0, sizeof (stackval));
 	sp->data.p = &valuetype_this;
 
-	// FIXME remove recursion
-	//
 	// FIXME It is unfortunate to outline a recursive case as it
 	// increases its stack usage. We do this however as it conserves
 	// stack for all the other recursive cases.
@@ -3474,7 +3480,6 @@ method_entry (ThreadContext *context, InterpFrame *frame, gboolean *out_tracing,
 	frame->state.ip = ip;  \
 	frame->state.sp = sp; \
 	frame->state.vt_sp = vt_sp; \
-	frame->state.is_void = is_void; \
 	frame->state.finally_ips = finally_ips; \
 	frame->state.clause_args = clause_args; \
 	} while (0)
@@ -3483,10 +3488,9 @@ method_entry (ThreadContext *context, InterpFrame *frame, gboolean *out_tracing,
 #define LOAD_INTERP_STATE(frame) do { \
 	ip = frame->state.ip; \
 	sp = frame->state.sp; \
-	is_void = frame->state.is_void; \
 	vt_sp = frame->state.vt_sp; \
 	finally_ips = frame->state.finally_ips; \
-	clause_args = frame->state.clause_args; \
+	clause_args = frame->state.clause_args;			\
 	locals = (unsigned char *)frame->stack + frame->imethod->stack_size + frame->imethod->vt_stack_size; \
 	frame->state.ip = NULL; \
 	} while (0)
@@ -3509,10 +3513,6 @@ method_entry (ThreadContext *context, InterpFrame *frame, gboolean *out_tracing,
 static MONO_NEVER_INLINE void
 interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error)
 {
-	InterpMethod *cmethod;
-	gboolean is_void;
-	stackval *retval;
-
 	/* Interpreter main loop state (InterpState) */
 	const guint16 *ip = NULL;
 	stackval *sp;
@@ -3765,7 +3765,6 @@ main_loop:
 			MonoMethodSignature *csignature;
 			InterpMethod *imethod;
 			stackval *retval;
-			// FIXME This assumes a grow-down stack.
 			gpointer native_stack_addr = frame->native_stack_addr ? (gpointer)((guint8*)frame->native_stack_addr - 1) : (gpointer)&retval;
 
 			frame->ip = ip;
@@ -3780,8 +3779,10 @@ main_loop:
 				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 
-			is_void = csignature->ret->type == MONO_TYPE_VOID;
-			retval = is_void ? NULL : sp;
+			if (csignature->ret->type != MONO_TYPE_VOID)
+				retval = sp;
+			else
+				retval = NULL;
 
 			sp->data.p = vt_sp;
 			/* decrement by the actual number of args */
@@ -3882,7 +3883,7 @@ main_loop:
 			stackval *retval;
 			MonoObject *this_arg;
 			InterpMethod *imethod;
-			is_void = *ip == MINT_VCALLVIRT_FAST;
+			gboolean is_void = *ip == MINT_VCALLVIRT_FAST;
 			int slot;
 
 			frame->ip = ip;
@@ -3924,7 +3925,6 @@ main_loop:
 			if (code_type == IMETHOD_CODE_INTERP) {
 				SAVE_INTERP_STATE (frame);
 
-				// FIXME &retval looks wrong
 				child_frame = alloc_frame (context, &retval, frame, imethod, sp, retval);
 
 				if (G_UNLIKELY (!imethod->transformed)) {
@@ -3962,43 +3962,48 @@ main_loop:
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CALL_VARARG) {
+			stackval *retval;
+			int num_varargs = 0;
 			MonoMethodSignature *csig;
-
-			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
-
-			/* The real signature for vararg calls */
-			csig = (MonoMethodSignature*) frame->imethod->data_items [ip [2]];
 
 			frame->ip = ip;
 
-			// Retval must be set unconditionally due to MINT_ARGLIST.
-			// is_void further guides exit_frame.
 			retval = sp;
-			is_void = csig->ret->type == MONO_TYPE_VOID;
-
+			child_frame = alloc_frame (context, &retval, frame, (InterpMethod*)frame->imethod->data_items [ip [1]], NULL, retval);
+			/* The real signature for vararg calls */
+			csig = (MonoMethodSignature*) frame->imethod->data_items [ip [2]];
 			/* Push all vararg arguments from normal sp to vt_sp together with the signature */
+			num_varargs = csig->param_count - csig->sentinelpos;
 			vt_sp = copy_varargs_vtstack (csig, sp, vt_sp);
 
 			ip += 3;
 			sp->data.p = vt_sp;
+			child_frame->retval = sp;
 
 			/* decrement by the actual number of args */
-			// FIXME This seems excessive: frame and csig param_count.
-			sp -= cmethod->param_count + cmethod->hasthis + csig->param_count - csig->sentinelpos;
+			sp -= child_frame->imethod->param_count + child_frame->imethod->hasthis + num_varargs;
 
-			goto call;
+			child_frame->stack_args = sp;
+			interp_exec_method_call_vararg (child_frame, context, error);
+			CHECK_RESUME_STATE (context);
+			if (csig->ret->type != MONO_TYPE_VOID) {
+				*sp = *retval;
+				sp++;
+			}
+			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_VCALL)
 		MINT_IN_CASE(MINT_CALL)
 		MINT_IN_CASE(MINT_CALLVIRT)
 		MINT_IN_CASE(MINT_VCALLVIRT) {
 			// FIXME CALLVIRT opcodes are not used on netcore. We should kill them.
-			// FIXME braces from here until call: label.
-			is_void = *ip == MINT_VCALL || *ip == MINT_VCALLVIRT;
-			gboolean is_virtual;
-			is_virtual = *ip == MINT_CALLVIRT || *ip == MINT_VCALLVIRT;
+			stackval *retval;
+			gboolean is_void = *ip == MINT_VCALL || *ip == MINT_VCALLVIRT;
+			gboolean is_virtual = *ip == MINT_CALLVIRT || *ip == MINT_VCALLVIRT;
+			gpointer native_stack_addr = frame->native_stack_addr ? (gpointer)((guint8*)frame->native_stack_addr - 1) : (gpointer)&retval;
+			InterpMethod *imethod;
 
-			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
+			imethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
 			sp->data.p = vt_sp;
 			retval = is_void ? NULL : sp;
 
@@ -4008,8 +4013,8 @@ main_loop:
 			if (is_virtual) {
 				MonoObject *this_arg = (MonoObject*)sp->data.p;
 
-				cmethod = get_virtual_method (cmethod, this_arg->vtable);
-				if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
+				imethod = get_virtual_method (imethod, this_arg->vtable);
+				if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (imethod->method->klass)) {
 					/* unbox */
 					gpointer unboxed = mono_object_unbox_internal (this_arg);
 					sp [0].data.p = unboxed;
@@ -4022,9 +4027,6 @@ main_loop:
 #else
 			ip += 3;
 #endif
-call:;
-			// FIXME This assumes a grow-down stack.
-			gpointer native_stack_addr = frame->native_stack_addr ? (gpointer)((guint8*)frame->native_stack_addr - 1) : (gpointer)&retval;
 
 			/*
 			 * Make a non-recursive call by loading the new interpreter state based on child frame,
@@ -4032,14 +4034,13 @@ call:;
 			 */
 			SAVE_INTERP_STATE (frame);
 
-			child_frame = alloc_frame (context, native_stack_addr, frame, cmethod, sp, retval);
+			child_frame = alloc_frame (context, native_stack_addr, frame, imethod, sp, retval);
 
-			if (G_UNLIKELY (!cmethod->transformed)) {
+			if (G_UNLIKELY (!imethod->transformed)) {
 				MonoException *ex;
 				gboolean tracing;
 
 				method_entry (context, child_frame, &tracing, &ex);
-
 				if (G_UNLIKELY (ex)) {
 					frame = child_frame;
 					frame->ip = NULL;
@@ -4047,7 +4048,7 @@ call:;
 					EXCEPTION_CHECKPOINT;
 				}
 			} else {
-				alloc_stack_data (context, child_frame, cmethod->alloca_size);
+				alloc_stack_data (context, child_frame, imethod->alloca_size);
 #if DEBUG_INTERP
 				debug_enter (child_frame, &tracing);
 #endif
@@ -5143,10 +5144,7 @@ call:;
 				frame->ip = ip;
 
 				child_frame = alloc_frame (context, &vtable, frame, ctor_method, sp, NULL);
-
-				// FIXME Remove recursion.
 				interp_exec_method_newobj_fast (child_frame, context, error);
-
 				CHECK_RESUME_STATE (context);
 				sp [0].data.o = o;
 				sp++;
@@ -5177,7 +5175,6 @@ call:;
 				sp->data.p = vt_sp;
 				ip += 4;
 
-				// FIXME remove recursion
 				interp_exec_method_newobj_vtst_fast (child_frame, context, error);
 
 				CHECK_RESUME_STATE (context);
@@ -5185,7 +5182,6 @@ call:;
 
 			} else {
 				ip += 3;
-				// FIXME remove recursion
 				mono_interp_newobj_vt (child_frame, context, error);
 				CHECK_RESUME_STATE (context);
 			}
@@ -5215,7 +5211,6 @@ call:;
 
 			child_frame->stack_args = sp;
 
-			// FIXME remove recursion
 			MonoException* const exc = mono_interp_newobj (child_frame, context, error, vt_sp);
 			if (exc)
 				THROW_EX (exc, ip);
@@ -7170,7 +7165,7 @@ exit_frame:
 
 		CHECK_RESUME_STATE (context);
 
-		if (retval && !is_void) {
+		if (retval) {
 			*sp = *retval;
 			sp ++;
 		}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18756,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This reverts commit 0e49716ff804bccf74a9c21a0383aa6ba7c49508.

It introduces failures on this test:
```console
$ make -C mcs/class/corlib run-xunit-test TEST_WITH_INTERPRETER=1 V=1 
[...]
    System.SpanTests.ReadOnlySpanTests.Equals [SKIP]
      Mono issue
    System.SpanTests.ReadOnlySpanTests.Test_ToLower_Culture [SKIP]
      Mono issue
    System.SpanTests.ReadOnlySpanTests.IndexOf_CyrillicE_InvariantCulture [SKIP]
      Mono issue
    System.SpanTests.ReadOnlySpanTests.IndexOf_TurkishI_EnglishUSCulture [SKIP]
      Mono issue
    System.SpanTests.ReadOnlySpanTests.StartsWith [SKIP]
      Mono issue
Killed
make[1]: *** [../../build/tests.make:369: run-xunit-test-lib] Error 1
make[1]: Leaving directory '/home/lewurm/work/mono/mcs/class/corlib'
make: *** [../../build/rules.make:220: do-run-xunit-test] Error 2
make: Leaving directory '/home/lewurm/work/mono/mcs/class/corlib'
```
I would say there is a ~50% chance that it will fail.  I have no good idea what the root cause is, so let's revert it for now. Also see https://jenkins.mono-project.com//job/test-mono-interpreter/

/cc @jaykrell 