### PR TITLE
Remove a couple allocations from Socket.Connect/Bind/etc.

### DIFF
--- a/src/libraries/Common/src/System/Net/Internals/IPEndPointExtensions.cs
+++ b/src/libraries/Common/src/System/Net/Internals/IPEndPointExtensions.cs
@@ -44,11 +44,6 @@ namespace System.Net.Sockets
             return thisObj.Create(address);
         }
 
-        internal static IPEndPoint Snapshot(this IPEndPoint thisObj)
-        {
-            return new IPEndPoint(thisObj.Address.Snapshot(), thisObj.Port);
-        }
-
         private static Internals.SocketAddress GetInternalSocketAddress(System.Net.SocketAddress address)
         {
             var result = new Internals.SocketAddress(address.Family, address.Size);


### PR DESCRIPTION
The Socket implementation calls the internal SnapshotAndSerialize method on a bunch of code paths, like Connect, Bind, etc.  The "snapshot" part of the name comes from the time of CAS (thanks for the hint, @GrabYourPitchforks), and the implementation needed to clone the instance to make security decisions.  We no longer make such decisions, but we're still cloning the objects.  We can stop doing that.  The main change is just a few lines; I then deleted a dead function it left behind, and renamed the SnapshotAndSerialize method, which is no longer snapshotting.

From a microbenchmark doing `var s = new Socket(...); s.Connect(...);` a thousand times...

Before:
![image](https://user-images.githubusercontent.com/2642209/74492371-88bd2180-4e83-11ea-8802-1978b8ea6eef.png)

After:
![image](https://user-images.githubusercontent.com/2642209/74492404-9bcff180-4e83-11ea-9d2a-3a3b5376353b.png)

cc: @dotnet/ncl