### PR TITLE
fix infinite recursion in crossgen2 on ARM

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -810,7 +810,7 @@ namespace ILCompiler
         /// This method decides whether the type needs aligned base offset in order to have layout resilient to 
         /// base class layout changes.
         /// </summary>
-        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
+        protected override void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
         {
             if (type.IsValueType)
             {
@@ -837,7 +837,8 @@ namespace ILCompiler
             }
 
             LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);
-            if (type.RequiresAlign8())
+
+            if (requiresAlign8)
             {
                 alignment = new LayoutInt(8);
             }


### PR DESCRIPTION
This PR fixes https://github.com/dotnet/runtime/issues/32120.

Despite it is not used in `ReadyToRunMetadataFieldLayoutAlgorithm::AlignBaseOffsetIfNecessary` I think we should pass proper default alignment, but I don't sure it is `4`: now field's alignment requirements are tracking by `MetadataFieldLayoutAlgorithm::ComputeAutoFieldLayout`.

Also if we try to call `TypeExtensions::RequiredAlign8(this TypeDesc)` just from `MetadataFieldLayoutAlgorithm`'s method we face missing dependency, so I decided to have `virtual` method to `override` in `ReadyToRunMetadataFieldLayoutAlgorithm`.