### PR TITLE
Fix ActiveIssue issue number to use full Url

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -53,7 +53,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]  // Some APIs are not supported on Linux
-        [ActiveIssue(18090)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/18090")]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())


### PR DESCRIPTION
This is the only one in the repo still using a number.