### PR TITLE
Disable dactablegen cross OS compilation

### DIFF
--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -8,6 +8,7 @@ if (CLR_CMAKE_HOST_OS STREQUAL CLR_CMAKE_TARGET_OS)
     set (CLR_CROSS_COMPONENTS_LIST
         crossgen
         clrjit
+        dactablegen
     )
 endif()
 

--- a/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
@@ -12,7 +12,7 @@ set(DACTABLEGEN_SOURCES
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "")
 
 set(CMAKE_CSharp_FLAGS "/platform:anycpu32bitpreferred")
-add_executable(dactablegen ${DACTABLEGEN_SOURCES})
+add_executable_clr(dactablegen ${DACTABLEGEN_SOURCES})
 
 set_target_properties(dactablegen PROPERTIES VS_DOTNET_REFERENCES "System")
 set_target_properties(dactablegen PROPERTIES VS_DOTNET_REFERENCE_DIALib ${CMAKE_CURRENT_SOURCE_DIR}/DIALib.dll)


### PR DESCRIPTION
This is the simplifies version of #31919 (Which I couldn't reopen, because I force pushed before reopening...  Go figure).