### PR TITLE
Disabling x86 Win7&8.1 helix test runs

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -108,14 +108,16 @@ jobs:
       # netcoreapp
       - ${{ if notIn(parameters.jobParameters.framework, 'allConfigurations', 'net472') }}:
         - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-          - Windows.7.Amd64.Open
-          - Windows.81.Amd64.Open
+          # TODO: Reopen when https://github.com/dotnet/runtime/issues/32231 is fixed
+          #- Windows.7.Amd64.Open
+          #- Windows.81.Amd64.Open
           - Windows.10.Amd64.ServerRS5.Open
           - Windows.10.Amd64.Server19H1.Open
         - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
           - ${{ if eq(parameters.jobParameters.buildConfig, 'Release') }}:
-            - Windows.7.Amd64.Open
-            - Windows.81.Amd64.Open
+            # TODO: Reopen when https://github.com/dotnet/runtime/issues/32231 is fixed
+            #- Windows.7.Amd64.Open
+            #- Windows.81.Amd64.Open
             - Windows.10.Amd64.Server19H1.ES.Open
           - ${{ if eq(parameters.jobParameters.buildConfig, 'Debug') }}:
             - Windows.10.Amd64.Server19H1.Open


### PR DESCRIPTION
These runs are failing frequently based on Client are fully patched.

https://github.com/dotnet/runtime/issues/32231