### PR TITLE
Shrink Dictionary asm by moving non-generic enumerator out

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -129,6 +129,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ArraySortHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\Comparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\Dictionary.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\DictionaryEnumerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\EqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\IAsyncEnumerable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\IAsyncEnumerator.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -302,10 +302,10 @@ namespace System.Collections.Generic
         }
 
         public Enumerator GetEnumerator()
-            => new Enumerator(this, Enumerator.KeyValuePair);
+            => new Enumerator(this);
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-            => new Enumerator(this, Enumerator.KeyValuePair);
+            => new Enumerator(this);
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -976,7 +976,7 @@ namespace System.Collections.Generic
         }
 
         IEnumerator IEnumerable.GetEnumerator()
-            => new Enumerator(this, Enumerator.KeyValuePair);
+            => new Enumerator(this);
 
         /// <summary>
         /// Ensures that the dictionary can hold up to 'capacity' entries without any further expansion of its backing storage
@@ -1152,7 +1152,7 @@ namespace System.Collections.Generic
         }
 
         IDictionaryEnumerator IDictionary.GetEnumerator()
-            => new Enumerator(this, Enumerator.DictEntry);
+            => new DictionaryEnumerator(this);
 
         void IDictionary.Remove(object key)
         {
@@ -1173,24 +1173,18 @@ namespace System.Collections.Generic
 #endif
         }
 
-        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>,
-            IDictionaryEnumerator
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
         {
             private readonly Dictionary<TKey, TValue> _dictionary;
             private readonly int _version;
             private int _index;
             private KeyValuePair<TKey, TValue> _current;
-            private readonly int _getEnumeratorRetType;  // What should Enumerator.Current return?
 
-            internal const int DictEntry = 1;
-            internal const int KeyValuePair = 2;
-
-            internal Enumerator(Dictionary<TKey, TValue> dictionary, int getEnumeratorRetType)
+            internal Enumerator(Dictionary<TKey, TValue> dictionary)
             {
                 _dictionary = dictionary;
                 _version = dictionary._version;
                 _index = 0;
-                _getEnumeratorRetType = getEnumeratorRetType;
                 _current = default;
             }
 
@@ -1234,14 +1228,7 @@ namespace System.Collections.Generic
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
                     }
 
-                    if (_getEnumeratorRetType == DictEntry)
-                    {
-                        return new DictionaryEntry(_current.Key, _current.Value);
-                    }
-                    else
-                    {
-                        return new KeyValuePair<TKey, TValue>(_current.Key, _current.Value);
-                    }
+                    return _current;
                 }
             }
 
@@ -1254,45 +1241,6 @@ namespace System.Collections.Generic
 
                 _index = 0;
                 _current = default;
-            }
-
-            DictionaryEntry IDictionaryEnumerator.Entry
-            {
-                get
-                {
-                    if (_index == 0 || (_index == _dictionary._count + 1))
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
-                    }
-
-                    return new DictionaryEntry(_current.Key, _current.Value);
-                }
-            }
-
-            object IDictionaryEnumerator.Key
-            {
-                get
-                {
-                    if (_index == 0 || (_index == _dictionary._count + 1))
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
-                    }
-
-                    return _current.Key;
-                }
-            }
-
-            object? IDictionaryEnumerator.Value
-            {
-                get
-                {
-                    if (_index == 0 || (_index == _dictionary._count + 1))
-                    {
-                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
-                    }
-
-                    return _current.Value;
-                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/DictionaryEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/DictionaryEnumerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Collections.Generic
+{
+    internal interface IKeyValue
+    {
+        public object? Key { get; }
+        public object? Value { get; }
+    }
+
+    internal class DictionaryEnumerator : IDictionaryEnumerator
+    {
+        private readonly IEnumerator _enumerator;
+        private IKeyValue? _current;
+
+        public DictionaryEnumerator(IEnumerable enumerable)
+        {
+            _enumerator = enumerable.GetEnumerator();
+            _current = null;
+        }
+
+        public object Key => _current?.Key!;
+
+        public object? Value => _current?.Value;
+
+        public DictionaryEntry Entry => new DictionaryEntry(_current?.Key!, _current?.Value);
+
+        public object? Current => _current;
+
+        public bool MoveNext()
+        {
+            bool result = _enumerator.MoveNext();
+            _current = (IKeyValue)_enumerator.Current!;
+            return result;
+        }
+
+        public void Reset() => _enumerator.Reset();
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/KeyValuePair.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/KeyValuePair.cs
@@ -49,7 +49,7 @@ namespace System.Collections.Generic
     // and IReadOnlyDictionary<TKey, TValue>.
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public readonly struct KeyValuePair<TKey, TValue>
+    public readonly struct KeyValuePair<TKey, TValue> : IKeyValue
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly TKey key; // Do not rename (binary serialization)
@@ -65,6 +65,10 @@ namespace System.Collections.Generic
         public TKey Key => key;
 
         public TValue Value => value;
+
+        object? IKeyValue.Key => key;
+
+        object? IKeyValue.Value => value;
 
         public override string ToString()
         {


### PR DESCRIPTION
I think my version of Jitdiff is reporting summary regression/improvement backwards in error?

```
Total bytes of diff: 624 (0.02% of base)
    diff is a regression.

Total byte diff includes -2303 bytes from reconciling methods
        Base had    4 unique methods,     2840 unique bytes
        Diff had    3 unique methods,      537 unique bytes

Top file regressions (bytes):
         624 : System.Private.CoreLib.dasm (0.02% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
         475 (55.88% of base) : System.Private.CoreLib.dasm - Enumerator:.ctor(Dictionary`2):this (22 base, 33 diff methods)
         250 (     ∞ of base) : System.Private.CoreLib.dasm - KeyValuePair`2:System.Collections.Generic.IKeyValue.get_Value():Object:this (0 base, 13 diff methods)
         236 (     ∞ of base) : System.Private.CoreLib.dasm - KeyValuePair`2:System.Collections.Generic.IKeyValue.get_Key():Object:this (0 base, 13 diff methods)
         111 (81.02% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:get_Entry():DictionaryEntry:this (1 base, 2 diff methods)
          82 (264.52% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:MoveNext():bool:this (1 base, 2 diff methods)
          51 (     ∞ of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:.ctor(IEnumerable):this (0 base, 1 diff methods)
          41 (67.21% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:get_Key():Object:this (1 base, 2 diff methods)
          41 (67.21% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:get_Value():Object:this (1 base, 2 diff methods)
          29 (100.00% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:Reset():this (1 base, 2 diff methods)
           5 ( 7.94% of base) : System.Private.CoreLib.dasm - DictionaryEnumerator:get_Current():Object:this (1 base, 2 diff methods)

Top method improvements (bytes):
       -1495 (-29.41% of base) : System.Private.CoreLib.dasm - Enumerator:System.Collections.IEnumerator.get_Current():Object:this (65 methods)
       -1138 (-100.00% of base) : System.Private.CoreLib.dasm - Enumerator:System.Collections.IDictionaryEnumerator.get_Entry():DictionaryEntry:this (11 base, 0 diff methods)
        -752 (-51.26% of base) : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.IDictionary.GetEnumerator():IDictionaryEnumerator:this (11 methods)
        -583 (-100.00% of base) : System.Private.CoreLib.dasm - Enumerator:System.Collections.IDictionaryEnumerator.get_Value():Object:this (11 base, 0 diff methods)
        -563 (-100.00% of base) : System.Private.CoreLib.dasm - Enumerator:.ctor(Dictionary`2,int):this (11 base, 0 diff methods)
        -556 (-100.00% of base) : System.Private.CoreLib.dasm - Enumerator:System.Collections.IDictionaryEnumerator.get_Key():Object:this (11 base, 0 diff methods)
         -51 (-6.22% of base) : System.Private.CoreLib.dasm - Dictionary`2:GetEnumerator():Enumerator:this (8 methods)
         -49 (-3.34% of base) : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator():IEnumerator`1:this (11 methods)
         -49 (-3.34% of base) : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.IEnumerable.GetEnumerator():IEnumerator:this (11 methods)
         -36 (-4.04% of base) : System.Private.CoreLib.dasm - ManyElementAsyncLocalValueMap:Set(IAsyncLocal,Object,bool):IAsyncLocalValueMap:this
         -15 (-4.31% of base) : System.Private.CoreLib.dasm - ManifestBuilder:GetChannelData():ref:this
          -6 (-0.12% of base) : System.Private.CoreLib.dasm - ManifestBuilder:CreateManifestString():String:this
          -5 (-1.47% of base) : System.Private.CoreLib.dasm - ResourceManager:ReleaseAllResources():this
          -3 (-0.73% of base) : System.Private.CoreLib.dasm - DiagnosticCounter:GetMetadataString():String:this
          -2 (-0.65% of base) : System.Private.CoreLib.dasm - AssemblyLoadContext:OnProcessExit()

25 total methods with Code Size differences (15 improved, 10 regressed), 20354 unchanged.
```

/cc @jkotas not sure if this is an interesting change?