### PR TITLE
[interp] Significantly decrease nonrecursive interpreter memory use.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -131,8 +131,11 @@ add_frag (FrameStack *stack, int size)
 {
 	StackFragment *new_frag;
 
-	// FIXME:
-	int frag_size = 4096;
+	// FIXME: The behavior of an allocation not
+	// fitting in current chunk is very poor. Attempt
+	// instead a scheme managing one growable chunk
+	// by using multiple adjacent alloca.
+	int frag_size = 65536;
 	if (size + sizeof (StackFragment) > frag_size)
 		frag_size = size + sizeof (StackFragment);
 	new_frag = stack_frag_new (frag_size);
@@ -461,9 +464,13 @@ get_context (void)
 		/*
 		 * Use two stacks, one for InterpFrame structures, one for data.
 		 * This is useful because InterpFrame structures don't need to be GC tracked.
+		 * It also useful to fit allocations into iframe_stack perfectly.
+		 * FIXME: The behavior when allocations do not fit in current data_stack
+		 * chunk is very poor. Attempt a scheme with one growable chunk instead
+		 * using multiple adjacent alloca.
 		 */
-		frame_stack_init (&context->iframe_stack, 8192);
-		frame_stack_init (&context->data_stack, 8192);
+		frame_stack_init (&context->iframe_stack, 1024 * sizeof (InterpFrame));
+		frame_stack_init (&context->data_stack, 65536);
 		set_context (context);
 	}
 	return context;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18766,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is a more correct, but still flawed, alternative
to https://github.com/mono/mono/pull/18756
and should go in before https://github.com/mono/mono/pull/18734,
though I can add it to it.

So, this PR would appear to use more memory, not less.
And sometimes it does.
But it will tend to use far less memory.

The problem is that the interpreter implements a custom
heap, and does so drastically favoring speed of allocation
over density.

Any allocation, big or small, that does not fit in the current
chunk, forces a new chunk to be allocated, and leaves unused
the tail of the prior chunk. Also chunks are never freed
until the entire thread is freed.

This larger 64K (or whatever is chosen) will still behave poorly
when straddling occurs, but it will much less often.

There are other approaches to consider:

 1. Only allocate one large chunk, that correlates with native
   stack size. Like 512k or 1mb or 8mb or whatever.
   Maybe, maybe not be willing to allocate more than one.

 2. The "split" technique, which does perfect fit frame
   allocation in the usual fixed size or alloca way.

 3. An as yet unimplemented idea:
   a. Multiple alloca in same frame are adjacent.
   b. Manage one growable chunk per frame via multiple alloca.
   c. Chunk growth is alloca.
   d. Chunk reclaim is only via return, like alloca.
   e. Free is setting the pointer back.
   f. Allocate is "bump", possibly with alloca for growth.
   g. Dynamically detect stack growth direction and manage accordingly.

   This should be tried later perhaps.
   The notion of adjacent repeated alloca is a little gross, but
   is used successfully in practise. Consider that alloca itself is not portable.

  4. Maybe be willing to g_free chunks in frame_stack_pop.
     This would suffer when going back and forth across boundaries,
     repeated g_free/g_malloc cycles.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
