### PR TITLE
Fix AppDomain.SetPrincipalPolicy bug for new threads

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -133,7 +133,7 @@ namespace System.Threading
         {
             get
             {
-                if (s_asyncLocalPrincipal is null)
+                if (s_asyncLocalPrincipal is null || s_asyncLocalPrincipal.Value is null)
                 {
                     CurrentPrincipal = AppDomain.CurrentDomain.GetThreadPrincipal();
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -133,11 +133,12 @@ namespace System.Threading
         {
             get
             {
-                if (s_asyncLocalPrincipal is null || s_asyncLocalPrincipal.Value is null)
+                IPrincipal? principal = s_asyncLocalPrincipal?.Value;
+                if (principal is null)
                 {
-                    CurrentPrincipal = AppDomain.CurrentDomain.GetThreadPrincipal();
+                    CurrentPrincipal = (principal = AppDomain.CurrentDomain.GetThreadPrincipal());
                 }
-                return s_asyncLocalPrincipal?.Value;
+                return principal;
             }
             set
             {

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -327,7 +327,8 @@ namespace System.Threading.Threads.Tests
             CultureInfo uiCulture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
 
             ExceptionDispatchInfo exceptionFromThread = null;
-            var t = new Thread(() => {
+            var t = new Thread(() =>
+            {
                 try
                 {
                     Assert.Same(culture, Thread.CurrentThread.CurrentCulture);
@@ -432,11 +433,12 @@ namespace System.Threading.Threads.Tests
             {
                 Thread.CurrentPrincipal = new ClaimsPrincipal();
 
-                await Task.Run(async() => {
+                await Task.Run(async () =>
+                {
 
                     Assert.IsType<ClaimsPrincipal>(Thread.CurrentPrincipal);
 
-                    await Task.Run(async() =>
+                    await Task.Run(async () =>
                     {
                         Assert.IsType<ClaimsPrincipal>(Thread.CurrentPrincipal);
 
@@ -465,7 +467,7 @@ namespace System.Threading.Threads.Tests
                 Thread.CurrentPrincipal = new ClaimsPrincipal();
 
                 Task task;
-                using(ExecutionContext.SuppressFlow())
+                using (ExecutionContext.SuppressFlow())
                 {
                     Assert.True(ExecutionContext.IsFlowSuppressed());
 
@@ -1109,6 +1111,86 @@ namespace System.Threading.Threads.Tests
                 AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
                 Assert.Equal(Environment.UserDomainName + @"\" + Environment.UserName, Thread.CurrentPrincipal.Identity.Name);
             }).Dispose();
+        }
+
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void WindowsPrincipalPolicyTest_Windows_NewThreads()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+
+                IPrincipal currentPrincipal = Thread.CurrentPrincipal;
+
+                Assert.NotNull(currentPrincipal);
+                Assert.True(currentPrincipal.Identity.IsAuthenticated);
+
+                var first = new Thread(CheckPrincipal);
+                first.Start(currentPrincipal);
+                first.Join();
+
+                var second = new Thread(CheckPrincipal);
+                second.Start(currentPrincipal);
+                second.Join();
+            }).Dispose();
+
+            static void CheckPrincipal(object principal)
+            {
+                Assert.True(Thread.CurrentPrincipal.Identity.IsAuthenticated);
+                Assert.NotNull(Thread.CurrentPrincipal);
+                Assert.Equal((IPrincipal)principal, Thread.CurrentPrincipal);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void NoPrincipalPolicyTest_Windows_NewThreads()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.NoPrincipal);
+
+                Assert.Null(Thread.CurrentPrincipal);
+
+                var first = new Thread(() => Assert.Null(Thread.CurrentPrincipal));
+                first.Start();
+                first.Join();
+
+                var second = new Thread(() => Assert.Null(Thread.CurrentPrincipal));
+                second.Start();
+                second.Join();
+            }).Dispose();
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void NoPrincipalToWindowsPrincipalPolicyTest_Windows_NewThreads()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.NoPrincipal);
+
+                Assert.Null(Thread.CurrentPrincipal);
+
+                var first = new Thread(() => Assert.Null(Thread.CurrentPrincipal));
+                first.Start();
+                first.Join();
+
+                AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+
+                var second = new Thread(CheckPrincipal);
+                second.Start(Thread.CurrentPrincipal);
+                second.Join();
+            }).Dispose();
+
+            static void CheckPrincipal(object principal)
+            {
+                Assert.True(Thread.CurrentPrincipal.Identity.IsAuthenticated);
+                Assert.NotNull(Thread.CurrentPrincipal);
+                Assert.Equal((IPrincipal)principal, Thread.CurrentPrincipal);
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -1145,8 +1145,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static void NoPrincipalPolicyTest_Windows_NewThreads()
+        public static void NoPrincipalPolicyTest_NewThreads()
         {
             RemoteExecutor.Invoke(() =>
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31717

Old code did 
```cs
return CurrentThread._principal ?? (CurrentThread._principal = AppDomain.CurrentDomain.GetThreadPrincipal());
```
I missed to bring principal null check 😡 

cc: @jkotas @stephentoub 

PS. Debug cross repo is great(lib->coreclr), but it's a bit slow due to debug build of EE, is there a way to build EE in release and only managed part(`System.Private.CoreLib`) in debug?