### PR TITLE
[mono] Allow the use of an override directory for LLVM.

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -33,7 +33,7 @@
         <_MonoExtraCXXFLAGS>-O2 -g</_MonoExtraCXXFLAGS>
     </PropertyGroup>
     <PropertyGroup>
-        <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'">$(_MonoConfigureParams) --enable--llvm --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
+        <_MonoConfigureParams Condition="'$(MonoLLVMDir)' != ''">$(_MonoConfigureParams) --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) --enable-maintainer-mode --enable-compile-warnings --with-core=only CFLAGS="$(_MonoExtraCFLAGS)" CXXFLAGS="$(_MonoExtraCXXFLAGS)"</_MonoConfigureParams>
     </PropertyGroup>
 

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MonoObjDir>$(ArtifactsObjDir)mono/$(PlatformConfigPathPart)/</MonoObjDir>
     <MonoEnableLLVM Condition="'$(MonoEnableLLVM)' == ''">false</MonoEnableLLVM>
-    <MonoLLVMDir Condition="'$(MonoEnableLLVM)' == 'true'">$(MonoObjDir)llvm</MonoLLVMDir>
+    <MonoLLVMDir Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">$(MonoObjDir)llvm</MonoLLVMDir>
     <DotNetExec Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</DotNetExec>
     <DotNetExec Condition="'$(DotNetExec)' == ''">dotnet</DotNetExec>
     <LocalDotnetDir>..\..\.dotnet</LocalDotnetDir>
@@ -33,7 +33,7 @@
         <_MonoExtraCXXFLAGS>-O2 -g</_MonoExtraCXXFLAGS>
     </PropertyGroup>
     <PropertyGroup>
-        <_MonoConfigureParams Condition="'$(MonoLLVMDir)' != ''">$(_MonoConfigureParams) --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
+        <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'">$(_MonoConfigureParams) --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) --enable-maintainer-mode --enable-compile-warnings --with-core=only CFLAGS="$(_MonoExtraCFLAGS)" CXXFLAGS="$(_MonoExtraCXXFLAGS)"</_MonoConfigureParams>
     </PropertyGroup>
 
@@ -89,7 +89,7 @@
 
   <Target Name="Restore">
     <MSBuild Projects="$(MonoProjectRoot)netcore\nuget\packages.builds" Targets="Restore" />
-    <MSBuild Condition="'$(MonoEnableLLVM)' == 'true'" Projects="$(MonoProjectRoot)llvm\llvm-init.proj" Targets="Restore" Properties="MonoObjDir=$(MonoObjDir);MonoLLVMDir=$(MonoLLVMDir)" />
+    <MSBuild Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == '$(MonoObjDir)llvm'" Projects="$(MonoProjectRoot)llvm\llvm-init.proj" Targets="Restore" Properties="MonoObjDir=$(MonoObjDir);MonoLLVMDir=$(MonoLLVMDir)" />
   </Target>
 
   <Target Name="Pack">


### PR DESCRIPTION
With this change, a custom LLVM directory can be set via the `MonoLLVMDir` property. When using a custom LLVM directory, llvm-init.proj will be ignored.

`--enable--llvm` (with two dashes) is not a valid mono configure argument, and `--enable-llvm` is implied by `--with-llvm`.