### PR TITLE
Set azure devops variable if any package reports are found and skip copy packages base on that

### DIFF
--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -153,7 +153,8 @@ jobs:
             inputs:
               sourceFolder: $(Build.SourcesDirectory)/artifacts/packages
               targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/packages
-          
+            condition: and(succeeded(), eq(variables['_librariesBuildProducedPackages'], true))
+
           - task: CopyFiles@2
             displayName: Prepare tmp assets to publish
             inputs:

--- a/src/libraries/packages.builds
+++ b/src/libraries/packages.builds
@@ -72,7 +72,7 @@
   <Import Project="$(MSBuildThisFileDirectory)dir.traversal.targets" />
 
   <Target Name="SetAzureDevOpsVariableForBuiltPackages"
-          Condition="'$(OfficialBuildId)' != ''"
+          Condition="'$(ContinuousIntegrationBuild)' == 'true'"
           AfterTargets="BuildAllProjects">
     <ItemGroup>
       <_PackageReports Include="$(PackageReportDir)*.json" />

--- a/src/libraries/packages.builds
+++ b/src/libraries/packages.builds
@@ -70,4 +70,14 @@
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)dir.traversal.targets" />
+
+  <Target Name="SetAzureDevOpsVariableForBuiltPackages"
+          Condition="'$(OfficialBuildId)' != ''"
+          AfterTargets="BuildAllProjects">
+    <ItemGroup>
+      <_PackageReports Include="$(PackageReportDir)*.json" />
+    </ItemGroup>
+
+    <Message Condition="'@(_PackageReports)' != ''" Importance="High" Text="##vso[task.setvariable variable=_librariesBuildProducedPackages]true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/32067

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=515211&_a=summary

cc: @dotnet/runtime-infrastructure 