### PR TITLE
Build failed due to -Werror option

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -495,7 +495,7 @@ int32_t SystemNative_GetNameInfo(const uint8_t* address,
                              (uint32_t)hostLength,
                              (char*)service,
                              (uint32_t)serviceLength,
-                             nativeFlags);
+                             (int)nativeFlags);
     }
     else
     {
@@ -508,7 +508,7 @@ int32_t SystemNative_GetNameInfo(const uint8_t* address,
                              (uint32_t)hostLength,
                              (char*)service,
                              (uint32_t)serviceLength,
-                             nativeFlags);
+                             (int)nativeFlags);
     }
 
     return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
@@ -1489,11 +1489,7 @@ int32_t SystemNative_Bind(intptr_t socket, int32_t protocolType, uint8_t* socket
     int err = bind(
         fd,
         (struct sockaddr*)socketAddress,
-#if BIND_ADDRLEN_UNSIGNED
         (socklen_t)socketAddressLen);
-#else
-        socketAddressLen);
-#endif
 
     return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }

--- a/src/libraries/Native/Unix/System.Native/pal_process.c
+++ b/src/libraries/Native/Unix/System.Native/pal_process.c
@@ -304,9 +304,9 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     // Process is still the clone of this one. This is a best-effort attempt, so ignore any errors.
     // If the child fails to exec we use the pipe to pass the errno to the parent process.
 #if HAVE_PIPE2
-    pipe2(waitForChildToExecPipe, O_CLOEXEC);
+    (void)! pipe2(waitForChildToExecPipe, O_CLOEXEC);
 #else
-    SystemNative_Pipe(waitForChildToExecPipe, PAL_O_CLOEXEC);
+    (void)! SystemNative_Pipe(waitForChildToExecPipe, PAL_O_CLOEXEC);
 #endif
 
     // The fork child must not be signalled until it calls exec(): our signal handlers do not


### PR DESCRIPTION
New compiler versions (both, clang and gcc) might produce more warnings than older version, due to this and the fact that -Werror option is enforced by build system, build might be failed due to minor warnings. This PR fixes such minor warnings.

Fix #32038