### PR TITLE
[interp] reclaim stack fragments when not used.

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -184,7 +184,7 @@ struct _StackFragment {
 };
 
 typedef struct {
-	StackFragment *first, *last, *current;
+	StackFragment *first, *current;
 	/* For GC sync */
 	int inited;
 } FrameStack;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18777,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When a requested frame size doesn't fit in an already allocated stack fragment, we instead allocate another, larger fragment.
When doing this we missed to free the existing stack fragment, and in combination with a second problem (`current->next` not being cleared when unused) it can accumulate to a lot of unused stack fragments and in worst-case to OOM, as it happened on Linux corlib xunit tests.

Thanks to Jay for tracking it down.
