### PR TITLE
Fix the parameter value checks for SetWindowPosition

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -939,16 +939,16 @@ namespace System
             Interop.Kernel32.SMALL_RECT srWindow = csbi.srWindow;
 
             // Check for arithmetic underflows & overflows.
-            int newRight = left + srWindow.Right - srWindow.Left + 1;
-            if (left < 0 || newRight > csbi.dwSize.X || newRight < 0)
+            int newRight = left + srWindow.Right - srWindow.Left;
+            if (left < 0 || newRight > csbi.dwSize.X - 1 || newRight < left)
                 throw new ArgumentOutOfRangeException(nameof(left), left, SR.ArgumentOutOfRange_ConsoleWindowPos);
-            int newBottom = top + srWindow.Bottom - srWindow.Top + 1;
-            if (top < 0 || newBottom > csbi.dwSize.Y || newBottom < 0)
+            int newBottom = top + srWindow.Bottom - srWindow.Top;
+            if (top < 0 || newBottom > csbi.dwSize.Y - 1 || newBottom < top)
                 throw new ArgumentOutOfRangeException(nameof(top), top, SR.ArgumentOutOfRange_ConsoleWindowPos);
 
             // Preserve the size, but move the position.
-            srWindow.Bottom -= (short)(srWindow.Top - top);
-            srWindow.Right -= (short)(srWindow.Left - left);
+            srWindow.Bottom = (short)newBottom;
+            srWindow.Right = (short)newRight;
             srWindow.Left = (short)left;
             srWindow.Top = (short)top;
 


### PR DESCRIPTION
Related to the issue #31949 

The parameter validation is currently done with `newRight` and `newBottom`, but the true value passed to the Win32 API is actually `newRight - 1` and `newBottom -1`.
This causes `SetConsoleWindowInfo` fail with the error `The parameter is incorrect` when the the bottom of the console window is dragged to the top to make the height be zero.

When the height of the console window is made zero, the `CONSOLE_SCREEN_BUFFER_INFO` struct returned from `GetBufferInfo` has the `srWindow.Bottom` to be `srWindow.Top - 1`. In that case, the currently parameter value validation passes, but the true `Bottom` value passed to `SetConsoleWindowInfo` becomes less than `Top`, and thus the native API fails.

Here is the restrictions of the parameters of `SetConsoleWindowInfo` from the [documentation](https://docs.microsoft.com/en-us/windows/console/setconsolewindowinfo#remarks):
> The function fails if the specified window rectangle extends beyond the boundaries of the console screen buffer. This means that the **Top** and **Left** members of the lpConsoleWindow rectangle (or the calculated top and left coordinates, if bAbsolute is FALSE) cannot be less than zero. Similarly, the **Bottom** and **Right** members (or the calculated bottom and right coordinates) cannot be greater than (screen buffer height – 1) and (screen buffer width – 1), respectively. The function also fails if the **Right** member (or calculated right coordinate) is less than _**or equal to**_ the **Left** member (or calculated left coordinate) or if the **Bottom** member (or calculated bottom coordinate) is less than _**or equal to**_ the **Top** member (or calculated top coordinate).

Be noted about the "_**or equal to**_" part in the documentation about "**Right**" and "**Bottom**. This part of the documentation is not right. The function `SetConsoleWindowInfo` doesn't fail when `Bottom == Top` or `Right == Left`:
- when `Bottom == Top`, the height of the console window will be set to `1`.
- when `Right == Left`, the width of the console window will be set to `1`. 

Therefore, the new validation below doesn't restrict on the "_**or equal to**_" part.

/cc @danmosemsft I don't think it's possible to add a test for this fix, because the fixed issue happens only when the height of the console window is zero, but I don't find a way to set the window height to zero programmatically.

As for `SetWindowSize`, the values used for `srWindow` is fine to be passed to `SetConsoleWindowInfo`:
- `srWindow.Top` and `srWindow.Left` are not changed
- The window buffer width will be resized to `srWindow.Left + width` if needed, and buffer height will be resized to `srWindow.Top + height` if needed
- `srWindow.Bottom` is set to `srWindow.Top + height - 1` and `srWindow.Right` is set to `srWindow.Left + width - 1` and both `height` and `width` are `> 0` (validated at the beginning), so `srWindow.Bottom` is guaranteed to be `<= bufferHeight - 1` and `srWindow.Right` is guaranteed to be `<= bufferWidth - 1`; also, `srWindow.Bottom` is guaranteed to be `>= srWindow.Top` and `srWindow.Right` is guaranteed to be `>= srWindow.Left`