### PR TITLE
Use SYSTEM_PRIVATE_CORELIB ifdef for consistency

### DIFF
--- a/src/libraries/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
+++ b/src/libraries/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
@@ -5,7 +5,7 @@
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsageAttribute(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false, AllowMultiple = false)]
-#if NETCOREAPP
+#if SYSTEM_PRIVATE_CORELIB
     public
 #else
     internal


### PR DESCRIPTION
To match pattern used by ReferenceEqualityComparer 