### PR TITLE
Simplify signature context management in Crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2232,7 +2232,7 @@ namespace Internal.JitInterface
                         
                         // Static fields outside of the version bubble need to be accessed using the ENCODE_FIELD_ADDRESS
                         // helper in accordance with ZapInfo::getFieldInfo in CoreCLR.
-                        pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldAddress(field, GetSignatureContext()));
+                        pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldAddress(field));
 
                         pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE;
 
@@ -2246,7 +2246,7 @@ namespace Internal.JitInterface
                     {
                         pResult->fieldLookup = CreateConstLookupToSymbol(
 #if READYTORUN
-                            _compilation.SymbolNodeFactory.CreateReadyToRunHelper(helperId, field.OwningType, GetSignatureContext())
+                            _compilation.SymbolNodeFactory.CreateReadyToRunHelper(helperId, field.OwningType)
 #else
                             _compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType)
 #endif

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -22,8 +22,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly bool _useInstantiatingStub;
 
-        private readonly SignatureContext _signatureContext;
-
         public DelayLoadHelperMethodImport(
             NodeFactory factory, 
             ImportSectionNode importSectionNode, 
@@ -32,13 +30,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             bool useVirtualCall,
             bool useInstantiatingStub,
             Signature instanceSignature, 
-            SignatureContext signatureContext,
             string callSite = null)
             : base(factory, importSectionNode, helper, instanceSignature, useVirtualCall, callSite)
         {
             _method = method;
             _useInstantiatingStub = useInstantiatingStub;
-            _signatureContext = signatureContext;
         }
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
@@ -55,8 +51,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     new MethodWithToken(canonMethod, _method.Token, constrainedType: null),
                     isUnboxingStub: false,
                     isInstantiatingStub: false,
-                    isPrecodeImportRequired: false,
-                    signatureContext: _signatureContext);
+                    isPrecodeImportRequired: false);
                 yield return new DependencyListEntry(canonMethodNode, "Canonical method for instantiating stub");
             }
         }
@@ -69,10 +64,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             DelayLoadHelperMethodImport otherNode = (DelayLoadHelperMethodImport)other;
             int result = _useInstantiatingStub.CompareTo(otherNode._useInstantiatingStub);
-            if (result != 0)
-                return result;
-
-            result = _signatureContext.CompareTo(otherNode._signatureContext, comparer);
             if (result != 0)
                 return result;
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -17,22 +17,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly ModuleToken _methodToken;
 
-        private readonly SignatureContext _signatureContext;
-
         public DelegateCtorSignature(
             TypeDesc delegateType,
             IMethodNode targetMethod,
-            ModuleToken methodToken,
-            SignatureContext signatureContext)
+            ModuleToken methodToken)
         {
             _delegateType = delegateType;
             _targetMethod = targetMethod;
             _methodToken = methodToken;
-            _signatureContext = signatureContext;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
-            signatureContext.Resolver.CompilerContext.EnsureLoadableType(delegateType);
-            signatureContext.Resolver.CompilerContext.EnsureLoadableMethod(targetMethod.Method);
+            CompilerTypeSystemContext compilerContext = (CompilerTypeSystemContext)delegateType.Context;
+            compilerContext.EnsureLoadableType(delegateType);
+            compilerContext.EnsureLoadableMethod(targetMethod.Method);
         }
 
         public override int ClassCode => 99885741;
@@ -44,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (!relocsOnly)
             {
-                SignatureContext innerContext = builder.EmitFixup(factory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, _signatureContext);
+                SignatureContext innerContext = builder.EmitFixup(factory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, factory.SignatureContext);
 
                 builder.EmitMethodSignature(
                     new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null),
@@ -93,11 +90,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (result != 0)
                 return result;
 
-            result = _methodToken.CompareTo(otherNode._methodToken);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return _methodToken.CompareTo(otherNode._methodToken);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -18,8 +18,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             bool isUnboxingStub,
-            bool isInstantiatingStub,
-            SignatureContext signatureContext)
+            bool isInstantiatingStub)
             : base(
                   factory,
                   factory.MethodImports,
@@ -28,8 +27,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                       fixupKind,
                       method,
                       isUnboxingStub,
-                      isInstantiatingStub,
-                      signatureContext))
+                      isInstantiatingStub))
         {
             _method = method;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -18,16 +18,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly FieldDesc _fieldDesc;
 
-        private readonly SignatureContext _signatureContext;
-
-        public FieldFixupSignature(ReadyToRunFixupKind fixupKind, FieldDesc fieldDesc, SignatureContext signatureContext)
+        public FieldFixupSignature(ReadyToRunFixupKind fixupKind, FieldDesc fieldDesc)
         {
             _fixupKind = fixupKind;
             _fieldDesc = fieldDesc;
-            _signatureContext = signatureContext;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
-            signatureContext.Resolver.CompilerContext.EnsureLoadableType(fieldDesc.OwningType);
+            ((CompilerTypeSystemContext)fieldDesc.Context).EnsureLoadableType(fieldDesc.OwningType);
         }
 
         public override int ClassCode => 271828182;
@@ -40,8 +37,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-                EcmaModule targetModule = _signatureContext.GetTargetModule(_fieldDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, _signatureContext);
+                EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_fieldDesc);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
 
                 dataBuilder.EmitFieldSignature(_fieldDesc, innerContext);
             }
@@ -62,11 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (result != 0)
                 return result;
 
-            result = comparer.Compare(_fieldDesc, otherNode._fieldDesc);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return comparer.Compare(_fieldDesc, otherNode._fieldDesc);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -27,16 +27,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly GenericContext _methodContext;
 
-        private readonly SignatureContext _signatureContext;
-
         public GenericLookupSignature(
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             TypeDesc typeArgument,
             MethodWithToken methodArgument,
             FieldDesc fieldArgument,
-            GenericContext methodContext,
-            SignatureContext signatureContext)
+            GenericContext methodContext)
         {
             Debug.Assert(typeArgument != null || methodArgument != null || fieldArgument != null);
             _runtimeLookupKind = runtimeLookupKind;
@@ -45,7 +42,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _methodArgument = methodArgument;
             _fieldArgument = fieldArgument;
             _methodContext = methodContext;
-            _signatureContext = signatureContext;
         }
 
         public override int ClassCode => 258608008;
@@ -65,11 +61,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             else if (_typeArgument != null)
             {
-                targetModule = _signatureContext.GetTargetModule(_typeArgument);
+                targetModule = factory.SignatureContext.GetTargetModule(_typeArgument);
             }
             else if (_fieldArgument != null)
             {
-                targetModule = _signatureContext.GetTargetModule(_fieldArgument);
+                targetModule = factory.SignatureContext.GetTargetModule(_fieldArgument);
             }
             else
             {
@@ -101,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);
 
-            SignatureContext innerContext = dataBuilder.EmitFixup(factory, fixupToEmit, targetModule, _signatureContext);
+            SignatureContext innerContext = dataBuilder.EmitFixup(factory, fixupToEmit, targetModule, factory.SignatureContext);
             if (contextTypeToEmit != null)
             {
                 dataBuilder.EmitTypeSignature(contextTypeToEmit, innerContext);
@@ -214,11 +210,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     return result;
             }
 
-            result = comparer.Compare(_methodContext.ContextMethod, otherNode._methodContext.ContextMethod);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return comparer.Compare(_methodContext.ContextMethod, otherNode._methodContext.ContextMethod);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -53,8 +53,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
 
                     bool enforceOwningType = false;
-                    ModuleToken moduleToken = method.SignatureContext.GetModuleTokenForMethod(method.Method.GetTypicalMethodDefinition());
-                    if (moduleToken.Module != factory.InputModuleContext.GlobalContext)
+                    ModuleToken moduleToken = factory.SignatureContext.GetModuleTokenForMethod(method.Method.GetTypicalMethodDefinition());
+                    if (moduleToken.Module != factory.SignatureContext.GlobalContext)
                     {
                         enforceOwningType = true;
                     }
@@ -64,7 +64,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         new MethodWithToken(method.Method, moduleToken, constrainedType: null),
                         enforceDefEncoding: true,
                         enforceOwningType,
-                        method.SignatureContext,
+                        factory.SignatureContext,
                         isUnboxingStub: false, 
                         isInstantiatingStub: false);
                     byte[] signature = signatureBuilder.ToArray();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
@@ -21,8 +21,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             MethodWithToken method,
             MethodWithGCInfo localMethod,
             bool isUnboxingStub,
-            bool isInstantiatingStub,
-            SignatureContext signatureContext)
+            bool isInstantiatingStub)
             : base(
                   factory,
                   factory.MethodImports,
@@ -31,8 +30,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                       fixupKind,
                       method,
                       isUnboxingStub,
-                      isInstantiatingStub,
-                      signatureContext))
+                      isInstantiatingStub))
         {
             _localMethod = localMethod;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -17,7 +17,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public readonly MethodGCInfoNode GCInfoNode;
 
         private readonly MethodDesc _method;
-        public SignatureContext SignatureContext { get; }
 
         private ObjectData _methodCode;
         private FrameInfo[] _frameInfos;
@@ -29,12 +28,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private List<ISymbolNode> _fixups;
         private MethodDesc[] _inlinedMethods;
 
-        public MethodWithGCInfo(MethodDesc methodDesc, SignatureContext signatureContext)
+        public MethodWithGCInfo(MethodDesc methodDesc)
         {
             GCInfoNode = new MethodGCInfoNode(this);
             _fixups = new List<ISymbolNode>();
             _method = methodDesc;
-            SignatureContext = signatureContext;
         }
 
         public void SetCode(ObjectData data)
@@ -294,11 +292,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             MethodWithGCInfo otherNode = (MethodWithGCInfo)other;
-            int result = comparer.Compare(_method, otherNode._method);
-            if (result != 0)
-                return result;
-
-            return SignatureContext.CompareTo(otherNode.SignatureContext, comparer);
+            return comparer.Compare(_method, otherNode._method);
         }
 
         public void InitializeInliningInfo(MethodDesc[] inlinedMethods)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -12,15 +12,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     public class NewArrayFixupSignature : Signature
     {
         private readonly ArrayType _arrayType;
-        private readonly SignatureContext _signatureContext;
 
-        public NewArrayFixupSignature(ArrayType arrayType, SignatureContext signatureContext)
+        public NewArrayFixupSignature(ArrayType arrayType)
         {
             _arrayType = arrayType;
-            _signatureContext = signatureContext;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
-            signatureContext.Resolver.CompilerContext.EnsureLoadableType(arrayType);
+            ((CompilerTypeSystemContext)arrayType.Context).EnsureLoadableType(arrayType);
         }
 
         public override int ClassCode => 815543321;
@@ -33,8 +31,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-                EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
-                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewArray, targetModule, _signatureContext);
+                EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_arrayType);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewArray, targetModule, factory.SignatureContext);
                 dataBuilder.EmitTypeSignature(_arrayType, innerContext);
             }
 
@@ -51,11 +49,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             NewArrayFixupSignature otherNode = (NewArrayFixupSignature)other;
-            int result = comparer.Compare(_arrayType, otherNode._arrayType);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return comparer.Compare(_arrayType, otherNode._arrayType);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/NewObjectFixupSignature.cs
@@ -12,15 +12,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     public class NewObjectFixupSignature : Signature
     {
         private readonly TypeDesc _typeDesc;
-        private readonly SignatureContext _signatureContext;
 
-        public NewObjectFixupSignature(TypeDesc typeDesc, SignatureContext signatureContext)
+        public NewObjectFixupSignature(TypeDesc typeDesc)
         {
             _typeDesc = typeDesc;
-            _signatureContext = signatureContext;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
-            signatureContext.Resolver.CompilerContext.EnsureLoadableType(typeDesc);
+            ((CompilerTypeSystemContext)typeDesc.Context).EnsureLoadableType(typeDesc);
         }
 
         public override int ClassCode => 551247760;
@@ -33,8 +31,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-                EcmaModule targetModule = _signatureContext.GetTargetModule(_typeDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewObject, targetModule, _signatureContext);
+                EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_typeDesc);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.NewObject, targetModule, factory.SignatureContext);
                 dataBuilder.EmitTypeSignature(_typeDesc, innerContext);
             }
 
@@ -51,11 +49,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             NewObjectFixupSignature otherNode = (NewObjectFixupSignature)other;
-            int result = comparer.Compare(_typeDesc, otherNode._typeDesc);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return comparer.Compare(_typeDesc, otherNode._typeDesc);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
@@ -22,16 +22,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             MethodWithToken method,
             MethodWithGCInfo localMethod,
             bool isUnboxingStub,
-            bool isInstantiatingStub,
-            SignatureContext signatureContext) :
+            bool isInstantiatingStub) :
             base (
                 factory,
                 factory.MethodSignature(
                       fixupKind,
                       method,
                       isUnboxingStub,
-                      isInstantiatingStub,
-                      signatureContext)
+                      isInstantiatingStub)
             )
         {
             _localMethod = localMethod;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImport.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImport.cs
@@ -10,8 +10,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private readonly ModuleToken _token;
 
-        public StringImport(ImportSectionNode table, ModuleToken token, SignatureContext signatureContext)
-            : base(table, new StringImportSignature(token, signatureContext))
+        public StringImport(ImportSectionNode table, ModuleToken token)
+            : base(table, new StringImportSignature(token))
         {
             _token = token;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/StringImportSignature.cs
@@ -11,12 +11,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private readonly ModuleToken _token;
 
-        private readonly SignatureContext _signatureContext;
-
-        public StringImportSignature(ModuleToken token, SignatureContext signatureContext)
+        public StringImportSignature(ModuleToken token)
         {
             _token = token;
-            _signatureContext = signatureContext;
         }
 
         public override int ClassCode => 324832559;
@@ -29,7 +26,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-                dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.StringHandle, _token.Module, _signatureContext);
+                dataBuilder.EmitFixup(factory, ReadyToRunFixupKind.StringHandle, _token.Module, factory.SignatureContext);
                 dataBuilder.EmitUInt(_token.TokenRid);
             }
 
@@ -45,10 +42,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             StringImportSignature otherNode = (StringImportSignature)other;
-            int result = _signatureContext.CompareTo(otherNode._signatureContext, comparer);
-            if (result != 0)
-                return result;
-
             return _token.CompareTo(otherNode._token);
         }
     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -17,16 +17,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly TypeDesc _typeDesc;
 
-        private readonly SignatureContext _signatureContext;
-
-        public TypeFixupSignature(ReadyToRunFixupKind fixupKind, TypeDesc typeDesc, SignatureContext signatureContext)
+        public TypeFixupSignature(ReadyToRunFixupKind fixupKind, TypeDesc typeDesc)
         {
             _fixupKind = fixupKind;
             _typeDesc = typeDesc;
-            _signatureContext = signatureContext;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
-            signatureContext.Resolver.CompilerContext.EnsureLoadableType(typeDesc);
+            ((CompilerTypeSystemContext)typeDesc.Context).EnsureLoadableType(typeDesc);
         }
 
         public override int ClassCode => 255607008;
@@ -39,8 +36,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 dataBuilder.AddSymbol(this);
 
-                EcmaModule targetModule = _signatureContext.GetTargetModule(_typeDesc);
-                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, _signatureContext);
+                EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_typeDesc);
+                SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
                 dataBuilder.EmitTypeSignature(_typeDesc, innerContext);
             }
 
@@ -61,11 +58,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (result != 0)
                 return result;
 
-            result = comparer.Compare(_typeDesc, otherNode._typeDesc);
-            if (result != 0)
-                return result;
-
-            return _signatureContext.CompareTo(otherNode._signatureContext, comparer);
+            return comparer.Compare(_typeDesc, otherNode._typeDesc);
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -47,36 +47,36 @@ namespace ILCompiler.DependencyAnalysis
 
         private void CreateNodeCaches()
         {
-            _importStrings = new NodeCache<ModuleTokenAndSignatureContext, ISymbolNode>(key =>
+            _importStrings = new NodeCache<ModuleToken, ISymbolNode>(key =>
             {
-                return new StringImport(_codegenNodeFactory.StringImports, key.ModuleToken, key.SignatureContext);
+                return new StringImport(_codegenNodeFactory.StringImports, key);
             });
 
             _r2rHelpers = new NodeCache<ReadyToRunHelperKey, ISymbolNode>(CreateReadyToRunHelper);
 
-            _fieldAddressCache = new NodeCache<FieldAndSignatureContext, ISymbolNode>(key =>
+            _fieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
             {
                 return new DelayLoadHelperImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.HelperImports,
                     ReadyToRunHelper.DelayLoad_Helper,
-                    new FieldFixupSignature(ReadyToRunFixupKind.FieldAddress, key.Field, key.SignatureContext)
+                    new FieldFixupSignature(ReadyToRunFixupKind.FieldAddress, key)
                 );
             });
 
-            _fieldOffsetCache = new NodeCache<FieldAndSignatureContext, ISymbolNode>(key =>
+            _fieldOffsetCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
-                    new FieldFixupSignature(ReadyToRunFixupKind.FieldOffset, key.Field, key.SignatureContext)
+                    new FieldFixupSignature(ReadyToRunFixupKind.FieldOffset, key)
                 );
             });
 
-            _fieldBaseOffsetCache = new NodeCache<TypeAndSignatureContext, ISymbolNode>(key =>
+            _fieldBaseOffsetCache = new NodeCache<TypeDesc, ISymbolNode>(key =>
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
-                    _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.FieldBaseOffset, key.Type, key.SignatureContext)
+                    _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.FieldBaseOffset, key)
                 );
             });
 
@@ -91,26 +91,23 @@ namespace ILCompiler.DependencyAnalysis
                     useInstantiatingStub: false,
                     _codegenNodeFactory.MethodSignature(ReadyToRunFixupKind.VirtualEntry,
                         cellKey.Method,
-                        cellKey.IsUnboxingStub, isInstantiatingStub: false, cellKey.SignatureContext),
-                    cellKey.SignatureContext,
+                        cellKey.IsUnboxingStub, isInstantiatingStub: false),
                     cellKey.CallSite);
             });
 
             _delegateCtors = new NodeCache<TypeAndMethod, ISymbolNode>(ctorKey =>
             {
-                SignatureContext signatureContext = ctorKey.SignatureContext;
                 IMethodNode targetMethodNode = _codegenNodeFactory.MethodEntrypoint(
                     ctorKey.Method,
                     isUnboxingStub: false,
                     isInstantiatingStub: ctorKey.Method.Method.HasInstantiation,
-                    isPrecodeImportRequired: false,
-                    signatureContext: signatureContext);
+                    isPrecodeImportRequired: false);
 
                 return new DelayLoadHelperImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.HelperImports,
                     ReadyToRunHelper.DelayLoad_Helper_ObjObj,
-                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Token, signatureContext));
+                    new DelegateCtorSignature(ctorKey.Type, targetMethodNode, ctorKey.Method.Token));
             });
 
             _genericLookupHelpers = new NodeCache<GenericLookupKey, ISymbolNode>(key =>
@@ -125,8 +122,7 @@ namespace ILCompiler.DependencyAnalysis
                         key.TypeArgument,
                         key.MethodArgument,
                         key.FieldArgument,
-                        key.MethodContext,
-                        key.SignatureContext));
+                        key.MethodContext));
             });
 
             _pInvokeTargetNodes = new NodeCache<PInvokeTargetKey, ISymbolNode>(key =>
@@ -136,65 +132,32 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory.MethodSignature(
                         key.IsIndirect ? ReadyToRunFixupKind.IndirectPInvokeTarget : ReadyToRunFixupKind.PInvokeTarget,
                         key.MethodWithToken,
-                        signatureContext: key.SignatureContext,
                         isUnboxingStub: false,
                         isInstantiatingStub: false));
             });
         }
 
-        private struct ModuleTokenAndSignatureContext : IEquatable<ModuleTokenAndSignatureContext>
+        private NodeCache<ModuleToken, ISymbolNode> _importStrings;
+
+        public ISymbolNode StringLiteral(ModuleToken moduleToken)
         {
-            public readonly ModuleToken ModuleToken;
-            public readonly SignatureContext SignatureContext;
-
-            public ModuleTokenAndSignatureContext(ModuleToken moduleToken, SignatureContext signatureContext)
-            {
-                ModuleToken = moduleToken;
-                SignatureContext = signatureContext;
-            }
-
-            public bool Equals(ModuleTokenAndSignatureContext other)
-            {
-                return ModuleToken.Equals(other.ModuleToken)
-                    && SignatureContext.Equals(other.SignatureContext);
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is ModuleTokenAndSignatureContext other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                return ModuleToken.GetHashCode() ^ (SignatureContext.GetHashCode() * 31);
-            }
-        }
-
-        private NodeCache<ModuleTokenAndSignatureContext, ISymbolNode> _importStrings;
-
-        public ISymbolNode StringLiteral(ModuleToken moduleToken, SignatureContext signatureContext)
-        {
-            return _importStrings.GetOrAdd(new ModuleTokenAndSignatureContext(moduleToken, signatureContext));
+            return _importStrings.GetOrAdd(moduleToken);
         }
 
         private struct ReadyToRunHelperKey
         {
             public readonly ReadyToRunHelperId Id;
             public readonly object Target;
-            public readonly SignatureContext SignatureContext;
 
-            public ReadyToRunHelperKey(ReadyToRunHelperId id, object target, SignatureContext signatureContext)
+            public ReadyToRunHelperKey(ReadyToRunHelperId id, object target)
             {
                 Id = id;
                 Target = target;
-                SignatureContext = signatureContext;
             }
 
             public bool Equals(ReadyToRunHelperKey other)
             {
-                return Id == other.Id
-                    && Target.Equals(other.Target)
-                    && SignatureContext.Equals(other.SignatureContext);
+                return Id == other.Id && Target.Equals(other.Target);
             }
 
             public override bool Equals(object obj)
@@ -204,9 +167,7 @@ namespace ILCompiler.DependencyAnalysis
 
             public override int GetHashCode()
             {
-                return Id.GetHashCode()
-                    ^ (Target.GetHashCode() * 23)
-                    ^ (SignatureContext.GetHashCode() * 31);
+                return Id.GetHashCode() ^ (Target.GetHashCode() * 23);
             }
         }
 
@@ -217,137 +178,137 @@ namespace ILCompiler.DependencyAnalysis
             switch (key.Id)
             {
                 case ReadyToRunHelperId.NewHelper:
-                    return CreateNewHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateNewHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.NewArr1:
-                    return CreateNewArrayHelper((ArrayType)key.Target, key.SignatureContext);
+                    return CreateNewArrayHelper((ArrayType)key.Target);
 
                 case ReadyToRunHelperId.GetGCStaticBase:
-                    return CreateGCStaticBaseHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateGCStaticBaseHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.GetNonGCStaticBase:
-                    return CreateNonGCStaticBaseHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateNonGCStaticBaseHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.GetThreadStaticBase:
-                    return CreateThreadGcStaticBaseHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateThreadGcStaticBaseHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.GetThreadNonGcStaticBase:
-                    return CreateThreadNonGcStaticBaseHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateThreadNonGcStaticBaseHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.IsInstanceOf:
-                    return CreateIsInstanceOfHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateIsInstanceOfHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.CastClass:
-                    return CreateCastClassHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateCastClassHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.TypeHandle:
-                    return CreateTypeHandleHelper((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateTypeHandleHelper((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.MethodHandle:
-                    return CreateMethodHandleHelper((MethodWithToken)key.Target, key.SignatureContext);
+                    return CreateMethodHandleHelper((MethodWithToken)key.Target);
 
                 case ReadyToRunHelperId.FieldHandle:
-                    return CreateFieldHandleHelper((FieldDesc)key.Target, key.SignatureContext);
+                    return CreateFieldHandleHelper((FieldDesc)key.Target);
 
                 case ReadyToRunHelperId.CctorTrigger:
-                    return CreateCctorTrigger((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateCctorTrigger((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.TypeDictionary:
-                    return CreateTypeDictionary((TypeDesc)key.Target, key.SignatureContext);
+                    return CreateTypeDictionary((TypeDesc)key.Target);
 
                 case ReadyToRunHelperId.MethodDictionary:
-                    return CreateMethodDictionary((MethodWithToken)key.Target, key.SignatureContext);
+                    return CreateMethodDictionary((MethodWithToken)key.Target);
 
                 default:
                     throw new NotImplementedException(key.Id.ToString());
             }
         }
 
-        public ISymbolNode CreateReadyToRunHelper(ReadyToRunHelperId id, object target, SignatureContext signatureContext)
+        public ISymbolNode CreateReadyToRunHelper(ReadyToRunHelperId id, object target)
         {
-            return _r2rHelpers.GetOrAdd(new ReadyToRunHelperKey(id, target, signatureContext));
+            return _r2rHelpers.GetOrAdd(new ReadyToRunHelperKey(id, target));
         }
 
-        private ISymbolNode CreateNewHelper(TypeDesc type, SignatureContext signatureContext)
-        {
-            return new DelayLoadHelperImport(
-                _codegenNodeFactory,
-                _codegenNodeFactory.HelperImports,
-                ReadyToRunHelper.DelayLoad_Helper,
-                new NewObjectFixupSignature(type, signatureContext));
-        }
-
-        private ISymbolNode CreateNewArrayHelper(ArrayType type, SignatureContext signatureContext)
+        private ISymbolNode CreateNewHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                new NewArrayFixupSignature(type, signatureContext));
+                new NewObjectFixupSignature(type));
         }
 
-        private ISymbolNode CreateGCStaticBaseHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateNewArrayHelper(ArrayType type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.StaticBaseGC, type, signatureContext));
+                new NewArrayFixupSignature(type));
         }
 
-        private ISymbolNode CreateNonGCStaticBaseHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateGCStaticBaseHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.StaticBaseNonGC, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.StaticBaseGC, type));
         }
 
-        private ISymbolNode CreateThreadGcStaticBaseHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateNonGCStaticBaseHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ThreadStaticBaseGC, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.StaticBaseNonGC, type));
         }
 
-        private ISymbolNode CreateThreadNonGcStaticBaseHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateThreadGcStaticBaseHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ThreadStaticBaseNonGC, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ThreadStaticBaseGC, type));
         }
 
-        private ISymbolNode CreateIsInstanceOfHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateThreadNonGcStaticBaseHelper(TypeDesc type)
+        {
+            return new DelayLoadHelperImport(
+                _codegenNodeFactory,
+                _codegenNodeFactory.HelperImports,
+                ReadyToRunHelper.DelayLoad_Helper,
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ThreadStaticBaseNonGC, type));
+        }
+
+        private ISymbolNode CreateIsInstanceOfHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper_Obj,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.IsInstanceOf, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.IsInstanceOf, type));
         }
 
-        private ISymbolNode CreateCastClassHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateCastClassHelper(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper_Obj,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ChkCast, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.ChkCast, type));
         }
 
-        private ISymbolNode CreateTypeHandleHelper(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateTypeHandleHelper(TypeDesc type)
         {
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.TypeHandle, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.TypeHandle, type));
         }
 
-        private ISymbolNode CreateMethodHandleHelper(MethodWithToken method, SignatureContext signatureContext)
+        private ISymbolNode CreateMethodHandleHelper(MethodWithToken method)
         {
             bool useUnboxingStub = method.Method.IsUnboxingThunk();
             if (useUnboxingStub)
@@ -363,35 +324,34 @@ namespace ILCompiler.DependencyAnalysis
                     ReadyToRunFixupKind.MethodHandle,
                     method,
                     isUnboxingStub: useUnboxingStub,
-                    isInstantiatingStub: useInstantiatingStub,
-                    signatureContext));
+                    isInstantiatingStub: useInstantiatingStub));
         }
 
-        private ISymbolNode CreateFieldHandleHelper(FieldDesc field, SignatureContext signatureContext)
+        private ISymbolNode CreateFieldHandleHelper(FieldDesc field)
         {
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
-                new FieldFixupSignature(ReadyToRunFixupKind.FieldHandle, field, signatureContext));
+                new FieldFixupSignature(ReadyToRunFixupKind.FieldHandle, field));
         }
 
-        private ISymbolNode CreateCctorTrigger(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateCctorTrigger(TypeDesc type)
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.HelperImports,
                 ReadyToRunHelper.DelayLoad_Helper,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.CctorTrigger, type, signatureContext));
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.CctorTrigger, type));
         }
 
-        private ISymbolNode CreateTypeDictionary(TypeDesc type, SignatureContext signatureContext)
+        private ISymbolNode CreateTypeDictionary(TypeDesc type)
         {
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
-                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.TypeDictionary, type, signatureContext)
+                _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.TypeDictionary, type)
             );
         }
 
-        private ISymbolNode CreateMethodDictionary(MethodWithToken method, SignatureContext signatureContext)
+        private ISymbolNode CreateMethodDictionary(MethodWithToken method)
         {
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
@@ -399,106 +359,48 @@ namespace ILCompiler.DependencyAnalysis
                     ReadyToRunFixupKind.MethodDictionary, 
                     method, 
                     isUnboxingStub: false,
-                    isInstantiatingStub: true,
-                    signatureContext));
+                    isInstantiatingStub: true));
         }
 
-        private struct FieldAndSignatureContext : IEquatable<FieldAndSignatureContext>
+        private NodeCache<FieldDesc, ISymbolNode> _fieldAddressCache;
+
+        public ISymbolNode FieldAddress(FieldDesc fieldDesc)
         {
-            public readonly FieldDesc Field;
-            public readonly SignatureContext SignatureContext;
-
-            public FieldAndSignatureContext(FieldDesc fieldDesc, SignatureContext signatureContext)
-            {
-                Field = fieldDesc;
-                SignatureContext = signatureContext;
-            }
-
-            public bool Equals(FieldAndSignatureContext other)
-            {
-                return Field.Equals(other.Field) &&
-                       SignatureContext.Equals(other.SignatureContext);
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is FieldAndSignatureContext other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                return Field.GetHashCode() ^ (SignatureContext.GetHashCode() * 31);
-            }
+            return _fieldAddressCache.GetOrAdd(fieldDesc);
         }
 
-        private NodeCache<FieldAndSignatureContext, ISymbolNode> _fieldAddressCache;
+        private NodeCache<FieldDesc, ISymbolNode> _fieldOffsetCache;
 
-        public ISymbolNode FieldAddress(FieldDesc fieldDesc, SignatureContext signatureContext)
+        public ISymbolNode FieldOffset(FieldDesc fieldDesc)
         {
-            return _fieldAddressCache.GetOrAdd(new FieldAndSignatureContext(fieldDesc, signatureContext));
+            return _fieldOffsetCache.GetOrAdd(fieldDesc);
         }
 
-        private NodeCache<FieldAndSignatureContext, ISymbolNode> _fieldOffsetCache;
+        private NodeCache<TypeDesc, ISymbolNode> _fieldBaseOffsetCache;
 
-        public ISymbolNode FieldOffset(FieldDesc fieldDesc, SignatureContext signatureContext)
+        public ISymbolNode FieldBaseOffset(TypeDesc typeDesc)
         {
-            return _fieldOffsetCache.GetOrAdd(new FieldAndSignatureContext(fieldDesc, signatureContext));
-        }
-
-        private struct TypeAndSignatureContext : IEquatable<TypeAndSignatureContext>
-        {
-            public readonly TypeDesc Type;
-            public readonly SignatureContext SignatureContext;
-
-            public TypeAndSignatureContext(TypeDesc typeDesc, SignatureContext signatureContext)
-            {
-                Type = typeDesc;
-                SignatureContext = signatureContext;
-            }
-
-            public bool Equals(TypeAndSignatureContext other)
-            {
-                return Type.Equals(other.Type) &&
-                       SignatureContext.Equals(other.SignatureContext);
-            }
-
-            public override bool Equals(object obj)
-            {
-                return obj is FieldAndSignatureContext other && Equals(other);
-            }
-
-            public override int GetHashCode()
-            {
-                return Type.GetHashCode() ^ (SignatureContext.GetHashCode() * 31);
-            }
-        }
-
-        private NodeCache<TypeAndSignatureContext, ISymbolNode> _fieldBaseOffsetCache;
-
-        public ISymbolNode FieldBaseOffset(TypeDesc typeDesc, SignatureContext signatureContext)
-        {
-            return _fieldBaseOffsetCache.GetOrAdd(new TypeAndSignatureContext(typeDesc, signatureContext));
+            return _fieldBaseOffsetCache.GetOrAdd(typeDesc);
         }
 
         private NodeCache<MethodAndCallSite, ISymbolNode> _interfaceDispatchCells = new NodeCache<MethodAndCallSite, ISymbolNode>();
 
-        public ISymbolNode InterfaceDispatchCell(MethodWithToken method, SignatureContext signatureContext, bool isUnboxingStub, string callSite)
+        public ISymbolNode InterfaceDispatchCell(MethodWithToken method, bool isUnboxingStub, string callSite)
         {
-            MethodAndCallSite cellKey = new MethodAndCallSite(method, isUnboxingStub, callSite, signatureContext);
+            MethodAndCallSite cellKey = new MethodAndCallSite(method, isUnboxingStub, callSite);
             return _interfaceDispatchCells.GetOrAdd(cellKey);
         }
 
         private NodeCache<TypeAndMethod, ISymbolNode> _delegateCtors = new NodeCache<TypeAndMethod, ISymbolNode>();
 
-        public ISymbolNode DelegateCtor(TypeDesc delegateType, MethodWithToken method, SignatureContext signatureContext)
+        public ISymbolNode DelegateCtor(TypeDesc delegateType, MethodWithToken method)
         {
             TypeAndMethod ctorKey = new TypeAndMethod(
                 delegateType,
                 method,
                 isUnboxingStub: false,
                 isInstantiatingStub: false,
-                isPrecodeImportRequired: false,
-                signatureContext);
+                isPrecodeImportRequired: false);
             return _delegateCtors.GetOrAdd(ctorKey);
         }
 
@@ -507,22 +409,17 @@ namespace ILCompiler.DependencyAnalysis
             public readonly MethodWithToken Method;
             public readonly bool IsUnboxingStub;
             public readonly string CallSite;
-            public readonly SignatureContext SignatureContext;
 
-            public MethodAndCallSite(MethodWithToken method, bool isUnboxingStub, string callSite, SignatureContext signatureContext)
+            public MethodAndCallSite(MethodWithToken method, bool isUnboxingStub, string callSite)
             {
                 CallSite = callSite;
                 IsUnboxingStub = isUnboxingStub;
                 Method = method;
-                SignatureContext = signatureContext;
             }
 
             public bool Equals(MethodAndCallSite other)
             {
-                return CallSite == other.CallSite 
-                    && Method.Equals(other.Method) 
-                    && IsUnboxingStub == other.IsUnboxingStub
-                    && SignatureContext.Equals(other.SignatureContext);
+                return CallSite == other.CallSite && Method.Equals(other.Method) && IsUnboxingStub == other.IsUnboxingStub;
             }
 
             public override bool Equals(object obj)
@@ -532,10 +429,9 @@ namespace ILCompiler.DependencyAnalysis
 
             public override int GetHashCode()
             {
-                return (CallSite != null ? CallSite.GetHashCode() : 0) 
+                return (CallSite != null ? CallSite.GetHashCode() : 0)
                     ^ unchecked(31 * Method.GetHashCode())
-                    ^ (IsUnboxingStub ? -0x80000000 : 0)
-                    ^ (23 * SignatureContext.GetHashCode());
+                    ^ (IsUnboxingStub ? -0x80000000 : 0);
             }
         }
 
@@ -547,7 +443,6 @@ namespace ILCompiler.DependencyAnalysis
             public readonly MethodWithToken MethodArgument;
             public readonly FieldDesc FieldArgument;
             public readonly GenericContext MethodContext;
-            public readonly SignatureContext SignatureContext;
 
             public GenericLookupKey(
                 CORINFO_RUNTIME_LOOKUP_KIND lookupKind,
@@ -555,8 +450,7 @@ namespace ILCompiler.DependencyAnalysis
                 TypeDesc typeArgument,
                 MethodWithToken methodArgument,
                 FieldDesc fieldArgument,
-                GenericContext methodContext,
-                SignatureContext signatureContext)
+                GenericContext methodContext)
             {
                 LookupKind = lookupKind;
                 FixupKind = fixupKind;
@@ -564,7 +458,6 @@ namespace ILCompiler.DependencyAnalysis
                 MethodArgument = methodArgument;
                 FieldArgument = fieldArgument;
                 MethodContext = methodContext;
-                SignatureContext = signatureContext;
             }
 
             public bool Equals(GenericLookupKey other)
@@ -599,8 +492,7 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunHelperId helperId,
             object helperArgument,
-            GenericContext methodContext,
-            SignatureContext signatureContext)
+            GenericContext methodContext)
         {
             switch (helperId)
             {
@@ -609,56 +501,49 @@ namespace ILCompiler.DependencyAnalysis
                         runtimeLookupKind,
                         ReadyToRunFixupKind.TypeHandle,
                         helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.MethodHandle:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.MethodHandle,
                         (MethodWithToken)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.MethodEntry:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.MethodEntry,
                         (MethodWithToken)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.MethodDictionary:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.MethodHandle,
                         (MethodWithToken)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.TypeDictionary:
                     return GenericLookupTypeHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.TypeDictionary,
                         (TypeDesc)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.VirtualDispatchCell:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.VirtualEntry,
                         (MethodWithToken)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 case ReadyToRunHelperId.FieldHandle:
                     return GenericLookupFieldHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.FieldHandle,
                         (FieldDesc)helperArgument,
-                        methodContext,
-                        signatureContext);
+                        methodContext);
 
                 default:
                     throw new NotImplementedException(helperId.ToString());
@@ -669,8 +554,7 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             object helperArgument,
-            GenericContext methodContext,
-            SignatureContext signatureContext)
+            GenericContext methodContext)
         {
             TypeDesc typeArgument;
             if (helperArgument is MethodWithToken methodWithToken)
@@ -686,7 +570,7 @@ namespace ILCompiler.DependencyAnalysis
                 typeArgument = (TypeDesc)helperArgument;
             }
 
-            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument, methodArgument: null, fieldArgument: null, methodContext, signatureContext);
+            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument, methodArgument: null, fieldArgument: null, methodContext);
             return _genericLookupHelpers.GetOrAdd(key);
         }
 
@@ -694,10 +578,9 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             FieldDesc fieldArgument,
-            GenericContext methodContext,
-            SignatureContext signatureContext)
+            GenericContext methodContext)
         {
-            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument: null, fieldArgument: fieldArgument, methodContext, signatureContext);
+            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument: null, fieldArgument: fieldArgument, methodContext);
             return _genericLookupHelpers.GetOrAdd(key);
         }
 
@@ -705,31 +588,26 @@ namespace ILCompiler.DependencyAnalysis
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
             MethodWithToken methodArgument,
-            GenericContext methodContext,
-            SignatureContext signatureContext)
+            GenericContext methodContext)
         {
-            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument, fieldArgument: null, methodContext, signatureContext);
+            GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument, fieldArgument: null, methodContext);
             return _genericLookupHelpers.GetOrAdd(key);
         }
 
         private struct PInvokeTargetKey : IEquatable<PInvokeTargetKey>
         {
             public readonly MethodWithToken MethodWithToken;
-            public readonly SignatureContext SignatureContext;
             public readonly bool IsIndirect;
 
-            public PInvokeTargetKey(MethodWithToken methodWithToken, SignatureContext signatureContext, bool isIndirect)
+            public PInvokeTargetKey(MethodWithToken methodWithToken, bool isIndirect)
             {
                 MethodWithToken = methodWithToken;
-                SignatureContext = signatureContext;
                 IsIndirect = isIndirect;
             }
 
             public bool Equals(PInvokeTargetKey other)
             {
-                return IsIndirect.Equals(other.IsIndirect)
-                    && MethodWithToken.Equals(other.MethodWithToken)
-                    && SignatureContext.Equals(other.SignatureContext);
+                return IsIndirect.Equals(other.IsIndirect) && MethodWithToken.Equals(other.MethodWithToken);
             }
 
             public override bool Equals(object obj)
@@ -739,22 +617,20 @@ namespace ILCompiler.DependencyAnalysis
 
             public override int GetHashCode()
             {
-                return IsIndirect.GetHashCode()
-                    ^ (MethodWithToken.GetHashCode() * 23)
-                    ^ (SignatureContext.GetHashCode() * 31);
+                return IsIndirect.GetHashCode() ^ (MethodWithToken.GetHashCode() * 23);
             }
         }
 
         private NodeCache<PInvokeTargetKey, ISymbolNode> _pInvokeTargetNodes = new NodeCache<PInvokeTargetKey, ISymbolNode>();
 
-        public ISymbolNode GetIndirectPInvokeTargetNode(MethodWithToken methodWithToken, SignatureContext signatureContext)
+        public ISymbolNode GetIndirectPInvokeTargetNode(MethodWithToken methodWithToken)
         {
-            return _pInvokeTargetNodes.GetOrAdd(new PInvokeTargetKey(methodWithToken, signatureContext, isIndirect: true));
+            return _pInvokeTargetNodes.GetOrAdd(new PInvokeTargetKey(methodWithToken, isIndirect: true));
         }
 
-        public ISymbolNode GetPInvokeTargetNode(MethodWithToken methodWithToken, SignatureContext signatureContext)
+        public ISymbolNode GetPInvokeTargetNode(MethodWithToken methodWithToken)
         {
-            return _pInvokeTargetNodes.GetOrAdd(new PInvokeTargetKey(methodWithToken, signatureContext, isIndirect: false));
+            return _pInvokeTargetNodes.GetOrAdd(new PInvokeTargetKey(methodWithToken, isIndirect: false));
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/TypeAndMethod.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/TypeAndMethod.cs
@@ -18,16 +18,14 @@ namespace ILCompiler.DependencyAnalysis
         public readonly bool IsUnboxingStub;
         public readonly bool IsInstantiatingStub;
         public readonly bool IsPrecodeImportRequired;
-        public readonly SignatureContext SignatureContext;
 
-        public TypeAndMethod(TypeDesc type, MethodWithToken method, bool isUnboxingStub, bool isInstantiatingStub, bool isPrecodeImportRequired, SignatureContext signatureContext)
+        public TypeAndMethod(TypeDesc type, MethodWithToken method, bool isUnboxingStub, bool isInstantiatingStub, bool isPrecodeImportRequired)
         {
             Type = type;
             Method = method;
             IsUnboxingStub = isUnboxingStub;
             IsInstantiatingStub = isInstantiatingStub;
             IsPrecodeImportRequired = isPrecodeImportRequired;
-            SignatureContext = signatureContext;
         }
 
         public bool Equals(TypeAndMethod other)
@@ -36,8 +34,7 @@ namespace ILCompiler.DependencyAnalysis
                    Method.Equals(other.Method) &&
                    IsUnboxingStub == other.IsUnboxingStub &&
                    IsInstantiatingStub == other.IsInstantiatingStub &&
-                   IsPrecodeImportRequired == other.IsPrecodeImportRequired &&
-                   SignatureContext.Equals(other.SignatureContext);
+                   IsPrecodeImportRequired == other.IsPrecodeImportRequired;
         }
 
         public override bool Equals(object obj)
@@ -47,12 +44,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public override int GetHashCode()
         {
-            return (Type?.GetHashCode() ?? 0) ^ 
-                unchecked(Method.GetHashCode() * 31) ^ 
-                (IsUnboxingStub ? -0x80000000 : 0) ^ 
+            return (Type?.GetHashCode() ?? 0) ^
+                unchecked(Method.GetHashCode() * 31) ^
+                (IsUnboxingStub ? -0x80000000 : 0) ^
                 (IsInstantiatingStub ? 0x40000000 : 0) ^
-                (IsPrecodeImportRequired ? 0x20000000 : 0) ^
-                (SignatureContext.GetHashCode() * 23);
+                (IsPrecodeImportRequired ? 0x20000000 : 0);
         }
     }
 }


### PR DESCRIPTION
Based on my recent design discussions with JanK it turns out that
we don't want heterogeneous import cells in composite R2R images.
An interesting corollary of this fact is that the signature context
only changes internally during recursive descent into generic
signatures and at the top level it's a singleton during the entire
build. Due to this fact we don't need to store it in the various
import nodes and keys and we can just use the singleton in
NodeFactory. I have highlighted this fact by renaming it from
InputModuleContext to SignatureContext.

Thanks

Tomas