### PR TITLE
[interp] Always init locals

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3298,7 +3298,18 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			g_free (name);
 		}
 
-		if (header->num_locals && header->init_locals)
+		/*
+		 * We initialize the locals regardless of the presence of the init_locals
+		 * flag. Locals holding references need to be zeroed so we don't risk
+		 * crashing the GC if they end up being stored in an object.
+		 *
+		 * FIXME
+		 * Track values of locals over multiple basic blocks. This would enable
+		 * us to kill the MINT_INITLOCALS instruction if all locals are initialized
+		 * before use. We also don't need this instruction if the init locals flag
+		 * is not set and there are no locals holding references.
+		 */
+		if (header->num_locals)
 			interp_add_ins (td, MINT_INITLOCALS);
 
 		guint16 enter_profiling = 0;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18811,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Storing uninitialized locals in a managed object shouldn't crash the runtime, so they should be zeroed. This doesn't seem to regress performance on wasm since the initlocals flag is always set, currently. We should be able to remove it most of the time, once we add some multi basic block support to the cprop phase. This will enable us to further reduce call overhead.

Fixes https://github.com/mono/mono/issues/18527



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
