### PR TITLE
Special-case two set loops in RegexCompiler

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -820,17 +820,21 @@ namespace System.Text.RegularExpressions
         /// <param name="chars">The span into which the chars should be stored.</param>
         /// <returns>
         /// The number of stored chars.  If they won't all fit, 0 is returned.
+        /// If 0 is returned, no assumptions can be made about the characters.
         /// </returns>
         /// <remarks>
-        /// Only considers character classes that only contain sets (no categories), no negation,
+        /// Only considers character classes that only contain sets (no categories)
         /// and no subtraction... just simple sets containing starting/ending pairs.
+        /// The returned characters may be negated: if IsNegated(set) is false, then
+        /// the returned characters are the only ones that match; if it returns true,
+        /// then the returned characters are the only ones that don't match.
         /// </remarks>
         public static int GetSetChars(string set, Span<char> chars)
         {
             // If the set is negated, it's likely to contain a large number of characters,
             // so we don't even try.  We also get the characters by enumerating the set
             // portion, so we validate that it's set up to enable that, e.g. no categories.
-            if (IsNegated(set) || !CanEasilyEnumerateSetContents(set))
+            if (!CanEasilyEnumerateSetContents(set))
             {
                 return 0;
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1471,7 +1471,8 @@ namespace System.Text.RegularExpressions
                 int setCharsCount = 0, charClassIndex = 0;
                 bool canUseIndexOf =
                     !_leadingCharClasses[0].CaseInsensitive &&
-                    (setCharsCount = RegexCharClass.GetSetChars(_leadingCharClasses[0].CharClass, setChars)) > 0;
+                    (setCharsCount = RegexCharClass.GetSetChars(_leadingCharClasses[0].CharClass, setChars)) > 0 &&
+                    !RegexCharClass.IsNegated(_leadingCharClasses[0].CharClass);
                 bool needLoop = !canUseIndexOf || _leadingCharClasses.Length > 1;
 
                 Label checkSpanLengthLabel = default;
@@ -2281,7 +2282,7 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Oneloopatomic:
                     case RegexNode.Notoneloopatomic:
                     case RegexNode.Setloopatomic:
-                        EmitAtomicSingleCharLoop(node);
+                        EmitSingleCharAtomicLoop(node);
                         break;
 
                     case RegexNode.Loop:
@@ -2755,7 +2756,7 @@ namespace System.Text.RegularExpressions
             }
 
             // Emits the code to handle a non-backtracking, variable-length loop around a single character comparison.
-            void EmitAtomicSingleCharLoop(RegexNode node)
+            void EmitSingleCharAtomicLoop(RegexNode node)
             {
                 Debug.Assert(
                     node.Type == RegexNode.Oneloopatomic ||
@@ -2785,7 +2786,12 @@ namespace System.Text.RegularExpressions
                 Label originalDoneLabel = doneLabel;
                 doneLabel = DefineLabel();
 
-                if (node.Type == RegexNode.Notoneloopatomic && maxIterations == int.MaxValue && !IsCaseInsensitive(node))
+                Span<char> setChars = stackalloc char[3]; // 3 is max we can use with IndexOfAny
+                int numSetChars = 0;
+
+                if (node.Type == RegexNode.Notoneloopatomic &&
+                    maxIterations == int.MaxValue &&
+                    !IsCaseInsensitive(node))
                 {
                     // For Notoneloopatomic, we're looking for a specific character, as everything until we find
                     // it is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
@@ -2806,6 +2812,54 @@ namespace System.Text.RegularExpressions
                     }
                     Ldc(node.Ch);
                     Call(s_spanIndexOf);
+                    Stloc(iterationLocal);
+
+                    // if (i != -1) goto doneLabel;
+                    Ldloc(iterationLocal);
+                    Ldc(-1);
+                    BneFar(doneLabel);
+
+                    // i = textSpan.Length - textSpanPos;
+                    Ldloca(textSpanLocal);
+                    Call(s_spanGetLengthMethod);
+                    if (textSpanPos > 0)
+                    {
+                        Ldc(textSpanPos);
+                        Sub();
+                    }
+                    Stloc(iterationLocal);
+                }
+                else if (node.Type == RegexNode.Setloopatomic &&
+                    maxIterations == int.MaxValue &&
+                    (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) > 1 &&
+                    RegexCharClass.IsNegated(node.Str!))
+                {
+                    // If the set is negated and contains only 2 or 3 characters (if it contained 1 and was negated, it would
+                    // have been reduced to a Notoneloopatomic), we can use an IndexOfAny to find any of the target characters.
+                    // As with the notoneloopatomic above, the unbounded constraint is purely for simplicity.
+
+                    // int i = textSpan.Slice(textSpanPos).IndexOfAny(ch1, ch2{, ch3});
+                    if (textSpanPos > 0)
+                    {
+                        Ldloca(textSpanLocal);
+                        Ldc(textSpanPos);
+                        Call(s_spanSliceIntMethod);
+                    }
+                    else
+                    {
+                        Ldloc(textSpanLocal);
+                    }
+                    Ldc(setChars[0]);
+                    Ldc(setChars[1]);
+                    if (numSetChars == 2)
+                    {
+                        Call(s_spanIndexOfAnyCharChar);
+                    }
+                    else
+                    {
+                        Ldc(setChars[2]);
+                        Call(s_spanIndexOfAnyCharCharChar);
+                    }
                     Stloc(iterationLocal);
 
                     // if (i != -1) goto doneLabel;
@@ -4416,6 +4470,11 @@ namespace System.Text.RegularExpressions
                             Ldc(c);
                             MarkLabel(l4);
                         }
+                        Stloc(lenLocal);
+
+                        string? set = Code() == RegexCode.Setloop || Code() == RegexCode.Setloopatomic ? _strings![Operand(0)] : null;
+                        Span<char> setChars = stackalloc char[3];
+                        int numSetChars;
 
                         // If this is a notoneloop{atomic} and we're left-to-right and case-sensitive,
                         // we can use the vectorized IndexOf to search for the target character.
@@ -4423,8 +4482,6 @@ namespace System.Text.RegularExpressions
                             !IsRightToLeft() &&
                             !IsCaseInsensitive())
                         {
-                            Stloc(lenLocal);
-
                             // i = runtext.AsSpan(runtextpos, len).IndexOf(ch);
                             Ldloc(_runtextLocal!);
                             Ldloc(_runtextposLocal!);
@@ -4469,10 +4526,69 @@ namespace System.Text.RegularExpressions
                         }
                         else if ((Code() == RegexCode.Setloop || Code() == RegexCode.Setloopatomic) &&
                             !IsRightToLeft() &&
-                            _strings![Operand(0)] == RegexCharClass.AnyClass)
+                            !IsCaseInsensitive() &&
+                            (numSetChars = RegexCharClass.GetSetChars(set!, setChars)) > 1 &&
+                            RegexCharClass.IsNegated(set!))
                         {
-                            Stloc(lenLocal);
+                            // Similarly, if this is a setloop{atomic} and we're left-to-right and case-sensitive,
+                            // and if the set contains only 2 or 3 negated chars, we can use the vectorized IndexOfAny
+                            // to search for those chars.
 
+                            // i = runtext.AsSpan(runtextpos, len).IndexOfAny(ch1, ch2{, ch3});
+                            Ldloc(_runtextLocal!);
+                            Ldloc(_runtextposLocal!);
+                            Ldloc(lenLocal);
+                            Call(s_stringAsSpanIntIntMethod);
+                            Ldc(setChars[0]);
+                            Ldc(setChars[1]);
+                            if (numSetChars == 2)
+                            {
+                                Call(s_spanIndexOfAnyCharChar);
+                            }
+                            else
+                            {
+                                Ldc(setChars[2]);
+                                Call(s_spanIndexOfAnyCharCharChar);
+                            }
+                            Stloc(iLocal);
+
+                            Label charFound = DefineLabel();
+
+                            // if (i != -1) goto charFound;
+                            Ldloc(iLocal);
+                            Ldc(-1);
+                            Bne(charFound);
+
+                            // runtextpos += len;
+                            // i = 0;
+                            // goto loopEnd;
+                            Ldloc(_runtextposLocal!);
+                            Ldloc(lenLocal);
+                            Add();
+                            Stloc(_runtextposLocal!);
+                            Ldc(0);
+                            Stloc(iLocal);
+                            BrFar(loopEnd);
+
+                            // charFound:
+                            // runtextpos += i;
+                            // i = len - i;
+                            // goto loopEnd;
+                            MarkLabel(charFound);
+                            Ldloc(_runtextposLocal!);
+                            Ldloc(iLocal);
+                            Add();
+                            Stloc(_runtextposLocal!);
+                            Ldloc(lenLocal);
+                            Ldloc(iLocal);
+                            Sub();
+                            Stloc(iLocal);
+                            BrFar(loopEnd);
+                        }
+                        else if ((Code() == RegexCode.Setloop || Code() == RegexCode.Setloopatomic) &&
+                            !IsRightToLeft() &&
+                            set == RegexCharClass.AnyClass)
+                        {
                             // If someone uses .* along with RegexOptions.Singleline, that becomes [anycharacter]*, which means it'll
                             // consume everything.  As such, we can simply update our position to be the last allowed, without
                             // actually checking anything.
@@ -4490,8 +4606,7 @@ namespace System.Text.RegularExpressions
                         {
                             // Otherwise, we emit the open-coded loop.
 
-                            Dup();
-                            Stloc(lenLocal);
+                            Ldloc(lenLocal);
                             Ldc(1);
                             Add();
                             Stloc(iLocal);
@@ -4879,7 +4994,7 @@ namespace System.Text.RegularExpressions
             {
                 Span<char> setChars = stackalloc char[3];
                 int numChars = RegexCharClass.GetSetChars(charClass, setChars);
-                if (numChars > 0)
+                if (numChars > 0 && !RegexCharClass.IsNegated(charClass))
                 {
                     // (ch == setChars[0]) | (ch == setChars[1]) { | (ch == setChars[2]) }
                     Debug.Assert(numChars == 2 || numChars == 3);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2831,6 +2831,7 @@ namespace System.Text.RegularExpressions
                 }
                 else if (node.Type == RegexNode.Setloopatomic &&
                     maxIterations == int.MaxValue &&
+                    !IsCaseInsensitive(node) &&
                     (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) > 1 &&
                     RegexCharClass.IsNegated(node.Str!))
                 {
@@ -2857,6 +2858,7 @@ namespace System.Text.RegularExpressions
                     }
                     else
                     {
+                        Debug.Assert(numSetChars == 3);
                         Ldc(setChars[2]);
                         Call(s_spanIndexOfAnyCharCharChar);
                     }
@@ -4547,6 +4549,7 @@ namespace System.Text.RegularExpressions
                             }
                             else
                             {
+                                Debug.Assert(numSetChars == 3);
                                 Ldc(setChars[2]);
                                 Call(s_spanIndexOfAnyCharCharChar);
                             }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -716,6 +716,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(?:abcd|efg[hij]*)k", "efgjk", RegexOptions.None, new string[] { "efgjk" } };
             yield return new object[] { null, @"[ace]?b[ace]?b[ace]?b[ace]?b", "cbbabeb", RegexOptions.None, new string[] { "cbbabeb" } };
             yield return new object[] { null, @"[ace]?b[ace]?b[ace]?b[ace]?b", "cBbAbEb", RegexOptions.IgnoreCase, new string[] { "cBbAbEb" } };
+            yield return new object[] { null, @"a[^wz]*w", "abcdcdcdwz", RegexOptions.None, new string[] { "abcdcdcdw" } };
+            yield return new object[] { null, @"a[^wyz]*w", "abcdcdcdwz", RegexOptions.None, new string[] { "abcdcdcdw" } };
             // Implicitly upgrading (or not) concat loops to be atomic
             yield return new object[] { null, @"(?:[ab]c[de]f)*", "", RegexOptions.None, new string[] { "" } };
             yield return new object[] { null, @"(?:[ab]c[de]f)*", "acdf", RegexOptions.None, new string[] { "acdf" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -718,6 +718,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"[ace]?b[ace]?b[ace]?b[ace]?b", "cBbAbEb", RegexOptions.IgnoreCase, new string[] { "cBbAbEb" } };
             yield return new object[] { null, @"a[^wz]*w", "abcdcdcdwz", RegexOptions.None, new string[] { "abcdcdcdw" } };
             yield return new object[] { null, @"a[^wyz]*w", "abcdcdcdwz", RegexOptions.None, new string[] { "abcdcdcdw" } };
+            yield return new object[] { null, @"a[^wyz]*W", "abcdcdcdWz", RegexOptions.IgnoreCase, new string[] { "abcdcdcdW" } };
             // Implicitly upgrading (or not) concat loops to be atomic
             yield return new object[] { null, @"(?:[ab]c[de]f)*", "", RegexOptions.None, new string[] { "" } };
             yield return new object[] { null, @"(?:[ab]c[de]f)*", "acdf", RegexOptions.None, new string[] { "acdf" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -96,6 +96,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { Case("(?>hi|hello|hey)hi"), "hellohi", options, 0, 0, false, string.Empty };
                 yield return new object[] { Case("(?:hi|hello|hey)hi"), "hellohi", options, 0, 7, true, "hellohi" }; // allow backtracking and it succeeds
                 yield return new object[] { Case("(?>hi|hello|hey)hi"), "hihi", options, 0, 4, true, "hihi" };
+                yield return new object[] { Case(@"a[^wyz]*w"), "abczw", RegexOptions.IgnoreCase, 0, 0, false, string.Empty };
             }
 
             // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"


### PR DESCRIPTION
- If an expression contains `.*` and RegexOptions.Singleline was specified, it ends up meaning `[everything]`*, in which case we don't have to match anything and can just jump to the last position.
- If an expression contains `[^xyz]*` with 2 or 3 negated chars in a set loop, we can use IndexOfAny for those chars to vectorize the search.

Contributes to https://github.com/dotnet/runtime/issues/1349
cc: @danmosemsft, @eerhardt, @ViktorHofer 