### PR TITLE
AV Fix for OleDb

### DIFF
--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -430,7 +430,7 @@ namespace System.Data.OleDb
                 {
                     fixed (tagDBPARAMBINDINFO* p = &bindInfo[i])
                     {
-                        bindInfo_x86[i] = (tagDBPARAMBINDINFO_x86)Marshal.PtrToStructure((IntPtr)p, typeof(tagDBPARAMBINDINFO_x86));
+                        bindInfo_x86[i] = *(tagDBPARAMBINDINFO_x86*)p;
                     }
                 }
                 fixed (tagDBPARAMBINDINFO_x86* p = &bindInfo_x86[0])

--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -419,7 +419,7 @@ namespace System.Data.OleDb
                 ordinals[i] = (IntPtr)(i + 1);
             }
 
-            OleDbHResult hr;
+            IntPtr bindingPtr;
 
             if (ODB.IsRunningOnX86)
             {
@@ -433,16 +433,18 @@ namespace System.Data.OleDb
                 }
                 fixed (tagDBPARAMBINDINFO_x86* p = &bindInfo_x86[0])
                 {
-                    hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)p);
+                    bindingPtr = (IntPtr)p;
                 }
             }
             else
             {
                 fixed (tagDBPARAMBINDINFO* p = &bindInfo[0])
                 {
-                    hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)p);
+                    bindingPtr = (IntPtr)p;
                 }
             }
+
+            OleDbHResult hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)bindingPtr);
 
             if (hr < 0)
             {

--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -44,8 +44,6 @@ namespace System.Data.OleDb
         private int _changeID;
         private int _lastChangeID;
 
-        private static readonly bool s_runningOnX86 = RuntimeInformation.ProcessArchitecture == Architecture.X86;
-
         public OleDbCommand() : base()
         {
             GC.SuppressFinalize(this);
@@ -423,7 +421,7 @@ namespace System.Data.OleDb
 
             OleDbHResult hr;
 
-            if (s_runningOnX86)
+            if (ODB.IsRunningOnX86)
             {
                 tagDBPARAMBINDINFO_x86[] bindInfo_x86 = new tagDBPARAMBINDINFO_x86[bindInfo.Length];
                 for (int i = 0; i < bindInfo.Length; i++)

--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -419,7 +419,7 @@ namespace System.Data.OleDb
                 ordinals[i] = (IntPtr)(i + 1);
             }
 
-            IntPtr bindingPtr;
+            OleDbHResult hr;
 
             if (ODB.IsRunningOnX86)
             {
@@ -433,18 +433,16 @@ namespace System.Data.OleDb
                 }
                 fixed (tagDBPARAMBINDINFO_x86* p = &bindInfo_x86[0])
                 {
-                    bindingPtr = (IntPtr)p;
+                    hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)p);
                 }
             }
             else
             {
                 fixed (tagDBPARAMBINDINFO* p = &bindInfo[0])
                 {
-                    bindingPtr = (IntPtr)p;
+                    hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)p);
                 }
             }
-
-            OleDbHResult hr = commandWithParameters.SetParameterInfo((IntPtr)bindInfo.Length, ordinals, (IntPtr)bindingPtr);
 
             if (hr < 0)
             {

--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -428,12 +428,10 @@ namespace System.Data.OleDb
                 tagDBPARAMBINDINFO_x86[] bindInfo_x86 = new tagDBPARAMBINDINFO_x86[bindInfo.Length];
                 for (int i = 0; i < bindInfo.Length; i++)
                 {
-                    bindInfo_x86[i].pwszDataSourceType = bindInfo[i].pwszDataSourceType;
-                    bindInfo_x86[i].pwszName = bindInfo[i].pwszName;
-                    bindInfo_x86[i].ulParamSize = bindInfo[i].ulParamSize;
-                    bindInfo_x86[i].dwFlags = bindInfo[i].dwFlags;
-                    bindInfo_x86[i].bPrecision = bindInfo[i].bPrecision;
-                    bindInfo_x86[i].bScale = bindInfo[i].bScale;
+                    fixed (tagDBPARAMBINDINFO* p = &bindInfo[i])
+                    {
+                        bindInfo_x86[i] = (tagDBPARAMBINDINFO_x86)Marshal.PtrToStructure((IntPtr)p, typeof(tagDBPARAMBINDINFO_x86));
+                    }
                 }
                 fixed (tagDBPARAMBINDINFO_x86* p = &bindInfo_x86[0])
                 {

--- a/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbCommand.cs
@@ -44,6 +44,8 @@ namespace System.Data.OleDb
         private int _changeID;
         private int _lastChangeID;
 
+        private static readonly bool s_runningOnX86 = RuntimeInformation.ProcessArchitecture == Architecture.X86;
+
         public OleDbCommand() : base()
         {
             GC.SuppressFinalize(this);
@@ -410,7 +412,7 @@ namespace System.Data.OleDb
             }
             _dbBindings = bindings;
         }
-        private static readonly bool s_runningOnX86 = RuntimeInformation.ProcessArchitecture == Architecture.X86;
+
         private unsafe void ApplyParameterBindings(UnsafeNativeMethods.ICommandWithParameters commandWithParameters, tagDBPARAMBINDINFO[] bindInfo)
         {
             IntPtr[] ordinals = new IntPtr[bindInfo.Length];

--- a/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
@@ -33,11 +33,65 @@ namespace System.Data.OleDb
     }
 #endif
 
-#if (WIN32 && !ARCH_arm)
-    [StructLayoutAttribute(LayoutKind.Sequential, Pack = 2)]
-#else
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    internal struct tagDBPARAMBINDINFO_x86
+    {
+        internal IntPtr pwszDataSourceType;
+        internal IntPtr pwszName;
+        internal IntPtr ulParamSize;
+        internal int dwFlags;
+        internal byte bPrecision;
+        internal byte bScale;
+
+#if DEBUG
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("tagDBPARAMBINDINFO").Append(Environment.NewLine);
+            if (IntPtr.Zero != pwszDataSourceType)
+            {
+                builder.Append("pwszDataSourceType =").Append(Marshal.PtrToStringUni(pwszDataSourceType)).Append(Environment.NewLine);
+            }
+            builder.Append("\tulParamSize  =" + ulParamSize.ToInt64().ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tdwFlags     =0x" + dwFlags.ToString("X4", CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tPrecision   =" + bPrecision.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tScale       =" + bScale.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            return builder.ToString();
+        }
 #endif
+    }
+
+
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    internal struct tagDBPARAMBINDINFO_x64
+    {
+        internal IntPtr pwszDataSourceType;
+        internal IntPtr pwszName;
+        internal IntPtr ulParamSize;
+        internal int dwFlags;
+        internal byte bPrecision;
+        internal byte bScale;
+
+#if DEBUG
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("tagDBPARAMBINDINFO").Append(Environment.NewLine);
+            if (IntPtr.Zero != pwszDataSourceType)
+            {
+                builder.Append("pwszDataSourceType =").Append(Marshal.PtrToStringUni(pwszDataSourceType)).Append(Environment.NewLine);
+            }
+            builder.Append("\tulParamSize  =" + ulParamSize.ToInt64().ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tdwFlags     =0x" + dwFlags.ToString("X4", CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tPrecision   =" + bPrecision.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            builder.Append("\tScale       =" + bScale.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
+            return builder.ToString();
+        }
+#endif
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     internal struct tagDBPARAMBINDINFO
     {
         internal IntPtr pwszDataSourceType;

--- a/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
@@ -62,35 +62,6 @@ namespace System.Data.OleDb
 #endif
     }
 
-
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    internal struct tagDBPARAMBINDINFO_x64
-    {
-        internal IntPtr pwszDataSourceType;
-        internal IntPtr pwszName;
-        internal IntPtr ulParamSize;
-        internal int dwFlags;
-        internal byte bPrecision;
-        internal byte bScale;
-
-#if DEBUG
-        public override string ToString()
-        {
-            StringBuilder builder = new StringBuilder();
-            builder.Append("tagDBPARAMBINDINFO").Append(Environment.NewLine);
-            if (IntPtr.Zero != pwszDataSourceType)
-            {
-                builder.Append("pwszDataSourceType =").Append(Marshal.PtrToStringUni(pwszDataSourceType)).Append(Environment.NewLine);
-            }
-            builder.Append("\tulParamSize  =" + ulParamSize.ToInt64().ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
-            builder.Append("\tdwFlags     =0x" + dwFlags.ToString("X4", CultureInfo.InvariantCulture)).Append(Environment.NewLine);
-            builder.Append("\tPrecision   =" + bPrecision.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
-            builder.Append("\tScale       =" + bScale.ToString(CultureInfo.InvariantCulture)).Append(Environment.NewLine);
-            return builder.ToString();
-        }
-#endif
-    }
-
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
     internal struct tagDBPARAMBINDINFO
     {

--- a/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbStruct.cs
@@ -48,7 +48,7 @@ namespace System.Data.OleDb
         public override string ToString()
         {
             StringBuilder builder = new StringBuilder();
-            builder.Append("tagDBPARAMBINDINFO").Append(Environment.NewLine);
+            builder.Append("tagDBPARAMBINDINFO_x86").Append(Environment.NewLine);
             if (IntPtr.Zero != pwszDataSourceType)
             {
                 builder.Append("pwszDataSourceType =").Append(Marshal.PtrToStringUni(pwszDataSourceType)).Append(Environment.NewLine);

--- a/src/libraries/System.Data.OleDb/src/OleDb_Util.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDb_Util.cs
@@ -687,6 +687,8 @@ namespace System.Data.OleDb
         internal const string DbInfoKeywords = "DbInfoKeywords";
         internal const string Keyword = "Keyword";
 
+        internal static readonly bool IsRunningOnX86 = RuntimeInformation.ProcessArchitecture == Architecture.X86;
+
         // Debug error string writeline
         internal static string ELookup(OleDbHResult hr)
         {

--- a/src/libraries/System.Data.OleDb/src/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Data.OleDb/src/UnsafeNativeMethods.cs
@@ -409,7 +409,7 @@ namespace System.Data.Common
             System.Data.OleDb.OleDbHResult SetParameterInfo(
                 [In] IntPtr cParams,
                 [In, MarshalAs(UnmanagedType.LPArray)] IntPtr[] rgParamOrdinals,
-                [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Struct)] System.Data.OleDb.tagDBPARAMBINDINFO[] rgParamBindInfo);
+                [In] IntPtr rgParamBindInfo);
         }
 
         [Guid("2206CCB1-19C1-11D1-89E0-00C04FD7A829"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport, SuppressUnmanagedCodeSecurity]

--- a/src/libraries/System.Data.OleDb/tests/Helpers.cs
+++ b/src/libraries/System.Data.OleDb/tests/Helpers.cs
@@ -11,7 +11,7 @@ namespace System.Data.OleDb.Tests
         public const string IsDriverAvailable = nameof(Helpers) + "." + nameof(GetIsDriverAvailable);
         public const string IsAceDriverAvailable = nameof(Helpers) + "." + nameof(GetIsAceDriverAvailable);
         public static bool GetIsDriverAvailable() => Nested.IsAvailable;
-        public static bool GetIsAceDriverAvailable() => GetIsDriverAvailable();// && !PlatformDetection.Is32BitProcess;
+        public static bool GetIsAceDriverAvailable() => GetIsDriverAvailable() && !PlatformDetection.Is32BitProcess;
         public static string ProviderName => Nested.ProviderName;
         public static string GetTableName(string memberName) => memberName + ".csv";
 
@@ -21,7 +21,7 @@ namespace System.Data.OleDb.Tests
             public static readonly string ProviderName;
             public static Nested Instance => s_instance;
             private static readonly Nested s_instance = new Nested();
-            private const string ExpectedProviderName = @"Microsoft.Jet.OLEDB.4.0";
+            private const string ExpectedProviderName = @"Microsoft.ACE.OLEDB.12.0";
             private Nested() { }
             static Nested()
             {
@@ -34,7 +34,7 @@ namespace System.Data.OleDb.Tests
                     providerNames.Add((string)row[providersRegistered]);
                 }
                 // skip if x86 or if the expected driver not available
-                IsAvailable = providerNames.Contains(ExpectedProviderName);
+                IsAvailable = !PlatformDetection.Is32BitProcess && providerNames.Contains(ExpectedProviderName);
                 if (!CultureInfo.CurrentCulture.Name.Equals("en-US", StringComparison.OrdinalIgnoreCase))
                 {
                     IsAvailable = false; // ActiveIssue: https://github.com/dotnet/corefx/issues/38737

--- a/src/libraries/System.Data.OleDb/tests/Helpers.cs
+++ b/src/libraries/System.Data.OleDb/tests/Helpers.cs
@@ -11,7 +11,7 @@ namespace System.Data.OleDb.Tests
         public const string IsDriverAvailable = nameof(Helpers) + "." + nameof(GetIsDriverAvailable);
         public const string IsAceDriverAvailable = nameof(Helpers) + "." + nameof(GetIsAceDriverAvailable);
         public static bool GetIsDriverAvailable() => Nested.IsAvailable;
-        public static bool GetIsAceDriverAvailable() => GetIsDriverAvailable() && !PlatformDetection.Is32BitProcess;
+        public static bool GetIsAceDriverAvailable() => GetIsDriverAvailable();// && !PlatformDetection.Is32BitProcess;
         public static string ProviderName => Nested.ProviderName;
         public static string GetTableName(string memberName) => memberName + ".csv";
 
@@ -21,7 +21,7 @@ namespace System.Data.OleDb.Tests
             public static readonly string ProviderName;
             public static Nested Instance => s_instance;
             private static readonly Nested s_instance = new Nested();
-            private const string ExpectedProviderName = @"Microsoft.ACE.OLEDB.12.0";
+            private const string ExpectedProviderName = @"Microsoft.Jet.OLEDB.4.0";
             private Nested() { }
             static Nested()
             {
@@ -34,7 +34,7 @@ namespace System.Data.OleDb.Tests
                     providerNames.Add((string)row[providersRegistered]);
                 }
                 // skip if x86 or if the expected driver not available
-                IsAvailable = !PlatformDetection.Is32BitProcess && providerNames.Contains(ExpectedProviderName);
+                IsAvailable = providerNames.Contains(ExpectedProviderName);
                 if (!CultureInfo.CurrentCulture.Name.Equals("en-US", StringComparison.OrdinalIgnoreCase))
                 {
                     IsAvailable = false; // ActiveIssue: https://github.com/dotnet/corefx/issues/38737


### PR DESCRIPTION
Fixes #981

The PR adapts from the PR at https://github.com/dotnet/runtime/pull/32150 and maintains the same idea around changing the pack structure of the enum on X86 execution, just before sending it over to OleDb to minimize changes in the way the structure is modified. 

The basic idea that the Packing of the structure needs to be changed, stems from the investigation done by @maryamariyan . 

Note: This PR changes a single struct. The other structs which are packed with size 2, should be addressed too, and I will be taking care of them in subsequent PRs. 

Testing: The tests were run on x86 build with the `Microsoft.Jet.OLEDB.4.0` driver which is meant for 32 bit usage. 

