### PR TITLE
SuperIlc changes for composite build mode support

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -46,15 +46,30 @@ namespace ReadyToRun.SuperIlc
             _compilations = new List<ProcessInfo[]>();
             _executions = new List<ProcessInfo[]>();
 
-            foreach (string file in _compilationInputFiles)
+            if (options.Composite)
             {
                 ProcessInfo[] fileCompilations = new ProcessInfo[(int)CompilerIndex.Count];
                 foreach (CompilerRunner runner in compilerRunners)
                 {
-                    ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _outputFolder, file));
+                    string outputFile = runner.GetOutputFileName(_outputFolder, "composite-r2r.dll");
+                    ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, outputFile, _compilationInputFiles));
                     fileCompilations[(int)runner.Index] = compilationProcess;
                 }
                 _compilations.Add(fileCompilations);
+            }
+            else
+            {
+                foreach (string file in _compilationInputFiles)
+                {
+                    ProcessInfo[] fileCompilations = new ProcessInfo[(int)CompilerIndex.Count];
+                    foreach (CompilerRunner runner in compilerRunners)
+                    {
+                        string outputFile = runner.GetOutputFileName(_outputFolder, file);
+                        ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, outputFile, new string[] { file }));
+                        fileCompilations[(int)runner.Index] = compilationProcess;
+                    }
+                    _compilations.Add(fileCompilations);
+                }
             }
 
             if (!options.NoExe)
@@ -98,7 +113,8 @@ namespace ReadyToRun.SuperIlc
                 {
                     compilationInputFiles.Add(file);
                 }
-                else if ((Path.GetExtension(file) != ".pdb") && (Path.GetExtension(file) != ".ilk")) // exclude .pdb and .ilk files that are large and not needed in the target folder
+                if ((!isManagedAssembly || options.Composite) &&
+                    (Path.GetExtension(file) != ".pdb") && (Path.GetExtension(file) != ".ilk")) // exclude .pdb and .ilk files that are large and not needed in the target folder
                 {
                     passThroughFiles.Add(file);
                 }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -163,7 +163,7 @@ namespace ReadyToRun.SuperIlc
             {
                 foreach (ProcessInfo[] compilation in folder.Compilations)
                 {
-                    string file = null;
+                    HashSet<string> failedFiles = new HashSet<string>();
                     string failedBuilders = null;
                     foreach (CompilerRunner runner in _compilerRunners)
                     {
@@ -184,17 +184,9 @@ namespace ReadyToRun.SuperIlc
                         else // runner process failed
                         {
                             _compilationFailureBuckets.AddCompilation(runnerProcess);
-                            try
+                            failedFiles.UnionWith(runnerProcess.Parameters.InputFileNames);
+                            if (failedBuilders == null)
                             {
-                                File.Copy(runnerProcess.Parameters.InputFileName, runnerProcess.Parameters.OutputFileName);
-                            }
-                            catch (Exception ex)
-                            {
-                                Console.Error.WriteLine("Error copying {0} to {1}: {2}", runnerProcess.Parameters.InputFileName, runnerProcess.Parameters.OutputFileName, ex.Message);
-                            }
-                            if (file == null)
-                            {
-                                file = runnerProcess.Parameters.InputFileName;
                                 failedBuilders = runner.CompilerName;
                             }
                             else
@@ -203,9 +195,12 @@ namespace ReadyToRun.SuperIlc
                             }
                         }
                     }
-                    if (file != null)
+                    if (failedFiles.Count > 0)
                     {
-                        failedCompilationsPerBuilder.Add(new KeyValuePair<string, string>(file, failedBuilders));
+                        foreach (string file in failedFiles)
+                        {
+                            failedCompilationsPerBuilder.Add(new KeyValuePair<string, string>(file, failedBuilders));
+                        }
                         success = false;
                     }
                     else
@@ -235,7 +230,7 @@ namespace ReadyToRun.SuperIlc
                         causeOfFailure = "Unknown cause of failure";
                     }
 
-                    Console.Error.WriteLine("Error running R2R dump on {0}: {1}", r2rDumpExecution.Parameters.InputFileName, causeOfFailure);
+                    Console.Error.WriteLine("Error running R2R dump on {0}: {1}", string.Join(", ", r2rDumpExecution.Parameters.InputFileNames), causeOfFailure);
                     success = false;
                 }
             }
@@ -271,23 +266,57 @@ namespace ReadyToRun.SuperIlc
             List<ProcessInfo> compilationsToRun = new List<ProcessInfo>();
             List<KeyValuePair<string, ProcessInfo[]>> compilationsPerRunner = new List<KeyValuePair<string, ProcessInfo[]>>();
             List<string> excludedAssemblies = new List<string>();
-            foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
-            {
-                string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
-                FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
 
+            if (_options.Composite)
+            {
                 ProcessInfo[] processes = new ProcessInfo[(int)CompilerIndex.Count];
-                compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                 foreach (CompilerRunner runner in frameworkRunners)
                 {
-                    if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                    List<string> inputFrameworkDlls = new List<string>();
+                    foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
                     {
-                        _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
-                        continue;
+                        string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
+                        FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
+                        if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                        {
+                            _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
+                        }
+                        else
+                        {
+                            inputFrameworkDlls.Add(frameworkDll);
+                            compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
+                        }
                     }
-                    ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, frameworkDll));
-                    compilationsToRun.Add(compilationProcess);
-                    processes[(int)runner.Index] = compilationProcess;
+
+                    if (inputFrameworkDlls.Count > 0)
+                    {
+                        string outputFileName = runner.GetOutputFileName(_options.CoreRootDirectory.FullName, "framework");
+                        ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, outputFileName, inputFrameworkDlls));
+                        compilationsToRun.Add(compilationProcess);
+                        processes[(int)runner.Index] = compilationProcess;
+                    }
+                }
+            }
+            else
+            {
+                foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
+                {
+                    string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
+                    FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
+
+                    ProcessInfo[] processes = new ProcessInfo[(int)CompilerIndex.Count];
+                    compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
+                    foreach (CompilerRunner runner in frameworkRunners)
+                    {
+                        if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                        {
+                            _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
+                            continue;
+                        }
+                        ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, new string[] { frameworkDll }));
+                        compilationsToRun.Add(compilationProcess);
+                        processes[(int)runner.Index] = compilationProcess;
+                    }
                 }
             }
 
@@ -313,7 +342,7 @@ namespace ReadyToRun.SuperIlc
                     }
                     else if (compilationProcess.Succeeded)
                     {
-                        skipCopying[(int)runner.Index].Add(compilationProcess.Parameters.InputFileName);
+                        skipCopying[(int)runner.Index].UnionWith(compilationProcess.Parameters.InputFileNames);
                         AnalyzeCompilationLog(compilationProcess, runner.Index);
                     }
                     else
@@ -450,7 +479,7 @@ namespace ReadyToRun.SuperIlc
             {
                 foreach (ProcessInfo[] execution in folder.Executions)
                 {
-                    string file = null;
+                    HashSet<string> failedFiles = new HashSet<string>();
                     string failedBuilders = null;
                     foreach (CompilerRunner runner in _compilerRunners)
                     {
@@ -459,9 +488,9 @@ namespace ReadyToRun.SuperIlc
                         {
                             _executionFailureBuckets.AddExecution(runnerProcess);
 
-                            if (file == null)
+                            failedFiles.UnionWith(runnerProcess.Parameters.InputFileNames);
+                            if (failedBuilders == null)
                             {
-                                file = runnerProcess.Parameters.InputFileName;
                                 failedBuilders = runner.CompilerName;
                             }
                             else
@@ -470,7 +499,7 @@ namespace ReadyToRun.SuperIlc
                             }
                         }
                     }
-                    if (file != null)
+                    if (failedFiles.Count > 0)
                     {
                         success = false;
                     }
@@ -572,7 +601,7 @@ namespace ReadyToRun.SuperIlc
 
             foreach (ProcessInfo processInfo in selection)
             {
-                logWriter.WriteLine($"{processInfo.DurationMilliseconds,10} | {processInfo.Parameters.InputFileName}");
+                logWriter.WriteLine($"{processInfo.DurationMilliseconds,10} | {processInfo.Parameters.OutputFileName}");
             }
         }
 
@@ -1205,7 +1234,7 @@ namespace ReadyToRun.SuperIlc
                                 ProcessInfo compilationProcess = compilation[(int)runner.Index];
                                 if (compilationProcess != null && !compilationProcess.IsEmpty)
                                 {
-                                    string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.InputFileName}";
+                                    string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.OutputFileName}";
                                     StreamWriter runnerLog = perRunnerLog[(int)runner.Index];
                                     runnerLog.WriteLine(log);
                                     combinedLog.WriteLine(log);
@@ -1242,7 +1271,7 @@ namespace ReadyToRun.SuperIlc
                                 ProcessInfo executionProcess = execution[(int)runner.Index];
                                 if (executionProcess != null)
                                 {
-                                    string header = $"\nEXECUTE {runner.CompilerName}:{executionProcess.Parameters.InputFileName}";
+                                    string header = $"\nEXECUTE {runner.CompilerName}:{executionProcess.Parameters.OutputFileName}";
                                     combinedLog.WriteLine(header);
                                     runnerLog.WriteLine(header);
                                     try
@@ -1500,7 +1529,7 @@ namespace ReadyToRun.SuperIlc
                             GetExecutionOutcome(executionPerRunner) == outcome &&
                             executionPerRunner.Parameters != null)
                         {
-                            filteredTestList.Add(executionPerRunner.Parameters.InputFileName);
+                            filteredTestList.Add(executionPerRunner.Parameters.OutputFileName);
                         }
                     }
                 }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -29,6 +29,7 @@ namespace ReadyToRun.SuperIlc
         public bool UseFramework { get; set; }
         public bool Release { get; set; }
         public bool LargeBubble { get; set; }
+        public bool Composite { get; set; }
         public int Crossgen2Parallelism { get; set; }
         public int CompilationTimeoutMinutes { get; set; }
         public int ExecutionTimeoutMinutes { get; set; }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -45,6 +45,7 @@ namespace ReadyToRun.SuperIlc
                         UseFramework(),
                         Release(),
                         LargeBubble(),
+                        Composite(),
                         Crossgen2Parallelism(),
                         ReferencePath(),
                         IssuesPath(),
@@ -78,6 +79,7 @@ namespace ReadyToRun.SuperIlc
                         UseFramework(),
                         Release(),
                         LargeBubble(),
+                        Composite(),
                         Crossgen2Parallelism(),
                         ReferencePath(),
                         IssuesPath(),
@@ -101,6 +103,7 @@ namespace ReadyToRun.SuperIlc
                         Sequential(),
                         Release(),
                         LargeBubble(),
+                        Composite(),
                         ReferencePath(),
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
@@ -202,6 +205,9 @@ namespace ReadyToRun.SuperIlc
 
             Option LargeBubble() =>
                 new Option(new[] { "--large-bubble" }, "Assume all input files as part of one version bubble", new Argument<bool>());
+
+            Option Composite() =>
+                new Option(new[] { "--composite" }, "Compile tests in composite R2R mode", new Argument<bool>());
 
             Option Crossgen2Parallelism() =>
                 new Option(new[] { "--crossgen2-parallelism" }, "Max number of threads to use in Crossgen2 (default = logical processor count)", new Argument<int>());

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/Commands/CompileFromCrossgenRspCommand.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/Commands/CompileFromCrossgenRspCommand.cs
@@ -107,7 +107,7 @@ namespace ReadyToRun.SuperIlc
                 List<ProcessInfo> fileCompilations = new List<ProcessInfo>();
                 foreach (CompilerRunner runner in compilerRunners)
                 {
-                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, responseFileOuputPath, crossgenArguments.InputFile));
+                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, responseFileOuputPath, new string[] { crossgenArguments.InputFile }));
                     fileCompilations.Add(compilationProcess);
                 }
 
@@ -121,7 +121,7 @@ namespace ReadyToRun.SuperIlc
                         success = false;
                         compilationFailures++;
 
-                        Console.WriteLine($"Failed compiling {compilationProcess.Parameters.InputFileName}");
+                        Console.WriteLine($"Failed compiling {compilationProcess.Parameters.OutputFileName}");
                     }
                 }
             }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -4,11 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.Build.Logging;
 
 namespace ReadyToRun.SuperIlc
 {
@@ -48,15 +46,14 @@ namespace ReadyToRun.SuperIlc
 
         protected virtual string CompilerPath => Path.Combine(_options.CoreRootDirectory.FullName, CompilerRelativePath, CompilerFileName);
 
-        protected abstract IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName);
+        protected abstract IEnumerable<string> BuildCommandLineArguments(IEnumerable<string> assemblyFileNames, string outputFileName);
 
-        public virtual ProcessParameters CompilationProcess(string outputRoot, string assemblyFileName)
+        public virtual ProcessParameters CompilationProcess(string outputFileName, IEnumerable<string> inputAssemblyFileNames)
         {
-            CreateOutputFolder(outputRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputFileName));
 
-            string outputFileName = GetOutputFileName(outputRoot, assemblyFileName);
-            string responseFile = GetResponseFileName(outputRoot, assemblyFileName);
-            var commandLineArgs = BuildCommandLineArguments(assemblyFileName, outputFileName);
+            string responseFile = outputFileName + ".rsp";
+            var commandLineArgs = BuildCommandLineArguments(inputAssemblyFileNames, outputFileName);
             CreateResponseFile(responseFile, commandLineArgs);
 
             ProcessParameters processParameters = new ProcessParameters();
@@ -71,9 +68,13 @@ namespace ReadyToRun.SuperIlc
                 processParameters.TimeoutMilliseconds = ProcessParameters.DefaultIlcTimeout;
             }
             processParameters.LogPath = outputFileName + ".ilc.log";
-            processParameters.InputFileName = assemblyFileName;
+            processParameters.InputFileNames = inputAssemblyFileNames;
             processParameters.OutputFileName = outputFileName;
-            processParameters.CompilationCostHeuristic = new FileInfo(assemblyFileName).Length;
+
+            foreach (string inputAssembly in inputAssemblyFileNames)
+            {
+                processParameters.CompilationCostHeuristic += new FileInfo(inputAssembly).Length;
+            }
 
             return processParameters;
         }
@@ -119,7 +120,7 @@ namespace ReadyToRun.SuperIlc
             param.Arguments = builder.ToString();
             param.TimeoutMilliseconds = R2RDumpTimeoutMilliseconds;
             param.LogPath = compiledExecutable + (naked ? ".naked.r2r.log" : ".raw.r2r.log");
-            param.InputFileName = compiledExecutable;
+            param.InputFileNames = new string[] { compiledExecutable };
             param.OutputFileName = outputFileName;
             try
             {
@@ -186,7 +187,7 @@ namespace ReadyToRun.SuperIlc
                 processParameters.Arguments = "-c " + scriptToRun;
             }
 
-            processParameters.InputFileName = scriptToRun;
+            processParameters.InputFileNames = new string[] { scriptToRun };
             processParameters.OutputFileName = scriptToRun;
             processParameters.LogPath = scriptToRun + ".log";
             processParameters.EnvironmentOverrides["CORE_ROOT"] = _options.CoreRootOutputPath(Index, isFramework: false);
@@ -199,7 +200,7 @@ namespace ReadyToRun.SuperIlc
             ProcessParameters processParameters = ExecutionProcess(modules, folders, _options.NoEtw);
             processParameters.ProcessPath = _options.CoreRunPath(Index, isFramework: false);
             processParameters.Arguments = exeToRun;
-            processParameters.InputFileName = exeToRun;
+            processParameters.InputFileNames = new string[] { exeToRun };
             processParameters.OutputFileName = exeToRun;
             processParameters.LogPath = exeToRun + ".log";
             processParameters.ExpectedExitCode = 100;
@@ -248,19 +249,19 @@ namespace ReadyToRun.SuperIlc
 
     public class CompilationProcessConstructor : CompilerRunnerProcessConstructor
     {
-        private readonly string _outputRoot;
-        private readonly string _assemblyFileName;
+        private readonly string _outputFileName;
+        private readonly IEnumerable<string> _inputAssemblyFileNames;
 
-        public CompilationProcessConstructor(CompilerRunner runner, string outputRoot, string assemblyFileName)
+        public CompilationProcessConstructor(CompilerRunner runner, string outputFileName, IEnumerable<string> inputAssemblyFileNames)
             : base(runner)
         {
-            _outputRoot = outputRoot;
-            _assemblyFileName = assemblyFileName;
+            _outputFileName = outputFileName;
+            _inputAssemblyFileNames = inputAssemblyFileNames;
         }
 
         public override ProcessParameters Construct()
         {
-            return _runner.CompilationProcess(_outputRoot, _assemblyFileName);
+            return _runner.CompilationProcess(_outputFileName, _inputAssemblyFileNames);
         }
     }
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -40,17 +40,22 @@ namespace ReadyToRun.SuperIlc
             return processParameters;
         }
 
-        protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
+        protected override IEnumerable<string> BuildCommandLineArguments(IEnumerable<string> assemblyFileNames, string outputFileName)
         {
+            if (assemblyFileNames.Count() > 1)
+            {
+                throw new NotImplementedException($@"Crossgen1 doesn't support composite build mode for compiling multiple input assemblies: {string.Join("; ", assemblyFileNames)}");
+            }
+
             // The file to compile
             yield return "/in";
-            yield return assemblyFileName;
+            yield return assemblyFileNames.First();
 
             // Output
             yield return "/out";
             yield return outputFileName;
 
-            if (_options.LargeBubble && Path.GetFileNameWithoutExtension(assemblyFileName) != "System.Private.CoreLib")
+            if (_options.LargeBubble && Path.GetFileNameWithoutExtension(assemblyFileNames.First()) != "System.Private.CoreLib")
             {
                 // There seems to be a bug in Crossgen on Linux we don't intend to fix -
                 // it crashes when trying to compile S.P.C in large version bubble mode.
@@ -59,7 +64,12 @@ namespace ReadyToRun.SuperIlc
 
             yield return "/platform_assemblies_paths";
 
-            IEnumerable<string> paths = new string[] { Path.GetDirectoryName(assemblyFileName) }.Concat(_referenceFolders);
+            HashSet<string> paths = new HashSet<string>();
+            foreach (string assemblyFileName in assemblyFileNames)
+            {
+                paths.Add(Path.GetDirectoryName(assemblyFileName));
+            }
+            paths.UnionWith(_referenceFolders);
 
             yield return paths.ConcatenatePaths();
         }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,9 +27,14 @@ namespace ReadyToRun.SuperIlc
         /// JIT runner has no compilation process as it doesn't transform the source IL code in any manner.
         /// </summary>
         /// <returns></returns>
-        public override ProcessParameters CompilationProcess(string outputRoot, string assemblyFileName)
+        public override ProcessParameters CompilationProcess(string outputFileName, IEnumerable<string> inputAssemblyFileNames)
         {
-            File.Copy(assemblyFileName, GetOutputFileName(outputRoot, assemblyFileName), overwrite: true);
+            if (inputAssemblyFileNames.Count() != 1)
+            {
+                throw new Exception($@"JIT builder doesn't support composite mode for building input assemblies: {string.Join("; ", inputAssemblyFileNames)}");
+            }
+
+            File.Copy(inputAssemblyFileNames.First(), outputFileName, overwrite: true);
             return null;
         }
 
@@ -40,7 +45,7 @@ namespace ReadyToRun.SuperIlc
             return processParameters;
         }
 
-        protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
+        protected override IEnumerable<string> BuildCommandLineArguments(IEnumerable<string> assemblyFileNames, string outputFileName)
         {
             // This should never get called as the overridden CompilationProcess returns null
             throw new NotImplementedException();

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -32,7 +32,7 @@ public class ProcessParameters
     public string LogPath;
     public int TimeoutMilliseconds;
     public int ExpectedExitCode;
-    public string InputFileName;
+    public IEnumerable<string> InputFileNames;
     public string OutputFileName;
     public long CompilationCostHeuristic;
     public bool CollectJittedMethods;

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ReadyToRun.SuperIlc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ReadyToRun.SuperIlc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platform>AnyCPU</Platform>
     <OutputPath>$(BinDir)\ReadyToRun.SuperIlc</OutputPath>


### PR DESCRIPTION
This change mostly modifies CompilerRunner to support processes
with multiple input paths so that we can run a single Crossgen2
compilation over a larger set of input files. Based on the latest
iteration of my overall composite R2R support change I have now
made it such that SuperIlc passes the framework assemblies to
Crossgen2 using the "-u" option which means "use as input but
don't automatically root all methods in the module i.o.w. compile
only what is transitively reachable from the test app input modules".

Thanks

Tomas