### PR TITLE
Crossgen2: ensure base address >= 4 GiB for 64-bit Windows targets

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
                 if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
                 {
                     // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (CanonTypesModule != null && ((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
+                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
                         return CanonTypesModule;
 
                     // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.

--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
                 if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
                 {
                     // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
+                    if (CanonTypesModule != null && ((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
                         return CanonTypesModule;
 
                     // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -193,7 +193,9 @@ namespace ILCompiler.PEWriter
                 case RelocType.IMAGE_REL_BASED_ARM64_PAGEBASE_REL21:
                     {
                         relocationLength = 4;
-                        delta = (targetRVA - sourceRVA) >> 12;
+                        int sourcePageRVA = sourceRVA & ~0xfff;
+                        // Page delta always fits in 21 bits as long as we use 4-byte RVAs
+                        delta = ((targetRVA - sourcePageRVA) >> 12) & 0x1ffff;
                         break;
                     }
 


### PR DESCRIPTION
Base addresses below 4 GiB are reserved for WoW on x64 and disallowed on ARM64.  If the input assembly was compiled for anycpu, its base address is 32-bit and we need to fix it.

Also fix ADRP's argument calculation for ARM64.