### PR TITLE
Minor R2RDump improvements

### DIFF
--- a/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -65,6 +65,7 @@ namespace Internal.Runtime
         AttributePresence = 113, // Added in V3.1
         InliningInfo2 = 114, // Added in 4.1
         ComponentAssemblies = 115, // Added in 4.1
+        OwnerCompositeExecutable = 116, // Added in 4.1
 
         //
         // CoreRT ReadyToRun sections

--- a/src/coreclr/src/tools/r2rdump/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rdump/CommandLineOptions.cs
@@ -28,6 +28,7 @@ namespace R2RDump
             command.AddOption(new Option(new[] { "--sectionContents", "--sc" }, "Dump section contents", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--entrypoints", "-e" }, "Dump list of method / instance entrypoints in the R2R file", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--normalize", "-n" }, "Normalize dump by sorting the various tables and methods (default = unsorted i.e. file order)", new Argument<bool>()));
+            command.AddOption(new Option(new[] { "--hide-transitions", "--ht" }, "Don't include GC transitions in disassembly output", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--verbose", "-v" }, "Dump disassembly, unwindInfo, gcInfo and sectionContents", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--diff" }, "Compare two R2R images", new Argument<bool>()));
             command.AddOption(new Option(new[] { "--diff-hide-same-disasm" }, "In matching method diff dump, hide functions with identical disassembly", new Argument<bool>()));

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -39,6 +39,7 @@ namespace R2RDump
         public bool SectionContents { get; set; }
         public bool EntryPoints { get; set; }
         public bool Normalize { get; set; }
+        public bool HideTransitions { get; set; }
         public bool Verbose { get; set; }
         public bool Diff { get; set; }
         public bool DiffHideSameDisasm { get; set; }


### PR DESCRIPTION
Based on JanV's suggestions and based on my own composite R2R work
I have made a few small improvements in R2RDump:

1) When normalization is on, we newly also normalize transition
records for a particular IP address.

2) New option --hide-transitions suppresses transition information
in the disassembly completely.

3) Logic for parsing the new OwnerCompositeExecutable R2R section.

Thanks

Tomas