### PR TITLE
Cut flaky mono-10127.cs in half -- time and allocation.

### DIFF
--- a/src/mono/mono/tests/bug-10127.cs
+++ b/src/mono/mono/tests/bug-10127.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 namespace WeakReferenceTest
 {
 	public static class Cache {
-		static GCHandle[] table = new GCHandle[1024 * 1024];
+		static GCHandle[] table = new GCHandle[1024 * 512];
 
 		public static T Probe<T>(int hc) where T : class
 		{
@@ -98,7 +98,7 @@ namespace WeakReferenceTest
 				tester.Start();
 			}
 
-			for (int i = 0; i < 4; ++i)
+			for (int i = 0; i < 2; ++i)
 			{
 				Thread.Sleep(TimeSpan.FromSeconds(1));
 			}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18761,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is failing Windows x64 C++.
The history shows it has failed interpreger (specifically?).