### PR TITLE
Disable constantly failing NetworkInformation test

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -53,6 +53,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]  // Some APIs are not supported on Linux
+        [ActiveIssue(18090)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())


### PR DESCRIPTION
Failed in the last few rolling builds at least: https://github.com/dotnet/runtime/issues/18090.

cc @dotnet/ncl 