### PR TITLE
Only output type parameter constraint blank line if type parameter has a constraint

### DIFF
--- a/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
@@ -2257,8 +2257,6 @@ namespace Microsoft.CSharp
             for (int i = 0; i < typeParameters.Count; i++)
             {
                 // generating something like: "where KeyType: IComparable, IEnumerable"
-
-                Output.WriteLine();
                 Indent++;
 
                 bool first = true;
@@ -2268,6 +2266,7 @@ namespace Microsoft.CSharp
                     {
                         if (first)
                         {
+                            Output.WriteLine();
                             Output.Write("where ");
                             Output.Write(typeParameters[i].Name);
                             Output.Write(" : ");
@@ -2285,6 +2284,7 @@ namespace Microsoft.CSharp
                 {
                     if (first)
                     {
+                        Output.WriteLine();
                         Output.Write("where ");
                         Output.Write(typeParameters[i].Name);
                         Output.Write(" : new()");

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
@@ -3485,5 +3485,37 @@ namespace System.CodeDom.Compiler.Tests
                       public static string StringWithSpecialNewLines = ""\u0085\u2028\u2029"";
                   }");
         }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void MethodTypeParameterConstraintLineOnlyAddedForTypesThatHaveConstraints()
+        {
+            var codeTypeDeclaration = new CodeTypeDeclaration("ClassWithGenericMethod") { IsClass = true };
+
+            var method = new CodeMemberMethod();
+            method.Name = "Test";
+            var t1 = new CodeTypeParameter("T1");
+            var t2 = new CodeTypeParameter("T2");
+            t2.Constraints.Add("MyBaseClass");
+            var t3 = new CodeTypeParameter("T3");
+            var t4 = new CodeTypeParameter("T4");
+
+            method.TypeParameters.Add(t1);
+            method.TypeParameters.Add(t2);
+            method.TypeParameters.Add(t3);
+            method.TypeParameters.Add(t4);
+
+            codeTypeDeclaration.Members.Add(method);
+
+            AssertEqualPreserveLineBreaks(codeTypeDeclaration,
+                @"
+                  public class ClassWithGenericMethod {
+
+                      private void Test<T1, T2, T3, T4>()
+                          where T2 : MyBaseClass {
+                      }
+                  }
+                ");
+        }
     }
 }


### PR DESCRIPTION
Blank lines are now only outputted for type constraints if they are required.

I expect the reason this has been missed before now is that the ``AssertEqual`` common method in the tests collapses whitespace, so the extra blank lines would not be compared.

I've added an ``AssertEqualPreserveLineBreaks`` method to preserve blank line characters.

New test has been added ``CSharpCodeGenerationTests.MethodTypeParameterConstraintLineOnlyAddedForTypesThatHaveConstraints``.

Fixes #31614