### PR TITLE
Update CODEOWNERS and scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/src/libraries/Common/src/System/Net/Http/aspnetcore/               @dotnet/http2
-/src/libraries/Common/tests/Tests/System/Net/aspnetcore/            @dotnet/http2
+/src/libraries/Common/src/System/Net/Http/aspnetcore/               @dotnet/http
+/src/libraries/Common/tests/Tests/System/Net/aspnetcore/            @dotnet/http
 /src/libraries/System.Text.Json/                                    @ahsonkhan @steveharter @layomia @Jozkee
 /src/libraries/System.Buffers/                                      @ahsonkhan
 /src/libraries/System.Memory/                                       @ahsonkhan

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
@@ -10,5 +10,6 @@ IF [%remote_repo%] == [] (
 
 echo ASPNETCORE_REPO: %remote_repo%
 
+REM https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code
 robocopy . %remote_repo%\src\Shared\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
 robocopy .\..\..\..\..\..\tests\Tests\System\Net\aspnetcore\ %remote_repo%\src\Shared\test\Shared.Tests\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
@@ -11,5 +11,5 @@ IF [%remote_repo%] == [] (
 echo ASPNETCORE_REPO: %remote_repo%
 
 REM https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code
-robocopy . %remote_repo%\src\Shared\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
-robocopy .\..\..\..\..\..\tests\Tests\System\Net\aspnetcore\ %remote_repo%\src\Shared\test\Shared.Tests\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
+(robocopy . %remote_repo%\src\Shared\runtime /MIR) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
+(robocopy .\..\..\..\..\..\tests\Tests\System\Net\aspnetcore\ %remote_repo%\src\Shared\test\Shared.Tests\runtime /MIR) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToAspNetCore.cmd
@@ -10,5 +10,5 @@ IF [%remote_repo%] == [] (
 
 echo ASPNETCORE_REPO: %remote_repo%
 
-robocopy . %remote_repo%\src\Shared\runtime /MIR
-robocopy .\..\..\..\..\..\tests\Tests\System\Net\aspnetcore\ %remote_repo%\src\Shared\test\Shared.Tests\runtime /MIR
+robocopy . %remote_repo%\src\Shared\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
+robocopy .\..\..\..\..\..\tests\Tests\System\Net\aspnetcore\ %remote_repo%\src\Shared\test\Shared.Tests\runtime /MIR ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToRuntime.cmd
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/CopyToRuntime.cmd
@@ -10,5 +10,6 @@ IF [%remote_repo%] == [] (
 
 echo RUNTIME_REPO: %remote_repo%
 
-robocopy . %remote_repo%\src\libraries\Common\src\System\Net\Http\aspnetcore /MIR
-robocopy .\..\test\Shared.Tests\runtime %remote_repo%\src\libraries\Common\tests\Tests\System\Net\aspnetcore /MIR
+REM https://superuser.com/questions/280425/getting-robocopy-to-return-a-proper-exit-code
+(robocopy . %remote_repo%\src\libraries\Common\src\System\Net\Http\aspnetcore /MIR) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0
+(robocopy .\..\test\Shared.Tests\runtime %remote_repo%\src\libraries\Common\tests\Tests\System\Net\aspnetcore /MIR) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0


### PR DESCRIPTION
The http2 team was renamed to http, updating CODEOWNERS accordingly.

Also adding exit code handling to the shared source copy scripts as part of https://github.com/dotnet/runtime/issues/1584#issuecomment-583624639.