### PR TITLE
Fix debugger crash during unload of assemblies in ALC

### DIFF
--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -5388,6 +5388,7 @@ DebuggerModule* Debugger::LookupOrCreateModule(Module* pModule, AppDomain *pAppD
     // If it doesn't exist, create it.
     if (dmod == NULL)
     {
+        LOG((LF_CORDB, LL_INFO1000, "D::LOCM dmod for m=0x%x ad=0x%x not found, creating.\n", pModule, pAppDomain));
         HRESULT hr = S_OK;
         EX_TRY
         {
@@ -5402,7 +5403,8 @@ DebuggerModule* Debugger::LookupOrCreateModule(Module* pModule, AppDomain *pAppD
     // The module must be in the AppDomain that was requested
     _ASSERTE( (dmod == NULL) || (dmod->GetAppDomain() == pAppDomain) );
 
-    LOG((LF_CORDB, LL_INFO1000, "D::LOCM m=0x%x ad=0x%x -> dm=0x%x\n", pModule, pAppDomain, dmod));
+    LOG((LF_CORDB, LL_INFO1000, "D::LOCM m=0x%x ad=0x%x -> dm=0x%x(Mod=0x%x, DomFile=0x%x, AD=0x%x)\n",
+        pModule, pAppDomain, dmod, dmod->GetRuntimeModule(), dmod->GetDomainFile(), dmod->GetAppDomain()));
     return dmod;
 }
 
@@ -10010,8 +10012,10 @@ void Debugger::UnloadModule(Module* pRuntimeModule,
         }
         _ASSERTE(module != NULL);
 
-        STRESS_LOG3(LF_CORDB, LL_INFO10000, "D::UM: Unloading Mod:%#08x, %#08x, %#08x\n",
-            pRuntimeModule, pAppDomain, pRuntimeModule->IsIStream());
+        STRESS_LOG6(LF_CORDB, LL_INFO10000,
+            "D::UM: Unloading RTMod:%#08x (DomFile: %#08x, IsISStream:%#08x); DMod:%#08x(RTMod:%#08x DomFile: %#08x)\n",
+            pRuntimeModule, pRuntimeModule->GetDomainFile(), pRuntimeModule->IsIStream(),
+            module, module->GetRuntimeModule(), module->GetDomainFile());
 
         // Note: the appdomain the module was loaded in must match the appdomain we're unloading it from. If it doesn't,
         // then we've either found the wrong DebuggerModule in LookupModule or we were passed bad data.

--- a/src/coreclr/src/debug/ee/debuggermodule.cpp
+++ b/src/coreclr/src/debug/ee/debuggermodule.cpp
@@ -245,22 +245,21 @@ void DebuggerModuleTable::RemoveModule(Module* pModule, AppDomain *pAppDomain)
     _ASSERTE(pModule != NULL);
 
     HASHFIND hf;
-    DebuggerModuleEntry *pDME; pDME = (DebuggerModuleEntry *) FindFirstEntry(&hf);
 
-    for (pDME = (DebuggerModuleEntry *) FindFirstEntry(&hf);
+    for (DebuggerModuleEntry *pDME = (DebuggerModuleEntry *) FindFirstEntry(&hf);
          pDME != NULL;
          pDME = (DebuggerModuleEntry*) FindNextEntry(&hf))
     {
         DebuggerModule *pDM = pDME->module;
-        Module* pRtModInDebugMod = pDM->GetRuntimeModule();
+        Module* pRuntimeModule = pDM->GetRuntimeModule();
 
-        if (pRtModInDebugMod == pModule && pDM->GetAppDomain() == pAppDomain)
+        if ((pRuntimeModule == pModule) && (pDM->GetAppDomain() == pAppDomain))
         {
             LOG((LF_CORDB, LL_INFO1000, "DMT::RM Removing DebuggerMod:0x%x - Module:0x%x DF:0x%x AD:0x%x\n",
                 pDM, pModule, pDM->GetDomainFile(), pAppDomain));
-            TRACE_FREE(pDME->module);
+            TRACE_FREE(pDM);
             DeleteInteropSafe(pDM);
-            Delete(HASH(pRtModInDebugMod), (HASHENTRY *) pDME);
+            Delete(HASH(pRuntimeModule), (HASHENTRY *) pDME);
             _ASSERTE(GetModule(pModule, pAppDomain) == NULL);
             return;
         }

--- a/src/coreclr/src/debug/ee/debuggermodule.cpp
+++ b/src/coreclr/src/debug/ee/debuggermodule.cpp
@@ -226,9 +226,8 @@ void DebuggerModuleTable::AddModule(DebuggerModule *pModule)
 }
 
 //-----------------------------------------------------------------------------
-// Remove a DebuggerModule  from the module table.
-// This occurs in response to AppDomain unload.
-// Note that this doesn't necessarily mean the EE Module is being unloaded (it may be shared)
+// Remove a DebuggerModule from the module table when it gets notified.
+// This occurs in response to the finalization of an unloaded AssemblyLoadContext.
 //-----------------------------------------------------------------------------
 void DebuggerModuleTable::RemoveModule(Module* pModule, AppDomain *pAppDomain)
 {


### PR DESCRIPTION
Fixes #2317