### PR TITLE
[tests] Disable bug-10127.exe runtime test on Windows x64 C++

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -1208,6 +1208,7 @@ if test x$enable_monotouch = xyes; then
 fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
+AM_CONDITIONAL(ENABLE_CXX, test x$enable_cxx = xyes)
 
 # mono/corefx/native has a lot of invalid C++98 in its headers
 # dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052

--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -1108,6 +1108,12 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
+
+if ENABLE_CXX
+# see https://github.com/mono/mono/issues/18827
+PLATFORM_DISABLED_TESTS += bug-10127.exe
+endif
+
 endif
 
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18828,  please do not edit or review it in this repo !!<br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>It hangs: https://github.com/mono/mono/issues/18827
