### PR TITLE
[llvmonly] Emit stubs for methods which failed compilation.

### DIFF
--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -142,6 +142,7 @@ MONO_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_iface_call) \
 MONO_JIT_ICALL (mini_llvmonly_resolve_iface_call_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
+MONO_JIT_ICALL (mini_llvmonly_throw_missing_method_exception) \
 MONO_JIT_ICALL (mono_amd64_resume_unwind)	\
 MONO_JIT_ICALL (mono_amd64_start_gsharedvt_call)	\
 MONO_JIT_ICALL (mono_amd64_throw_corlib_exception)	\

--- a/src/mono/mono/mini/aot-runtime.h
+++ b/src/mono/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 172
+#define MONO_AOT_FILE_VERSION 173
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -843,3 +843,15 @@ mini_llvmonly_throw_nullref_exception (void)
 
 	mono_llvm_throw_corlib_exception (ex_token_index);
 }
+
+static GENERATE_GET_CLASS_WITH_CACHE (missing_method, "System", "MissingMethodException")
+
+void
+mini_llvmonly_throw_missing_method_exception (void)
+{
+	MonoClass *klass = mono_class_get_missing_method_class ();
+
+	guint32 ex_token_index = m_class_get_type_token (klass) - MONO_TOKEN_TYPE_DEF;
+
+	mono_llvm_throw_corlib_exception (ex_token_index);
+}

--- a/src/mono/mono/mini/llvmonly-runtime.h
+++ b/src/mono/mono/mini/llvmonly-runtime.h
@@ -35,4 +35,6 @@ G_EXTERN_C void mini_llvm_init_gshared_method_vtable  (MonoAotFileInfo *info, gp
 
 G_EXTERN_C void mini_llvmonly_throw_nullref_exception (void);
 
+G_EXTERN_C void mini_llvmonly_throw_missing_method_exception (void);
+
 #endif

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4667,6 +4667,7 @@ register_icalls (void)
 	register_icall (mini_llvmonly_init_delegate, mono_icall_sig_void_object, TRUE);
 	register_icall (mini_llvmonly_init_delegate_virtual, mono_icall_sig_void_object_object_ptr, TRUE);
 	register_icall (mini_llvmonly_throw_nullref_exception, mono_icall_sig_void, TRUE);
+	register_icall (mini_llvmonly_throw_missing_method_exception, mono_icall_sig_void, TRUE);
 
 	register_icall (mono_get_assembly_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18802,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Emit a stub for methods which failed llvm compilation. Currently the stub will
throw a MissingMethodException, later it can fall back to the interpreter etc.
This is required for cross-assembly direct calls, since the caller doesn't
know that the callee has failed llvm compilation leading to missing
symbols during linking.