### PR TITLE
Move crossgen2 user-facing strings to resx

### DIFF
--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -52,110 +52,110 @@ namespace ILCompiler
                 new Argument<FileInfo[]>() 
                 { 
                     Name = "input-file-paths", 
-                    Description = "Input file(s) to compile",
+                    Description = SR.InputFilesToCompile,
                     Arity = arbitraryArity,
                 },
-                new Option(new[] { "--reference", "-r" }, "Reference file(s) for compilation")
+                new Option(new[] { "--reference", "-r" }, SR.ReferenceFiles)
                 { 
                     Argument = new Argument<string[]>() 
                     { 
                         Arity = arbitraryArity
                     } 
                 },
-                new Option(new[] { "--mibc", "-m" }, "Mibc file(s) for profile guided optimization")
+                new Option(new[] { "--mibc", "-m" }, SR.MibcFiles)
                 {
                     Argument = new Argument<string[]>()
                     {
                         Arity = arbitraryArity
                     }
                 },
-                new Option(new[] { "--outputfilepath", "--out", "-o" }, "Output file path")
+                new Option(new[] { "--outputfilepath", "--out", "-o" }, SR.OutputFilePath)
                 {
                     Argument = new Argument<FileInfo>()
                 },
-                new Option(new[] { "--optimize", "-O" }, "Enable optimizations") 
+                new Option(new[] { "--optimize", "-O" }, SR.EnableOptimizationsOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--optimize-space", "--Os" }, "Enable optimizations, favor code space") 
+                new Option(new[] { "--optimize-space", "--Os" }, SR.OptimizeSpaceOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--optimize-time", "--Ot" }, "Enable optimizations, favor code speed"),
-                new Option(new[] { "--inputbubble" }, "True when the entire input forms a version bubble (default = per-assembly bubble)"),
-                new Option(new[] { "--tuning" }, "Generate IBC tuning image") 
+                new Option(new[] { "--optimize-time", "--Ot" }, SR.OptimizeSpeedOption),
+                new Option(new[] { "--inputbubble" }, SR.InputBubbleOption),
+                new Option(new[] { "--tuning" }, SR.TuningImageOption) 
                 {
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--partial" }, "Generate partial image driven by profile") 
+                new Option(new[] { "--partial" }, SR.PartialImageOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--compilebubblegenerics" }, "Compile instantiations from reference modules used in the current module") 
+                new Option(new[] { "--compilebubblegenerics" }, SR.BubbleGenericsOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--dgml-log-file-name", "--dmgllog" }, "Save result of dependency analysis as DGML") 
+                new Option(new[] { "--dgml-log-file-name", "--dmgllog" }, SR.SaveDependencyLogOption) 
                 { 
                     Argument = new Argument<FileInfo>() 
                 },
-                new Option(new[] { "--generate-full-dmgl-log", "--fulllog" }, "Save detailed log of dependency analysis") 
+                new Option(new[] { "--generate-full-dmgl-log", "--fulllog" }, SR.SaveDetailedLogOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--verbose" }, "Enable verbose logging") 
+                new Option(new[] { "--verbose" }, SR.VerboseLoggingOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--systemmodule" }, "System module name (default: System.Private.CoreLib)") 
+                new Option(new[] { "--systemmodule" }, SR.SystemModuleOverrideOption) 
                 { 
                     Argument = new Argument<string>() 
                 },
-                new Option(new[] { "--waitfordebugger" }, "Pause to give opportunity to attach debugger") 
+                new Option(new[] { "--waitfordebugger" }, SR.WaitForDebuggerOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--codegen-options", "--codegenopt" }, "Define a codegen option") 
+                new Option(new[] { "--codegen-options", "--codegenopt" }, SR.CodeGenOptions) 
                 { 
                     Argument = new Argument<string[]>()
                     {
                         Arity = arbitraryArity
                     }
                 },
-                new Option(new[] { "--resilient" }, "Disable behavior where unexpected compilation failures cause overall compilation failure") 
+                new Option(new[] { "--resilient" }, SR.ResilientOption) 
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--targetarch" }, "Target architecture for cross compilation") 
+                new Option(new[] { "--targetarch" }, SR.TargetArchOption) 
                 { 
                     Argument = new Argument<string>() 
                 },
-                new Option(new[] { "--targetos" }, "Target OS for cross compilation") 
+                new Option(new[] { "--targetos" }, SR.TargetOSOption) 
                 { 
                     Argument = new Argument<string>() 
                 },
-                new Option(new[] { "--jitpath" }, "Path to JIT compiler library") 
+                new Option(new[] { "--jitpath" }, SR.JitPathOption) 
                 { 
                     Argument =  new Argument<FileInfo>() 
                 },
-                new Option(new[] { "--singlemethodtypename" }, "Single method compilation: name of the owning type") 
+                new Option(new[] { "--singlemethodtypename" }, SR.SingleMethodTypeName) 
                 { 
                     Argument = new Argument<string>() 
                 },
-                new Option(new[] { "--singlemethodname" }, "Single method compilation: generic arguments to the method") 
+                new Option(new[] { "--singlemethodname" }, SR.SingleMethodMethodName) 
                 { 
                     Argument = new Argument<string>() 
                 },
-                new Option(new[] { "--singlemethodgenericarg" }, "Single method compilation: generic arguments to the method") 
+                new Option(new[] { "--singlemethodgenericarg" }, SR.SingleMethodGenericArgs) 
                 { 
                     // We don't need to override arity here as 255 is the maximum number of generic arguments
                     Argument = new Argument<string[]>()
                 },
-                new Option(new[] { "--parallelism" }, "Maximum number of threads to use during compilation")
+                new Option(new[] { "--parallelism" }, SR.ParalellismOption)
                 { 
                     Argument = new Argument<int>(() => Environment.ProcessorCount)
                 },
-                new Option(new[] { "--map" }, "Generate the map file")
+                new Option(new[] { "--map" }, SR.MapFileOption)
                 {
                     Argument = new Argument<bool>()
                 },

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
@@ -1,0 +1,240 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BubbleGenericsOption" xml:space="preserve">
+    <value>Compile instantiations from reference modules used in the current module</value>
+  </data>
+  <data name="CodeGenOptions" xml:space="preserve">
+    <value>Define a codegen option</value>
+  </data>
+  <data name="DumpReproInstructions" xml:space="preserve">
+    <value>To repro, add following arguments to the command line:</value>
+  </data>
+  <data name="EmittingPEFile" xml:space="preserve">
+    <value>Emitting R2R PE file: {0}</value>
+  </data>
+  <data name="EnableOptimizationsOption" xml:space="preserve">
+    <value>Enable optimizations</value>
+  </data>
+  <data name="GenericArgCountMismatch" xml:space="preserve">
+    <value>Expected {0} generic arguments for method '{1}' on type '{2}'</value>
+  </data>
+  <data name="InputBubbleOption" xml:space="preserve">
+    <value>True when the entire input forms a version bubble (default = per-assembly bubble)</value>
+  </data>
+  <data name="InputFilesToCompile" xml:space="preserve">
+    <value>Input file(s) to compile</value>
+  </data>
+  <data name="JitPathOption" xml:space="preserve">
+    <value>Path to JIT compiler library</value>
+  </data>
+  <data name="MapFileOption" xml:space="preserve">
+    <value>Generate the map file</value>
+  </data>
+  <data name="MethodNotFoundOnType" xml:space="preserve">
+    <value>Method '{0}' not found in '{1}'</value>
+  </data>
+  <data name="MibcFiles" xml:space="preserve">
+    <value>Mibc file(s) for profile guided optimization</value>
+  </data>
+  <data name="MissingOutputFile" xml:space="preserve">
+    <value>Output filename must be specified (/out &lt;file&gt;)</value>
+  </data>
+  <data name="NoInputFiles" xml:space="preserve">
+    <value>No input files specified</value>
+  </data>
+  <data name="OptimizeSpaceOption" xml:space="preserve">
+    <value>Enable optimizations, favor code space</value>
+  </data>
+  <data name="OptimizeSpeedOption" xml:space="preserve">
+    <value>Enable optimizations, favor code speed</value>
+  </data>
+  <data name="OutputFilePath" xml:space="preserve">
+    <value>Output file path</value>
+  </data>
+  <data name="ParalellismOption" xml:space="preserve">
+    <value>Maximum number of threads to use during compilation</value>
+  </data>
+  <data name="PartialImageOption" xml:space="preserve">
+    <value>Generate partial image driven by profile</value>
+  </data>
+  <data name="ProgramError" xml:space="preserve">
+    <value>Error: {0}</value>
+  </data>
+  <data name="ReferenceFiles" xml:space="preserve">
+    <value>Reference file(s) for compilation</value>
+  </data>
+  <data name="ResilientOption" xml:space="preserve">
+    <value>Disable behavior where unexpected compilation failures cause overall compilation failure</value>
+  </data>
+  <data name="SaveDependencyLogOption" xml:space="preserve">
+    <value>Save result of dependency analysis as DGML</value>
+  </data>
+  <data name="SaveDetailedLogOption" xml:space="preserve">
+    <value>Save detailed log of dependency analysis</value>
+  </data>
+  <data name="SingleMethodGenericArgs" xml:space="preserve">
+    <value>Single method compilation: generic arguments to the method</value>
+  </data>
+  <data name="SingleMethodMethodName" xml:space="preserve">
+    <value>Single method compilation: generic arguments to the method</value>
+  </data>
+  <data name="SingleMethodTypeName" xml:space="preserve">
+    <value>Single method compilation: name of the owning type</value>
+  </data>
+  <data name="SystemModuleOverrideOption" xml:space="preserve">
+    <value>System module name (default: System.Private.CoreLib)</value>
+  </data>
+  <data name="TargetArchitectureUnsupported" xml:space="preserve">
+    <value>Target architecture is not supported</value>
+  </data>
+  <data name="TargetArchOption" xml:space="preserve">
+    <value>Target architecture for cross compilation</value>
+  </data>
+  <data name="TargetOSOption" xml:space="preserve">
+    <value>Target OS for cross compilation</value>
+  </data>
+  <data name="TargetOSUnsupported" xml:space="preserve">
+    <value>Target OS is not supported</value>
+  </data>
+  <data name="TuningImageOption" xml:space="preserve">
+    <value>Generate IBC tuning image</value>
+  </data>
+  <data name="TypeAndMethodNameNeeded" xml:space="preserve">
+    <value>Both method name and type name are required parameters for single method mode</value>
+  </data>
+  <data name="TypeNotFound" xml:space="preserve">
+    <value>Type '{0}' not found</value>
+  </data>
+  <data name="VerboseLoggingOption" xml:space="preserve">
+    <value>Enable verbose logging</value>
+  </data>
+  <data name="WaitForDebuggerOption" xml:space="preserve">
+    <value>Pause to give opportunity to attach debugger</value>
+  </data>
+  <data name="WaitingForDebuggerAttach" xml:space="preserve">
+    <value>Waiting for debugger to attach. Press ENTER to continue</value>
+  </data>
+  <data name="WarningIgnoringBubbleGenerics" xml:space="preserve">
+    <value>Warning: ignoring --compilebubblegenerics because --inputbubble was not specified</value>
+  </data>
+  <data name="WarningOverridingOptimizeSpace" xml:space="preserve">
+    <value>Warning: overriding -Ot with -Os</value>
+  </data>
+</root>

--- a/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -16,7 +16,15 @@
     <OutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(BinDir)/crossgen2</OutputPath>
     <GenerateDependencyFile Condition="'$(BuildingInsideVisualStudio)' == 'true'">false</GenerateDependencyFile>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
+
+  <ItemGroup Label="Embedded Resources">
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <GenerateSource>true</GenerateSource>
+      <ClassName>System.SR</ClassName>
+    </EmbeddedResource>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ILCompiler.DependencyAnalysisFramework\ILCompiler.DependencyAnalysisFramework.csproj" />


### PR DESCRIPTION
* Move user-visible strings for command line use and argument validation to a resx file so they can be localized.
* Logging strings are left alone. When we collect logs from customers, we'll want them in English.

cc @dotnet/crossgen-contrib 