### PR TITLE
Use span-based IndexOfAny in ModuleBuilder

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -600,7 +600,7 @@ namespace System.Reflection.Emit
             while (startIndex <= className.Length)
             {
                 // Are there any possible special characters left?
-                int i = className.IndexOfAny(new char[] { '[', '*', '&' }, startIndex);
+                int i = className.AsSpan(startIndex).IndexOfAny('[', '*', '&');
                 if (i == -1)
                 {
                     // No, type name is simple.
@@ -608,6 +608,7 @@ namespace System.Reflection.Emit
                     parameters = null;
                     break;
                 }
+                i += startIndex;
 
                 // Found a potential special character, but it might be escaped.
                 int slashes = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -150,7 +150,7 @@ namespace System
                 ReadOnlySpan<char> versionSpan = versionString.AsSpan();
 
                 // Strip optional suffixes
-                int separatorIndex = versionSpan.IndexOfAny("-+ ");
+                int separatorIndex = versionSpan.IndexOfAny('-', '+', ' ');
                 if (separatorIndex != -1)
                     versionSpan = versionSpan.Slice(0, separatorIndex);
 


### PR DESCRIPTION
Removes an unnecessary char[] allocation per iteration.

(Also simplified one IndexOfAny usage in Environment.cs as I was auditing other IndexOfAny calls.)