### PR TITLE
Reg struct copy.

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -5501,6 +5501,8 @@ void MethodContext::dmpCompareTypesForEquality(DLDL key, DWORD value)
 }
 TypeCompareState MethodContext::repCompareTypesForEquality(CORINFO_CLASS_HANDLE cls1, CORINFO_CLASS_HANDLE cls2)
 {
+    AssertCodeMsg(CompareTypesForEquality != nullptr, EXCEPTIONCODE_MC, "Didn't find anything for CompareTypesForEquality");
+
     DLDL key;
     ZeroMemory(&key, sizeof(DLDL)); // We use the input structs as a key and use memcmp to compare.. so we need to zero
                                     // out padding too

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -4574,8 +4574,9 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
         }
 #endif // defined(FEATURE_SIMD) && defined(TARGET_X86)
 
-        GetEmitter()->emitIns_R_S(ins_Load(tree->TypeGet(), compiler->isSIMDTypeLocalAligned(tree->GetLclNum())),
-                                  emitTypeSize(tree), tree->GetRegNum(), tree->GetLclNum(), 0);
+        var_types type = varDsc->GetRegisterType(tree);
+        GetEmitter()->emitIns_R_S(ins_Load(type, compiler->isSIMDTypeLocalAligned(tree->GetLclNum())),
+                                  emitTypeSize(type), tree->GetRegNum(), tree->GetLclNum(), 0);
         genProduceReg(tree);
     }
 }
@@ -4624,9 +4625,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 {
     assert(tree->OperIs(GT_STORE_LCL_VAR));
 
-    var_types targetType = tree->TypeGet();
-    regNumber targetReg  = tree->GetRegNum();
-    emitter*  emit       = GetEmitter();
+    regNumber targetReg = tree->GetRegNum();
+    emitter*  emit      = GetEmitter();
 
     GenTree* op1 = tree->gtGetOp1();
 
@@ -4638,15 +4638,24 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
     }
     else
     {
-        noway_assert(targetType != TYP_STRUCT);
-        assert(varTypeUsesFloatReg(targetType) == varTypeUsesFloatReg(op1->TypeGet()));
-        assert(!varTypeUsesFloatReg(targetType) || (emitTypeSize(targetType) == emitTypeSize(op1->TypeGet())));
-
         unsigned   lclNum = tree->GetLclNum();
-        LclVarDsc* varDsc = &(compiler->lvaTable[lclNum]);
+        LclVarDsc* varDsc = compiler->lvaGetDesc(lclNum);
 
-        // Ensure that lclVar nodes are typed correctly.
-        assert(!varDsc->lvNormalizeOnStore() || (targetType == genActualType(varDsc->TypeGet())));
+        var_types targetType = varDsc->GetRegisterType(tree);
+
+#ifdef DEBUG
+        var_types op1Type = op1->TypeGet();
+        if (op1Type == TYP_STRUCT)
+        {
+            assert(op1->IsLocal());
+            GenTreeLclVar* op1LclVar = op1->AsLclVar();
+            unsigned       op1lclNum = op1LclVar->GetLclNum();
+            LclVarDsc*     op1VarDsc = compiler->lvaGetDesc(op1lclNum);
+            op1Type                  = op1VarDsc->GetRegisterType(op1LclVar);
+        }
+        assert(varTypeUsesFloatReg(targetType) == varTypeUsesFloatReg(op1Type));
+        assert(!varTypeUsesFloatReg(targetType) || (emitTypeSize(targetType) == emitTypeSize(op1Type)));
+#endif
 
 #if !defined(TARGET_64BIT)
         if (targetType == TYP_LONG)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -5053,6 +5053,13 @@ struct GenTreeIndir : public GenTreeOp
         return gtOp1;
     }
 
+    void SetAddr(GenTree* addr)
+    {
+        assert(addr != nullptr);
+        assert(addr->TypeIs(TYP_I_IMPL, TYP_BYREF));
+        gtOp1 = addr;
+    }
+
     // these methods provide an interface to the indirection node which
     bool     HasBase();
     bool     HasIndex();

--- a/src/coreclr/src/jit/layout.h
+++ b/src/coreclr/src/jit/layout.h
@@ -120,6 +120,42 @@ public:
         return m_size;
     }
 
+    //------------------------------------------------------------------------
+    // GetRegisterType: Determine register type for the layout.
+    //
+    // Return Value:
+    //    TYP_UNDEF if the layout is enregistrable, register type otherwise.
+    //
+    var_types GetRegisterType() const
+    {
+        if (HasGCPtr())
+        {
+            return (GetSlotCount() == 1) ? GetGCPtrType(0) : TYP_UNDEF;
+        }
+
+        switch (m_size)
+        {
+            case 1:
+                return TYP_UBYTE;
+            case 2:
+                return TYP_USHORT;
+            case 4:
+                return TYP_INT;
+#ifdef TARGET_64BIT
+            case 8:
+                return TYP_LONG;
+#endif
+#ifdef FEATURE_SIMD
+            // TODO: check TYP_SIMD12 profitability,
+            // it will need additional support in `BuildStoreLoc`.
+            case 16:
+                return TYP_SIMD16;
+#endif
+            default:
+                return TYP_UNDEF;
+        }
+    }
+
     unsigned GetSlotCount() const
     {
         return roundUp(m_size, TARGET_POINTER_SIZE) / TARGET_POINTER_SIZE;

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -735,7 +735,9 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc)
     // If the source is a containable immediate, make it contained, unless it is
     // an int-size or larger store of zero to memory, because we can generate smaller code
     // by zeroing a register and then storing it.
-    if (IsContainableImmed(storeLoc, op1) && (!op1->IsIntegralConst(0) || varTypeIsSmall(storeLoc)))
+    const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
+    var_types        type   = varDsc->GetRegisterType(storeLoc);
+    if (IsContainableImmed(storeLoc, op1) && (!op1->IsIntegralConst(0) || varTypeIsSmall(type)))
     {
         MakeSrcContained(storeLoc, op1);
     }

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -1953,7 +1953,9 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc)
     // If the source is a containable immediate, make it contained, unless it is
     // an int-size or larger store of zero to memory, because we can generate smaller code
     // by zeroing a register and then storing it.
-    if (IsContainableImmed(storeLoc, op1) && (!op1->IsIntegralConst(0) || varTypeIsSmall(storeLoc)))
+    const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
+    var_types        type   = varDsc->GetRegisterType(storeLoc);
+    if (IsContainableImmed(storeLoc, op1) && (!op1->IsIntegralConst(0) || varTypeIsSmall(type)))
     {
         MakeSrcContained(storeLoc, op1);
     }

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -1072,7 +1072,16 @@ private:
     // Get the type that this tree defines.
     var_types getDefType(GenTree* tree)
     {
-        return tree->TypeGet();
+        var_types type = tree->TypeGet();
+        if (type == TYP_STRUCT)
+        {
+            assert(tree->OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR));
+            GenTreeLclVar* lclVar = tree->AsLclVar();
+            LclVarDsc*     varDsc = compiler->lvaGetDesc(lclVar);
+            type                  = varDsc->GetRegisterType(lclVar);
+        }
+        assert(type != TYP_UNDEF && type != TYP_STRUCT);
+        return type;
     }
 
     // Managing internal registers during the BuildNode process.
@@ -1551,7 +1560,6 @@ private:
     void BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates = RBM_NONE);
     void BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
 
-    int BuildStoreLoc(GenTree* tree);
     int BuildReturn(GenTree* tree);
 #ifdef TARGET_XARCH
     // This method, unlike the others, returns the number of sources, since it may be called when

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8673,6 +8673,12 @@ GenTree* Compiler::fgMorphOneAsgBlockOp(GenTree* tree)
 
         if (asgType == TYP_STRUCT)
         {
+            // It is possible to use `initobj` to init a primitive type on the stack,
+            // like `ldloca.s 1; initobj 1B000003` where `V01` has type `ref`;
+            // in this case we generate `ASG struct(BLK<8> struct(ADDR byref(LCL_VAR ref)), 0)`
+            // and this code path transforms it into `ASG ref(LCL_VARref, 0)` because it is not a real
+            // struct assignment.
+
             if (size == REGSIZE_BYTES)
             {
                 if (clsHnd == NO_CLASS_HANDLE)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8652,56 +8652,60 @@ GenTree* Compiler::fgMorphOneAsgBlockOp(GenTree* tree)
         return nullptr;
     }
 
-    //
-    //  See if we can do a simple transformation:
-    //
-    //          GT_ASG <TYP_size>
-    //          /   \.
-    //      GT_IND GT_IND or CNS_INT
-    //         |      |
-    //       [dest] [src]
-    //
-
-    if (asgType == TYP_STRUCT)
-    {
-        if (size == REGSIZE_BYTES)
-        {
-            if (clsHnd == NO_CLASS_HANDLE)
-            {
-                // A register-sized cpblk can be treated as an integer asignment.
-                asgType = TYP_I_IMPL;
-            }
-            else
-            {
-                BYTE gcPtr;
-                info.compCompHnd->getClassGClayout(clsHnd, &gcPtr);
-                asgType = getJitGCType(gcPtr);
-            }
-        }
-        else
-        {
-            switch (size)
-            {
-                case 1:
-                    asgType = TYP_BYTE;
-                    break;
-                case 2:
-                    asgType = TYP_SHORT;
-                    break;
-
-#ifdef TARGET_64BIT
-                case 4:
-                    asgType = TYP_INT;
-                    break;
-#endif // TARGET_64BIT
-            }
-        }
-    }
-
     if ((destVarDsc != nullptr) && varTypeIsStruct(destLclVarTree) && destVarDsc->lvPromoted)
     {
         // Let fgMorphCopyBlock handle it.
         return nullptr;
+    }
+
+    if ((destVarDsc != nullptr) && !varTypeIsStruct(destVarDsc->TypeGet()))
+    {
+
+        //
+        //  See if we can do a simple transformation:
+        //
+        //          GT_ASG <TYP_size>
+        //          /   \.
+        //      GT_IND GT_IND or CNS_INT
+        //         |      |
+        //       [dest] [src]
+        //
+
+        if (asgType == TYP_STRUCT)
+        {
+            if (size == REGSIZE_BYTES)
+            {
+                if (clsHnd == NO_CLASS_HANDLE)
+                {
+                    // A register-sized cpblk can be treated as an integer asignment.
+                    asgType = TYP_I_IMPL;
+                }
+                else
+                {
+                    BYTE gcPtr;
+                    info.compCompHnd->getClassGClayout(clsHnd, &gcPtr);
+                    asgType = getJitGCType(gcPtr);
+                }
+            }
+            else
+            {
+                switch (size)
+                {
+                    case 1:
+                        asgType = TYP_BYTE;
+                        break;
+                    case 2:
+                        asgType = TYP_SHORT;
+                        break;
+
+#ifdef TARGET_64BIT
+                    case 4:
+                        asgType = TYP_INT;
+                        break;
+#endif // TARGET_64BIT
+                }
+            }
+        }
     }
 
     GenTree*   srcLclVarTree = nullptr;

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -353,48 +353,6 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
             }
         }
 #endif // FEATURE_SIMD
-        if ((location->TypeGet() == TYP_STRUCT) && !assignment->IsPhiDefn() && !value->IsMultiRegCall())
-        {
-            if ((location->OperGet() == GT_LCL_VAR))
-            {
-                // We need to construct a block node for the location.
-                // Modify lcl to be the address form.
-                location->SetOper(addrForm(locationOp));
-                LclVarDsc* varDsc     = &(comp->lvaTable[location->AsLclVarCommon()->GetLclNum()]);
-                location->gtType      = TYP_BYREF;
-                GenTreeBlk*  storeBlk = nullptr;
-                unsigned int size     = varDsc->lvExactSize;
-
-                if (varDsc->HasGCPtr())
-                {
-                    CORINFO_CLASS_HANDLE structHnd = varDsc->lvVerTypeInfo.GetClassHandle();
-                    GenTreeObj*          objNode   = comp->gtNewObjNode(structHnd, location);
-                    objNode->ChangeOper(GT_STORE_OBJ);
-                    objNode->SetData(value);
-                    storeBlk = objNode;
-                }
-                else
-                {
-                    storeBlk = new (comp, GT_STORE_BLK)
-                        GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, location, value, comp->typGetBlkLayout(size));
-                }
-                storeBlk->gtFlags |= GTF_ASG;
-                storeBlk->gtFlags |= ((location->gtFlags | value->gtFlags) & GTF_ALL_EFFECT);
-
-                GenTree* insertionPoint = location->gtNext;
-                BlockRange().InsertBefore(insertionPoint, storeBlk);
-                use.ReplaceWith(comp, storeBlk);
-                BlockRange().Remove(assignment);
-                JITDUMP("After transforming local struct assignment into a block op:\n");
-                DISPTREERANGE(BlockRange(), use.Def());
-                JITDUMP("\n");
-                return;
-            }
-            else
-            {
-                assert(location->OperIsBlk());
-            }
-        }
     }
 
     switch (locationOp)


### PR DESCRIPTION
This PR changes the way we handle struct copies. 
https://github.com/dotnet/runtime/pull/32362/commits/cc8c36679c41b0929f03bc80da4cc16b2f568ef8: First, it deletes rationalize transformation that was converting `ASG(LCL_VAR struct, smth)` into `STORE_BLK` or `STORE_OBJ`.
https://github.com/dotnet/runtime/pull/32362/commits/3bc8f8e7c0dbe44450dee72134cfe78713b57c70: Then it skips `fgMorphOneAsgBlockOp` transformation for `ASG(LCL_VAR struct, smth)`, where `struct` can be replaced with a primitive type.

The overall diffs are positive, but small because of most of these structs are still marked as `doNotEnreg` in `impNormStructVal`, it will be fixed next.

Positive diffs come from:
1. using `movups` (for `STORE_LCL_VAR` instead of `movdqu` that is currently used for `STORE_BLK`), there was a PR https://github.com/dotnet/runtime/pull/1367/files that would use `movups` for all, but for now, it is useful for me to have different codegen for them, allows me to find diffs easily.
2. VN and CSE can propagate `ASG(struct, 0)` and similar constructions now, so we can coalesce chains of struct assignments now for zero-init, I will add non-zero cases later. It gives us diffs like `-29 (-53.70% of base) : System.Private.CoreLib.dasm - SyncSuccessSentinelStateMachineBox[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor():this`, that will be an issue in the next PR, see the discussion here https://github.com/dotnet/runtime/issues/1231#issuecomment-576477779;

The negative diffs come from:
1. `STORE_BLK` contained logic is less efficient, it often doesn't mark `Data` as contained when it is generating only one instruction;
2. `fgMorphOneAsgBlockOp` could retype structs with one gcField into primitive type copy without barriers and reporting, now we are generating costly `STORE_OBJ`, a primitive fix for it fails on a few library tests, I am checking them now.

<details>
 <summary>diffs for the Reg struct copies commit, x64, crossgen framework</summary>

```
Total bytes of diff: -4957 (-0.02% of base)
    diff is an improvement.
Top file improvements (bytes):
       -1274 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.04% of base)
       -1075 : System.Private.Xml.dasm (-0.03% of base)
        -496 : System.Linq.Expressions.dasm (-0.02% of base)
        -324 : System.Data.Common.dasm (-0.03% of base)
        -322 : System.Private.CoreLib.dasm (-0.01% of base)
        -308 : System.Transactions.Local.dasm (-0.30% of base)
        -179 : Newtonsoft.Json.dasm (-0.03% of base)
        -140 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -140 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.01% of base)
        -114 : System.Linq.dasm (-0.08% of base)
         -98 : System.Linq.Parallel.dasm (-0.02% of base)
         -76 : System.Security.AccessControl.dasm (-0.12% of base)
         -62 : xunit.performance.metrics.dasm (-0.46% of base)
         -56 : System.Private.DataContractSerialization.dasm (-0.01% of base)
         -54 : Microsoft.CodeAnalysis.dasm (-0.01% of base)
         -36 : System.IO.FileSystem.dasm (-0.06% of base)
         -35 : xunit.execution.dotnet.dasm (-0.02% of base)
         -28 : Microsoft.CSharp.dasm (-0.01% of base)
         -24 : System.Reflection.Metadata.dasm (-0.01% of base)
         -20 : System.Security.Cryptography.X509Certificates.dasm (-0.01% of base)
37 total files with Code Size differences (37 improved, 0 regressed), 72 unchanged.
Top method improvements (bytes):
        -304 (-0.91% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -296 (-0.82% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -256 (-0.53% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -74 (-0.07% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -50 (-2.43% of base) : System.Private.Xml.dasm - System.Xml.Schema.Compiler:CalculateEffectiveTotalRange(System.Xml.Schema.XmlSchemaParticle,byref,byref):this
         -50 (-2.42% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaCollectionCompiler:CalculateEffectiveTotalRange(System.Xml.Schema.XmlSchemaParticle,byref,byref):this
         -44 (-1.50% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:MakeDecimalLiteral(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.ConstantValue):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
         -44 (-2.42% of base) : System.Data.Common.dasm - System.Data.Common.TimeSpanStorage:Aggregate(System.Int32[],int):System.Object:this
         -40 (-0.87% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ExpressionEvaluator:PerformCompileTimeBinaryOperation(ushort,byte,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ExpressionSyntax):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst
         -40 (-1.66% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.Utilities.ConvertUtils:DecimalTryParse(System.Char[],int,int,byref):int
         -32 (-3.02% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaCollectionCompiler:CalculateSequenceRange(System.Xml.Schema.XmlSchemaSequence,byref,byref):this
         -30 (-2.48% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.StartStopActivityComputer:FixAndProcessWindowsASP(Microsoft.Diagnostics.Tracing.TraceEvent,System.Collections.Generic.KeyValuePair`2[System.Guid,System.Guid][]):this
         -30 (-3.35% of base) : System.Private.Xml.dasm - System.Xml.Schema.Compiler:IsSequenceFromChoice(System.Xml.Schema.XmlSchemaSequence,System.Xml.Schema.XmlSchemaChoice):bool:this
         -30 (-1.68% of base) : System.Private.Xml.dasm - System.Xml.Xsl.IlGen.XmlILOptimizerVisitor:FoldArithmetic(int,System.Xml.Xsl.Qil.QilLiteral,System.Xml.Xsl.Qil.QilLiteral):System.Xml.Xsl.Qil.QilNode:this
         -26 (-0.66% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object
         -26 (-0.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:ScanNumericLiteral(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.VisualBasicSyntaxNode, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxToken:this
         -26 (-2.50% of base) : System.Private.CoreLib.dasm - System.TimeZoneInfo:CreateAdjustmentRuleFromTimeZoneInformation(byref,System.DateTime,System.DateTime,int):AdjustmentRule
         -24 (-0.37% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:FoldNeverOverflowBinaryOperators(int,Microsoft.CodeAnalysis.ConstantValue,Microsoft.CodeAnalysis.ConstantValue):System.Object
         -24 (-2.11% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.Semantics.ExpressionBinder:BindDecimalConstCast(Microsoft.CSharp.RuntimeBinder.Semantics.CType,Microsoft.CSharp.RuntimeBinder.Semantics.CType,Microsoft.CSharp.RuntimeBinder.Semantics.ExprConstant):Microsoft.CSharp.RuntimeBinder.Semantics.Expr
         -24 (-1.17% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - <>c__DisplayClass0_0:<.ctor>b__1(Microsoft.Diagnostics.Tracing.TraceEvent):this
```
</details>

```
Total diffs for frameworks:
x64 Total bytes of diff: -5890 (-0.02% of base)
1338 total methods with Code Size differences (1262 improved, 76 regressed), 178158 unchanged.

arm64 Total bytes of diff: -23656 (-0.02% of base)
489 total methods with Code Size differences (311 improved, 178 regressed), 157900 unchanged.

arm Total bytes of diff: -1576 (-0.00% of base)
250 total methods with Code Size differences (169 improved, 81 regressed), 158053 unchanged.

x86 Total bytes of diff: -2962 (-0.01% of base)
580 total methods with Code Size differences (535 improved, 45 regressed), 178824 unchanged.
```

Based on https://github.com/dotnet/runtime/issues/1231#issuecomment-570156628.

Side note: `varTypeIsSmall` and similar functions in `vartype.h` should assert on `TYP_STRUCT` because they don't have enough information to get a correct result, the callers should be responsible for handling that. It is a preexisting issue, but that change bumps its priority, I am working on a fix in another branch.
