### PR TITLE
Display stack trace at stack overflow

### DIFF
--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -8961,7 +8961,7 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
             CONTEXT contextToAdjust;
             BOOL adjustedContext = FALSE;
             memcpy(&contextToAdjust, pContext, sizeof(CONTEXT));
-            adjustedContext = g_pEEInterface->AdjustContextForWriteBarrierForDebugger(&contextToAdjust);
+            adjustedContext = g_pEEInterface->AdjustContextForJITHelpersForDebugger(&contextToAdjust);
             if (adjustedContext)
             {
                 LOG((LF_CORDB, LL_INFO10000, "D::DDBP: HIT DATA BREAKPOINT INSIDE WRITE BARRIER...\n"));

--- a/src/coreclr/src/inc/ex.h
+++ b/src/coreclr/src/inc/ex.h
@@ -112,7 +112,7 @@ void GenerateTopLevelHRExceptionMessage(HRESULT hresult, SString &result);
 //   We save current ExceptionPointers using VectoredExceptionHandler.  The save data is only valid
 //   duing exception handling.  GetCurrentExceptionPointers returns the saved data.
 // ---------------------------------------------------------------------------
-void GetCurrentExceptionPointers(PEXCEPTION_POINTERS pExceptionInfo);
+void GetCurrentExceptionPointers(PEXCEPTION_POINTERS pExceptionInfo DEBUG_ARG(bool checkExceptionRecordLocation));
 
 // ---------------------------------------------------------------------------
 //   We save current ExceptionPointers using VectoredExceptionHandler.  The save data is only valid

--- a/src/coreclr/src/pal/src/arch/amd64/signalhandlerhelper.cpp
+++ b/src/coreclr/src/pal/src/arch/amd64/signalhandlerhelper.cpp
@@ -13,10 +13,11 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 /*++
 Function :
-    signal_handler_worker
+    ExecuteHandlerOnCustomStack
 
-    Handles signal on the original stack where the signal occured.
-    Invoked via setcontext.
+    Execute signal handler on a custom stack, the current stack pointer is specified by the customSp
+    If the customSp is 0, then the handler is executed on the original stack where the signal was fired.
+    It installs a fake stack frame to enable stack unwinding to the signal source location.
 
 Parameters :
     POSIX signal handler parameter list ("man sigaction" for details)
@@ -24,12 +25,18 @@ Parameters :
 
     (no return value)
 --*/
-void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint)
+void ExecuteHandlerOnCustomStack(int code, siginfo_t *siginfo, void *context, size_t customSp, SignalHandlerWorkerReturnPoint* returnPoint)
 {
     ucontext_t *ucontext = (ucontext_t *)context;
     size_t faultSp = (size_t)MCREG_Rsp(ucontext->uc_mcontext);
 
     _ASSERTE(IS_ALIGNED(faultSp, 8));
+
+    if (customSp == 0)
+    {
+        // preserve 128 bytes long red zone and align stack pointer
+        customSp = ALIGN_DOWN(faultSp - 128, 16);
+    }
 
     size_t fakeFrameReturnAddress;
 
@@ -42,8 +49,7 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
         fakeFrameReturnAddress = (size_t)SignalHandlerWorkerReturnOffset8 + (size_t)CallSignalHandlerWrapper8;
     }
 
-    // preserve 128 bytes long red zone and align stack pointer
-    size_t* sp = (size_t*)ALIGN_DOWN(faultSp - 128, 16);
+    size_t* sp = (size_t*)customSp;
 
     // Build fake stack frame to enable the stack unwinder to unwind from signal_handler_worker to the faulting instruction
     *--sp = (size_t)MCREG_Rip(ucontext->uc_mcontext);
@@ -51,7 +57,7 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
     size_t fp = (size_t)sp;
     *--sp = fakeFrameReturnAddress;
 
-    // Switch the current context to the signal_handler_worker and the original stack
+    // Switch the current context to the signal_handler_worker and the custom stack
     CONTEXT context2;
     RtlCaptureContext(&context2);
 

--- a/src/coreclr/src/pal/src/arch/arm/signalhandlerhelper.cpp
+++ b/src/coreclr/src/pal/src/arch/arm/signalhandlerhelper.cpp
@@ -13,10 +13,11 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 /*++
 Function :
-    signal_handler_worker
+    ExecuteHandlerOnCustomStack
 
-    Handles signal on the original stack where the signal occured.
-    Invoked via setcontext.
+    Execute signal handler on a custom stack, the current stack pointer is specified by the customSp
+    If the customSp is 0, then the handler is executed on the original stack where the signal was fired.
+    It installs a fake stack frame to enable stack unwinding to the signal source location.
 
 Parameters :
     POSIX signal handler parameter list ("man sigaction" for details)
@@ -24,12 +25,18 @@ Parameters :
 
     (no return value)
 --*/
-void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint)
+void ExecuteHandlerOnCustomStack(int code, siginfo_t *siginfo, void *context, size_t customSp, SignalHandlerWorkerReturnPoint* returnPoint)
 {
     ucontext_t *ucontext = (ucontext_t *)context;
     size_t faultSp = (size_t)MCREG_Sp(ucontext->uc_mcontext);
 
     _ASSERTE(IS_ALIGNED(faultSp, 4));
+
+    if (customSp == 0)
+    {
+        // preserve 8 bytes long red zone and align stack pointer
+        customSp = ALIGN_DOWN(faultSp - 8, 8);
+    }
 
     size_t fakeFrameReturnAddress;
 
@@ -42,8 +49,7 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
         fakeFrameReturnAddress = (size_t)SignalHandlerWorkerReturnOffset4 + (size_t)CallSignalHandlerWrapper4;
     }
 
-    // preserve 8 bytes long red zone and align stack pointer
-    size_t* sp = (size_t*)ALIGN_DOWN(faultSp - 8, 8);
+    size_t* sp = (size_t*)customSp;
 
 #ifndef __linux__
     size_t cpsr = (size_t)MCREG_Cpsr(ucontext->uc_mcontext);

--- a/src/coreclr/src/pal/src/arch/arm64/signalhandlerhelper.cpp
+++ b/src/coreclr/src/pal/src/arch/arm64/signalhandlerhelper.cpp
@@ -13,10 +13,11 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 /*++
 Function :
-    signal_handler_worker
+    ExecuteHandlerOnCustomStack
 
-    Handles signal on the original stack where the signal occured.
-    Invoked via setcontext.
+    Execute signal handler on a custom stack, the current stack pointer is specified by the customSp
+    If the customSp is 0, then the handler is executed on the original stack where the signal was fired.
+    It installs a fake stack frame to enable stack unwinding to the signal source location.
 
 Parameters :
     POSIX signal handler parameter list ("man sigaction" for details)
@@ -24,11 +25,17 @@ Parameters :
 
     (no return value)
 --*/
-void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint)
+void ExecuteHandlerOnCustomStack(int code, siginfo_t *siginfo, void *context, size_t customSp, SignalHandlerWorkerReturnPoint* returnPoint)
 {
     ucontext_t *ucontext = (ucontext_t *)context;
     size_t faultSp = (size_t)MCREG_Sp(ucontext->uc_mcontext);
     _ASSERTE(IS_ALIGNED(faultSp, 8));
+
+    if (customSp == 0)
+    {
+        // preserve 128 bytes long red zone and align stack pointer
+        customSp = ALIGN_DOWN(faultSp - 128, 16);
+    }
 
     size_t fakeFrameReturnAddress;
 
@@ -42,7 +49,7 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
     }
 
     // preserve 128 bytes long red zone and align stack pointer
-    size_t* sp = (size_t*)ALIGN_DOWN(faultSp - 128, 16);
+    size_t* sp = (size_t*)customSp;
 
     // Build fake stack frame to enable the stack unwinder to unwind from signal_handler_worker to the faulting instruction
     // pushed LR

--- a/src/coreclr/src/pal/src/exception/seh.cpp
+++ b/src/coreclr/src/pal/src/exception/seh.cpp
@@ -28,6 +28,7 @@ Abstract:
 #include "pal/process.h"
 #include "pal/malloc.hpp"
 #include "pal/signal.hpp"
+#include "pal/virtual.h"
 
 #if HAVE_MACH_EXCEPTIONS
 #include "machexception.h"
@@ -268,14 +269,16 @@ SEHProcessException(PAL_SEHException* exception)
                     // Check if the failed access has hit a stack guard page. In such case, it
                     // was a stack probe that detected that there is not enough stack left.
                     void* stackLimit = CPalThread::GetStackLimit();
-                    void* stackGuard = (void*)((size_t)stackLimit - getpagesize());
+                    void* stackOverflowBottom = (void*)((size_t)stackLimit - GetVirtualPageSize());
+                    // On some versions of glibc / platforms the stackLimit is an address of the guard page, on some
+                    // it is right above the guard page. 
+                    // So consider SIGSEGV in one page above and below stack limit to be stack overflow.
+                    void* stackOverflowTop = (void*)((size_t)stackLimit + GetVirtualPageSize());
                     void* violationAddr = (void*)exceptionRecord->ExceptionInformation[1];
-                    if ((violationAddr >= stackGuard) && (violationAddr < stackLimit))
+
+                    if ((violationAddr >= stackOverflowBottom) && (violationAddr < stackOverflowTop))
                     {
-                        // The exception happened in the page right below the stack limit,
-                        // so it is a stack overflow
-                        (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
-                        PROCAbort();
+                        exceptionRecord->ExceptionCode = EXCEPTION_STACK_OVERFLOW;
                     }
                 }
 

--- a/src/coreclr/src/pal/src/exception/signal.cpp
+++ b/src/coreclr/src/pal/src/exception/signal.cpp
@@ -113,6 +113,9 @@ struct sigaction g_previous_activation;
 // Offset of the local variable containing pointer to windows style context in the common_signal_handler function.
 // This offset is relative to the frame pointer.
 int g_common_signal_handler_context_locvar_offset = 0;
+
+// TOP of special stack for handling stack overflow
+volatile void* g_stackOverflowHandlerStack = NULL;
 #endif // !HAVE_MACH_EXCEPTIONS
 
 /* public function definitions ************************************************/
@@ -175,6 +178,26 @@ BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
         {
             return FALSE;
         }
+
+        // Allocate the minimal stack necessary for handling stack overflow
+        int stackOverflowStackSize = ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + 7 * 4096;
+        // Align the size to virtual page size and add one virtual page as a stack guard
+        stackOverflowStackSize = ALIGN_UP(stackOverflowStackSize, GetVirtualPageSize()) + GetVirtualPageSize();
+        g_stackOverflowHandlerStack = mmap(NULL, stackOverflowStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
+        if (g_stackOverflowHandlerStack == MAP_FAILED)
+        {
+            return FALSE;
+        }
+
+        // create a guard page for the alternate stack
+        int st = mprotect((void*)g_stackOverflowHandlerStack, GetVirtualPageSize(), PROT_NONE);
+        if (st != 0)
+        {
+            munmap((void*)g_stackOverflowHandlerStack, stackOverflowStackSize);
+            return FALSE;
+        }
+
+        g_stackOverflowHandlerStack = (void*)((size_t)g_stackOverflowHandlerStack + stackOverflowStackSize);
     }
 
     /* The default action for SIGPIPE is process termination.
@@ -432,6 +455,41 @@ bool IsRunningOnAlternateStack(void *context)
 
 /*++
 Function :
+    SwitchStackAndExecuteHandler
+
+    Switch to the stack specified by the sp argument
+
+Parameters :
+    POSIX signal handler parameter list ("man sigaction" for details)
+    sp - stack pointer of the stack to execute the handler on.
+         If sp == 0, execute it on the original stack where the signal has occured.
+Return :
+    The return value from the signal handler
+--*/
+static bool SwitchStackAndExecuteHandler(int code, siginfo_t *siginfo, void *context, size_t sp)
+{
+    // Establish a return point in case the common_signal_handler returns
+
+    volatile bool contextInitialization = true;
+
+    void *ptr = alloca(sizeof(SignalHandlerWorkerReturnPoint) + alignof(SignalHandlerWorkerReturnPoint) - 1);
+    SignalHandlerWorkerReturnPoint *pReturnPoint = (SignalHandlerWorkerReturnPoint *)ALIGN_UP(ptr, alignof(SignalHandlerWorkerReturnPoint));
+    RtlCaptureContext(&pReturnPoint->context);
+
+    // When the signal handler worker completes, it uses setcontext to return to this point
+
+    if (contextInitialization)
+    {
+        contextInitialization = false;
+        ExecuteHandlerOnCustomStack(code, siginfo, context, sp, pReturnPoint);
+        _ASSERTE(FALSE); // The ExecuteHandlerOnCustomStack should never return
+    }
+
+    return pReturnPoint->returnFromHandler;
+}
+
+/*++
+Function :
     sigsegv_handler
 
     handle SIGSEGV signal (EXCEPTION_ACCESS_VIOLATION, others)
@@ -453,8 +511,30 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
         // we have a stack overflow.
         if ((failureAddress - (sp - GetVirtualPageSize())) < 2 * GetVirtualPageSize())
         {
-            (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
-            PROCAbort();
+            if (GetCurrentPalThread())
+            {
+                size_t handlerStackTop = __sync_val_compare_and_swap((size_t*)&g_stackOverflowHandlerStack, (size_t)g_stackOverflowHandlerStack, 0);
+                if (handlerStackTop == 0)
+                {
+                    // We have only one stack for handling stack overflow preallocated. We let only the first thread that hits stack overflow to
+                    // run the exception handling code on that stack (which ends up just dumping the stack trace and aborting the process).
+                    // Other threads are held spinning and sleeping here until the process exits.
+                    while (true)
+                    {
+                        sleep(1);
+                    }
+                }
+
+                if (SwitchStackAndExecuteHandler(code, siginfo, context, (size_t)handlerStackTop))
+                {
+                    PROCAbort();
+                }
+            }
+            else
+            {
+                (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
+                PROCAbort();
+            }            
         }
 
         // Now that we know the SIGSEGV didn't happen due to a stack overflow, execute the common
@@ -462,24 +542,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
         if (GetCurrentPalThread() && IsRunningOnAlternateStack(context))
         {
-            // Establish a return point in case the common_signal_handler returns
-
-            volatile bool contextInitialization = true;
-
-            void *ptr = alloca(sizeof(SignalHandlerWorkerReturnPoint) + alignof(SignalHandlerWorkerReturnPoint) - 1);
-            SignalHandlerWorkerReturnPoint *pReturnPoint = (SignalHandlerWorkerReturnPoint *)ALIGN_UP(ptr, alignof(SignalHandlerWorkerReturnPoint));
-            RtlCaptureContext(&pReturnPoint->context);
-
-            // When the signal handler worker completes, it uses setcontext to return to this point
-
-            if (contextInitialization)
-            {
-                contextInitialization = false;
-                ExecuteHandlerOnOriginalStack(code, siginfo, context, pReturnPoint);
-                _ASSERTE(FALSE); // The ExecuteHandlerOnOriginalStack should never return
-            }
-
-            if (pReturnPoint->returnFromHandler)
+            if (SwitchStackAndExecuteHandler(code, siginfo, context, 0 /* sp */)) // sp == 0 indicates execution on the original stack
             {
                 return;
             }
@@ -692,7 +755,10 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
 {
 #ifdef INJECT_ACTIVATION_SIGNAL
     int status = pthread_kill(pThread->GetPThreadSelf(), INJECT_ACTIVATION_SIGNAL);
-    if (status != 0)
+    // We can get EAGAIN when printing stack overflow stack trace and when other threads hit
+    // stack overflow too. Those are held in the sigsegv_handler with blocked signals until
+    // the process exits.
+    if ((status != 0) && (status != EAGAIN))
     {
         // Failure to send the signal is fatal. There are only two cases when sending
         // the signal can fail. First, if the signal ID is invalid and second,

--- a/src/coreclr/src/pal/src/include/pal/signal.hpp
+++ b/src/coreclr/src/pal/src/include/pal/signal.hpp
@@ -78,10 +78,11 @@ extern "C" void signal_handler_worker(int code, siginfo_t *siginfo, void *contex
 
 /*++
 Function :
-    ExecuteHandlerOnOriginalStack
+    ExecuteHandlerOnCustomStack
 
-    Executes signal_handler_worker on the original stack where the signal occured.
-    It installs fake stack frame to enable stack unwinding to the signal source location.
+    Execute signal handler on a custom stack, the current stack pointer is specified by the customSp
+    If the customSp is 0, then the handler is executed on the original stack where the signal was fired.
+    It installs a fake stack frame to enable stack unwinding to the signal source location.
 
 Parameters :
     POSIX signal handler parameter list ("man sigaction" for details)
@@ -89,7 +90,7 @@ Parameters :
 
     (no return value)
 --*/
-void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint);
+void ExecuteHandlerOnCustomStack(int code, siginfo_t *siginfo, void *context, size_t sp, SignalHandlerWorkerReturnPoint* returnPoint);
 
 #endif // !HAVE_MACH_EXCEPTIONS
 

--- a/src/coreclr/src/pal/src/thread/thread.cpp
+++ b/src/coreclr/src/pal/src/thread/thread.cpp
@@ -2808,7 +2808,7 @@ PAL_InjectActivation(
         palError = InjectActivationInternal(pTargetThread);
     }
 
-    if (palError == NO_ERROR)
+    if (palError != NO_ERROR)
     {
         pCurrentThread->SetLastError(palError);
     }

--- a/src/coreclr/src/utilcode/ex.cpp
+++ b/src/coreclr/src/utilcode/ex.cpp
@@ -1216,7 +1216,7 @@ void GenerateTopLevelHRExceptionMessage(HRESULT hresult, SString &result)
 
 #if !defined(DACCESS_COMPILE)
 
-void GetCurrentExceptionPointers(PEXCEPTION_POINTERS pExceptionInfo)
+void GetCurrentExceptionPointers(PEXCEPTION_POINTERS pExceptionInfo DEBUG_ARG(bool checkExceptionRecordLocation))
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1227,7 +1227,7 @@ void GetCurrentExceptionPointers(PEXCEPTION_POINTERS pExceptionInfo)
     pExceptionInfo->ExceptionRecord = pRecord;
 
 #ifdef _DEBUG
-    if (pRecord != NULL)
+    if (pRecord != NULL && checkExceptionRecordLocation)
     {
         _ASSERTE ((PVOID)(pRecord) > (PVOID)(&pRecord));
     }

--- a/src/coreclr/src/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/src/vm/amd64/JitHelpers_Fast.asm
@@ -651,6 +651,6 @@ ProbeLoop:
 
         ret
 
-LEAF_END JIT_StackProbe, _TEXT
+LEAF_END_MARKED JIT_StackProbe, _TEXT
 
         end

--- a/src/coreclr/src/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/src/vm/amd64/jithelpers_fast.S
@@ -550,7 +550,7 @@ LEAF_END JIT_Stelem_Ref__ArrayStoreCheck_Helper, _TEXT
 
 #define PAGE_SIZE 0x1000
 
-NESTED_ENTRY JIT_StackProbe, _TEXT, NoHandler
+LEAF_ENTRY JIT_StackProbe, _TEXT
         // On entry:
         //   r11 - points to the lowest address on the stack frame being allocated (i.e. [InitialSp - FrameSize])
         //   rsp - points to some byte on the last probed page
@@ -577,4 +577,4 @@ LOCAL_LABEL(ProbeLoop):
         RESET_FRAME_WITH_RBP
         ret
 
-NESTED_END JIT_StackProbe, _TEXT
+LEAF_END_MARKED JIT_StackProbe, _TEXT

--- a/src/coreclr/src/vm/arm/asmhelpers.S
+++ b/src/coreclr/src/vm/arm/asmhelpers.S
@@ -1466,7 +1466,7 @@ DelayLoad_Helper\suffix:
 #define PAGE_SIZE      0x1000
 #define PAGE_SIZE_LOG2 12
 
-        NESTED_ENTRY JIT_StackProbe, _TEXT, NoHandler
+        LEAF_ENTRY JIT_StackProbe, _TEXT
         PROLOG_PUSH "{r7}"
         PROLOG_STACK_SAVE r7
 
@@ -1484,4 +1484,4 @@ ProbeLoop:
         EPILOG_STACK_RESTORE r7
         EPILOG_POP "{r7}"
         EPILOG_BRANCH_REG lr
-        NESTED_END JIT_StackProbe, _TEXT
+        LEAF_END_MARKED JIT_StackProbe, _TEXT

--- a/src/coreclr/src/vm/arm/asmhelpers.asm
+++ b/src/coreclr/src/vm/arm/asmhelpers.asm
@@ -2160,7 +2160,7 @@ $__RealName
 ;
 ; NOTE: this helper will probe at least one page below the one pointed to by sp.
 #define PAGE_SIZE_LOG2 12
-    NESTED_ENTRY JIT_StackProbe
+    LEAF_ENTRY JIT_StackProbe
     PROLOG_PUSH {r7}
     PROLOG_STACK_SAVE r7
 
@@ -2178,7 +2178,7 @@ ProbeLoop
     EPILOG_STACK_RESTORE r7
     EPILOG_POP {r7}
     EPILOG_BRANCH_REG lr
-    NESTED_END
+    LEAF_END_MARKED JIT_StackProbe
 
 ; Must be at very end of file
     END

--- a/src/coreclr/src/vm/eedbginterface.h
+++ b/src/coreclr/src/vm/eedbginterface.h
@@ -375,7 +375,7 @@ public:
 #endif
 
 #ifndef DACCESS_COMPILE
-    virtual BOOL AdjustContextForWriteBarrierForDebugger(CONTEXT* context) = 0;
+    virtual BOOL AdjustContextForJITHelpersForDebugger(CONTEXT* context) = 0;
 #endif
 };
 

--- a/src/coreclr/src/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/src/vm/eedbginterfaceimpl.cpp
@@ -1584,11 +1584,11 @@ void EEDbgInterfaceImpl::ObjectRefFlush(Thread *pThread)
 
 #ifndef DACCESS_COMPILE
 
-BOOL AdjustContextForWriteBarrier(EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pContext);
-BOOL EEDbgInterfaceImpl::AdjustContextForWriteBarrierForDebugger(CONTEXT* context)
+BOOL AdjustContextForJITHelpers(EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pContext);
+BOOL EEDbgInterfaceImpl::AdjustContextForJITHelpersForDebugger(CONTEXT* context)
 {
     WRAPPER_NO_CONTRACT;
-    return AdjustContextForWriteBarrier(nullptr, context);
+    return AdjustContextForJITHelpers(nullptr, context);
 }
 #endif
 

--- a/src/coreclr/src/vm/eedbginterfaceimpl.h
+++ b/src/coreclr/src/vm/eedbginterfaceimpl.h
@@ -345,7 +345,7 @@ public:
 #endif
 
 #ifndef DACCESS_COMPILE
-    virtual BOOL AdjustContextForWriteBarrierForDebugger(CONTEXT* context);
+    virtual BOOL AdjustContextForJITHelpersForDebugger(CONTEXT* context);
 #endif
 };
 

--- a/src/coreclr/src/vm/excep.h
+++ b/src/coreclr/src/vm/excep.h
@@ -32,6 +32,8 @@ BOOL IsIPinVirtualStub(PCODE f_IP);
 #endif // VSD_STUB_CAN_THROW_AV
 bool IsIPInMarkedJitHelper(UINT_PTR uControlPc);
 
+BOOL AdjustContextForJITHelpers(EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pContext);
+
 #if defined(FEATURE_HIJACK) && (!defined(TARGET_X86) || defined(TARGET_UNIX))
 
 // General purpose functions for use on an IP in jitted code.

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -5217,6 +5217,13 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
 {
     _ASSERTE(IsSafeToHandleHardwareException(ex->GetContextRecord(), ex->GetExceptionRecord()));
 
+    if (ex->GetExceptionRecord()->ExceptionCode == EXCEPTION_STACK_OVERFLOW)
+    {
+        GetThread()->SetExecutingOnAltStack();
+        EEPolicy::HandleFatalStackOverflow(&ex->ExceptionPointers, FALSE);
+        UNREACHABLE();
+    }
+
     if (ex->GetExceptionRecord()->ExceptionCode != STATUS_BREAKPOINT && ex->GetExceptionRecord()->ExceptionCode != STATUS_SINGLE_STEP)
     {
         // A hardware exception is handled only if it happened in a jitted code or

--- a/src/coreclr/src/vm/frames.cpp
+++ b/src/coreclr/src/vm/frames.cpp
@@ -402,7 +402,8 @@ VOID Frame::Push(Thread *pThread)
     // in which the C compiler will lay them out in the stack frame.
     // So GetOsPageSize() is a guess of the maximum stack frame size of any method
     // with multiple Frames in mscorwks.dll
-    _ASSERTE(((m_Next == FRAME_TOP) ||
+    _ASSERTE(pThread->IsExecutingOnAltStack() ||
+              ((m_Next == FRAME_TOP) ||
               (PBYTE(m_Next) + (2 * GetOsPageSize())) > PBYTE(this)) &&
              "Pushing a frame out of order ?");
 

--- a/src/coreclr/src/vm/i386/jithelp.S
+++ b/src/coreclr/src/vm/i386/jithelp.S
@@ -27,8 +27,8 @@
 //
 // *******************************************************************************
 
-//  The code here is tightly coupled with AdjustContextForWriteBarrier, if you change
-//  anything here, you might need to change AdjustContextForWriteBarrier as well
+//  The code here is tightly coupled with AdjustContextForJITHelpers, if you change
+//  anything here, you might need to change AdjustContextForJITHelpers as well
 .macro WriteBarrierHelper rg
 .align 4
 
@@ -80,7 +80,7 @@ PATCH_LABEL JIT_DebugWriteBarrier\rg
 
 #ifdef WRITE_BARRIER_CHECK
     // Test dest here so if it is bad AV would happen before we change register/stack
-    // status. This makes job of AdjustContextForWriteBarrier easier.
+    // status. This makes job of AdjustContextForJITHelpers easier.
     cmp     BYTE PTR [edx], 0
     // ALSO update the shadow GC heap if that is enabled
     // Make ebp into the temporary src register. We need to do this so that we can use ecx
@@ -226,8 +226,8 @@ NESTED_END JIT_CheckedWriteBarrier\rg, _TEXT
 //
 // *******************************************************************************
 //
-//  The code here is tightly coupled with AdjustContextForWriteBarrier, if you change
-//  anything here, you might need to change AdjustContextForWriteBarrier as well
+//  The code here is tightly coupled with AdjustContextForJITHelpers, if you change
+//  anything here, you might need to change AdjustContextForJITHelpers as well
 //
 .macro ByRefWriteBarrierHelper
 .align 4
@@ -253,7 +253,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
 
 #ifdef WRITE_BARRIER_CHECK
     // Test dest here so if it is bad AV would happen before we change register/stack
-    // status. This makes job of AdjustContextForWriteBarrier easier.
+    // status. This makes job of AdjustContextForJITHelpers easier.
     cmp     BYTE PTR [edi], 0
 
     // ALSO update the shadow GC heap if that is enabled

--- a/src/coreclr/src/vm/stackwalk.cpp
+++ b/src/coreclr/src/vm/stackwalk.cpp
@@ -2570,9 +2570,9 @@ StackWalkAction StackFrameIterator::NextRaw(void)
 
         PTR_VOID newSP = PTR_VOID((TADDR)GetRegdisplaySP(m_crawl.pRD));
 #ifndef NO_FIXED_STACK_LIMIT
-        FAIL_IF_SPECULATIVE_WALK(newSP >= m_crawl.pThread->GetCachedStackLimit());
+        FAIL_IF_SPECULATIVE_WALK(m_crawl.pThread->IsExecutingOnAltStack() || newSP >= m_crawl.pThread->GetCachedStackLimit());
 #endif // !NO_FIXED_STACK_LIMIT
-        FAIL_IF_SPECULATIVE_WALK(newSP < m_crawl.pThread->GetCachedStackBase());
+        FAIL_IF_SPECULATIVE_WALK(m_crawl.pThread->IsExecutingOnAltStack() || newSP < m_crawl.pThread->GetCachedStackBase());
 
 #undef FAIL_IF_SPECULATIVE_WALK
 

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -1035,6 +1035,8 @@ public:
         if(STSGuarantee_Force == fScope)
             return TRUE;
 
+        // For debug, always enable setting thread stack guarantee so that we can print the stack trace
+#ifndef DEBUG
         //The runtime must be hosted to have escalation policy
         //If escalation policy is enabled but StackOverflow is not part of the policy
         //   then we don't use SetThreadStackGuarantee
@@ -1044,6 +1046,7 @@ public:
             //FAIL_StackOverflow is ProcessExit so don't use SetThreadStackGuarantee
             return FALSE;
         }
+#endif // DEBUG
         return TRUE;
     }
 
@@ -1081,7 +1084,7 @@ public:
 
         TS_LegalToJoin            = 0x00000020,    // Is it now legal to attempt a Join()
 
-        // unused                 = 0x00000040,
+        TS_ExecutingOnAltStack    = 0x00000040,    // Runtime is executing on an alternate stack located anywhere in the memory
 
 #ifdef FEATURE_HIJACK
         TS_Hijacked               = 0x00000080,    // Return address has been hijacked
@@ -1415,6 +1418,18 @@ public:
         return HasThreadStateOpportunistic(TS_CatchAtSafePoint);
     }
 #endif // DACCESS_COMPILE
+
+    DWORD IsExecutingOnAltStack()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (m_State & TS_ExecutingOnAltStack);
+    }
+
+    void SetExecutingOnAltStack()
+    {
+        LIMITED_METHOD_CONTRACT;
+        FastInterlockOr((ULONG *) &m_State, TS_ExecutingOnAltStack);
+    }
 
     DWORD IsBackground()
     {
@@ -1841,7 +1856,7 @@ public:
         {
             void* curSP;
             curSP = (void *)GetCurrentSP();
-            _ASSERTE((curSP <= m_pFrame && m_pFrame < m_CacheStackBase) || m_pFrame == (Frame*) -1);
+            _ASSERTE(IsExecutingOnAltStack() || (curSP <= m_pFrame && m_pFrame < m_CacheStackBase) || m_pFrame == (Frame*) -1);
         }
 #endif
 


### PR DESCRIPTION
This is a fixed version of the reverted commit.

This change enables printing stack trace at stack overflow to the
console. In case multiple threads fail with stack overflow in parallel,
only the trace of the first thread is printed.

There are couple of interesting details:

The stack trace is printed in a compressed form. The algorithm finds the
largest sequence of frames starting from the top of the stack that is
repeated and prints it just once with the repeat count.
Only the first thread that hits stack overflow gets its stack printed.
On Linux, others threads that hit stack overflow are held spinning until
the process exits. This enables having a single preallocated stack for
handling stack overflow. On Windows, we just don't print the stack
trace, as it would be messy anyways due to the interleaving of output
from multiple threads and the value of getting stack overflow traces of
multiple threads is questionable.
On debug / checked builds for Windows, I had to bump the stack guarantee
by two pages and also enable setting the stack guarantee for all threads
in these build flavors.
At couple of places in the runtime, there were debug checks comparing
explicit frame and some other struct addresses to the current SP. These
were firing on Linux when we are running on an extra stack overflow
handling stack. I've fixed it by adding a flag to the Thread that
indicates that we are running on an alternate stack and these checks
should be skipped.
I've fixed the x86 Windows JIT_StackProbe to first probe at SP-4 and
then move the SP to leave more stack space for the handler.
I've fixed stack overflow check on Linux for some glibc / distros. The
stack limit returned by the pthread_attr_getstack returns the address of
the guard page in some of the glibc / distros and address of the last
accessible page before the guard page on others. So I've relaxed the
check to consider +/- 1 page around the stack limit to recognize sigsegv
as stack overflow.