### PR TITLE
[runtime] Call mono_stack_mark_record_size () only in a checked build, its slow, and the __FUNCTION__ argument creates a C string for every function name.

### DIFF
--- a/src/mono/mono/metadata/handle.h
+++ b/src/mono/mono/metadata/handle.h
@@ -192,13 +192,20 @@ Icall macros
 	HandleStackMark __mark;	\
 	mono_stack_mark_init (mono_thread_info_current_var ? mono_thread_info_current_var : mono_thread_info_current (), &__mark);
 
+#ifdef ENABLE_CHECKED_BUILD
+/* __FUNCTION__ creates a C string for every icall */
 // FIXME This should be one function call since it is not fully inlined.
 #define CLEAR_ICALL_FRAME	\
 	mono_stack_mark_pop (mono_stack_mark_record_size (mono_thread_info_current_var, &__mark, __FUNCTION__), &__mark);
-
 // FIXME This should be one function call since it is not fully inlined.
 #define CLEAR_ICALL_FRAME_VALUE(RESULT, HANDLE)				\
 	(RESULT) = g_cast (mono_stack_mark_pop_value (mono_stack_mark_record_size (mono_thread_info_current_var, &__mark, __FUNCTION__), &__mark, (HANDLE)));
+#else
+#define CLEAR_ICALL_FRAME	\
+	mono_stack_mark_pop (mono_thread_info_current_var ? mono_thread_info_current_var : mono_thread_info_current (), &__mark);
+#define CLEAR_ICALL_FRAME_VALUE(RESULT, HANDLE)				\
+	(RESULT) = g_cast (mono_stack_mark_pop_value (mono_thread_info_current_var ? mono_thread_info_current_var : mono_thread_info_current (), &__mark, (HANDLE)));
+#endif
 
 #define HANDLE_FUNCTION_ENTER() do {				\
 	MONO_DISABLE_WARNING(4459) /* declaration of 'identifier' hides global declaration */ \


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18773,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>