### PR TITLE
Linux NIC speed type made long to fit the actual value

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -156,6 +156,12 @@ echo pushd $EXECUTION_DIR
 [[RunCommandsEcho]]
 echo popd
 echo ===========================================================================================================
+echo Manicka!!!
+if [ "$(uname -s)" == "Linux" ]; then
+  ethtool eth0
+else
+  networksetup -listallhardwareports ; ifconfig -a
+fi
 pushd $EXECUTION_DIR
 [[RunCommands]]
 test_exitcode=$?

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -156,12 +156,6 @@ echo pushd $EXECUTION_DIR
 [[RunCommandsEcho]]
 echo popd
 echo ===========================================================================================================
-echo Manicka!!!
-if [ "$(uname -s)" == "Linux" ]; then
-  ethtool eth0
-else
-  networksetup -listallhardwareports ; ifconfig -a
-fi
 pushd $EXECUTION_DIR
 [[RunCommands]]
 test_exitcode=$?

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
@@ -33,7 +33,7 @@ internal static partial class Interop
         {
             public fixed byte Name[16];
             public int InterfaceIndex;
-            public int Speed;
+            public long Speed;
             public int Mtu;
             public ushort HardwareType;
             public byte OperationalState;

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
@@ -32,8 +32,8 @@ internal static partial class Interop
         public unsafe struct NetworkInterfaceInfo
         {
             public fixed byte Name[16];
-            public int InterfaceIndex;
             public long Speed;
+            public int InterfaceIndex;
             public int Mtu;
             public ushort HardwareType;
             public byte OperationalState;

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -373,7 +373,7 @@ int32_t SystemNative_GetNetworkInterfaces(int32_t * interfaceCount, NetworkInter
                         ecmd.cmd = ETHTOOL_GSET;
                         if (ioctl(socketfd, SIOCETHTOOL, &ifr) == 0)
                         {
-                            nii->Speed = (int)ethtool_cmd_speed(&ecmd);
+                            nii->Speed = (int64_t)ethtool_cmd_speed(&ecmd);
                             if (nii->Speed > 0)
                             {
                                 // If we did not get -1

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.h
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.h
@@ -37,8 +37,8 @@ typedef struct
 typedef struct
 {
     char Name[16];              // OS Interface name.
-    uint32_t InterfaceIndex;    // Interface index.
     int64_t Speed;              // Link speed for physical interfaces.
+    uint32_t InterfaceIndex;    // Interface index.
     int32_t Mtu;                // Interface MTU.
     uint16_t HardwareType;      // Interface mapped from L2 to NetworkInterfaceType.
     uint8_t OperationalState;   // Operational status.

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.h
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.h
@@ -38,7 +38,7 @@ typedef struct
 {
     char Name[16];              // OS Interface name.
     uint32_t InterfaceIndex;    // Interface index.
-    int32_t Speed;              // Link speed for physical interfaces.
+    int64_t Speed;              // Link speed for physical interfaces.
     int32_t Mtu;                // Interface MTU.
     uint16_t HardwareType;      // Interface mapped from L2 to NetworkInterfaceType.
     uint8_t OperationalState;   // Operational status.

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -53,7 +53,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]  // Some APIs are not supported on Linux
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/18090")]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())


### PR DESCRIPTION
Fixes #18090 

Linux pal level struct for network info had only int32 field for speed. Even though our [public API](https://docs.microsoft.com/en-us/dotnet/api/system.net.networkinformation.networkinterface.speed?view=netcore-3.1) has it as long. The problem was in value overflowing in calculation MBits --> Bits.