### PR TITLE
[monodis] Escape names that start with a digit

### DIFF
--- a/src/mono/mono/dis/get.c
+++ b/src/mono/mono/dis/get.c
@@ -1577,7 +1577,8 @@ get_escaped_name (const char *name)
 	}
 
 	for (s = name; *s; s++) {
-		if (isalnum (*s) || *s == '_' || *s == '$' || *s == '@' ||
+		if (isalpha (*s) || (isdigit (*s) && s != name) ||
+		    *s == '_' || *s == '$' || *s == '@' ||
 		    *s == '?' || (*s == '.' && s != name) || *s == 0 || *s == '!' || *s == '`')
 			continue;
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18759,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Code like this:

```
using System;
class Program
{
    static byte[] bla = new byte[] {1,2,3,4,5};
    static void Main()
    {
    }
}
```

Compiles to a private field declaration for the array with a compiler generated
name, that name should be quoted if it starts with a digit.  For example:

```
	IL_0007:  ldtoken field valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=5' '<PrivateImplementationDetails>'::'74F81FE167D99B4CB41D6D0CCDA82278CAEE9F3E2F25D5E5A3936FF3DCEC60D0'
```

Fixes https://github.com/mono/mono/issues/18750



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
