### PR TITLE
R2RDump changes for composite R2R format support

### DIFF
--- a/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -64,6 +64,7 @@ namespace Internal.Runtime
         ManifestMetadata = 112, // Added in v2.3
         AttributePresence = 113, // Added in V3.1
         InliningInfo2 = 114, // Added in 4.1
+        ComponentAssemblies = 115, // Added in 4.1
 
         //
         // CoreRT ReadyToRun sections

--- a/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,7 +12,9 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_FLAG_PlatformNeutralSource = 0x00000001,     // Set if the original IL assembly was platform-neutral
         READYTORUN_FLAG_SkipTypeValidation = 0x00000002,        // Set of methods with native code was determined using profile data
         READYTORUN_FLAG_Partial = 0x00000004,
-        READYTORUN_FLAG_NonSharedPInvokeStubs = 0x00000008      // PInvoke stubs compiled into image are non-shareable (no secret parameter)
+        READYTORUN_FLAG_NonSharedPInvokeStubs = 0x00000008,     // PInvoke stubs compiled into image are non-shareable (no secret parameter)
+        READYTORUN_FLAG_EmbeddedMSIL = 0x00000010,              // MSIL is embedded in the composite R2R executable
+        READYTORUN_FLAG_Component = 0x00000020,                 // This is the header describing a component assembly of composite R2R
     }
 
     /// <summary>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -236,8 +237,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         code.NextFrameOffset = (int)offset * 16;
                         if ((UnwindCodeArray[i].FrameOffset & 0xF0000000) != 0)
                         {
-                            // TODO (refactoring) - what should we do?
-                            // R2RDump.WriteWarning("Illegal unwindInfo unscaled offset: too large");
+                            Console.WriteLine("Warning: Illegal unwindInfo unscaled offset: too large");
                         }
                     }
                     break;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -95,7 +95,15 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_KIND_MASK) == CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_NONE)
             {
-                ClassName = MetadataNameFormatter.FormatHandle(reader.MetadataReader, MetadataTokens.Handle((int)ClassTokenOrFilterOffset));
+                if (reader.Composite)
+                {
+                    // TODO: EH clauses in composite mode
+                    ClassName = "TODO-composite module in EH clause";
+                }
+                else
+                {
+                    ClassName = MetadataNameFormatter.FormatHandle(reader.GetGlobalMetadataReader(), MetadataTokens.Handle((int)ClassTokenOrFilterOffset));
+                }
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/IAssemblyResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     public interface IAssemblyResolver
     {
         MetadataReader FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile);
+        MetadataReader FindAssembly(string simpleName, string parentFile);
         // TODO (refactoring) - signature formatting options should be independent of assembly resolver
         bool Naked { get; }
         bool SignatureBinary { get; }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Common\Internal\Runtime\CorConstants.cs" Link="Common\CorConstants.cs" />
+    <Compile Include="..\..\Common\Internal\Runtime\ModuleHeaders.cs" Link="Common\ModuleHeaders.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunConstants.cs" Link="Common\ReadyToRunConstants.cs" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace ILCompiler.Reflection.ReadyToRun
+{
+    public class PEExportTable
+    {
+        private readonly Dictionary<string, int> _namedExportRva;
+        private readonly Dictionary<int, int> _ordinalRva;
+
+        private PEExportTable(PEReader peReader)
+        {
+            _namedExportRva = new Dictionary<string, int>();
+            _ordinalRva = new Dictionary<int, int>();
+
+            DirectoryEntry exportTable = peReader.PEHeaders.PEHeader.ExportTableDirectory;
+            PEMemoryBlock peImage = peReader.GetEntireImage();
+            BlobReader exportTableHeader = peImage.GetReader(peReader.GetOffset(exportTable.RelativeVirtualAddress), exportTable.Size);
+            if (exportTableHeader.Length == 0)
+            {
+                return;
+            }
+
+            // +0x00: reserved
+            exportTableHeader.ReadUInt32();
+            // +0x04: TODO: time/date stamp
+            exportTableHeader.ReadUInt32();
+            // +0x08: major version
+            exportTableHeader.ReadUInt16();
+            // +0x0A: minor version
+            exportTableHeader.ReadUInt16();
+            // +0x0C: DLL name RVA
+            exportTableHeader.ReadUInt32();
+            // +0x10: ordinal base
+            int minOrdinal = exportTableHeader.ReadInt32();
+            // +0x14: number of entries in the address table
+            int addressEntryCount = exportTableHeader.ReadInt32();
+            // +0x18: number of name pointers
+            int namePointerCount = exportTableHeader.ReadInt32();
+            // +0x1C: export address table RVA
+            int addressTableRVA = exportTableHeader.ReadInt32();
+            // +0x20: name pointer RVA
+            int namePointerRVA = exportTableHeader.ReadInt32();
+            // +0x24: ordinal table RVA
+            int ordinalTableRVA = exportTableHeader.ReadInt32();
+
+            int[] addressTable = new int[addressEntryCount];
+            BlobReader addressTableReader = peImage.GetReader(peReader.GetOffset(addressTableRVA), sizeof(int) * addressEntryCount);
+            for (int entryIndex = 0; entryIndex < addressEntryCount; entryIndex++)
+            {
+                addressTable[entryIndex] = addressTableReader.ReadInt32();
+            }
+
+            ushort[] ordinalTable = new ushort[namePointerCount];
+            BlobReader ordinalTableReader = peImage.GetReader(peReader.GetOffset(ordinalTableRVA), sizeof(ushort) * namePointerCount);
+            for (int entryIndex = 0; entryIndex < namePointerCount; entryIndex++)
+            {
+                ushort ordinalIndex = ordinalTableReader.ReadUInt16();
+                ordinalTable[entryIndex] = ordinalIndex;
+                _ordinalRva.Add(entryIndex + minOrdinal, addressTable[ordinalIndex]);
+            }
+
+            BlobReader namePointerReader = peImage.GetReader(peReader.GetOffset(namePointerRVA), sizeof(int) * namePointerCount);
+            for (int entryIndex = 0; entryIndex < namePointerCount; entryIndex++)
+            {
+                int nameRVA = namePointerReader.ReadInt32();
+                if (nameRVA != 0)
+                {
+                    int nameOffset = peReader.GetOffset(nameRVA);
+                    BlobReader nameReader = peImage.GetReader(nameOffset, peImage.Length - nameOffset);
+                    StringBuilder nameBuilder = new StringBuilder();
+                    for (byte ascii; (ascii = nameReader.ReadByte()) != 0;)
+                    {
+                        nameBuilder.Append((char)ascii);
+                    }
+                    _namedExportRva.Add(nameBuilder.ToString(), addressTable[ordinalTable[entryIndex]]);
+                }
+            }
+        }
+
+        public static PEExportTable Parse(PEReader peReader)
+        {
+            return new PEExportTable(peReader);
+        }
+
+        public bool TryGetValue(string exportName, out int rva) => _namedExportRva.TryGetValue(exportName, out rva);
+        public bool TryGetValue(int ordinal, out int rva) => _ordinalRva.TryGetValue(ordinal, out rva);
+    }
+
+    public static class PEReaderExtensions
+    {
+        /// <summary>
+        /// Get the index in the image byte array corresponding to the RVA
+        /// </summary>
+        /// <param name="reader">PE reader representing the executable image to parse</param>
+        /// <param name="rva">The relative virtual address</param>
+        public static int GetOffset(this PEReader reader, int rva)
+        {
+            int index = reader.PEHeaders.GetContainingSectionIndex(rva);
+            if (index == -1)
+            {
+                throw new BadImageFormatException("Failed to convert invalid RVA to offset: " + rva);
+            }
+            SectionHeader containingSection = reader.PEHeaders.SectionHeaders[index];
+            return rva - containingSection.VirtualAddress + containingSection.PointerToRawData;
+        }
+
+        /// <summary>
+        /// Parse export table directory for a given PE reader.
+        /// </summary>
+        /// <param name="reader">PE reader representing the executable image to parse</param>
+        public static PEExportTable GetExportTable(this PEReader reader)
+        {
+            return PEExportTable.Parse(reader);
+        }
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,13 +7,92 @@ using System.Collections.Generic;
 using System.Text;
 
 using Internal.ReadyToRunConstants;
+using Internal.Runtime;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
+    /// Structure representing an element of the assembly table in composite R2R images.
+    /// </summary>
+    public class ComponentAssembly
+    {
+        public const int Size = 4 * sizeof(int);
+
+        public readonly int CorHeaderRVA;
+        public readonly int CorHeaderSize;
+        public readonly int AssemblyHeaderRVA;
+        public readonly int AssemblyHeaderSize;
+
+        public ComponentAssembly(byte[] image, ref int curOffset)
+        {
+            CorHeaderRVA = BitConverter.ToInt32(image, curOffset);
+            curOffset += sizeof(int);
+            CorHeaderSize = BitConverter.ToInt32(image, curOffset);
+            curOffset += sizeof(int);
+            AssemblyHeaderRVA = BitConverter.ToInt32(image, curOffset);
+            curOffset += sizeof(int);
+            AssemblyHeaderSize = BitConverter.ToInt32(image, curOffset);
+            curOffset += sizeof(int);
+        }
+    }
+
+    /// <summary>
+    /// Fields common to the global R2R header and per assembly headers in composite R2R images.
+    /// </summary>
+    public class ReadyToRunCoreHeader
+    {
+        /// <summary>
+        /// Flags in the header
+        /// eg. PLATFORM_NEUTRAL_SOURCE, SKIP_TYPE_VALIDATION
+        /// </summary>
+        public uint Flags { get; set; }
+
+        /// <summary>
+        /// The ReadyToRun section RVAs and sizes
+        /// </summary>
+        public IDictionary<ReadyToRunSectionType, ReadyToRunSection> Sections { get; private set; }
+
+        public ReadyToRunCoreHeader()
+        {
+        }
+
+        public ReadyToRunCoreHeader(byte[] image, ref int curOffset)
+        {
+            ParseCoreHeader(image, ref curOffset);
+        }
+
+        /// <summary>
+        /// Parse core header fields common to global R2R file header and per assembly headers in composite R2R images.
+        /// </summary>
+        /// <param name="image">PE image</param>
+        /// <param name="curOffset">Index in the image byte array to the start of the ReadyToRun core header</param>
+        public void ParseCoreHeader(byte[] image, ref int curOffset)
+        {
+            Flags = NativeReader.ReadUInt32(image, ref curOffset);
+            int nSections = NativeReader.ReadInt32(image, ref curOffset);
+            Sections = new Dictionary<ReadyToRunSectionType, ReadyToRunSection>();
+
+            for (int i = 0; i < nSections; i++)
+            {
+                int type = NativeReader.ReadInt32(image, ref curOffset);
+                var sectionType = (ReadyToRunSectionType)type;
+                if (!Enum.IsDefined(typeof(ReadyToRunSectionType), type))
+                {
+                    // TODO (refactoring) - what should we do?
+                    // R2RDump.WriteWarning("Invalid ReadyToRun section type");
+                }
+                Sections[sectionType] = new ReadyToRunSection(sectionType,
+                    NativeReader.ReadInt32(image, ref curOffset),
+                    NativeReader.ReadInt32(image, ref curOffset));
+            }
+        }
+    }
+
+
+    /// <summary>
     /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_HEADER
     /// </summary>
-    public class ReadyToRunHeader
+    public class ReadyToRunHeader : ReadyToRunCoreHeader
     {
         /// <summary>
         /// The expected signature of a ReadyToRun header
@@ -42,17 +121,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         public ushort MajorVersion { get; set; }
         public ushort MinorVersion { get; set; }
 
-        /// <summary>
-        /// Flags in the header
-        /// eg. PLATFORM_NEUTRAL_SOURCE, SKIP_TYPE_VALIDATION
-        /// </summary>
-        public uint Flags { get; set; }
-
-        /// <summary>
-        /// The ReadyToRun section RVAs and sizes
-        /// </summary>
-        public IDictionary<ReadyToRunSection.SectionType, ReadyToRunSection> Sections { get; }
-
         public ReadyToRunHeader() { }
 
         /// <summary>
@@ -78,23 +146,8 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             MajorVersion = NativeReader.ReadUInt16(image, ref curOffset);
             MinorVersion = NativeReader.ReadUInt16(image, ref curOffset);
-            Flags = NativeReader.ReadUInt32(image, ref curOffset);
-            int nSections = NativeReader.ReadInt32(image, ref curOffset);
-            Sections = new Dictionary<ReadyToRunSection.SectionType, ReadyToRunSection>();
 
-            for (int i = 0; i < nSections; i++)
-            {
-                int type = NativeReader.ReadInt32(image, ref curOffset);
-                var sectionType = (ReadyToRunSection.SectionType)type;
-                if (!Enum.IsDefined(typeof(ReadyToRunSection.SectionType), type))
-                {
-                    // TODO (refactoring) - what should we do?
-                    // R2RDump.WriteWarning("Invalid ReadyToRun section type");
-                }
-                Sections[sectionType] = new ReadyToRunSection(sectionType,
-                    NativeReader.ReadInt32(image, ref curOffset),
-                    NativeReader.ReadInt32(image, ref curOffset));
-            }
+            ParseCoreHeader(image, ref curOffset);
 
             Size = curOffset - startOffset;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -78,12 +78,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 var sectionType = (ReadyToRunSectionType)type;
                 if (!Enum.IsDefined(typeof(ReadyToRunSectionType), type))
                 {
-                    // TODO (refactoring) - what should we do?
-                    // R2RDump.WriteWarning("Invalid ReadyToRun section type");
+                    Console.WriteLine("Warning: Invalid ReadyToRun section type");
                 }
-                Sections[sectionType] = new ReadyToRunSection(sectionType,
-                    NativeReader.ReadInt32(image, ref curOffset),
-                    NativeReader.ReadInt32(image, ref curOffset));
+                int sectionStartRva = NativeReader.ReadInt32(image, ref curOffset);
+                int sectionLength = NativeReader.ReadInt32(image, ref curOffset);
+                Sections[sectionType] = new ReadyToRunSection(sectionType, sectionStartRva, sectionLength);
             }
         }
     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 
 using Internal.CorConstants;
+using Internal.Runtime;
 using Internal.ReadyToRunConstants;
 
 using Debug = System.Diagnostics.Debug;
@@ -48,14 +49,26 @@ namespace ILCompiler.Reflection.ReadyToRun
     public sealed class ReadyToRunReader
     {
         private readonly IAssemblyResolver _assemblyResolver;
-        private Dictionary<int, MetadataReader> _assemblyCache;
+
+        /// <summary>
+        /// Reference assembly cache indexed by module indices as used in signatures
+        /// </summary>
+        private List<MetadataReader> _assemblyCache;
+
+        /// <summary>
+        /// Assembly headers for composite R2R images
+        /// </summary>
+        private List<ReadyToRunCoreHeader> _assemblyHeaders;
 
         // Header
         private OperatingSystem _operatingSystem;
         private Machine _machine;
         private Architecture _architecture;
+        private bool _composite;
         private ulong _imageBase;
+        private int _readyToRunHeaderRVA;
         private ReadyToRunHeader _readyToRunHeader;
+        private List<ReadyToRunCoreHeader> _readyToRunAssemblyHeaders;
 
         // DebugInfo
         private Dictionary<int, DebugInfo> _runtimeFunctionToDebugInfo;
@@ -72,11 +85,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// or section list.
         /// </summary>
         public PEReader PEReader { get; private set; }
-
-        /// <summary>
-        /// MetadataReader is used to access the MSIL metadata in the R2R file.
-        /// </summary>
-        public MetadataReader MetadataReader { get; private set; }
 
         /// <summary>
         /// Byte array containing the ReadyToRun image
@@ -147,6 +155,18 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
+        /// Return true when the executable is a composite R2R image.
+        /// </summary>
+        public bool Composite
+        {
+            get
+            {
+                EnsureHeader();
+                return _composite;
+            }
+        }
+
+        /// <summary>
         /// The preferred address of the first byte of image when loaded into memory;
         /// must be a multiple of 64K.
         /// </summary>
@@ -168,6 +188,15 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 EnsureHeader();
                 return _readyToRunHeader;
+            }
+        }
+
+        public IList<ReadyToRunCoreHeader> ReaderToRunAssemblyHeaders
+        {
+            get
+            {
+                EnsureHeader();
+                return _readyToRunAssemblyHeaders;
             }
         }
 
@@ -245,10 +274,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         public ReadyToRunReader(IAssemblyResolver assemblyResolver, MetadataReader metadata, PEReader peReader, string filename)
         {
             _assemblyResolver = assemblyResolver;
-            MetadataReader = metadata;
             PEReader = peReader;
             Filename = filename;
-            Initialize();
+            Initialize(metadata);
         }
 
         /// <summary>
@@ -260,37 +288,50 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             _assemblyResolver = assemblyResolver;
             Filename = filename;
-            Initialize();
+            Initialize(metadata: null);
         }
 
-        private unsafe void Initialize()
+        private unsafe void Initialize(MetadataReader metadata)
         {
-            _assemblyCache = new Dictionary<int, MetadataReader>();
+            _assemblyCache = new List<MetadataReader>();
+            _assemblyHeaders = new List<ReadyToRunCoreHeader>();
 
-            if (MetadataReader == null)
+            if (PEReader == null)
             {
                 byte[] image = File.ReadAllBytes(Filename);
                 Image = image;
 
                 PEReader = new PEReader(Unsafe.As<byte[], ImmutableArray<byte>>(ref image));
+            }
 
-                if (!PEReader.HasMetadata)
+            if (metadata == null && PEReader.HasMetadata)
+            {
+                metadata = PEReader.GetMetadataReader();
+            }
+
+            if (metadata != null)
+            {
+                if ((PEReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) == 0)
                 {
-                    throw new Exception($"ECMA metadata not found in file '{Filename}'");
+                    throw new BadImageFormatException("The file is not a ReadyToRun image");
                 }
 
-                MetadataReader = PEReader.GetMetadataReader();
+                _assemblyCache.Add(metadata);
 
+                DirectoryEntry r2rHeaderDirectory = PEReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;
+                _readyToRunHeaderRVA = r2rHeaderDirectory.RelativeVirtualAddress;
             }
-            else
+            else if (!TryLocateNativeReadyToRunHeader())
             {
-                ImmutableArray<byte> content = PEReader.GetEntireImage().GetContent();
-                Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
+                throw new BadImageFormatException($"ECMA metadata / RTR_HEADER not found in file '{Filename}'");
             }
 
-            if ((PEReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) == 0)
+            ImmutableArray<byte> content = PEReader.GetEntireImage().GetContent();
+            Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
+
+            if (_composite)
             {
-                throw new BadImageFormatException("The file is not a ReadyToRun image");
+                ParseComponentAssemblies();
             }
 
             // This is a work in progress toward lazy initialization.
@@ -303,11 +344,9 @@ namespace ILCompiler.Reflection.ReadyToRun
             Methods = new List<ReadyToRunMethod>();
             InstanceMethods = new List<InstanceMethod>();
 
-            if (ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS))
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.RuntimeFunctions, out ReadyToRunSection runtimeFunctionSection))
             {
                 int runtimeFunctionSize = CalculateRuntimeFunctionSize();
-                ReadyToRunSection runtimeFunctionSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS];
-
                 uint nRuntimeFunctions = (uint)(runtimeFunctionSection.Size / runtimeFunctionSize);
                 int runtimeFunctionOffset = GetOffset(runtimeFunctionSection.RelativeVirtualAddress);
                 bool[] isEntryPoint = new bool[nRuntimeFunctions];
@@ -322,6 +361,23 @@ namespace ILCompiler.Reflection.ReadyToRun
             ParseAvailableTypes();
 
             CompilerIdentifier = ParseCompilerIdentifier();
+        }
+
+        private bool TryLocateNativeReadyToRunHeader()
+        {
+            PEExportTable exportTable = PEReader.GetExportTable();
+            if (exportTable.TryGetValue("RTR_HEADER", out _readyToRunHeaderRVA))
+            {
+                _composite = true;
+                return true;
+            }
+            return false;
+        }
+
+        public MetadataReader GetGlobalMetadataReader()
+        {
+            EnsureHeader();
+            return (_composite ? null : _assemblyCache[0]);
         }
 
         private unsafe void EnsureHeader()
@@ -374,13 +430,9 @@ namespace ILCompiler.Reflection.ReadyToRun
             _imageBase = PEReader.PEHeaders.PEHeader.ImageBase;
 
             // Initialize R2RHeader
-            DirectoryEntry r2rHeaderDirectory = PEReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;
-            int r2rHeaderOffset = GetOffset(r2rHeaderDirectory.RelativeVirtualAddress);
-            _readyToRunHeader = new ReadyToRunHeader(Image, r2rHeaderDirectory.RelativeVirtualAddress, r2rHeaderOffset);
-            if (r2rHeaderDirectory.Size != ReadyToRunHeader.Size)
-            {
-                throw new BadImageFormatException("The calculated size of the R2RHeader doesn't match the size saved in the ManagedNativeHeaderDirectory");
-            }
+            Debug.Assert(_readyToRunHeaderRVA != 0);
+            int r2rHeaderOffset = GetOffset(_readyToRunHeaderRVA);
+            _readyToRunHeader = new ReadyToRunHeader(Image, _readyToRunHeaderRVA, r2rHeaderOffset);
         }
 
         private void EnsureDebugInfo()
@@ -390,12 +442,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 return;
             }
             _runtimeFunctionToDebugInfo = new Dictionary<int, DebugInfo>();
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_DEBUG_INFO))
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.DebugInfo, out ReadyToRunSection debugInfoSection))
             {
                 return;
             }
 
-            ReadyToRunSection debugInfoSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_DEBUG_INFO];
             int debugInfoSectionOffset = GetOffset(debugInfoSection.RelativeVirtualAddress);
 
             NativeArray debugInfoArray = new NativeArray(Image, (uint)debugInfoSectionOffset);
@@ -419,9 +470,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                 return;
             }
             _manifestReferences = new List<AssemblyReferenceHandle>();
-            if (ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA))
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.ManifestMetadata, out ReadyToRunSection manifestMetadata))
             {
-                ReadyToRunSection manifestMetadata = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA];
                 fixed (byte* image = Image)
                 {
                     _manifestReader = new MetadataReader(image + GetOffset(manifestMetadata.RelativeVirtualAddress), manifestMetadata.Size);
@@ -442,9 +492,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                 return;
             }
             _runtimeFunctionToEHInfo = new Dictionary<int, EHInfo>();
-            if (ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO))
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.ExceptionInfo, out ReadyToRunSection exceptionInfoSection))
             {
-                ReadyToRunSection exceptionInfoSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO];
                 int offset = GetOffset(exceptionInfoSection.RelativeVirtualAddress);
                 int length = exceptionInfoSection.Size;
                 int methodRva = BitConverter.ToInt32(Image, offset);
@@ -492,12 +541,33 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         private void ParseMethodDefEntrypoints(bool[] isEntryPoint)
         {
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_METHODDEF_ENTRYPOINTS))
+            ReadyToRunSection methodEntryPointSection;
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out methodEntryPointSection))
             {
-                return;
+                ParseMethodDefEntrypointsSection(methodEntryPointSection, GetGlobalMetadataReader(), isEntryPoint);
             }
-            int methodDefEntryPointsRVA = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_METHODDEF_ENTRYPOINTS].RelativeVirtualAddress;
-            int methodDefEntryPointsOffset = GetOffset(methodDefEntryPointsRVA);
+            else if (_readyToRunAssemblyHeaders != null)
+            {
+                for (int assemblyIndex = 0; assemblyIndex < _readyToRunAssemblyHeaders.Count; assemblyIndex++)
+                {
+                    if (_readyToRunAssemblyHeaders[assemblyIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out methodEntryPointSection))
+                    {
+                        ParseMethodDefEntrypointsSection(methodEntryPointSection, OpenReferenceAssembly(assemblyIndex + 2), isEntryPoint);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parse a single method def entrypoint section. For composite R2R images, this method is called multiple times
+        /// are method entrypoints are stored separately for each component assembly of the composite R2R executable.
+        /// </summary>
+        /// <param name="section">Method entrypoint section to parse</param>
+        /// <param name="metadataReader">ECMA metadata reader representing this method entrypoint section</param>
+        /// <param name="isEntryPoint">Set to true for each runtime function index representing a method entrypoint</param>
+        private void ParseMethodDefEntrypointsSection(ReadyToRunSection section, MetadataReader metadataReader, bool[] isEntryPoint)
+        {
+            int methodDefEntryPointsOffset = GetOffset(section.RelativeVirtualAddress);
             NativeArray methodEntryPoints = new NativeArray(Image, (uint)methodDefEntryPointsOffset);
             uint nMethodEntryPoints = methodEntryPoints.GetCount();
 
@@ -510,7 +580,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     int runtimeFunctionId;
                     int? fixupOffset;
                     GetRuntimeFunctionIndexFromOffset(offset, out runtimeFunctionId, out fixupOffset);
-                    ReadyToRunMethod method = new ReadyToRunMethod(this, Methods.Count, this.MetadataReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, fixupOffset: fixupOffset);
+                    ReadyToRunMethod method = new ReadyToRunMethod(this, Methods.Count, metadataReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, fixupOffset: fixupOffset);
 
                     if (method.EntryPointRuntimeFunctionId < 0 || method.EntryPointRuntimeFunctionId >= isEntryPoint.Length)
                     {
@@ -527,11 +597,10 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         private void ParseInstanceMethodEntrypoints(bool[] isEntryPoint)
         {
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS))
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.InstanceMethodEntryPoints, out ReadyToRunSection instMethodEntryPointSection))
             {
                 return;
             }
-            ReadyToRunSection instMethodEntryPointSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS];
             int instMethodEntryPointsOffset = GetOffset(instMethodEntryPointSection.RelativeVirtualAddress);
             NativeParser parser = new NativeParser(Image, (uint)instMethodEntryPointsOffset);
             NativeHashtable instMethodEntryPoints = new NativeHashtable(Image, parser, (uint)(instMethodEntryPointsOffset + instMethodEntryPointSection.Size));
@@ -540,7 +609,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             while (!curParser.IsNull())
             {
                 SignatureDecoder decoder = new SignatureDecoder(_assemblyResolver, this, (int)curParser.Offset);
-                MetadataReader mdReader = MetadataReader;
+                MetadataReader mdReader = _composite ? null : _assemblyCache[0];
 
                 string owningType = null;
 
@@ -548,6 +617,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
                 {
                     mdReader = decoder.GetMetadataReaderFromModuleOverride();
+                    if (mdReader == null)
+                    {
+                        // The only types that don't have module overrides on them in composite images are primitive types within System.Private.CoreLib
+                        mdReader = _assemblyResolver.FindAssembly("System.Private.CoreLib", Filename);
+                    }
                     owningType = decoder.ReadTypeSignatureNoEmit();
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
@@ -587,7 +661,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 ReadyToRunMethod method = new ReadyToRunMethod(
                     this,
                     Methods.Count,
-                    mdReader == null ? MetadataReader : mdReader,
+                    mdReader,
                     methodHandle,
                     runtimeFunctionId,
                     owningType,
@@ -692,12 +766,31 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         private void ParseAvailableTypes()
         {
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES))
+            ReadyToRunSection availableTypesSection;
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.AvailableTypes, out availableTypesSection))
             {
-                return;
+                ParseAvailableTypesSection(availableTypesSection, GetGlobalMetadataReader());
             }
+            else if (_readyToRunAssemblyHeaders != null)
+            {
+                for (int assemblyIndex = 0; assemblyIndex < _readyToRunAssemblyHeaders.Count; assemblyIndex++)
+                {
+                    if (_readyToRunAssemblyHeaders[assemblyIndex].Sections.TryGetValue(
+                        ReadyToRunSectionType.AvailableTypes, out availableTypesSection))
+                    {
+                        ParseAvailableTypesSection(availableTypesSection, OpenReferenceAssembly(assemblyIndex + 2));
+                    }
+                }
+            }
+        }
 
-            ReadyToRunSection availableTypesSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES];
+        /// <summary>
+        /// Parse a single available types section. For composite R2R images this method is called multiple times
+        /// as available types are stored separately for each component assembly of the composite R2R executable.
+        /// </summary>
+        /// <param name="availableTypesSection"></param>
+        private void ParseAvailableTypesSection(ReadyToRunSection availableTypesSection, MetadataReader metadataReader)
+        {
             int availableTypesOffset = GetOffset(availableTypesSection.RelativeVirtualAddress);
             NativeParser parser = new NativeParser(Image, (uint)availableTypesOffset);
             NativeHashtable availableTypes = new NativeHashtable(Image, parser, (uint)(availableTypesOffset + availableTypesSection.Size));
@@ -713,13 +806,13 @@ namespace ILCompiler.Reflection.ReadyToRun
                 if (isExportedType)
                 {
                     ExportedTypeHandle exportedTypeHandle = MetadataTokens.ExportedTypeHandle((int)rid);
-                    string exportedTypeName = GetExportedTypeFullName(MetadataReader, exportedTypeHandle);
+                    string exportedTypeName = GetExportedTypeFullName(metadataReader, exportedTypeHandle);
                     AvailableTypes.Add("exported " + exportedTypeName);
                 }
                 else
                 {
                     TypeDefinitionHandle typeDefHandle = MetadataTokens.TypeDefinitionHandle((int)rid);
-                    string typeDefName = MetadataNameFormatter.FormatHandle(MetadataReader, typeDefHandle);
+                    string typeDefName = MetadataNameFormatter.FormatHandle(metadataReader, typeDefHandle);
                     AvailableTypes.Add(typeDefName);
                 }
 
@@ -732,11 +825,10 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         private string ParseCompilerIdentifier()
         {
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_COMPILER_IDENTIFIER))
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.CompilerIdentifier, out ReadyToRunSection compilerIdentifierSection))
             {
                 return "";
             }
-            ReadyToRunSection compilerIdentifierSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_COMPILER_IDENTIFIER];
             byte[] identifier = new byte[compilerIdentifierSection.Size - 1];
             int identifierOffset = GetOffset(compilerIdentifierSection.RelativeVirtualAddress);
             Array.Copy(Image, identifierOffset, identifier, 0, compilerIdentifierSection.Size - 1);
@@ -744,15 +836,41 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
+        /// Decode the ReadyToRun section READYTORUN_SECTION_ASSEMBLIES containing a list of per assembly R2R core headers
+        /// for each assembly comprising the composite R2R executable.
+        /// </summary>
+        private void ParseComponentAssemblies()
+        {
+            ReadyToRunSection componentAssembliesSection;
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.ComponentAssemblies, out componentAssembliesSection))
+            {
+                return;
+            }
+
+            _readyToRunAssemblyHeaders = new List<ReadyToRunCoreHeader>();
+
+            int offset = GetOffset(componentAssembliesSection.RelativeVirtualAddress);
+            int numberOfAssemblyHeaderRVAs = componentAssembliesSection.Size / ComponentAssembly.Size;
+
+            for (int assemblyIndex = 0; assemblyIndex < numberOfAssemblyHeaderRVAs; assemblyIndex++)
+            {
+                ComponentAssembly assembly = new ComponentAssembly(Image, ref offset);
+                int headerOffset = GetOffset(assembly.AssemblyHeaderRVA);
+
+                ReadyToRunCoreHeader assemblyHeader = new ReadyToRunCoreHeader(Image, ref headerOffset);
+                _readyToRunAssemblyHeaders.Add(assemblyHeader);
+            }
+        }
+
+        /// <summary>
         /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/zap/zapimport.cpp">ZapImportSectionsTable::Save</a>
         /// </summary>
         private void ParseImportSections()
         {
-            if (!ReadyToRunHeader.Sections.ContainsKey(ReadyToRunSection.SectionType.READYTORUN_SECTION_IMPORT_SECTIONS))
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.ImportSections, out ReadyToRunSection importSectionsSection))
             {
                 return;
             }
-            ReadyToRunSection importSectionsSection = ReadyToRunHeader.Sections[ReadyToRunSection.SectionType.READYTORUN_SECTION_IMPORT_SECTIONS];
             int offset = GetOffset(importSectionsSection.RelativeVirtualAddress);
             int endOffset = offset + importSectionsSection.Size;
             while (offset < endOffset)
@@ -822,13 +940,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="rva">The relative virtual address</param>
         public int GetOffset(int rva)
         {
-            int index = PEReader.PEHeaders.GetContainingSectionIndex(rva);
-            if (index == -1)
-            {
-                throw new BadImageFormatException("Failed to convert invalid RVA to offset: " + rva);
-            }
-            SectionHeader containingSection = PEReader.PEHeaders.SectionHeaders[index];
-            return rva - containingSection.VirtualAddress + containingSection.PointerToRawData;
+            return PEReader.GetOffset(rva);
         }
 
         /// <summary>
@@ -887,11 +999,11 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             Debug.Assert(refAsmIndex != 0);
 
-            int assemblyRefCount = MetadataReader.GetTableRowCount(TableIndex.AssemblyRef);
+            int assemblyRefCount = (_composite ? 0 : _assemblyCache[0].GetTableRowCount(TableIndex.AssemblyRef));
             AssemblyReferenceHandle assemblyReferenceHandle;
             if (refAsmIndex <= assemblyRefCount)
             {
-                metadataReader = MetadataReader;
+                metadataReader = _assemblyCache[0];
                 assemblyReferenceHandle = MetadataTokens.AssemblyReferenceHandle(refAsmIndex);
             }
             else
@@ -916,13 +1028,8 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <returns>MetadataReader instance representing the reference assembly</returns>
         internal MetadataReader OpenReferenceAssembly(int refAsmIndex)
         {
-            if (refAsmIndex == 0)
-            {
-                return this.MetadataReader;
-            }
-
-            MetadataReader result;
-            if (!_assemblyCache.TryGetValue(refAsmIndex, out result))
+            MetadataReader result = (refAsmIndex < _assemblyCache.Count ? _assemblyCache[refAsmIndex] : null);
+            if (result == null)
             {
                 AssemblyReferenceHandle assemblyReferenceHandle = GetAssemblyAtIndex(refAsmIndex, out MetadataReader metadataReader);
 
@@ -932,7 +1039,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                     string name = metadataReader.GetString(metadataReader.GetAssemblyReference(assemblyReferenceHandle).Name);
                     throw new Exception($"Missing reference assembly: {name}");
                 }
-                _assemblyCache.Add(refAsmIndex, result);
+                while (_assemblyCache.Count <= refAsmIndex)
+                {
+                    _assemblyCache.Add(null);
+                }
+                _assemblyCache[refAsmIndex] = result;
             }
             return result;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSection.cs
@@ -1,41 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+
+using Internal.Runtime;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
     public struct ReadyToRunSection
     {
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> ReadyToRunSectionType
-        /// </summary>
-        public enum SectionType
-        {
-            READYTORUN_SECTION_COMPILER_IDENTIFIER = 100,
-            READYTORUN_SECTION_IMPORT_SECTIONS = 101,
-            READYTORUN_SECTION_RUNTIME_FUNCTIONS = 102,
-            READYTORUN_SECTION_METHODDEF_ENTRYPOINTS = 103,
-            READYTORUN_SECTION_EXCEPTION_INFO = 104,
-            READYTORUN_SECTION_DEBUG_INFO = 105,
-            READYTORUN_SECTION_DELAYLOAD_METHODCALL_THUNKS = 106,
-            READYTORUN_SECTION_AVAILABLE_TYPES = 108,
-            READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS = 109,
-            READYTORUN_SECTION_INLINING_INFO = 110,
-            READYTORUN_SECTION_PROFILEDATA_INFO = 111,
-            READYTORUN_SECTION_MANIFEST_METADATA = 112, // Added in v2.3
-            READYTORUN_SECTION_ATTRIBUTEPRESENCE = 113, // Added in V3.1
-            READYTORUN_SECTION_INLINING_INFO2 = 114, // Added in 4.1
-        }
-
-        /// <summary>
         /// The ReadyToRun section type
         /// </summary>
-        public SectionType Type { get; set; }
+        public ReadyToRunSectionType Type { get; set; }
 
         /// <summary>
         /// The RVA to the section
@@ -47,7 +25,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public int Size { get; set; }
 
-        public ReadyToRunSection(SectionType type, int rva, int size)
+        public ReadyToRunSection(ReadyToRunSectionType type, int rva, int size)
         {
             Type = type;
             RelativeVirtualAddress = rva;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -383,7 +383,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="offset">Signature offset within the PE file byte array</param>
         public SignatureDecoder(IAssemblyResolver options, ReadyToRunReader r2rReader, int offset)
         {
-            _metadataReader = r2rReader.MetadataReader;
+            _metadataReader = r2rReader.GetGlobalMetadataReader();
             _options = options;
             _image = r2rReader.Image;
             _offset = offset;

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.Reflection.ReadyToRun;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
-using System.Text;
+
+using ILCompiler.Reflection.ReadyToRun;
+using Internal.Runtime;
 
 namespace R2RDump
 {
@@ -112,7 +113,7 @@ namespace R2RDump
 
         public static void WriteTo(this ReadyToRunSection theThis, TextWriter writer, DumpOptions options)
         {
-            writer.WriteLine($"Type:  {Enum.GetName(typeof(ReadyToRunSection.SectionType), theThis.Type)} ({theThis.Type:D})");
+            writer.WriteLine($"Type:  {Enum.GetName(typeof(ReadyToRunSectionType), theThis.Type)} ({theThis.Type:D})");
             if (!options.Naked)
             {
                 writer.WriteLine($"RelativeVirtualAddress: 0x{theThis.RelativeVirtualAddress:X8}");

--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.Reflection.ReadyToRun;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Text;
+
+using ILCompiler.Reflection.ReadyToRun;
+using Internal.Runtime;
 
 namespace R2RDump
 {
@@ -193,7 +195,7 @@ namespace R2RDump
         {
             Dictionary<string, int> sectionMap = new Dictionary<string, int>();
 
-            foreach (KeyValuePair<ReadyToRunSection.SectionType, ReadyToRunSection> typeAndSection in reader.ReadyToRunHeader.Sections)
+            foreach (KeyValuePair<ReadyToRunSectionType, ReadyToRunSection> typeAndSection in reader.ReadyToRunHeader.Sections)
             {
                 string name = typeAndSection.Key.ToString();
                 sectionMap.Add(name, typeAndSection.Value.Size);

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,9 +12,10 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using ILCompiler.Reflection.ReadyToRun;
+
+using Internal.Runtime;
 
 namespace R2RDump
 {
@@ -55,16 +56,29 @@ namespace R2RDump
         private readonly static string[] ProbeExtensions = new string[] { ".ni.exe", ".ni.dll", ".exe", ".dll" };
 
         /// <summary>
-        /// Try to locate a (reference) assembly using the list of explicit reference assemblies
+        /// Try to locate a (reference) assembly based on an AssemblyRef handle using the list of explicit reference assemblies
         /// and the list of reference paths passed to R2RDump.
         /// </summary>
-        /// <param name="simpleName">Simple name of the assembly to look up</param>
+        /// <param name="metadataReader">Containing metadata reader for the assembly reference handle</param>
+        /// <param name="assemblyReferenceHandle">Handle representing the assembly reference</param>
         /// <param name="parentFile">Name of assembly from which we're performing the lookup</param>
         /// <returns></returns>
 
         public MetadataReader FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile)
         {
             string simpleName = metadataReader.GetString(metadataReader.GetAssemblyReference(assemblyReferenceHandle).Name);
+            return FindAssembly(simpleName, parentFile);
+        }
+
+        /// <summary>
+        /// Try to locate a (reference) assembly using the list of explicit reference assemblies
+        /// and the list of reference paths passed to R2RDump.
+        /// </summary>
+        /// <param name="simpleName">Simple name of the assembly to look up</param>
+        /// <param name="parentFile">Name of assembly from which we're performing the lookup</param>
+        /// <returns></returns>
+        public MetadataReader FindAssembly(string simpleName, string parentFile)
+        {
             foreach (FileInfo refAsm in Reference ?? Enumerable.Empty<FileInfo>())
             {
                 if (Path.GetFileNameWithoutExtension(refAsm.FullName).Equals(simpleName, StringComparison.OrdinalIgnoreCase))
@@ -80,10 +94,16 @@ namespace R2RDump
             {
                 foreach (string extension in ProbeExtensions)
                 {
-                    string probeFile = Path.Combine(refPath, simpleName + extension);
-                    if (File.Exists(probeFile))
+                    try
                     {
-                        return Open(probeFile);
+                        string probeFile = Path.Combine(refPath, simpleName + extension);
+                        if (File.Exists(probeFile))
+                        {
+                            return Open(probeFile);
+                        }
+                    }
+                    catch (BadImageFormatException)
+                    {
                     }
                 }
             }
@@ -99,7 +119,7 @@ namespace R2RDump
 
             if (!peReader.HasMetadata)
             {
-                throw new Exception($"ECMA metadata not found in file '{filename}'");
+                throw new BadImageFormatException($"ECMA metadata not found in file '{filename}'");
             }
 
             return peReader.GetMetadataReader();
@@ -176,7 +196,7 @@ namespace R2RDump
     class R2RDump
     {
         private readonly DumpOptions _options;
-        private readonly Dictionary<ReadyToRunSection.SectionType, bool> _selectedSections = new Dictionary<ReadyToRunSection.SectionType, bool>();
+        private readonly Dictionary<ReadyToRunSectionType, bool> _selectedSections = new Dictionary<ReadyToRunSectionType, bool>();
         private readonly TextWriter _writer;
         private Dumper _dumper;
 
@@ -404,7 +424,7 @@ namespace R2RDump
         {
             int queryInt;
             bool isNum = ArgStringToInt(query, out queryInt);
-            string typeName = Enum.GetName(typeof(ReadyToRunSection.SectionType), section.Type);
+            string typeName = Enum.GetName(typeof(ReadyToRunSectionType), section.Type);
 
             return (isNum && (int)section.Type == queryInt) || typeName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -1,8 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using ILCompiler.Reflection.ReadyToRun;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,8 +9,9 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Text;
-using System.Xml;
+
+using ILCompiler.Reflection.ReadyToRun;
+using Internal.Runtime;
 
 namespace R2RDump
 {
@@ -270,7 +270,7 @@ namespace R2RDump
         {
             switch (section.Type)
             {
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES:
+                case ReadyToRunSectionType.AvailableTypes:
                     if (!_options.Naked)
                     {
                         uint availableTypesSectionOffset = (uint)_r2r.GetOffset(section.RelativeVirtualAddress);
@@ -284,14 +284,14 @@ namespace R2RDump
                         _writer.WriteLine(name);
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_METHODDEF_ENTRYPOINTS:
+                case ReadyToRunSectionType.MethodDefEntryPoints:
                     if (!_options.Naked)
                     {
                         NativeArray methodEntryPoints = new NativeArray(_r2r.Image, (uint)_r2r.GetOffset(section.RelativeVirtualAddress));
                         _writer.Write(methodEntryPoints.ToString());
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS:
+                case ReadyToRunSectionType.InstanceMethodEntryPoints:
                     if (!_options.Naked)
                     {
                         uint instanceSectionOffset = (uint)_r2r.GetOffset(section.RelativeVirtualAddress);
@@ -305,7 +305,7 @@ namespace R2RDump
                         _writer.WriteLine($@"0x{instanceMethod.Bucket:X2} -> {instanceMethod.Method.SignatureString}");
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS:
+                case ReadyToRunSectionType.RuntimeFunctions:
                     int rtfOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int rtfEndOffset = rtfOffset + section.Size;
                     int rtfIndex = 0;
@@ -326,10 +326,10 @@ namespace R2RDump
                         rtfIndex++;
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_COMPILER_IDENTIFIER:
+                case ReadyToRunSectionType.CompilerIdentifier:
                     _writer.WriteLine(_r2r.CompilerIdentifier);
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_IMPORT_SECTIONS:
+                case ReadyToRunSectionType.ImportSections:
                     if (_options.Naked)
                     {
                         DumpNakedImportSections();
@@ -366,14 +366,19 @@ namespace R2RDump
                         }
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_MANIFEST_METADATA:
-                    int assemblyRefCount = _r2r.MetadataReader.GetTableRowCount(TableIndex.AssemblyRef);
-                    _writer.WriteLine($"MSIL AssemblyRef's ({assemblyRefCount} entries):");
-                    for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
+                case ReadyToRunSectionType.ManifestMetadata:
+                    int assemblyRefCount = 0;
+                    if (!_r2r.Composite)
                     {
-                        AssemblyReference assemblyRef = _r2r.MetadataReader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(assemblyRefIndex));
-                        string assemblyRefName = _r2r.MetadataReader.GetString(assemblyRef.Name);
-                        _writer.WriteLine($"[ID 0x{assemblyRefIndex:X2}]: {assemblyRefName}");
+                        MetadataReader globalReader = _r2r.GetGlobalMetadataReader();
+                        assemblyRefCount = globalReader.GetTableRowCount(TableIndex.AssemblyRef);
+                        _writer.WriteLine($"MSIL AssemblyRef's ({assemblyRefCount} entries):");
+                        for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
+                        {
+                            AssemblyReference assemblyRef = globalReader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(assemblyRefIndex));
+                            string assemblyRefName = globalReader.GetString(assemblyRef.Name);
+                            _writer.WriteLine($"[ID 0x{assemblyRefIndex:X2}]: {assemblyRefName}");
+                        }
                     }
 
                     _writer.WriteLine($"Manifest metadata AssemblyRef's ({_r2r.ManifestReferenceAssemblies.Count()} entries):");
@@ -384,20 +389,20 @@ namespace R2RDump
                         manifestAsmIndex++;
                     }
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_ATTRIBUTEPRESENCE:
+                case ReadyToRunSectionType.AttributePresence:
                     int attributesStartOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int attributesEndOffset = attributesStartOffset + section.Size;
                     NativeCuckooFilter attributes = new NativeCuckooFilter(_r2r.Image, attributesStartOffset, attributesEndOffset);
                     _writer.WriteLine("Attribute presence filter");
                     _writer.WriteLine(attributes.ToString());
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_INLINING_INFO:
+                case ReadyToRunSectionType.InliningInfo:
                     int iiOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int iiEndOffset = iiOffset + section.Size;
                     InliningInfoSection inliningInfoSection = new InliningInfoSection(_r2r, iiOffset, iiEndOffset);
                     _writer.WriteLine(inliningInfoSection.ToString());
                     break;
-                case ReadyToRunSection.SectionType.READYTORUN_SECTION_INLINING_INFO2:
+                case ReadyToRunSectionType.InliningInfo2:
                     int ii2Offset = _r2r.GetOffset(section.RelativeVirtualAddress);
                     int ii2EndOffset = ii2Offset + section.Size;
                     InliningInfoSection2 inliningInfoSection2 = new InliningInfoSection2(_r2r, ii2Offset, ii2EndOffset);


### PR DESCRIPTION
I have separated the R2RDump-specific changes from my broader
composite R2R change. The gist of the change is becoming able to
read the new "native R2R header" flavor and look up MSIL in
separate DLL's next to the R2R executable.

On top of this basic scheme I have removed the section ID
duplication between ReadyToRunSection.cs and RuntimeHeaders.cs.
I have also slightly cleaned up unnecessary double dictionary
lookups for R2R sections.

For now I have made EH clause parsing work in single-assembly build
mode only, for composite R2R that will require additional changes.

Thanks

Tomas