### PR TITLE
Fix native CoreCLR build with special feature flags used by Tizen

### DIFF
--- a/src/coreclr/src/debug/daccess/nidump.cpp
+++ b/src/coreclr/src/debug/daccess/nidump.cpp
@@ -8828,7 +8828,7 @@ StandardEntryDisplay:
 }
 
 #ifdef FEATURE_READYTORUN
-IMAGE_DATA_DIRECTORY * NativeImageDumper::FindReadyToRunSection(DWORD type)
+IMAGE_DATA_DIRECTORY * NativeImageDumper::FindReadyToRunSection(ReadyToRunSectionType type)
 {
     PTR_READYTORUN_SECTION pSections = dac_cast<PTR_READYTORUN_SECTION>(dac_cast<TADDR>(m_pReadyToRunHeader) + sizeof(READYTORUN_HEADER));
     for (DWORD i = 0; i < m_pReadyToRunHeader->NumberOfSections; i++)

--- a/src/coreclr/src/debug/daccess/nidump.h
+++ b/src/coreclr/src/debug/daccess/nidump.h
@@ -244,7 +244,7 @@ private:
     NativeFormat::NativeReader  m_nativeReader;
     NativeFormat::NativeArray   m_methodDefEntryPoints;
 
-    IMAGE_DATA_DIRECTORY * FindReadyToRunSection(DWORD type);
+    IMAGE_DATA_DIRECTORY * FindReadyToRunSection(ReadyToRunSectionType type);
 
 public:
     void DumpReadyToRun();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/32109

/cc @viewizard - if by any chance you could locally double-check this indeed fixes your issue, that would be just awesome.

Thanks

Tomas

P.S. Apparently the key ingredient for reproing this is the feature flag <code>FEATURE_PREJIT</code> without which the nidump module is not getting built at all. I'm wondering whether it might make sense to turn this flag on for some of our lab runs (or perhaps create a dedicated job using it) to watch out for similar future regressions.