### PR TITLE
Allow quic listener to accept files paths for options temporarily until msquic supports x509 certs

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -74,6 +74,8 @@ namespace System.Net.Quic
     public class QuicListenerOptions
     {
         public SslServerAuthenticationOptions ServerAuthenticationOptions { get => throw null; set => throw null; }
+        public string CertificateFilePath { get => throw null; set => throw null; }
+        public string PrivateKeyFilePath { get => throw null; set => throw null; }
         public IPEndPoint ListenEndPoint { get => throw null; set => throw null; }
         public int ListenBacklog { get => throw null; set => throw null; }
         public long MaxBidirectionalStreams { get => throw null; set => throw null; }

--- a/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
@@ -477,5 +477,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal uint Length;
             internal byte* Buffer;
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct CertFileParams
+        {
+            internal IntPtr CertificateFilePath;
+            internal IntPtr PrivateKeyFilePath;
+        }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -234,13 +234,13 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             uint secConfigCreateStatus = MsQuicStatusCodes.InternalError;
             uint createConfigStatus;
             IntPtr unmanagedAddr = IntPtr.Zero;
-            CertFileParams fileParams = default;
+            MsQuicNativeMethods.CertFileParams fileParams = default;
 
             try
             {
                 if (certFilePath != null && privateKeyFilePath != null)
                 {
-                    fileParams = new CertFileParams
+                    fileParams = new MsQuicNativeMethods.CertFileParams
                     {
                         CertificateFilePath = Marshal.StringToHGlobalAnsi(certFilePath),
                         PrivateKeyFilePath = Marshal.StringToHGlobalAnsi(privateKeyFilePath)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -239,8 +239,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             {
                 CertFileParams param = new CertFileParams
                 {
-                    CertificateFile = Marshal.StringToHGlobalAnsi(certFilePath),
-                    PrivateKeyFile = Marshal.StringToHGlobalAnsi(privateKeyFilePath)
+                    CertificateFilePath = Marshal.StringToHGlobalAnsi(certFilePath),
+                    PrivateKeyFilePath = Marshal.StringToHGlobalAnsi(privateKeyFilePath)
                 };
 
                 unmanagedAddr = Marshal.AllocHGlobal(Marshal.SizeOf(param));

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -242,8 +242,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 {
                     fileParams = new MsQuicNativeMethods.CertFileParams
                     {
-                        CertificateFilePath = Marshal.StringToHGlobalAnsi(certFilePath),
-                        PrivateKeyFilePath = Marshal.StringToHGlobalAnsi(privateKeyFilePath)
+                        CertificateFilePath = Marshal.StringToCoTaskMemUTF8(certFilePath),
+                        PrivateKeyFilePath = Marshal.StringToCoTaskMemUTF8(privateKeyFilePath)
                     };
 
                     unmanagedAddr = Marshal.AllocHGlobal(Marshal.SizeOf(fileParams));
@@ -316,7 +316,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     Marshal.FreeHGlobal(unmanagedAddr);
                 }
             }
-            
+
             return secConfig;
         }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -303,12 +303,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             {
                 if (fileParams.CertificateFilePath != IntPtr.Zero)
                 {
-                    Marshal.FreeHGlobal(fileParams.CertificateFilePath);
+                    Marshal.FreeCoTaskMem(fileParams.CertificateFilePath);
                 }
 
                 if (fileParams.PrivateKeyFilePath != IntPtr.Zero)
                 {
-                    Marshal.FreeHGlobal(fileParams.PrivateKeyFilePath);
+                    Marshal.FreeCoTaskMem(fileParams.PrivateKeyFilePath);
                 }
 
                 if (unmanagedAddr != IntPtr.Zero)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -86,9 +86,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
         }
 
-        internal async ValueTask SetSecurityConfigForConnection(X509Certificate cert)
+        internal async ValueTask SetSecurityConfigForConnection(X509Certificate cert, string certFilePath, string privateKeyFilePath)
         {
-            _securityConfig = await MsQuicApi.Api.CreateSecurityConfig(cert);
+            _securityConfig = await MsQuicApi.Api.CreateSecurityConfig(cert, certFilePath, privateKeyFilePath);
             // TODO this isn't being set correctly
             MsQuicParameterHelpers.SetSecurityConfig(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.CONNECTION, (uint)QUIC_PARAM_CONN.SEC_CONFIG, _securityConfig.NativeObjPtr);
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -30,6 +30,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         // Ssl listening options (ALPN, cert, etc)
         private SslServerAuthenticationOptions _sslOptions;
 
+        private QuicListenerOptions _options;
         private volatile bool _disposed;
         private IPEndPoint _listenEndPoint;
 
@@ -44,11 +45,11 @@ namespace System.Net.Quic.Implementations.MsQuic
                 SingleWriter = true
             });
 
+            _options = options;
             _sslOptions = options.ServerAuthenticationOptions;
             _listenEndPoint = options.ListenEndPoint;
 
             _ptr = _session.ListenerOpen(options);
-
         }
 
         internal override IPEndPoint ListenEndPoint
@@ -76,7 +77,9 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new QuicOperationAbortedException();
             }
 
-            await connection.SetSecurityConfigForConnection(_sslOptions.ServerCertificate);
+            await connection.SetSecurityConfigForConnection(_sslOptions.ServerCertificate,
+                _options.CertificateFilePath,
+                _options.PrivateKeyFilePath);
 
             if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
             return connection;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListenerOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListenerOptions.cs
@@ -17,6 +17,16 @@ namespace System.Net.Quic
         public SslServerAuthenticationOptions ServerAuthenticationOptions { get; set; }
 
         /// <summary>
+        /// Optional path to certificate file to configure the security configuration.
+        /// </summary>
+        public string CertificateFilePath { get; set; }
+
+        /// <summary>
+        /// Optional path to private key file to configure the security configuration.
+        /// </summary>
+        public string PrivateKeyFilePath { get; set; }
+
+        /// <summary>
         /// The endpoint to listen on.
         /// </summary>
         public IPEndPoint ListenEndPoint { get; set; }


### PR DESCRIPTION
Currently, msquic doesn't support supplying the X509 certificate to configure openssl; the only option is to pass in file paths for the certificate file and the private key file. 

This adds a temporary option to accept a certificate file path and private key file path for the QuicListener. Mostly this is precautionary, if we get msquic support for X509 certs relatively soon, we can revert this change. However, I'd like to be able to have customers be able to try HTTP/3 in Kestrel.
