### PR TITLE
Fix nullability warnings in System.Diagnostics.Process

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 namespace System.Threading.Tasks
 {
     /// <summary>
@@ -25,7 +26,7 @@ namespace System.Threading.Tasks
         public async ValueTask<T> WaitWithCancellationAsync(CancellationToken cancellationToken)
         {
             _cancellationToken = cancellationToken;
-            using (cancellationToken.UnsafeRegister(s => ((TaskCompletionSourceWithCancellation<T>)s).OnCancellation(), this))
+            using (cancellationToken.UnsafeRegister(s => ((TaskCompletionSourceWithCancellation<T>)s!).OnCancellation(), this))
             {
                 return await Task.ConfigureAwait(false);
             }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1426,9 +1426,9 @@ namespace System.Diagnostics
                 throw;
             }
 
-            var tcs = new TaskCompletionSourceWithCancellation<object>();
+            var tcs = new TaskCompletionSourceWithCancellation<bool>();
 
-            EventHandler handler = (s, e) => tcs.TrySetResult(null);
+            EventHandler handler = (s, e) => tcs.TrySetResult(true);
             Exited += handler;
 
             try


### PR DESCRIPTION
Two PRs (one to nullable-annotate S.D.Process, and one to add a method to the assembly) raced in CI.
cc: @safern, @AndyAyersMS 