### PR TITLE
Skip res. intensive BinaryFormatter tests on chk

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
-        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(BasicObjectsRoundtrip_MemberData))]
         public void ValidateBasicObjectsRoundtrip(object obj, FormatterAssemblyStyle assemblyFormat, TypeFilterLevel filterLevel, FormatterTypeStyle typeFormat)
         {
@@ -61,13 +61,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
-        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(SerializableObjects_MemberData))]
         public void ValidateAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, false);
 
         [Theory]
-        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
+        [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(SerializableEqualityComparers_MemberData))]
         public void ValidateEqualityComparersAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, true);

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -46,6 +46,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
+        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(BasicObjectsRoundtrip_MemberData))]
         public void ValidateBasicObjectsRoundtrip(object obj, FormatterAssemblyStyle assemblyFormat, TypeFilterLevel filterLevel, FormatterTypeStyle typeFormat)
         {
@@ -60,11 +61,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [Theory]
+        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(SerializableObjects_MemberData))]
         public void ValidateAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, false);
 
         [Theory]
+        [SkipOnCoreClrAttribute("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(SerializableEqualityComparers_MemberData))]
         public void ValidateEqualityComparersAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, true);


### PR DESCRIPTION
Those tests are taking too long for our default timeout on Checked
configurations and that configuration doesn't provide much value there.

Fixes https://github.com/dotnet/runtime/issues/32240