### PR TITLE
fix solution build for release mode

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -11,6 +11,7 @@
     <RuntimePropsFile>$([MSBuild]::NormalizePath('$(ArtifactsDir)', 'tmp', '$(Configuration)', 'RuntimeOS.props'))</RuntimePropsFile>
     <RuntimeGraph>$(LibrariesProjectRoot)\OSGroups.json</RuntimeGraph>
     <BuildTargetFramework>netcoreapp5.0</BuildTargetFramework>
+    <ShouldUnsetParentConfigurationAndPlatform>false</ShouldUnsetParentConfigurationAndPlatform>
     <AdditionalBuildTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(AdditionalBuildTargetFrameworks);$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-NetBSD;$(NetCoreAppCurrent)-FreeBSD</AdditionalBuildTargetFrameworks>  
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32202

Before
```
C:\git\runtime>dotnet msbuild src\libraries\System.Drawing.Common\System.Drawing.Common.sln /p:Configuration=release /bl
C:\git\runtime\.dotnet
Microsoft (R) Build Engine version 16.6.0-preview-20071-03+4400fa4e1 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\dotnet.dll -maxcpucount -verbosity:m /bl /p:Configuration=release src\libraries\System.Drawing.Common\System.Drawing.Common.sln
  System.Runtime -> C:\git\runtime\artifacts\bin\System.Runtime\ref\netcoreapp5.0-Debug\System.Runtime.dll
  System.Security.Principal -> C:\git\runtime\artifacts\bin\System.Security.Principal\ref\netcoreapp5.0-Debug\System.Security.Principal.dll
  System.ComponentModel -> C:\git\runtime\artifacts\bin\System.ComponentModel\ref\netcoreapp5.0-Debug\System.ComponentModel.dll
  System.Collections -> C:\git\runtime\artifacts\bin\System.Collections\ref\netcoreapp5.0-Debug\System.Collections.dll
  System.Runtime.Extensions -> C:\git\runtime\artifacts\bin\System.Runtime.Extensions\ref\netcoreapp5.0-Debug\System.Runtime.Extensions.dll
  System.Runtime.InteropServices -> C:\git\runtime\artifacts\bin\System.Runtime.InteropServices\ref\netcoreapp5.0-Debug\System.Runtime.InteropServices.dll
  System.ObjectModel -> C:\git\runtime\artifacts\bin\System.ObjectModel\ref\netcoreapp5.0-Debug\System.ObjectModel.dll
  System.Collections.NonGeneric -> C:\git\runtime\artifacts\bin\System.Collections.NonGeneric\ref\netcoreapp5.0-Debug\System.Collections.NonGeneric.dll
  System.ComponentModel.Primitives -> C:\git\runtime\artifacts\bin\System.ComponentModel.Primitives\ref\netcoreapp5.0-Debug\System.ComponentModel.Primitives.dll
  System.Drawing.Primitives -> C:\git\runtime\artifacts\bin\System.Drawing.Primitives\ref\netcoreapp5.0-Debug\System.Drawing.Primitives.dll
  System.Drawing.Common -> C:\git\runtime\artifacts\bin\System.Drawing.Common\ref\netcoreapp5.0-Release\System.Drawing.Common.dll
  System.Drawing.Common -> C:\git\runtime\artifacts\bin\System.Drawing.Common\netcoreapp5.0-Windows_NT-Release\System.Drawing.Common.dll
C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.ConflictResolution.targets(39,5): error NETSDK1042: Could not load PlatformManifest from 'C:\git\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\shared\Microsoft.NETCore.App\5.0.0\PlatformManifest.txt' because it did not exist. [C:\git\runtime\src\libraries\Common\tests\CoreFx.Private.TestUtilities\CoreFx.Private.TestUtilities.csproj]
```

After
```
C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\MSBuild.dll -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\git\runtime\.dotnet\sdk\5.0.100-alpha.1.20073.4\dotnet.dll -maxcpucount -verbosity:m /bl /p:Configuration=release src\libraries\System.Drawing.Common\System.Drawing.Common.sln
  System.Runtime -> C:\git\runtime\artifacts\bin\System.Runtime\ref\netcoreapp5.0-Release\System.Runtime.dll
  System.Security.Principal -> C:\git\runtime\artifacts\bin\System.Security.Principal\ref\netcoreapp5.0-Release\System.Security.Principal.dll
  System.Runtime.Extensions -> C:\git\runtime\artifacts\bin\System.Runtime.Extensions\ref\netcoreapp5.0-Release\System.Runtime.Extensions.dll
  System.Collections.NonGeneric -> C:\git\runtime\artifacts\bin\System.Collections.NonGeneric\ref\netcoreapp5.0-Release\System.Collections.NonGeneric.dll
  System.ComponentModel -> C:\git\runtime\artifacts\bin\System.ComponentModel\ref\netcoreapp5.0-Release\System.ComponentModel.dll
  System.Collections -> C:\git\runtime\artifacts\bin\System.Collections\ref\netcoreapp5.0-Release\System.Collections.dll
  System.ObjectModel -> C:\git\runtime\artifacts\bin\System.ObjectModel\ref\netcoreapp5.0-Release\System.ObjectModel.dll
  System.ComponentModel.Primitives -> C:\git\runtime\artifacts\bin\System.ComponentModel.Primitives\ref\netcoreapp5.0-Release\System.ComponentModel.Primitives.dll
  System.Drawing.Primitives -> C:\git\runtime\artifacts\bin\System.Drawing.Primitives\ref\netcoreapp5.0-Release\System.Drawing.Primitives.dll
  System.Runtime.InteropServices -> C:\git\runtime\artifacts\bin\System.Runtime.InteropServices\ref\netcoreapp5.0-Release\System.Runtime.InteropServices.dll
  System.Drawing.Common -> C:\git\runtime\artifacts\bin\System.Drawing.Common\ref\netcoreapp5.0-Release\System.Drawing.Common.dll
  System.Drawing.Common -> C:\git\runtime\artifacts\bin\System.Drawing.Common\netcoreapp5.0-Windows_NT-Release\System.Drawing.Common.dll
  CoreFx.Private.TestUtilities -> C:\git\runtime\artifacts\bin\CoreFx.Private.TestUtilities\netcoreapp5.0-Release\CoreFx.Private.TestUtilities.dll
  System.Drawing.Common.Tests -> C:\git\runtime\artifacts\bin\System.Drawing.Common.Tests\netcoreapp5.0-Release\System.Drawing.Common.Tests.dll
```


Earlier the solution build was removing the parent configuration and architecture for project references which was resulting in chidren project references building in debug mode. This fixes our solution build

cc @adamsitnik 