### PR TITLE
Add PreserveDependency to StackFrameHelper

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.Diagnostics
 {
@@ -82,6 +83,13 @@ namespace System.Diagnostics
         // rgiLineNumber and rgiColumnNumber fields using the portable PDB reader if not already
         // done by GetStackFramesInternal (on Windows for old PDB format).
         //
+
+        // This is necessary because linker can't add new assemblies to the closure when recognizing Type.GetType
+        // so the code below is actually recognized by linker, but fails to resolve the type since the System.Diagnostics.StackTrace
+        // is not always part of the closure linker works on.
+        // PreserveDependencyAttribute on the other hand can pull in additional assemblies.
+        [PreserveDependency("GetSourceLineInfo", "System.Diagnostics.StackTraceSymbols", "System.Diagnostics.StackTrace")]
+        [PreserveDependency(".ctor()", "System.Diagnostics.StackTraceSymbols", "System.Diagnostics.StackTrace")]
         internal void InitializeSourceInfo(int iSkip, bool fNeedFileInfo, Exception? exception)
         {
             StackTrace.GetStackFramesInternal(this, iSkip, fNeedFileInfo, exception);

--- a/src/libraries/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
+++ b/src/libraries/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="System.Diagnostics.StackTrace">
+    <!-- used by System.Private.CoreLib StackTrace code to load portable pdbs for the runtime diagnostic stack trace to get source/line info -->
+    <type fullname="System.Diagnostics.StackTraceSymbols" required="true" />
+  </assembly>
+</linker>
+

--- a/src/libraries/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
+++ b/src/libraries/System.Diagnostics.StackTrace/src/ILLinkTrim.xml
@@ -1,7 +1,0 @@
-<linker>
-  <assembly fullname="System.Diagnostics.StackTrace">
-    <!-- used by System.Private.CoreLib StackTrace code to load portable pdbs for the runtime diagnostic stack trace to get source/line info -->
-    <type fullname="System.Diagnostics.StackTraceSymbols" required="true" />
-  </assembly>
-</linker>
-


### PR DESCRIPTION
While linker can recognize the hardcoded type name in the `InitializeSoruceInfo` it sometimes fails to resolve the type as the `System.Diagnostics.StackTrace` is not directly referenced by most assemblies. This is partially an internal linker limitation and the attribute is a workaround.

That said linker would not be able to recognize the `GetMethod` or `CreateInstance` calls which follow and in member-level trimming mode would not correctly keep the `GetSourceLineInfo` nor the `.ctor` of the type.

This comes with a tradeoff for small apps. Console Hello World gains almost 200K in size when trimmed aggressively (member-level trimming), because the `System.Diagnostics.StackTrace` has dependencies on `System.IO` and `System.Reflection.Metadata`. But without this change linker effectively breaks the functionality of showing source file information in stack traces.

See https://github.com/dotnet/sdk/issues/4017 for customer issue.