### PR TITLE
use TestHelper to create client and server stream

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -80,9 +80,9 @@ namespace System.Net.Security.Tests
             RemoteCertificateValidationCallback rCallback = (sender, certificate, chain, errors) => { return true; };
             LocalCertificateSelectionCallback lCallback = (sender, host, localCertificates, remoteCertificate, issuers) => { return null; };
 
-            VirtualNetwork network = new VirtualNetwork();
-            using (var clientStream = new VirtualNetworkStream(network, false))
-            using (var serverStream = new VirtualNetworkStream(network, true))
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
             using (var client = new SslStream(clientStream, false, rCallback, lCallback, EncryptionPolicy.RequireEncryption))
             using (var server = new SslStream(serverStream, false, rCallback))
             using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
@@ -106,9 +106,9 @@ namespace System.Net.Security.Tests
         [MemberData(nameof(Alpn_TestData))]
         public async Task SslStream_StreamToStream_Alpn_Success(List<SslApplicationProtocol> clientProtocols, List<SslApplicationProtocol> serverProtocols, SslApplicationProtocol expected)
         {
-            VirtualNetwork network = new VirtualNetwork();
-            using (var clientStream = new VirtualNetworkStream(network, false))
-            using (var serverStream = new VirtualNetworkStream(network, true))
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
             using (var client = new SslStream(clientStream, false))
             using (var server = new SslStream(serverStream, false))
             {


### PR DESCRIPTION
This is a fragment of deprecated #1949. It allows switching easily between real socket and MemoryStream. With socket, one can use Wireshark to decode SSL handshake and that is handy to investigate test failures.