### PR TITLE
Rename JsonPropertyInfo<TConverter> to JsonPropertyInfo<TTypeToConvert>.

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -122,7 +122,7 @@
     <Compile Include="System\Text\Json\Serialization\JsonNamingPolicy.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonObjectConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfo.cs" />
-    <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoOfTConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoOfTTypeToConvert.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonResumableConverterOfT.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleMetadata.cs" />


### PR DESCRIPTION
Using `TConverter` to refer to the generic type that the `JsonConverter<T>` supports seemed odd (it makes it seem like we are referring to the converter, not the T that the converter supports).

If you have other suggestions that might be clearer, let me know.

cc @stephentoub 