### PR TITLE
Avoid throwing NRE when system module is not passed to crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/src/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -106,31 +106,22 @@ namespace ILCompiler
             return GetModuleForSimpleName(name.Name, throwIfNotFound);
         }
 
-        public ModuleDesc GetModuleForSimpleName(string simpleName, bool throwIfNotFound = true)
+        public EcmaModule GetModuleForSimpleName(string simpleName, bool throwIfNotFound = true)
         {
-            ModuleData existing;
-            if (_simpleNameHashtable.TryGetValue(simpleName, out existing))
+            if (_simpleNameHashtable.TryGetValue(simpleName, out ModuleData existing))
                 return existing.Module;
 
-            string filePath;
-            if (!InputFilePaths.TryGetValue(simpleName, out filePath))
-            {
-                if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
-                {
-                    // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
-                        return CanonTypesModule;
+            if (InputFilePaths.TryGetValue(simpleName, out string filePath)
+                || ReferenceFilePaths.TryGetValue(simpleName, out filePath))
+                return AddModule(filePath, simpleName, true);
 
-                    // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.
-                    // The other reason is that on CoreCLR, the exception also captures the reason. We should be passing two
-                    // string IDs. This makes this rather annoying.
-                    if (throwIfNotFound)
-                        ThrowHelper.ThrowFileNotFoundException(ExceptionStringID.FileLoadErrorGeneric, simpleName);
-                    return null;
-                }
-            }
+            // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.
+            // The other reason is that on CoreCLR, the exception also captures the reason. We should be passing two
+            // string IDs. This makes this rather annoying.
+            if (throwIfNotFound)
+                ThrowHelper.ThrowFileNotFoundException(ExceptionStringID.FileLoadErrorGeneric, simpleName);
 
-            return AddModule(filePath, simpleName, true);
+            return null;
         }
 
         public EcmaModule GetModuleFromPath(string filePath)

--- a/src/coreclr/src/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -71,7 +71,7 @@ namespace Internal.TypeSystem
 
         public override bool IsExplicitLayout => false;
 
-        public override ModuleDesc Module => _context.CanonTypesModule;
+        public override ModuleDesc Module => _context.SystemModule;
 
         public override bool IsModuleType => false;
 

--- a/src/coreclr/src/tools/Common/TypeSystem/Canon/TypeSystemContext.Canon.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Canon/TypeSystemContext.Canon.cs
@@ -44,11 +44,6 @@ namespace Internal.TypeSystem
             }
         }
 
-        protected internal virtual ModuleDesc CanonTypesModule
-        {
-            get { return SystemModule; }
-        }
-
         /// <summary>
         /// Returns true if and only if the '<paramref name="type"/>' is __Canon or __UniversalCanon
         /// that matches the <paramref name="kind"/> parameter.


### PR DESCRIPTION
Crossgen2 throws a `NullReferenceException` if the system module was not provided.  That is caused by dereferencing `CompilerTypeSystemContext.CanonTypesModule` before it set.  See dotnet/corert#7972 for the context.

My fix consists of removing the `CanonTypesModule` usage that was needed for .NET Native only and inverting the `if` conditions to simplify the code a little.