### PR TITLE
Fix rethrow to retain stack

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -96,7 +96,7 @@ namespace System.Configuration
             // (1) Company name
             string part1 = Validate(_companyName, limitSize: true);
 
-            // (2) Domain or product name & an application urit hash
+            // (2) Domain or product name & an application uri hash
             string namePrefix = Validate(AppDomain.CurrentDomain.FriendlyName, limitSize: true);
             if (string.IsNullOrEmpty(namePrefix))
                 namePrefix = Validate(ProductName, limitSize: true);

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -125,7 +125,7 @@ namespace System.Configuration
         protected override object CreateSectionFactory(FactoryRecord factoryRecord)
         {
             // Get the type of the factory
-            Type type = TypeUtil.GetType(Host, factoryRecord.FactoryTypeName, true);
+            Type type = TypeUtil.GetType(Host, factoryRecord.FactoryTypeName, throwOnError: true);
 
             // If the type is not a ConfigurationSection, use the DefaultSection if the type
             // implements IConfigurationSectionHandler.

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
@@ -86,23 +86,24 @@ namespace System.Configuration
         // exception as indicated by throwOnError.
         internal static Type GetType(string typeString, bool throwOnError)
         {
-            Type type = null;
-            Exception originalException = null;
+            Type type;
 
             try
             {
                 type = Type.GetType(typeString, throwOnError);
             }
-            catch (Exception e)
+            catch
             {
-                originalException = e;
+                type = GetImplicitType(typeString);
+                if (type == null)
+                {
+                    throw;
+                }
             }
 
             if (type == null)
             {
                 type = GetImplicitType(typeString);
-                if ((type == null) && (originalException != null))
-                    throw originalException;
             }
 
             return type;
@@ -113,23 +114,23 @@ namespace System.Configuration
         // exception as indicated by throwOnError.
         internal static Type GetType(IInternalConfigHost host, string typeString, bool throwOnError)
         {
-            Type type = null;
-            Exception originalException = null;
-
+            Type type;
             try
             {
                 type = host.GetConfigType(typeString, throwOnError);
             }
-            catch (Exception e)
+            catch
             {
-                originalException = e;
+                type = GetImplicitType(typeString);
+                if (type == null)
+                {
+                    throw;
+                }
             }
 
             if (type == null)
             {
                 type = GetImplicitType(typeString);
-                if ((type == null) && (originalException != null))
-                    throw originalException;
             }
 
             return type;

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -191,5 +191,52 @@ namespace System.ConfigurationTests
             Assert.Equal(typeof(TestProvider), property.Provider.GetType());
             Assert.Equal(SettingsSerializeAs.Binary, property.SerializeAs);
         }
+
+        [Fact]
+        public void SettingsChanging_Success()
+        {
+            SimpleSettings settings = new SimpleSettings();
+            bool changingFired = false;
+            int newValue = 1976;
+
+            settings.SettingChanging += (object sender, SettingChangingEventArgs e)
+                =>
+                {
+                    changingFired = true;
+                    Assert.Equal(nameof(SimpleSettings.IntProperty), e.SettingName);
+                    Assert.Equal(typeof(SimpleSettings).FullName, e.SettingClass);
+                    Assert.Equal(newValue, e.NewValue);
+                };
+
+            settings.IntProperty = newValue;
+
+            Assert.True(changingFired);
+            Assert.Equal(newValue, settings.IntProperty);
+        }
+
+        [Fact]
+        public void SettingsChanging_Canceled()
+        {
+            int oldValue = 1776;
+            SimpleSettings settings = new SimpleSettings
+            {
+                IntProperty = oldValue
+            };
+
+            bool changingFired = false;
+            int newValue = 1976;
+
+            settings.SettingChanging += (object sender, SettingChangingEventArgs e)
+                =>
+            {
+                changingFired = true;
+                e.Cancel = true;
+            };
+
+            settings.IntProperty = newValue;
+
+            Assert.True(changingFired);
+            Assert.Equal(oldValue, settings.IntProperty);
+        }
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
@@ -50,10 +50,12 @@ namespace System.ConfigurationTests
             InlineData(
                 "System.Configuration.UserSettingsGroup, System.Configuration.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
                 typeof(UserSettingsGroup)),
+            // Mono doesn't care about the versioning here and will resolve the type back
             InlineData(
                 "System.Configuration.UserSettingsGroup, System.Configuration.ConfigurationManager, Version=255.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
                 null)
             ]
+        [SkipOnMono("Mono always resolves backwards for the second type.")]
         public void GetType_ConfigurationManagerTypes(string typeString, Type expectedType)
         {
             Assert.Equal(expectedType, TypeUtil.GetType(typeString, throwOnError: false));

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
@@ -37,9 +37,24 @@ namespace System.ConfigurationTests
             InlineData("System.Collections.Specialized.StringDictionary", typeof(StringDictionary)),
             InlineData("System.Collections.Specialized.OrderedDictionary", typeof(OrderedDictionary)),
             InlineData("System.Collections.Specialized.StringCollection", typeof(StringCollection)),
-            InlineData("System.Collections.Specialized.NameValueCollection", typeof(NameValueCollection))
+            InlineData("System.Collections.Specialized.NameValueCollection", typeof(NameValueCollection)),
             ]
         public void GetType_NoAssemblyQualifcation(string typeString, Type expectedType)
+        {
+            Assert.Equal(expectedType, TypeUtil.GetType(typeString, throwOnError: false));
+        }
+
+
+        [Theory,
+            // ConfigurationManager types roll forward
+            InlineData(
+                "System.Configuration.UserSettingsGroup, System.Configuration.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
+                typeof(UserSettingsGroup)),
+            InlineData(
+                "System.Configuration.UserSettingsGroup, System.Configuration.ConfigurationManager, Version=255.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
+                null)
+            ]
+        public void GetType_ConfigurationManagerTypes(string typeString, Type expectedType)
         {
             Assert.Equal(expectedType, TypeUtil.GetType(typeString, throwOnError: false));
         }


### PR DESCRIPTION
When resolving types we were re-throwing after attempting to get implicit types. Switching to a parameter-less re-throw to ensure that we keep the original stack.

Add a test for roll-forward behavior.

Add a few tests for settings events.

Re-enabling test that appeared to have failed when rerunning under an older framework.

Minor code style fixes.