### PR TITLE
JIT: Remove double-negation during morph phase

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13585,6 +13585,12 @@ DONE_MORPHING_CHILDREN:
 
         case GT_NOT:
         case GT_NEG:
+            // Remove double negation/not
+            if (op1->OperIs(oper) && opts.OptimizationEnabled())
+            {
+                GenTree* child = op1->AsOp()->gtGetOp1();
+                return child;
+            }
 
             /* Any constant cases should have been folded earlier */
             noway_assert(!op1->OperIsConst() || !opts.OptEnabled(CLFLG_CONSTANTFOLD) || optValnumCSE_phase);

--- a/src/tests/JIT/opt/perf/doublenegate/doublenegate.cs
+++ b/src/tests/JIT/opt/perf/doublenegate/doublenegate.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace coreclr_test_13647
+{
+    class doublenegate
+    {
+        static int _dummyValueInt = 6;
+        static double _dummyValueDouble = 6.0;
+
+        static int Main(string[] args)
+        {
+            if (Test1() && Test2() && Test3()) {
+                Console.WriteLine("PASSED");
+                return 100;
+            }
+            Console.WriteLine("FAILED");
+            return 1;
+        }
+
+        static bool Test1()
+        {
+            var x = DoubleNegationInt(6);
+            var y = 
+                DoubleNegationInt(
+                    DoubleNegationInt(
+                        DoubleNegationInt(x)));
+            var z = DoubleNegationInt(_dummyValueInt);
+
+           if (x == 6 && y == 6 && z == 6)
+                return true;
+            return false;
+        }       
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static int NegationInt(int value) => -value;
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static int DoubleNegationInt(int value) => NegationInt(NegationInt(value));
+
+        static bool Test2()
+        {
+            var x = DoubleNegationDouble(6.0);
+            var y = 
+                DoubleNegationDouble(
+                    DoubleNegationDouble(
+                        DoubleNegationDouble(x)));
+            var z = DoubleNegationDouble(_dummyValueDouble);
+
+            if (x == 6.0 && y == 6.0 && z == 6.0)
+                return true;
+            return false;
+        }       
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static double NegationDouble(double value) => -value;
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static double DoubleNegationDouble(double value) => NegationDouble(NegationDouble(value));
+
+        static bool Test3()
+        {
+            var x = DoubleNotInt(6);
+            var y = 
+                DoubleNotInt(
+                    DoubleNotInt(
+                        DoubleNotInt(x)));
+            var z = DoubleNotInt(_dummyValueInt);
+
+           if (x == 6 && y == 6 && z == 6)
+                return true;
+            return false;
+        }       
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static int NotInt(int value) => ~value;
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        static int DoubleNotInt(int value) => NotInt(NotInt(value));
+    }
+}

--- a/src/tests/JIT/opt/perf/doublenegate/doublenegate.csproj
+++ b/src/tests/JIT/opt/perf/doublenegate/doublenegate.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <PropertyGroup>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="doublenegate.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- fixes #13647
- Co-authored with @EgorBo holding my hand :)

This is a continuation/redo of:
https://github.com/dotnet/coreclr/pull/27779

I've tried figuring out how to run jit-diffs, but it isn't easy for me to figure out how to build the tests on which the jit-diff is supposed to run in the current/new runtime super-repo.

If anyone has proper links to any sample of how to get this done, I'll be happy to try and get some jit-diffing to work, and post results here.