### PR TITLE
Annotate System.IO.Pipes.AccessControl for nullable reference types

### DIFF
--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.cs
@@ -69,11 +69,11 @@ namespace System.IO.Pipes
 
     public static class AnonymousPipeServerStreamAcl
     {
-        public static System.IO.Pipes.AnonymousPipeServerStream Create(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize, System.IO.Pipes.PipeSecurity pipeSecurity) { throw null; }
+        public static System.IO.Pipes.AnonymousPipeServerStream Create(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity) { throw null; }
     }
 
     public static class NamedPipeServerStreamAcl
     {
-        public static System.IO.Pipes.NamedPipeServerStream Create(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize, System.IO.Pipes.PipeSecurity pipeSecurity, System.IO.HandleInheritability inheritability = System.IO.HandleInheritability.None, System.IO.Pipes.PipeAccessRights additionalAccessRights = default) { throw null; }
+        public static System.IO.Pipes.NamedPipeServerStream Create(string pipeName, System.IO.Pipes.PipeDirection direction, int maxNumberOfServerInstances, System.IO.Pipes.PipeTransmissionMode transmissionMode, System.IO.Pipes.PipeOptions options, int inBufferSize, int outBufferSize, System.IO.Pipes.PipeSecurity? pipeSecurity, System.IO.HandleInheritability inheritability = System.IO.HandleInheritability.None, System.IO.Pipes.PipeAccessRights additionalAccessRights = default) { throw null; }
     }
 }

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
@@ -4,6 +4,7 @@
         The reference assembly version needs to be frozen so that our desktop compat facades point to the version from the package. -->
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Pipes.AccessControl.cs" />

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -6,6 +6,7 @@
     <OmitResources Condition="'$(TargetsWindows)' == 'true'">true</OmitResources>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStream.Windows.cs
@@ -13,7 +13,7 @@ namespace System.IO.Pipes
     /// </summary>
     public sealed partial class AnonymousPipeServerStream : PipeStream
     {
-        internal AnonymousPipeServerStream(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
+        internal AnonymousPipeServerStream(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity? pipeSecurity)
             : base(direction, bufferSize)
         {
             if (direction == PipeDirection.InOut)

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStreamAcl.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/AnonymousPipeServerStreamAcl.cs
@@ -17,7 +17,7 @@ namespace System.IO.Pipes
         /// <remarks>Setting <paramref name="pipeSecurity" /> to <see langword="null" /> is equivalent to calling the `System.IO.Pipes.AnonymousPipeServerStream(System.IO.Pipes.PipeDirection direction, System.IO.HandleInheritability inheritability, int bufferSize)` constructor directly.</remarks>
         /// <exception cref="NotSupportedException"><paramref name="direction" /> is <see cref="PipeDirection.InOut" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="inheritability" /> is not set to a valid <see cref="HandleInheritability" /> enum value.</exception>
-        public static AnonymousPipeServerStream Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity pipeSecurity)
+        public static AnonymousPipeServerStream Create(PipeDirection direction, HandleInheritability inheritability, int bufferSize, PipeSecurity? pipeSecurity)
         {
             return new AnonymousPipeServerStream(direction, inheritability, bufferSize, pipeSecurity);
         }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -27,7 +27,7 @@ namespace System.IO.Pipes
             PipeOptions options,
             int inBufferSize,
             int outBufferSize,
-            PipeSecurity pipeSecurity,
+            PipeSecurity? pipeSecurity,
             HandleInheritability inheritability = HandleInheritability.None,
             PipeAccessRights additionalAccessRights = default)
             : base(direction, transmissionMode, outBufferSize)

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStreamAcl.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStreamAcl.cs
@@ -41,7 +41,7 @@ namespace System.IO.Pipes
             PipeOptions options,
             int inBufferSize,
             int outBufferSize,
-            PipeSecurity pipeSecurity,
+            PipeSecurity? pipeSecurity,
             HandleInheritability inheritability = HandleInheritability.None,
             PipeAccessRights additionalAccessRights = default)
         {

--- a/src/libraries/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/libraries/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -4,7 +4,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetsNetFx)' == 'true'">true</OmitResources>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_Principal</GeneratePlatformNotSupportedAssemblyMessage>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;netstandard2.0;netcoreapp2.0-Windows_NT;netcoreapp2.0-Unix;netcoreapp2.1-Windows_NT;netcoreapp2.1-Unix;net461-Windows_NT;$(NetFrameworkCurrent)-Windows_NT</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
@@ -12,11 +11,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
-    <!-- Work around reference source generation issue with 'notsupported' implementations -->
+    <!-- Work around 'notsupported.cs' source generation of explicit interface implementations issue -->
+    <!-- https://github.com/dotnet/arcade/issues/4722 -->
     <GeneratePlatformNotSupportedAssemblyMessage>SR.PlatformNotSupported_Principal</GeneratePlatformNotSupportedAssemblyMessage>
     <Nullable>annotations</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeAccessTokenHandle.cs" />
     <Compile Include="System\Security\Principal\IdentityNotMappedException.cs" />


### PR DESCRIPTION
Contributes to #2339
