### PR TITLE
Use ref for stream event in System.Net.Quic

### DIFF
--- a/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
@@ -435,7 +435,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal delegate uint StreamCallbackDelegate(
             IntPtr stream,
             IntPtr context,
-            StreamEvent streamEvent);
+            ref StreamEvent streamEvent);
 
         internal delegate uint StreamOpenDelegate(
             IntPtr connection,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -487,14 +487,14 @@ namespace System.Net.Quic.Implementations.MsQuic
         }
 
         internal static uint NativeCallbackHandler(
-           IntPtr stream,
-           IntPtr context,
-           StreamEvent connectionEventStruct)
+            IntPtr stream,
+            IntPtr context,
+            ref StreamEvent streamEvent)
         {
             var handle = GCHandle.FromIntPtr(context);
             var quicStream = (MsQuicStream)handle.Target;
 
-            return quicStream.HandleEvent(ref connectionEventStruct);
+            return quicStream.HandleEvent(ref streamEvent);
         }
 
         private uint HandleEvent(ref StreamEvent evt)


### PR DESCRIPTION
Found this when debugging why msquic was failing on linux. I'm surprised this worked at all to say the least...

