### PR TITLE
Simplify CheckIsReserved in IriHelper

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -84,19 +84,12 @@ namespace System
         //
         internal static bool CheckIsReserved(char ch, UriComponents component)
         {
-            if ((component != UriComponents.Scheme) &&
-                    (component != UriComponents.UserInfo) &&
-                    (component != UriComponents.Host) &&
-                    (component != UriComponents.Port) &&
-                    (component != UriComponents.Path) &&
-                    (component != UriComponents.Query) &&
-                    (component != UriComponents.Fragment)
-                )
+            if ((UriComponents.AbsoluteUri & component) == 0)
             {
-                return (component == (UriComponents)0) ? UriHelper.IsGenDelim(ch) : false;
+                return (component == 0) ? UriHelper.IsGenDelim(ch) : false;
             }
 
-            return UriHelper.RFC3986ReservedMarks.IndexOf(ch) >= 0;
+            return UriHelper.RFC3986ReservedMarks.Contains(ch);
         }
 
         //

--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -86,7 +86,7 @@ namespace System
         {
             if ((UriComponents.AbsoluteUri & component) == 0)
             {
-                return (component == 0) ? UriHelper.IsGenDelim(ch) : false;
+                return component == 0 && UriHelper.IsGenDelim(ch);
             }
 
             return UriHelper.RFC3986ReservedMarks.Contains(ch);


### PR DESCRIPTION
`UriComponents.AbsoluteUri` is defined as
`Scheme | UserInfo | Host | Port | Path | Query | Fragment`, so that check can be simplified.