### PR TITLE
Update to the latest available Intellisense transport package.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
     <XUnitXmlTestLoggerVersion>2.1.26</XUnitXmlTestLoggerVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>3.1.0-preview-20200129.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <ILLinkTasksVersion>0.1.6-prerelease.19567.1</ILLinkTasksVersion>
     <!-- Mono LLVM -->

--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -12,7 +12,7 @@
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
 
     <!-- Used by PackageLibs.targets -->
-    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
+    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/IntellisenseFiles/netcoreapp</XmlDocFileRoot>
 
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->

--- a/eng/restore/docs.targets
+++ b/eng/restore/docs.targets
@@ -9,7 +9,7 @@
           AfterTargets="Restore">
 
     <ItemGroup>
-      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/xmldocs/netcoreapp/**/*.xml"/>
+      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/IntellisenseFiles/netcoreapp/**/*.xml"/>
       <DocFile>
         <!-- trim off slash since it differs by platform and we need to do a string compare -->
         <LCID>$([System.String]::new('%(RecursiveDir)').TrimEnd('\/'))</LCID>


### PR DESCRIPTION
The docs team now takes the latest documentation from https://github.com/dotnet/dotnet-api-docs  and publishes an intermediary transport package to our internal NuGet feed that we can consume within our libraries: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json.

The next steps are to figure out a way to automate the consumption of the "latest" version of the `Microsoft.Private.Intellisense` package (get auto-PRs that update the version using DARC).

cc @carlossanlop, @safern 