### PR TITLE
Make FPU settings configurable for installer

### DIFF
--- a/src/installer/settings.cmake
+++ b/src/installer/settings.cmake
@@ -174,6 +174,18 @@ else()
     add_compile_options(-Wno-unused-local-typedef)
     add_compile_options(-Wno-unused-macros)
     add_compile_options(-Wno-unused-parameter)
+
+    if(CLR_CMAKE_TARGET_ARCH_ARM)
+        if (NOT DEFINED CLR_ARM_FPU_TYPE)
+            set(CLR_ARM_FPU_TYPE vfpv3)
+        endif(NOT DEFINED CLR_ARM_FPU_TYPE)
+
+        if (NOT DEFINED CLR_ARM_FPU_CAPABILITY)
+            set(CLR_ARM_FPU_CAPABILITY 0x7)
+        endif(NOT DEFINED CLR_ARM_FPU_CAPABILITY)
+
+        add_definitions(-DCLR_ARM_FPU_CAPABILITY=${CLR_ARM_FPU_CAPABILITY})
+    endif()
 endif()
 
 # Older CMake doesn't support CMAKE_CXX_STANDARD and GCC/Clang need a switch to enable C++ 11


### PR DESCRIPTION
#32029

@jkotas, seems like `CLR_ARM_FPU_CAPABILITY` change in `eng/common/toolchain.cmake` was overwritten by @dotnet-bot at https://github.com/dotnet/runtime/commit/4528f841896b5e887f1c44cf342008e38c04947d#diff-ee3a7f0d86bfe417f1acbec7d1c0082a. I think the proper way was to push the changes https://github.com/dotnet/arcade/.

`eng/common/toolchain.cmake` is only used in one place in the runtime repo, so I have copied it to `eng/native/` directory, next to where it is used. We can delete this file from dotnet/arcade.