### PR TITLE
Enable GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -137,7 +137,7 @@ namespace System.Net.Http.Functional.Tests
 
             using (HttpClient client = CreateHttpClient())
             {
-                client.Timeout = Timeout.InfiniteTimeSpan;
+                client.Timeout = TimeSpan.FromSeconds(60);
                 var cts = new CancellationTokenSource();
 
                 await LoopbackServerFactory.CreateServerAsync(async (server, url) =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -126,7 +126,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/28805")]
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {
@@ -135,6 +134,9 @@ namespace System.Net.Http.Functional.Tests
                 // There is no chunked encoding or connection header in HTTP/2
                 return;
             }
+
+            var timeoutSource = new CancellationTokenSource();
+            timeoutSource.CancelAfter(TimeSpan.FromMinutes(2));
 
             using (HttpClient client = CreateHttpClient())
             {
@@ -178,7 +180,7 @@ namespace System.Net.Http.Functional.Tests
                         clientFinished.SetResult(true);
                         await serverTask;
                     } catch { }
-                });
+                }).WithCancellation(timeoutSource.Token);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -139,7 +139,6 @@ namespace System.Net.Http.Functional.Tests
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;
                 var cts = new CancellationTokenSource();
-                const int timeout = 60_000;
 
                 await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
                 {
@@ -155,10 +154,10 @@ namespace System.Net.Http.Functional.Tests
                             headers.Add(new HttpHeaderData("Connection", "close"));
                         }
 
-                        await connection.ReadRequestDataAsync().TimeoutAfter(timeout);
-                        await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, content: "123", isFinal: false).TimeoutAfter(timeout);
+                        await connection.ReadRequestDataAsync();
+                        await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, content: "123", isFinal: false);
                         responseHeadersSent.TrySetResult(true);
-                        await clientFinished.Task.TimeoutAfter(timeout);
+                        await clientFinished.Task;
                     });
 
                     await ValidateClientCancellationAsync(async () =>
@@ -167,16 +166,16 @@ namespace System.Net.Http.Functional.Tests
                         req.Headers.ConnectionClose = connectionClose;
 
                         Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token);
-                        await responseHeadersSent.Task.TimeoutAfter(timeout);
+                        await responseHeadersSent.Task;
                         await Task.Delay(1); // make it more likely that client will have started processing response body
                         Cancel(mode, client, cts);
-                        await getResponse.TimeoutAfter(timeout);
-                    }).TimeoutAfter(timeout);
+                        await getResponse;
+                    });
 
                     try
                     {
                         clientFinished.SetResult(true);
-                        await serverTask.TimeoutAfter(timeout);
+                        await serverTask;
                     } catch { }
                 }, 300_000);
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -139,6 +139,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;
                 var cts = new CancellationTokenSource();
+                int timeout = 120_000;
 
                 await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
                 {
@@ -166,11 +167,11 @@ namespace System.Net.Http.Functional.Tests
                         req.Headers.ConnectionClose = connectionClose;
 
                         Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token);
-                        await responseHeadersSent.Task;
+                        await responseHeadersSent.Task.TimeoutAfter(timeout);
                         await Task.Delay(1); // make it more likely that client will have started processing response body
                         Cancel(mode, client, cts);
-                        await getResponse;
-                    });
+                        await getResponse.TimeoutAfter(timeout);
+                    }).TimeoutAfter(timeout);
 
                     try
                     {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;
                 var cts = new CancellationTokenSource();
-                const int timeout = 600000;
+                const int timeout = 60_000;
 
                 await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
                 {
@@ -166,11 +166,11 @@ namespace System.Net.Http.Functional.Tests
                         var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                         req.Headers.ConnectionClose = connectionClose;
 
-                        Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token).TimeoutAfter(timeout);
+                        Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token);
                         await responseHeadersSent.Task.TimeoutAfter(timeout);
                         await Task.Delay(1); // make it more likely that client will have started processing response body
                         Cancel(mode, client, cts);
-                        await getResponse;
+                        await getResponse.TimeoutAfter(timeout);
                     }).TimeoutAfter(timeout);
 
                     try
@@ -178,7 +178,7 @@ namespace System.Net.Http.Functional.Tests
                         clientFinished.SetResult(true);
                         await serverTask.TimeoutAfter(timeout);
                     } catch { }
-                }, 180_000);
+                }, 300_000);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -135,9 +135,6 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            var timeoutSource = new CancellationTokenSource();
-            timeoutSource.CancelAfter(TimeSpan.FromMinutes(2));
-
             using (HttpClient client = CreateHttpClient())
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;
@@ -180,7 +177,7 @@ namespace System.Net.Http.Functional.Tests
                         clientFinished.SetResult(true);
                         await serverTask;
                     } catch { }
-                }).WithCancellation(timeoutSource.Token);
+                });
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -177,7 +177,7 @@ namespace System.Net.Http.Functional.Tests
                         clientFinished.SetResult(true);
                         await serverTask;
                     } catch { }
-                });
+                }, 120_000);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -177,7 +177,7 @@ namespace System.Net.Http.Functional.Tests
                         clientFinished.SetResult(true);
                         await serverTask;
                     } catch { }
-                }, 300_000);
+                }, 500_000);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -168,7 +168,7 @@ namespace System.Net.Http.Functional.Tests
 
                         Task<HttpResponseMessage> getResponse = client.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token);
                         await responseHeadersSent.Task.TimeoutAfter(timeout);
-                        await Task.Delay(1); // make it more likely that client will have started processing response body
+                        //await Task.Delay(1).TimeoutAfter(timeout); // make it more likely that client will have started processing response body
                         Cancel(mode, client, cts);
                         await getResponse.TimeoutAfter(timeout);
                     }).TimeoutAfter(timeout);

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -884,7 +884,7 @@ namespace System.Net.Test.Common
 
         public override Task CreateServerAsync(Func<GenericLoopbackServer, Uri, Task> funcAsync, int millisecondsTimeout = 60_000, GenericLoopbackOptions options = null)
         {
-            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri), options: CreateOptions(options));
+            return LoopbackServer.CreateServerAsync((server, uri) => funcAsync(server, uri).TimeoutAfter(millisecondsTimeout), options: CreateOptions(options));
         }
 
         private static LoopbackServer.Options CreateOptions(GenericLoopbackOptions options)


### PR DESCRIPTION
It enables GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly test and limits its execution time by 2 minutes.
Fixes #25760 