### PR TITLE
Move common project reference to the S.T.E.W ref into a separate ItemGroup.

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -17,7 +17,7 @@
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
-  <!-- Since S.T.E.W is live built as part of the repo as both an in-box library and a standalone netstandard2.0 assembly,
+  <!-- Since S.T.E.W continues to be built live within this repo (as both an in-box library and a standalone netstandard2.0 assembly),
     we should use ProjectReference instead of Reference to make sure that its ref assembly gets built first before S.T.Json, regardless of the TFM.
   -->
   <ItemGroup>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -18,8 +18,7 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
   <!-- Since S.T.E.W continues to be built live within this repo (as both an in-box library and a standalone netstandard2.0 assembly),
-    we should use ProjectReference instead of Reference to make sure that its ref assembly gets built first before S.T.Json, regardless of the TFM.
-  -->
+    we should use ProjectReference instead of Reference to make sure that its ref assembly gets built first before S.T.Json, regardless of the TFM. -->
   <ItemGroup>
     <ProjectReference Include="..\..\System.Text.Encodings.Web\ref\System.Text.Encodings.Web.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -9,7 +9,6 @@
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
     <ProjectReference Include="..\..\System.Memory\ref\System.Memory.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Text.Encodings.Web\ref\System.Text.Encodings.Web.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' != 'true'">
     <Reference Include="mscorlib" />
@@ -17,6 +16,11 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+  <!-- Since S.T.E.W is built as part of the repo as both an in-box library and a standalone netstandard2.0 assembly,
+    we should use ProjectReference instead of Reference to make sure that its ref gets built first before S.T.Json, regardless of the TFM.
+  -->
+  <ItemGroup>
     <ProjectReference Include="..\..\System.Text.Encodings.Web\ref\System.Text.Encodings.Web.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -17,8 +17,8 @@
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
-  <!-- Since S.T.E.W is built as part of the repo as both an in-box library and a standalone netstandard2.0 assembly,
-    we should use ProjectReference instead of Reference to make sure that its ref gets built first before S.T.Json, regardless of the TFM.
+  <!-- Since S.T.E.W is live built as part of the repo as both an in-box library and a standalone netstandard2.0 assembly,
+    we should use ProjectReference instead of Reference to make sure that its ref assembly gets built first before S.T.Json, regardless of the TFM.
   -->
   <ItemGroup>
     <ProjectReference Include="..\..\System.Text.Encodings.Web\ref\System.Text.Encodings.Web.csproj" />


### PR DESCRIPTION
Since the `ProjectReference` to S.T.E.W was common for all conditions, moved it to a separate condition-less `ItemGroup` with a comment explaining why we use `ProjectReference` here instead of `Reference`. Seeing `ProjectReference` in this case had thrown me off before where I thought that was an unintentional bug, especially within the `ItemGroup` that only used `Reference`.

Raw Notes from our discussion:
```
There are 3 stages of runtime build:
 - restore - restore packages for all assets that are not live built that are "Referenced" - from targeting pack: (e.g. E:\GitHub\Fork\runtime\artifacts\bin\ref\netstandard2.0)
 - build the ref assemblies - potential race condition - updates bin\ref\ directory
 - build the source project - in source.csproj always use Reference (exception: ReferenceFromRuntime)

project reference -> ensure gets built, ensures dependency is valid and reference the dll of that project
```

cc @joperezr, @safern - can you please review the explanation?