### PR TITLE
[mini] Wrap check for debug info enabled in ENABLE_NETCORE in all places

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -200,7 +200,9 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
+#ifdef ENABLE_NETCORE
 	opt->enabled = TRUE;
+#endif
 
 	do {
 		if (!*p) {

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -263,7 +263,9 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean top_runtime_invoke_unhandled;
 
+#ifdef ENABLE_NETCORE
 	gboolean enabled;
+#endif
 } MonoDebugOptions;
 
 /*


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18789,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>See if this fixes the weird bug-10127.exe test failure that only occurs on Windows C++ builds.
