### PR TITLE
Change COMPlus_DiagnosticsServerTransportPath

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -717,7 +717,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"
 //
 // Diagnostics Server
 //
-RETAIL_CONFIG_STRING_INFO(EXTERNAL_DiagnosticsServerAddress, W("DiagnosticsServerAddress"), "The full path including filename for the OS transport (NamedPipe on Windows; Unix Domain Socket on Linux) to be used by the Diagnostics Server");
+RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_DOTNET_DiagnosticsServerAddress, W("DOTNET_DiagnosticsServerAddress"), "The full path including filename for the OS transport (NamedPipe on Windows; Unix Domain Socket on Linux) to be used by the Diagnostics Server", CLRConfig::DontPrependCOMPlus_);
 
 //
 // LTTng

--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -717,7 +717,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"
 //
 // Diagnostics Server
 //
-RETAIL_CONFIG_STRING_INFO(EXTERNAL_DiagnosticsServerTransportPath, W("DiagnosticsServerTransportPath"), "The full path including filename for the OS transport (NamedPipe on Windows; Unix Domain Socket on Linux) to be used by the Diagnostics Server");
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_DiagnosticsServerAddress, W("DiagnosticsServerAddress"), "The full path including filename for the OS transport (NamedPipe on Windows; Unix Domain Socket on Linux) to be used by the Diagnostics Server");
 
 //
 // LTTng

--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -136,7 +136,7 @@ bool DiagnosticServer::Initialize()
         };
 
         NewArrayHolder<char> address = nullptr;
-        CLRConfigStringHolder wAddress = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DiagnosticsServerAddress);
+        CLRConfigStringHolder wAddress = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DOTNET_DiagnosticsServerAddress);
         int nCharactersWritten = 0;
         if (wAddress != nullptr)
         {

--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -135,24 +135,22 @@ bool DiagnosticServer::Initialize()
                 szMessage);                                           // data2
         };
 
-        // char transportPath[MAX_PATH];
-        NewArrayHolder<char> transportPath = nullptr;
-        CLRConfigStringHolder wTransportPath = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DiagnosticsServerTransportPath);
+        NewArrayHolder<char> address = nullptr;
+        CLRConfigStringHolder wAddress = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_DiagnosticsServerAddress);
         int nCharactersWritten = 0;
-        if (wTransportPath != nullptr)
+        if (wAddress != nullptr)
         {
-            nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wTransportPath, -1, NULL, 0, NULL, NULL);
+            nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wAddress, -1, NULL, 0, NULL, NULL);
             if (nCharactersWritten != 0)
             {
-                transportPath = new char[nCharactersWritten];
-                nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wTransportPath, -1, transportPath, nCharactersWritten, NULL, NULL);
+                address = new char[nCharactersWritten];
+                nCharactersWritten = WideCharToMultiByte(CP_UTF8, 0, wAddress, -1, address, nCharactersWritten, NULL, NULL);
                 assert(nCharactersWritten != 0);
             }
         }
 
         // TODO: Should we handle/assert that (s_pIpc == nullptr)?
-        s_pIpc = IpcStream::DiagnosticsIpc::Create(
-            transportPath, ErrorCallback);
+        s_pIpc = IpcStream::DiagnosticsIpc::Create(address, ErrorCallback);
 
         if (s_pIpc != nullptr)
         {


### PR DESCRIPTION
Change `COMPlus_DiagnosticsServerTransportPath` to `DOTNET_DiagnosticsServerAddress` based on feedback. (Note the lack of `COMPlus_` prefix)

CC @noahfalk @davidfowl @shirhatti 