### PR TITLE
Remove lock allocation from SafeSocketHandle on Windows

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -13,7 +12,6 @@ namespace System.Net.Sockets
     {
         private ThreadPoolBoundHandle _iocpBoundHandle;
         private bool _skipCompletionPortOnSuccess;
-        private readonly object _iocpBindingLock = new object();
 
         internal void SetExposed() { /* nop */ }
 
@@ -40,7 +38,7 @@ namespace System.Net.Sockets
                 return _iocpBoundHandle;
             }
 
-            lock (_iocpBindingLock)
+            lock (this)
             {
                 ThreadPoolBoundHandle boundHandle = _iocpBoundHandle;
 


### PR DESCRIPTION
The first time a Socket is used, we bind its handle to the ThreadPool for overlapped I/O.  In order to avoid this happening on multiple threads concurrently if multiple threads concurrently race to perform this initialization, we take a lock.  We currently allocate an object and store it for the lifetime of the Socket, purely to do this one-time synchronization, after which the object is useless.  While in general we prefer not to lock on `this` on exposed objects (in order to avoid any issues that might occur from an external consumer also locking on the same object), the chances of someone locking on this object are slim to none, and even if they did, it wouldn't make any difference once the socket was already initialized, and even if the socket wasn't yet initialized, it would only be a one-time contention, without lock ordering concerns. (Completely degenerate code could take and never release a lock on a socket's SafeHandle prior to first use, and that would then block that Socket from operating, but such code could also cause problems by just closing the exposed handle, and the answer would be the same: don't do that.)

On the same test as in https://github.com/dotnet/runtime/pull/32271...

Before:
![image](https://user-images.githubusercontent.com/2642209/74494117-eef87300-4e88-11ea-902b-5de07949bd99.png)

After:
![image](https://user-images.githubusercontent.com/2642209/74494132-fcadf880-4e88-11ea-83c7-a48e44e8bbd0.png)
(this still includes the allocations removed in #32271)

cc: @dotnet/ncl