### PR TITLE
Forcibly disable use of libstdc++ C++11 ABI on Mono LLVM

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -30,7 +30,7 @@
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <_MonoExtraCFLAGS>-O2 -g</_MonoExtraCFLAGS>
-        <_MonoExtraCXXFLAGS>-O2 -g</_MonoExtraCXXFLAGS>
+        <_MonoExtraCXXFLAGS>-O2 -g -D_GLIBCXX_USE_CXX11_ABI=0</_MonoExtraCXXFLAGS>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetArchitecture)' == 'arm64' ">
         <_MonoTuple>aarch64-linux-gnu</_MonoTuple>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -25,7 +25,7 @@
   <Target Name="ConfigureMonoRuntimeUnix" Condition="'$(OS)' != 'Windows_NT'" Inputs="$(MonoProjectRoot)configure.ac" Outputs="$(MonoObjDir)config.h">
       <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
         <_MonoExtraCFLAGS>-O0 -ggdb3 -fno-omit-frame-pointer</_MonoExtraCFLAGS>
-        <_MonoExtraCXXFLAGS>-O0 -ggdb3 -fno-omit-frame-pointer</_MonoExtraCXXFLAGS>
+        <_MonoExtraCXXFLAGS>-O0 -ggdb3 -fno-omit-frame-pointer -D_GLIBCXX_USE_CXX11_ABI=0</_MonoExtraCXXFLAGS>
         <_MonoConfigureParams>--enable-checked-build=private_types</_MonoConfigureParams>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
This feature is documented at https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

Basically, the C++ ABI of the LLVM libraries needs to match the ABI of Mono. The CentOS7 images we build with on CI use the old (GCC 4 style) ABI by default, which ends up embedded in our LLVM nupkgs. This results in linker errors when building runtime.git on distributions which use the C++11 ABI instead, like Ubuntu 16.04+:

```
./.libs/libmini.a(llvm-jit.o): In function `mono_llvm_create_ee':
/home/directhex/Projects/runtime/src/mono/mono/mini/llvm-jit.cpp:447: undefined reference to `MonoEHFrameSymbol[abi:cxx11]'
./.libs/libmini.a(llvm-jit.o): In function `llvm::RTDyldMemoryManager::getSymbolAddress(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/directhex/Projects/runtime/artifacts/obj/mono/Linux.x64.Debug/llvm/include/llvm/ExecutionEngine/RTDyldMemoryManager.h:84: undefined reference to `llvm::RTDyldMemoryManager::getSymbolAddressInProcess(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
./.libs/libmini.a(llvm-jit.o):(.data.rel.ro+0x90): undefined reference to `llvm::RTDyldMemoryManager::getPointerToNamedFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)'
```

Adding a define to `CXXFLAGS`, `-D _GLIBCXX_USE_CXX11_ABI=0` forces the build to use the same ABI as the LLVM nupkgs we produce.

The alternative would be to modify our LLVM build to enable the non-default-in-our-CentOS-images C++11 ABI.