### PR TITLE
Added JsonContent to System.Net.Http

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -219,6 +219,30 @@ namespace System.Net.Http
         public System.Net.Http.HttpResponseMessage EnsureSuccessStatusCode() { throw null; }
         public override string ToString() { throw null; }
     }
+    public partial class JsonContent : ByteArrayContent
+    {
+        public JsonContent(object content)
+            : base(default(byte[]))
+        {
+        }
+
+        public JsonContent(object content, string mediaType)
+            : base(default(byte[]))
+        {
+        }
+
+        public JsonContent(object content, System.Text.Json.JsonSerializerOptions options)
+            : base(default(byte[]))
+        {
+        }
+
+        public JsonContent(object content, string mediaType, System.Text.Json.JsonSerializerOptions options)
+            : base(default(byte[]))
+        {
+        }
+
+        protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, TransportContext context, System.Threading.CancellationToken cancellationToken) => throw null;
+    }
     public abstract partial class MessageProcessingHandler : System.Net.Http.DelegatingHandler
     {
         protected MessageProcessingHandler() { }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
@@ -11,5 +11,6 @@
     <ProjectReference Include="..\..\System.Net.Security\ref\System.Net.Security.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />
     <ProjectReference Include="..\..\System.Text.Encoding\ref\System.Text.Encoding.csproj" />
+    <ProjectReference Include="..\..\System.Text.Json\ref\System.Text.Json.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -51,6 +51,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthority.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
+    <Compile Include="System\Net\Http\JsonContent.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />
     <Compile Include="System\Net\Http\Headers\AuthenticationHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\BaseHeaderParser.cs" />
@@ -737,6 +738,7 @@
     <Reference Include="System.Security.Cryptography.X509Certificates" />
     <Reference Include="System.Security.Principal" Condition="'$(TargetsWindows)' == 'true'" />
     <Reference Include="System.Security.Principal.Windows" />
+    <Reference Include="System.Text.Json" />
     <Reference Include="System.Threading" />
     <Reference Include="System.IO.Compression.Brotli" />
   </ItemGroup>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/JsonContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/JsonContent.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    public class JsonContent : ByteArrayContent
+    {
+        private const string DefaultMediaType = "application/json";
+
+        public JsonContent(object content)
+            : this(content, null, null)
+        {
+        }
+
+        public JsonContent(object content, string mediaType)
+            : this(content, mediaType, null)
+        {
+        }
+
+        public JsonContent(object content, JsonSerializerOptions options)
+            : this(content, null, options)
+        {
+        }
+
+        public JsonContent(object content, string mediaType, JsonSerializerOptions options)
+            : base(GetContentByteArray(content, options))
+        {
+            // Initialize the 'Content-Type' header with information provided by parameters.
+            MediaTypeHeaderValue headerValue = new MediaTypeHeaderValue((mediaType == null) ? DefaultMediaType : mediaType);
+            headerValue.CharSet = Encoding.UTF8.WebName;
+
+            Headers.ContentType = headerValue;
+        }
+
+        // A JsonContent is essentially a ByteArrayContent. We serialize the object into a byte-array in the
+        // constructor using utf-8. When this content is sent, the Content-Length can be retrieved easily (length of the array).
+        private static byte[] GetContentByteArray(object content, JsonSerializerOptions options)
+        {
+            return JsonSerializer.SerializeToUtf8Bytes(content, options);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(JsonContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
+
+        internal override Stream TryCreateContentReadStream() =>
+            GetType() == typeof(JsonContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
+            null;
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/JsonContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/JsonContentTest.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class JsonContentTest
+    {
+        [Fact]
+        public void Ctor_Null_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new JsonContent(null));
+        }
+
+        [Fact]
+        public async Task Ctor_JsonContent_Accept()
+        {
+            var content = new JsonContent(new {Success = true});
+
+            Assert.Equal("application/json", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            Stream result = await content.ReadAsStreamAsync();
+            Assert.Equal(16, result.Length);
+        }
+
+        [Fact]
+        public async Task Ctor_UseCustomMediaType_ContentTypeHeaderUpdated()
+        {
+            var content = new JsonContent(new {Success = true}, "application/custom");
+
+            Assert.Equal("application/custom", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(@"{""Success"":true}", destinationString);
+        }
+
+        [Fact]
+        public async Task Ctor_UseSerializerOptions_ContentSerializedCorrectly()
+        {
+            var content = new JsonContent(new { Success = true }, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(@"{""success"":true}", destinationString);
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -193,6 +193,7 @@
       <Link>Common\System\Net\Http\SchSendAuxRecordHttpTest.cs</Link>
     </Compile>
     <Compile Include="StreamContentTest.cs" />
+    <Compile Include="JsonContentTest.cs" />
     <Compile Include="StringContentTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\SyncBlockingContent.cs">
       <Link>Common\System\Net\Http\SyncBlockingContent.cs</Link>


### PR DESCRIPTION
JsonContent takes an object and serializes it to an utf8 byte array.

This fixes #1754