### PR TITLE
Show all files in file explorer and some extent of refactoring

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -206,4 +206,9 @@
     <ExcludeFromPackage Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)' and '$(ExcludeCurrentNetCoreAppFromPackage)' == 'true'">true</ExcludeFromPackage>
     <ExcludeFromPackage Condition="'$(TargetFramework)' == '$(NetFrameworkCurrent)' and '$(ExcludeCurrentFullFrameworkFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildProjectDirectory)\**\*.cs"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -207,7 +207,7 @@
     <ExcludeFromPackage Condition="'$(TargetFramework)' == '$(NetFrameworkCurrent)' and '$(ExcludeCurrentFullFrameworkFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
-  <!-- The Default behavior in VS is to show the files for first target framework in TargetFrameworks property.
+  <!-- The Default behavior in VS is to show files for the first target framework in TargetFrameworks property.
         This is required to show all the files corresponding to all target frameworks in VS. -->
   <ItemGroup>
     <None Include="$(MSBuildProjectDirectory)\**\*.cs"

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -207,6 +207,8 @@
     <ExcludeFromPackage Condition="'$(TargetFramework)' == '$(NetFrameworkCurrent)' and '$(ExcludeCurrentFullFrameworkFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
+  <!-- The Default behavior in the VS is to show the files for first target framework in target frameworks property.
+        This is required to show all the files corresponding to all target frameworks in the VS -->
   <ItemGroup>
     <None Include="$(MSBuildProjectDirectory)\**\*.cs"
           Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -207,8 +207,8 @@
     <ExcludeFromPackage Condition="'$(TargetFramework)' == '$(NetFrameworkCurrent)' and '$(ExcludeCurrentFullFrameworkFromPackage)' == 'true'">true</ExcludeFromPackage>
   </PropertyGroup>
 
-  <!-- The Default behavior in the VS is to show the files for first target framework in target frameworks property.
-        This is required to show all the files corresponding to all target frameworks in the VS -->
+  <!-- The Default behavior in VS is to show the files for first target framework in TargetFrameworks property.
+        This is required to show all the files corresponding to all target frameworks in VS. -->
   <ItemGroup>
     <None Include="$(MSBuildProjectDirectory)\**\*.cs"
           Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31902

Currently we show files only for the first TargetFramework in TargetFrameworks list.
After this change
- we will be able to see all the files in the directory.
- the navigation, intelligence and refactoring will also work for these files.

. Renaming files won't work i.e wont update the references or the compile items in the csproj