### PR TITLE
[mono] Change library id to @rpath/libcoreclr.dylib when copying

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -85,6 +85,7 @@
           DestinationFiles="%(_MonoRuntimeArtifacts.Destination)"
           SkipUnchangedFiles="true" />
 
+    <Exec Condition="'$(TargetsOSX)' == 'true'" Command="install_name_tool -id @rpath/$(_CoreClrFileName) %(_MonoRuntimeArtifacts.Destination)" />
   </Target>
 
   <Target Name="Restore">


### PR DESCRIPTION
Imitates what we do in mac.mk