### PR TITLE
Build cross OS DACs in default Windows builds

### DIFF
--- a/src/coreclr/build.cmd
+++ b/src/coreclr/build.cmd
@@ -277,6 +277,15 @@ REM Determine if this is a cross-arch build. Only do cross-arch build if we're a
 
 if %__SkipCrossArchNative% EQU 0 (
     if %__BuildNative% EQU 1 (
+        if %__BuildCrossArchNative% EQU 0 (
+            if /i not "%__BuildArch%"=="x86" (
+                REM Make recursive calls to build the cross OS DAC
+                call :BuildCrossOSDac -alpinedac
+                if not !errorlevel! == 0 (
+                    goto ExitWithError
+                )
+            )
+        )
         if /i "%__BuildArch%"=="arm64" (
             set __BuildCrossArchNative=1
         )
@@ -897,6 +906,20 @@ exit /b 1
 
 :ExitWithCode
 exit /b !__exitCode!
+
+:BuildCrossOSDac
+setlocal
+set __BuildDacOption=%1
+set __NextCmd=call %__ThisScriptFull% %__BuildDacOption% %__BuildArch% %__BuildType% %__PassThroughArgs%
+echo %__MsgPrefix%Invoking: %__NextCmd%
+%__NextCmd%
+if not !errorlevel! == 0 (
+    echo %__MsgPrefix%    %__BuildDacOption% %__BuildArch% %__BuildType% %__PassThroughArgs%
+    endlocal
+    goto ExitWithError
+)
+endlocal
+exit /b 0
 
 :Usage
 echo.

--- a/src/coreclr/build.cmd
+++ b/src/coreclr/build.cmd
@@ -280,7 +280,7 @@ if %__SkipCrossArchNative% EQU 0 (
         if %__BuildCrossArchNative% EQU 0 (
             if /i not "%__BuildArch%"=="x86" (
                 REM Make recursive calls to build the cross OS DAC
-                call :BuildCrossOSDac -alpinedac
+                call :BuildCrossOSDac -linuxdac
                 if not !errorlevel! == 0 (
                     goto ExitWithError
                 )

--- a/src/coreclr/src/debug/daccess/enummem.cpp
+++ b/src/coreclr/src/debug/daccess/enummem.cpp
@@ -200,7 +200,7 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
         return hr;
     }
     // Add the dac table memory in coreclr
-    CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED ( ReportMem(dacTableAddress, sizeof(g_dacGlobals)); )
+    CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED ( ReportMem((TADDR)dacTableAddress, sizeof(g_dacGlobals)); )
 #endif
 
     // Cannot use CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -23,14 +23,12 @@
 #define PRId PRId64
 #define PRIA "016"
 #define PRIxA PRIA PRIx
-#define TARGET_WORDSIZE 64
 #else
 #define PRIx PRIx32
 #define PRIu PRIu32
 #define PRId PRId32
 #define PRIA "08"
 #define PRIxA PRIA PRIx
-#define TARGET_WORDSIZE 32
 #endif
 
 #ifdef HOST_UNIX

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -281,7 +281,7 @@ uint32_t
 ElfReader::Hash(const std::string& symbolName)
 {
     uint32_t h = 5381;
-    for (int i = 0; i < symbolName.length(); i++)
+    for (unsigned int i = 0; i < symbolName.length(); i++)
     {
         h = (h << 5) + h + symbolName[i];
     }

--- a/src/coreclr/src/debug/dbgutil/elfreader.h
+++ b/src/coreclr/src/debug/dbgutil/elfreader.h
@@ -9,6 +9,12 @@
 #include <string>
 #include <vector>
 
+#if TARGET_64BIT
+#define TARGET_WORDSIZE 64
+#else
+#define TARGET_WORDSIZE 32
+#endif
+
 #ifndef ElfW
 /* We use this macro to refer to ELF types independent of the native wordsize.
    `ElfW(TYPE)' is used in place of `Elf32_TYPE' or `Elf64_TYPE'.  */


### PR DESCRIPTION
This is my draft patch to build the Cross OS DACs by default.

This should enable building a Windows Hosted DAC targeting Linux and Alpine Linux for Amd64, Arm64, and Arm.
 
~~**BLOCKED:** This needs #32331 before Cross OS DAC builds will successfully compile.~~