### PR TITLE
Add Socket.OSSupportsUnixDomainSocket

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -2,68 +2,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Net.Internals;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace System.Net
 {
-    internal class SocketProtocolSupportPal
+    internal static class SocketProtocolSupportPal
     {
-        private static bool s_ipv4 = true;
-        private static bool s_ipv6 = true;
+        public static bool OSSupportsIPv6 { get; } = IsSupported(AddressFamily.InterNetworkV6);
+        public static bool OSSupportsIPv4 { get; } = IsSupported(AddressFamily.InterNetwork);
+        public static bool OSSupportsUnixDomainSockets { get; } = IsSupported(AddressFamily.Unix);
 
-        private static bool s_initialized;
-        private static readonly object s_initializedLock = new object();
-
-        public static bool OSSupportsIPv6
+        private static unsafe bool IsSupported(AddressFamily af)
         {
-            get
-            {
-                EnsureInitialized();
-                return s_ipv6;
-            }
-        }
-
-        public static bool OSSupportsIPv4
-        {
-            get
-            {
-                EnsureInitialized();
-                return s_ipv4;
-            }
-        }
-
-        private static void EnsureInitialized()
-        {
-            if (!Volatile.Read(ref s_initialized))
-            {
-                lock (s_initializedLock)
-                {
-                    if (!s_initialized)
-                    {
-                        s_ipv4 = IsProtocolSupported(AddressFamily.InterNetwork);
-                        s_ipv6 = IsProtocolSupported(AddressFamily.InterNetworkV6);
-
-                        Volatile.Write(ref s_initialized, true);
-                    }
-                }
-            }
-        }
-
-        private static unsafe bool IsProtocolSupported(AddressFamily af)
-        {
-            IntPtr socket = (IntPtr)(-1);
+            IntPtr invalid = (IntPtr)(-1);
+            IntPtr socket = invalid;
             try
             {
-                Interop.Error err = Interop.Sys.Socket(af, SocketType.Dgram, (ProtocolType)0, &socket);
-                return err != Interop.Error.EAFNOSUPPORT;
+                return Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket) != Interop.Error.EAFNOSUPPORT;
             }
             finally
             {
-                if (socket != (IntPtr)(-1))
+                if (socket == invalid)
                 {
                     Interop.Sys.Close(socket);
                 }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -241,6 +241,7 @@ namespace System.Net.Sockets
         public bool NoDelay { get { throw null; } set { } }
         public static bool OSSupportsIPv4 { get { throw null; } }
         public static bool OSSupportsIPv6 { get { throw null; } }
+        public static bool OSSupportsUnixDomainSockets { get { throw null; } }
         public System.Net.Sockets.ProtocolType ProtocolType { get { throw null; } }
         public int ReceiveBufferSize { get { throw null; } set { } }
         public int ReceiveTimeout { get { throw null; } set { } }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -152,6 +152,15 @@ namespace System.Net.Sockets
             }
         }
 
+        public static bool OSSupportsUnixDomainSockets
+        {
+            get
+            {
+                InitializeSockets();
+                return SocketProtocolSupportPal.OSSupportsUnixDomainSockets;
+            }
+        }
+
         // Gets the amount of data pending in the network's input buffer that can be
         // read from the socket.
         public int Available

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
@@ -12,20 +12,6 @@ namespace System.Net.Sockets
     {
         private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
 
-        private static readonly Encoding s_pathEncoding = Encoding.UTF8;
-        private static readonly Lazy<bool> s_udsSupported = new Lazy<bool>(() =>
-        {
-            try
-            {
-                new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified).Dispose();
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        });
-
         private readonly string _path;
         private readonly byte[] _encodedPath;
 
@@ -39,7 +25,7 @@ namespace System.Net.Sockets
             // Pathname socket addresses should be null-terminated.
             // Linux abstract socket addresses start with a zero byte, they must not be null-terminated.
             bool isAbstract = IsAbstract(path);
-            int bufferLength = s_pathEncoding.GetByteCount(path);
+            int bufferLength = Encoding.UTF8.GetByteCount(path);
             if (!isAbstract)
             {
                 // for null terminator
@@ -55,10 +41,10 @@ namespace System.Net.Sockets
 
             _path = path;
             _encodedPath = new byte[bufferLength];
-            int bytesEncoded = s_pathEncoding.GetBytes(path, 0, path.Length, _encodedPath, 0);
+            int bytesEncoded = Encoding.UTF8.GetBytes(path, 0, path.Length, _encodedPath, 0);
             Debug.Assert(bufferLength - (isAbstract ? 0 : 1) == bytesEncoded);
 
-            if (!s_udsSupported.Value)
+            if (!Socket.OSSupportsUnixDomainSockets)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -95,7 +81,7 @@ namespace System.Net.Sockets
                         length--;
                     }
                 }
-                _path = s_pathEncoding.GetString(_encodedPath, 0, length);
+                _path = Encoding.UTF8.GetString(_encodedPath, 0, length);
             }
             else
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketDuplicationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketDuplicationTests.cs
@@ -240,8 +240,7 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SocketCtr_SocketInformation_NonIpSocket_ThrowsNotSupportedException()
         {
-            // UDS unsupported:
-            if (!PlatformDetection.IsWindows10Version1803OrGreater || !Environment.Is64BitProcess) return;
+            if (!Socket.OSSupportsUnixDomainSockets) return;
 
             using Socket original = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             SocketInformation info = original.DuplicateAndClose(CurrentProcessId);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/863
cc: @dotnet/ncl

I also noticed that a) we had non-trivial duplication of code between a .Windows.cs and .Unix.cs file, and b) we were using 0 as INVALID_SOCKET when it's actually -1.  I fixed both.