### PR TITLE
SmtpClientTest: disable TestZeroTimeout

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,6 +309,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/31719")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and may not time out for low values")]
         [PlatformSpecific(~TestPlatforms.OSX)] // on OSX, not all synchronous operations (e.g. connect) can be aborted by closing the socket.
         public void TestZeroTimeout()


### PR DESCRIPTION
Disable to prevent CI failures.

I'll re-enable the test in case the coredumps we got aren't usable (for me).

cc @stephentoub @ViktorHofer

Contributes to #31719