### PR TITLE
Improve ProcessManager.Win

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
@@ -11,6 +11,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32EnumProcessModules")]
-        internal static extern bool EnumProcessModules(SafeProcessHandle handle, IntPtr[] modules, int size, out int needed);
+        internal static extern bool EnumProcessModules(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
@@ -11,6 +11,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32EnumProcessModules")]
-        internal static extern bool EnumProcessModules(SafeProcessHandle handle, IntPtr modules, int size, ref int needed);
+        internal static extern bool EnumProcessModules(SafeProcessHandle handle, IntPtr[] modules, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_SafeProcessHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.IsWow64Process_SafeProcessHandle.cs
@@ -10,6 +10,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool IsWow64Process(SafeProcessHandle hProcess, ref bool Wow64Process);
+        internal static extern bool IsWow64Process(SafeProcessHandle hProcess, out bool Wow64Process);
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.ComponentModel;
 
 namespace System.Diagnostics
 {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics
     {
         internal readonly List<ThreadInfo> _threadInfoList = new List<ThreadInfo>();
         internal int BasePriority { get; set; }
-        internal string ProcessName { get; set; }
+        internal string ProcessName { get; set; } = string.Empty;
         internal int ProcessId { get; set; }
         internal long PoolPagedBytes { get; set; }
         internal long PoolNonPagedBytes { get; set; }
@@ -29,23 +29,5 @@ namespace System.Diagnostics
         internal long PrivateBytes { get; set; }
         internal int SessionId { get; set; }
         internal int HandleCount { get; set; }
-
-        internal ProcessInfo()
-        {
-            BasePriority = 0;
-            ProcessName = "";
-            ProcessId = 0;
-            PoolPagedBytes = 0;
-            PoolNonPagedBytes = 0;
-            VirtualBytes = 0;
-            VirtualBytesPeak = 0;
-            WorkingSet = 0;
-            WorkingSetPeak = 0;
-            PageFileBytes = 0;
-            PageFileBytesPeak = 0;
-            PrivateBytes = 0;
-            SessionId = 0;
-            HandleCount = 0;
-        }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessInfo.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics
     /// </summary>
     internal sealed class ProcessInfo
     {
-        internal readonly List<ThreadInfo> _threadInfoList = new List<ThreadInfo>();
+        internal readonly List<ThreadInfo> _threadInfoList;
         internal int BasePriority { get; set; }
         internal string ProcessName { get; set; } = string.Empty;
         internal int ProcessId { get; set; }
@@ -29,5 +29,15 @@ namespace System.Diagnostics
         internal long PrivateBytes { get; set; }
         internal int SessionId { get; set; }
         internal int HandleCount { get; set; }
+
+        internal ProcessInfo()
+        {
+            _threadInfoList = new List<ThreadInfo>();
+        }
+
+        internal ProcessInfo(int threadsNumber)
+        {
+            _threadInfoList = new List<ThreadInfo>(threadsNumber);
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -128,7 +128,7 @@ namespace System.Diagnostics
 
                 int modulesCount;
                 IntPtr[] moduleHandles;
-                for (; ; )
+                while (true)
                 {
                     int size = needed;
                     modulesCount = size / IntPtr.Size;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -386,7 +386,7 @@ namespace System.Diagnostics
                     }
                     else
                     {
-                        string processName = GetProcessShortName(Marshal.PtrToStringUni(pi.ImageName.Buffer, pi.ImageName.Length / sizeof(char)));
+                        string processName = GetProcessShortName(new ReadOnlySpan<char>(pi.ImageName.Buffer.ToPointer(), pi.ImageName.Length / sizeof(char)));
                         processInfo.ProcessName = processName;
                     }
 
@@ -430,9 +430,9 @@ namespace System.Diagnostics
         //
         // This is from GetProcessShortName in NT code base.
         // Check base\screg\winreg\perfdlls\process\perfsprc.c for details.
-        internal static string GetProcessShortName(string name)
+        internal static string GetProcessShortName(ReadOnlySpan<char> name)
         {
-            if (string.IsNullOrEmpty(name))
+            if (name.IsEmpty)
             {
                 return string.Empty;
             }
@@ -455,7 +455,7 @@ namespace System.Diagnostics
                 // if a period was found, then see if the extension is
                 // .EXE, if so drop it, if not, then use end of string
                 // (i.e. include extension in name)
-                ReadOnlySpan<char> extension = name.AsSpan(period);
+                ReadOnlySpan<char> extension = name.Slice(period);
 
                 if (extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
                     period--;                 // point to character before period
@@ -470,7 +470,7 @@ namespace System.Diagnostics
 
             // copy characters between period (or end of string) and
             // slash (or start of string) to make image name
-            return name.Substring(slash, period - slash + 1);
+            return name.Slice(slash, period - slash + 1).ToString();
         }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -114,7 +114,7 @@ namespace System.Diagnostics
                             SafeProcessHandle hCurProcess = SafeProcessHandle.InvalidHandle;
                             try
                             {
-                                hCurProcess = ProcessManager.OpenProcess(unchecked((int)Interop.Kernel32.GetCurrentProcessId()), Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, true);
+                                hCurProcess = ProcessManager.OpenProcess((int)Interop.Kernel32.GetCurrentProcessId(), Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, true);
 
                                 if (!Interop.Kernel32.IsWow64Process(hCurProcess, ref sourceProcessIsWow64))
                                 {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -126,17 +126,21 @@ namespace System.Diagnostics
                     EnumProcessModulesUntilSuccess(processHandle, null, 0, out needed);
                 }
 
-                int modulesCount;
-                IntPtr[] moduleHandles;
+                int modulesCount = needed / IntPtr.Size;
+                IntPtr[] moduleHandles = new IntPtr[modulesCount];
                 while (true)
                 {
                     int size = needed;
-                    modulesCount = size / IntPtr.Size;
-                    moduleHandles = new IntPtr[modulesCount];
                     EnumProcessModulesUntilSuccess(processHandle, moduleHandles, size, out needed);
                     if (size == needed)
                     {
                         break;
+                    }
+
+                    if (needed > size && needed / IntPtr.Size > modulesCount)
+                    {
+                        modulesCount = needed / IntPtr.Size;
+                        moduleHandles = new IntPtr[modulesCount];
                     }
                 }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -353,7 +353,7 @@ namespace System.Diagnostics
                 if (processIdFilter == null || processIdFilter(processInfoProcessId))
                 {
                     // get information for a process
-                    ProcessInfo processInfo = new ProcessInfo();
+                    ProcessInfo processInfo = new ProcessInfo((int)pi.NumberOfThreads);
                     processInfo.ProcessId = processInfoProcessId;
                     processInfo.SessionId = (int)pi.SessionId;
                     processInfo.PoolPagedBytes = (long)pi.QuotaPagedPoolUsage;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -219,14 +219,18 @@ namespace System.Diagnostics
             // This is no easy solution to this problem. The only reliable way to fix this is to
             // suspend all the threads in target process. Of course we don't want to do this in Process class.
             // So we just to try avoid the race by calling the same method 50 (an arbitrary number) times.
+            if (Interop.Kernel32.EnumProcessModules(processHandle, modules, size, out needed))
+            {
+                return;
+            }
+
             for (int i = 0; i < 50; i++)
             {
+                Thread.Sleep(1);
                 if (Interop.Kernel32.EnumProcessModules(processHandle, modules, size, out needed))
                 {
                     return;
                 }
-
-                Thread.Sleep(1);
             }
 
             throw new Win32Exception();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -148,7 +148,6 @@ namespace System.Diagnostics
                                 {
                                     break;
                                 }
-                                Thread.Sleep(1);
                             }
                         }
                     }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -31,7 +31,7 @@ namespace System.Diagnostics
 
         public IntPtr FindMainWindow(int processId)
         {
-            _bestHandle = (IntPtr)0;
+            _bestHandle = IntPtr.Zero;
             _processId = processId;
 
             Interop.User32.EnumThreadWindowsCallback callback = new Interop.User32.EnumThreadWindowsCallback(EnumWindowsCallback);
@@ -43,7 +43,7 @@ namespace System.Diagnostics
 
         private bool IsMainWindow(IntPtr handle)
         {
-            if (Interop.User32.GetWindow(handle, GW_OWNER) != (IntPtr)0 || !Interop.User32.IsWindowVisible(handle))
+            if (Interop.User32.GetWindow(handle, GW_OWNER) != IntPtr.Zero || !Interop.User32.IsWindowVisible(handle))
                 return false;
 
             return true;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -225,6 +225,8 @@ namespace System.Diagnostics
                 {
                     return;
                 }
+
+                Thread.Sleep(1);
             }
 
             throw new Win32Exception();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -368,20 +368,22 @@ namespace System.Diagnostics
                 if (processIdFilter == null || processIdFilter(processInfoProcessId))
                 {
                     // get information for a process
-                    ProcessInfo processInfo = new ProcessInfo((int)pi.NumberOfThreads);
-                    processInfo.ProcessId = processInfoProcessId;
-                    processInfo.SessionId = (int)pi.SessionId;
-                    processInfo.PoolPagedBytes = (long)pi.QuotaPagedPoolUsage;
-                    processInfo.PoolNonPagedBytes = (long)pi.QuotaNonPagedPoolUsage;
-                    processInfo.VirtualBytes = (long)pi.VirtualSize;
-                    processInfo.VirtualBytesPeak = (long)pi.PeakVirtualSize;
-                    processInfo.WorkingSetPeak = (long)pi.PeakWorkingSetSize;
-                    processInfo.WorkingSet = (long)pi.WorkingSetSize;
-                    processInfo.PageFileBytesPeak = (long)pi.PeakPagefileUsage;
-                    processInfo.PageFileBytes = (long)pi.PagefileUsage;
-                    processInfo.PrivateBytes = (long)pi.PrivatePageCount;
-                    processInfo.BasePriority = pi.BasePriority;
-                    processInfo.HandleCount = (int)pi.HandleCount;
+                    ProcessInfo processInfo = new ProcessInfo((int)pi.NumberOfThreads)
+                    {
+                        ProcessId = processInfoProcessId,
+                        SessionId = (int)pi.SessionId,
+                        PoolPagedBytes = (long)pi.QuotaPagedPoolUsage,
+                        PoolNonPagedBytes = (long)pi.QuotaNonPagedPoolUsage,
+                        VirtualBytes = (long)pi.VirtualSize,
+                        VirtualBytesPeak = (long)pi.PeakVirtualSize,
+                        WorkingSetPeak = (long)pi.PeakWorkingSetSize,
+                        WorkingSet = (long)pi.WorkingSetSize,
+                        PageFileBytesPeak = (long)pi.PeakPagefileUsage,
+                        PageFileBytes = (long)pi.PagefileUsage,
+                        PrivateBytes = (long)pi.PrivatePageCount,
+                        BasePriority = pi.BasePriority,
+                        HandleCount = (int)pi.HandleCount,
+                    };
 
                     if (pi.ImageName.Buffer == IntPtr.Zero)
                     {
@@ -413,15 +415,16 @@ namespace System.Diagnostics
                     {
                         ref readonly SYSTEM_THREAD_INFORMATION ti = ref MemoryMarshal.AsRef<SYSTEM_THREAD_INFORMATION>(data.Slice(threadInformationOffset));
 
-                        ThreadInfo threadInfo = new ThreadInfo();
-
-                        threadInfo._processId = (int)ti.ClientId.UniqueProcess;
-                        threadInfo._threadId = (ulong)ti.ClientId.UniqueThread;
-                        threadInfo._basePriority = ti.BasePriority;
-                        threadInfo._currentPriority = ti.Priority;
-                        threadInfo._startAddress = ti.StartAddress;
-                        threadInfo._threadState = (ThreadState)ti.ThreadState;
-                        threadInfo._threadWaitReason = NtProcessManager.GetThreadWaitReason((int)ti.WaitReason);
+                        ThreadInfo threadInfo = new ThreadInfo
+                        {
+                            _processId = (int)ti.ClientId.UniqueProcess,
+                            _threadId = (ulong)ti.ClientId.UniqueThread,
+                            _basePriority = ti.BasePriority,
+                            _currentPriority = ti.Priority,
+                            _startAddress = ti.StartAddress,
+                            _threadState = (ThreadState)ti.ThreadState,
+                            _threadWaitReason = NtProcessManager.GetThreadWaitReason((int)ti.WaitReason),
+                        };
 
                         processInfo._threadInfoList.Add(threadInfo);
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -18,8 +18,7 @@ namespace System.Diagnostics
     {
         public static IntPtr GetMainWindowHandle(int processId)
         {
-            MainWindowFinder finder = new MainWindowFinder();
-            return finder.FindMainWindow(processId);
+            return new MainWindowFinder().FindMainWindow(processId);
         }
     }
 
@@ -116,16 +115,13 @@ namespace System.Diagnostics
                             try
                             {
                                 hCurProcess = ProcessManager.OpenProcess(unchecked((int)Interop.Kernel32.GetCurrentProcessId()), Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, true);
-                                bool wow64Ret;
 
-                                wow64Ret = Interop.Kernel32.IsWow64Process(hCurProcess, ref sourceProcessIsWow64);
-                                if (!wow64Ret)
+                                if (!Interop.Kernel32.IsWow64Process(hCurProcess, ref sourceProcessIsWow64))
                                 {
                                     throw new Win32Exception();
                                 }
 
-                                wow64Ret = Interop.Kernel32.IsWow64Process(processHandle, ref targetProcessIsWow64);
-                                if (!wow64Ret)
+                                if (!Interop.Kernel32.IsWow64Process(processHandle, ref targetProcessIsWow64))
                                 {
                                     throw new Win32Exception();
                                 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -81,80 +81,68 @@ namespace System.Diagnostics
                 processHandle = ProcessManager.OpenProcess(processId, Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION | Interop.Advapi32.ProcessOptions.PROCESS_VM_READ, true);
 
                 IntPtr[] moduleHandles = new IntPtr[64];
-                GCHandle moduleHandlesArrayHandle = default;
-                int moduleCount = 0;
+                int moduleCount;
                 while (true)
                 {
-                    bool enumResult = false;
-                    try
+                    bool enumResult = Interop.Kernel32.EnumProcessModules(processHandle, moduleHandles, moduleHandles.Length * IntPtr.Size, out moduleCount);
+
+                    // The API we need to use to enumerate process modules differs on two factors:
+                    //   1) If our process is running in WOW64.
+                    //   2) The bitness of the process we wish to introspect.
+                    //
+                    // If we are not running in WOW64 or we ARE in WOW64 but want to inspect a 32 bit process
+                    // we can call psapi!EnumProcessModules.
+                    //
+                    // If we are running in WOW64 and we want to inspect the modules of a 64 bit process then
+                    // psapi!EnumProcessModules will return false with ERROR_PARTIAL_COPY (299).  In this case we can't
+                    // do the enumeration at all.  So we'll detect this case and bail out.
+                    //
+                    // Also, EnumProcessModules is not a reliable method to get the modules for a process.
+                    // If OS loader is touching module information, this method might fail and copy part of the data.
+                    // This is no easy solution to this problem. The only reliable way to fix this is to
+                    // suspend all the threads in target process. Of course we don't want to do this in Process class.
+                    // So we just to try avoid the race by calling the same method 50 (an arbitrary number) times.
+                    //
+                    if (!enumResult)
                     {
-                        moduleHandlesArrayHandle = GCHandle.Alloc(moduleHandles, GCHandleType.Pinned);
-                        enumResult = Interop.Kernel32.EnumProcessModules(processHandle, moduleHandlesArrayHandle.AddrOfPinnedObject(), moduleHandles.Length * IntPtr.Size, ref moduleCount);
-
-                        // The API we need to use to enumerate process modules differs on two factors:
-                        //   1) If our process is running in WOW64.
-                        //   2) The bitness of the process we wish to introspect.
-                        //
-                        // If we are not running in WOW64 or we ARE in WOW64 but want to inspect a 32 bit process
-                        // we can call psapi!EnumProcessModules.
-                        //
-                        // If we are running in WOW64 and we want to inspect the modules of a 64 bit process then
-                        // psapi!EnumProcessModules will return false with ERROR_PARTIAL_COPY (299).  In this case we can't
-                        // do the enumeration at all.  So we'll detect this case and bail out.
-                        //
-                        // Also, EnumProcessModules is not a reliable method to get the modules for a process.
-                        // If OS loader is touching module information, this method might fail and copy part of the data.
-                        // This is no easy solution to this problem. The only reliable way to fix this is to
-                        // suspend all the threads in target process. Of course we don't want to do this in Process class.
-                        // So we just to try avoid the race by calling the same method 50 (an arbitrary number) times.
-                        //
-                        if (!enumResult)
+                        SafeProcessHandle hCurProcess = SafeProcessHandle.InvalidHandle;
+                        try
                         {
-                            bool sourceProcessIsWow64 = false;
-                            bool targetProcessIsWow64 = false;
-                            SafeProcessHandle hCurProcess = SafeProcessHandle.InvalidHandle;
-                            try
+                            hCurProcess = ProcessManager.OpenProcess((int)Interop.Kernel32.GetCurrentProcessId(), Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, true);
+
+                            if (!Interop.Kernel32.IsWow64Process(hCurProcess, out bool sourceProcessIsWow64))
                             {
-                                hCurProcess = ProcessManager.OpenProcess((int)Interop.Kernel32.GetCurrentProcessId(), Interop.Advapi32.ProcessOptions.PROCESS_QUERY_INFORMATION, true);
-
-                                if (!Interop.Kernel32.IsWow64Process(hCurProcess, ref sourceProcessIsWow64))
-                                {
-                                    throw new Win32Exception();
-                                }
-
-                                if (!Interop.Kernel32.IsWow64Process(processHandle, ref targetProcessIsWow64))
-                                {
-                                    throw new Win32Exception();
-                                }
-
-                                if (sourceProcessIsWow64 && !targetProcessIsWow64)
-                                {
-                                    // Wow64 isn't going to allow this to happen, the best we can do is give a descriptive error to the user.
-                                    throw new Win32Exception(Interop.Errors.ERROR_PARTIAL_COPY, SR.EnumProcessModuleFailedDueToWow);
-                                }
-                            }
-                            finally
-                            {
-                                if (hCurProcess != SafeProcessHandle.InvalidHandle)
-                                {
-                                    hCurProcess.Dispose();
-                                }
+                                throw new Win32Exception();
                             }
 
-                            // If the failure wasn't due to Wow64, try again.
-                            for (int i = 0; i < 50; i++)
+                            if (!Interop.Kernel32.IsWow64Process(processHandle, out bool targetProcessIsWow64))
                             {
-                                enumResult = Interop.Kernel32.EnumProcessModules(processHandle, moduleHandlesArrayHandle.AddrOfPinnedObject(), moduleHandles.Length * IntPtr.Size, ref moduleCount);
-                                if (enumResult)
-                                {
-                                    break;
-                                }
+                                throw new Win32Exception();
+                            }
+
+                            if (sourceProcessIsWow64 && !targetProcessIsWow64)
+                            {
+                                // Wow64 isn't going to allow this to happen, the best we can do is give a descriptive error to the user.
+                                throw new Win32Exception(Interop.Errors.ERROR_PARTIAL_COPY, SR.EnumProcessModuleFailedDueToWow);
                             }
                         }
-                    }
-                    finally
-                    {
-                        moduleHandlesArrayHandle.Free();
+                        finally
+                        {
+                            if (hCurProcess != SafeProcessHandle.InvalidHandle)
+                            {
+                                hCurProcess.Dispose();
+                            }
+                        }
+
+                        // If the failure wasn't due to Wow64, try again.
+                        for (int i = 0; i < 50; i++)
+                        {
+                            enumResult = Interop.Kernel32.EnumProcessModules(processHandle, moduleHandles, moduleHandles.Length * IntPtr.Size, out moduleCount);
+                            if (enumResult)
+                            {
+                                break;
+                            }
+                        }
                     }
 
                     if (!enumResult)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -34,10 +34,8 @@ namespace System.Diagnostics
             _bestHandle = IntPtr.Zero;
             _processId = processId;
 
-            Interop.User32.EnumThreadWindowsCallback callback = new Interop.User32.EnumThreadWindowsCallback(EnumWindowsCallback);
-            Interop.User32.EnumWindows(callback, IntPtr.Zero);
+            Interop.User32.EnumWindows(EnumWindowsCallback, IntPtr.Zero);
 
-            GC.KeepAlive(callback);
             return _bestHandle;
         }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Win32.cs
@@ -170,7 +170,9 @@ namespace System.Diagnostics
 
                 var modules = new ProcessModuleCollection(firstModuleOnly ? 1 : moduleCount);
 
-                char[] chars = ArrayPool<char>.Shared.Rent(1024);
+                const int MaxShortPath = 260;
+                int minimumLength = MaxShortPath;
+                char[] chars = ArrayPool<char>.Shared.Rent(minimumLength);
                 try
                 {
                     for (int i = 0; i < moduleCount; i++)
@@ -210,16 +212,27 @@ namespace System.Diagnostics
 
                         module.ModuleName = new string(chars, 0, length);
 
-                        length = Interop.Kernel32.GetModuleFileNameEx(processHandle, moduleHandle, chars, chars.Length);
+                        for (; ; )
+                        {
+                            length = Interop.Kernel32.GetModuleFileNameEx(processHandle, moduleHandle, chars, chars.Length);
+                            if (length == chars.Length)
+                            {
+                                ArrayPool<char>.Shared.Return(chars);
+                                minimumLength *= 2;
+                                chars = ArrayPool<char>.Shared.Rent(minimumLength);
+                                continue;
+                            }
+
+                            break;
+                        }
+
                         if (length == 0)
                         {
                             HandleError();
                             continue;
                         }
 
-                        module.FileName = (length >= 4 && chars[0] == '\\' && chars[1] == '\\' && chars[2] == '?' && chars[3] == '\\') ?
-                            new string(chars, 4, length - 4) :
-                            new string(chars, 0, length);
+                        module.FileName = new string(chars, 0, length);
 
                         modules.Add(module);
                     }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
 using static Interop.Advapi32;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -33,11 +33,12 @@ namespace System.Diagnostics
             // Otherwise enumerate all processes and compare ids
             if (!IsRemoteMachine(machineName))
             {
-                using SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId);
-
-                if (!processHandle.IsInvalid)
+                using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId))
                 {
-                    return true;
+                    if (!processHandle.IsInvalid)
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -440,9 +440,12 @@ namespace System.Diagnostics
                                 // at the end.  If instanceName ends in ".", ".e", or ".ex" we remove it.
                                 if (instanceName.Length == 15)
                                 {
-                                    if (instanceName.EndsWith(".", StringComparison.Ordinal)) instanceName = instanceName.Slice(0, 14);
-                                    else if (instanceName.EndsWith(".e", StringComparison.Ordinal)) instanceName = instanceName.Slice(0, 13);
-                                    else if (instanceName.EndsWith(".ex", StringComparison.Ordinal)) instanceName = instanceName.Slice(0, 12);
+                                    if (instanceName.EndsWith(".", StringComparison.Ordinal))
+                                        instanceName = instanceName.Slice(0, 14);
+                                    else if (instanceName.EndsWith(".e", StringComparison.Ordinal))
+                                        instanceName = instanceName.Slice(0, 13);
+                                    else if (instanceName.EndsWith(".ex", StringComparison.Ordinal))
+                                        instanceName = instanceName.Slice(0, 12);
                                 }
                                 processInfo.ProcessName = instanceName.ToString();
                                 processInfos.Add(processInfo.ProcessId, processInfo);
@@ -452,7 +455,8 @@ namespace System.Diagnostics
                     else if (type.ObjectNameTitleIndex == threadIndex)
                     {
                         ThreadInfo threadInfo = GetThreadInfo(data.Slice(instancePos + instance.ByteLength), counters);
-                        if (threadInfo._threadId != 0) threadInfos.Add(threadInfo);
+                        if (threadInfo._threadId != 0)
+                            threadInfos.Add(threadInfo);
                     }
 
                     instancePos += instance.ByteLength;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -426,11 +426,17 @@ namespace System.Diagnostics
                                 if (instanceName.Length == 15)
                                 {
                                     if (instanceName.EndsWith(".", StringComparison.Ordinal))
+                                    {
                                         instanceName = instanceName.Slice(0, 14);
+                                    }
                                     else if (instanceName.EndsWith(".e", StringComparison.Ordinal))
+                                    {
                                         instanceName = instanceName.Slice(0, 13);
+                                    }
                                     else if (instanceName.EndsWith(".ex", StringComparison.Ordinal))
+                                    {
                                         instanceName = instanceName.Slice(0, 12);
+                                    }
                                 }
                                 processInfo.ProcessName = instanceName.ToString();
                                 processInfos.Add(processInfo.ProcessId, processInfo);
@@ -441,7 +447,9 @@ namespace System.Diagnostics
                     {
                         ThreadInfo threadInfo = GetThreadInfo(data.Slice(instancePos + instance.ByteLength), counters);
                         if (threadInfo._threadId != 0)
+                        {
                             threadInfos.Add(threadInfo);
+                        }
                     }
 
                     instancePos += instance.ByteLength;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -419,7 +419,7 @@ namespace System.Diagnostics
                     }
                     else if (type.ObjectNameTitleIndex == processIndex)
                     {
-                        ProcessInfo processInfo = GetProcessInfo(in type, data.Slice(instancePos + instance.ByteLength), counters);
+                        ProcessInfo processInfo = GetProcessInfo(data.Slice(instancePos + instance.ByteLength), counters);
                         if (processInfo.ProcessId == 0 && !instanceName.Equals("Idle", StringComparison.OrdinalIgnoreCase))
                         {
                             // Sometimes we'll get a process structure that is not completely filled in.
@@ -452,7 +452,7 @@ namespace System.Diagnostics
                     }
                     else if (type.ObjectNameTitleIndex == threadIndex)
                     {
-                        ThreadInfo threadInfo = GetThreadInfo(in type, data.Slice(instancePos + instance.ByteLength), counters);
+                        ThreadInfo threadInfo = GetThreadInfo(data.Slice(instancePos + instance.ByteLength), counters);
                         if (threadInfo._threadId != 0) threadInfos.Add(threadInfo);
                     }
 
@@ -478,7 +478,7 @@ namespace System.Diagnostics
             return temp;
         }
 
-        private static ThreadInfo GetThreadInfo(in PERF_OBJECT_TYPE type, ReadOnlySpan<byte> instanceData, PERF_COUNTER_DEFINITION[] counters)
+        private static ThreadInfo GetThreadInfo(ReadOnlySpan<byte> instanceData, PERF_COUNTER_DEFINITION[] counters)
         {
             ThreadInfo threadInfo = new ThreadInfo();
             for (int i = 0; i < counters.Length; i++)
@@ -542,7 +542,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static ProcessInfo GetProcessInfo(in PERF_OBJECT_TYPE type, ReadOnlySpan<byte> instanceData, PERF_COUNTER_DEFINITION[] counters)
+        private static ProcessInfo GetProcessInfo(ReadOnlySpan<byte> instanceData, PERF_COUNTER_DEFINITION[] counters)
         {
             ProcessInfo processInfo = new ProcessInfo();
             for (int i = 0; i < counters.Length; i++)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -188,7 +188,7 @@ namespace System.Diagnostics
 
             if (processId == 0)
             {
-                throw new Win32Exception(5);
+                throw new Win32Exception(Interop.Errors.ERROR_ACCESS_DENIED);
             }
 
             // If the handle is invalid because the process has exited, only throw an exception if throwIfExited is true.
@@ -283,14 +283,14 @@ namespace System.Diagnostics
             {
                 if (!Interop.Kernel32.EnumProcesses(processIds, processIds.Length * 4, out size))
                     throw new Win32Exception();
-                if (size == processIds.Length * 4)
+                if (size == processIds.Length * sizeof(int))
                 {
                     processIds = new int[processIds.Length * 2];
                     continue;
                 }
                 break;
             }
-            int[] ids = new int[size / 4];
+            int[] ids = new int[size / sizeof(int)];
             Array.Copy(processIds, ids, ids.Length);
             return ids;
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -143,7 +143,7 @@ namespace System.Diagnostics
             // So we will try to get the privilege here.
             // We could fail if the user account doesn't have right to do this, but that's fair.
 
-            Interop.Advapi32.LUID luid = default;
+            Interop.Advapi32.LUID luid;
             if (!Interop.Advapi32.LookupPrivilegeValue(null, Interop.Advapi32.SeDebugPrivilege, out luid))
             {
                 return;
@@ -329,10 +329,9 @@ namespace System.Diagnostics
 
         public static ProcessInfo[] GetProcessInfos(string machineName, bool isRemoteMachine)
         {
-            PerformanceCounterLib? library = null;
             try
             {
-                library = PerformanceCounterLib.GetPerformanceCounterLib(machineName, new CultureInfo("en"));
+                PerformanceCounterLib library = PerformanceCounterLib.GetPerformanceCounterLib(machineName, new CultureInfo("en"));
                 return GetProcessInfos(library);
             }
             catch (Exception e)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -609,7 +609,7 @@ namespace System.Diagnostics
             if ((counterType & PerfCounterOptions.NtPerfCounterSizeLarge) != 0)
                 return MemoryMarshal.Read<long>(data);
             else
-                return (long)MemoryMarshal.Read<int>(data);
+                return MemoryMarshal.Read<int>(data);
         }
 
         private enum ValueId

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -278,19 +278,23 @@ namespace System.Diagnostics
         public static int[] GetProcessIds()
         {
             int[] processIds = new int[256];
-            int size;
+            int needed;
             while (true)
             {
-                if (!Interop.Kernel32.EnumProcesses(processIds, processIds.Length * 4, out size))
+                int size = processIds.Length * sizeof(int);
+                if (!Interop.Kernel32.EnumProcesses(processIds, size, out needed))
                     throw new Win32Exception();
-                if (size == processIds.Length * sizeof(int))
+
+                if (needed == size)
                 {
                     processIds = new int[processIds.Length * 2];
                     continue;
                 }
+
                 break;
             }
-            int[] ids = new int[size / sizeof(int)];
+
+            int[] ids = new int[needed / sizeof(int)];
             Array.Copy(processIds, ids, ids.Length);
             return ids;
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -33,12 +33,11 @@ namespace System.Diagnostics
             // Otherwise enumerate all processes and compare ids
             if (!IsRemoteMachine(machineName))
             {
-                using (SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId))
+                using SafeProcessHandle processHandle = Interop.Kernel32.OpenProcess(ProcessOptions.PROCESS_QUERY_INFORMATION, false, processId);
+
+                if (!processHandle.IsInvalid)
                 {
-                    if (!processHandle.IsInvalid)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -305,22 +305,6 @@ namespace System.Diagnostics
             return modules.Count == 0 ? null : modules[0];
         }
 
-        private static void HandleError()
-        {
-            int lastError = Marshal.GetLastWin32Error();
-            switch (lastError)
-            {
-                case Interop.Errors.ERROR_INVALID_HANDLE:
-                case Interop.Errors.ERROR_PARTIAL_COPY:
-                    // It's possible that another thread caused this module to become
-                    // unloaded (e.g FreeLibrary was called on the module).  Ignore it and
-                    // move on.
-                    break;
-                default:
-                    throw new Win32Exception(lastError);
-            }
-        }
-
         public static int GetProcessIdFromHandle(SafeProcessHandle processHandle)
         {
             return Interop.Kernel32.GetProcessId(processHandle);

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -315,6 +315,8 @@ namespace System.Diagnostics
         {
             try
             {
+                // We don't want to call library.Close() here because that would cause us to unload all of the perflibs.
+                // On the next call to GetProcessInfos, we'd have to load them all up again, which is SLOW!
                 PerformanceCounterLib library = PerformanceCounterLib.GetPerformanceCounterLib(machineName, new CultureInfo("en"));
                 return GetProcessInfos(library);
             }
@@ -329,8 +331,6 @@ namespace System.Diagnostics
                     throw;
                 }
             }
-            // We don't want to call library.Close() here because that would cause us to unload all of the perflibs.
-            // On the next call to GetProcessInfos, we'd have to load them all up again, which is SLOW!
         }
 
         private static ProcessInfo[] GetProcessInfos(PerformanceCounterLib library)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -534,7 +534,7 @@ namespace System.Diagnostics
                 case 12: return ThreadWaitReason.Suspended;
                 case 6:
                 case 13: return ThreadWaitReason.UserRequest;
-                case 14: return ThreadWaitReason.EventPairHigh; ;
+                case 14: return ThreadWaitReason.EventPairHigh;
                 case 15: return ThreadWaitReason.EventPairLow;
                 case 16: return ThreadWaitReason.LpcReceive;
                 case 17: return ThreadWaitReason.LpcReply;


### PR DESCRIPTION
Fixes #22633

Replies to @JeremyKuhne's comments:

---

> Why aren't we using EnumProcessModulesEx to get info in this case?

From **EnumProcessModulesEx**'s Remarks:

> This function is intended primarily for 64-bit applications. If the function is called by a 32-bit application running under WOW64, the *dwFilterFlag* option is ignored and the function provides the same results as the **EnumProcessModules** function.

---

> This seems unlikely to be happening in Win7+. Do you have evidence of this on an OS we support?

From **EnumProcessModules**' Remarks:

> The **EnumProcessModules** function is primarily designed for use by debuggers and similar applications that must extract module information from another process. If the module list in the target process is corrupted or not yet initialized, or if the module list changes during the function call as a result of DLLs being loaded or unloaded, **EnumProcessModules** may fail or return incorrect information.

<details>
<summary>A small program to reproduce <b>EnumProcessModules</b> failures on live processes</summary>

```cpp
#include <assert.h>
#include <stdio.h>
#include <Windows.h>
#include <Psapi.h>

int main(int argc, char** argv)
{
    if (**argv != '_')
    {
        WCHAR fileName[MAX_PATH];
        assert(GetModuleFileNameW(nullptr, fileName, MAX_PATH));
        WCHAR commandLine[]{ L'_', L'\0' };
        STARTUPINFOW startInfo{ sizeof(STARTUPINFOW) };
        PROCESS_INFORMATION processInfo;
        assert(CreateProcessW(fileName, commandLine, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &startInfo, &processInfo));
        HANDLE process = processInfo.hProcess;
        while (WaitForSingleObject(process, 0))
        {
            DWORD needed;
            int retries = 0;
            for (; retries < 50; retries++)
            {
                if (K32EnumProcessModules(process, nullptr, 0, &needed))
                {
                    break;
                }
            }

            if (retries > 0)
            {
                printf("%d\n", retries);
            }
        }

        assert(TerminateProcess(process, UINT_MAX));
        assert(CloseHandle(processInfo.hProcess));
        assert(CloseHandle(processInfo.hThread));
    }
    else
    {
        for (; ; )
        {
            HMODULE library = LoadLibraryW(L"C:\\Program Files\\dotnet\\host\\fxr\\3.1.0\\hostfxr.dll");
            assert(library);
            FreeLibrary(library);
        }
    }
}

// Sample output
//
// 10 <- initializing
// 1  <- loading/unloading
// 1
// 1
```
</details>

---

Anyway PTAL.