### PR TITLE
Improve Span<char>.ToString codegen

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -321,14 +321,25 @@ namespace System
         /// For <see cref="ReadOnlySpan{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
         /// Otherwise, returns a <see cref="string"/> with the name of the type and the number of elements.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override string ToString()
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _pointer.Value), _length));
+                return string.CreateFromSpan(ref Unsafe.As<T, char>(ref _pointer.Value), _length);
             }
+            else
+            {
+                return ToStringSlow();
+            }
+        }
+
+        private string ToStringSlow()
+        {
+            Debug.Assert(typeof(T) != typeof(char));
+
 #if FEATURE_UTF8STRING
-            else if (typeof(T) == typeof(Char8))
+            if (typeof(T) == typeof(Char8))
             {
                 // TODO_UTF8STRING: Call into optimized transcoding routine when it's available.
                 return Encoding.UTF8.GetString(new ReadOnlySpan<byte>(ref Unsafe.As<T, byte>(ref _pointer.Value), _length));

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -401,14 +401,25 @@ namespace System
         /// For <see cref="Span{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
         /// Otherwise, returns a <see cref="string"/> with the name of the type and the number of elements.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override string ToString()
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _pointer.Value), _length));
+                return string.CreateFromSpan(ref Unsafe.As<T, char>(ref _pointer.Value), _length);
             }
+            else
+            {
+                return ToStringSlow();
+            }
+        }
+
+        private string ToStringSlow()
+        {
+            Debug.Assert(typeof(T) != typeof(char));
+
 #if FEATURE_UTF8STRING
-            else if (typeof(T) == typeof(Char8))
+            if (typeof(T) == typeof(Char8))
             {
                 // TODO_UTF8STRING: Call into optimized transcoding routine when it's available.
                 return Encoding.UTF8.GetString(new ReadOnlySpan<byte>(ref Unsafe.As<T, byte>(ref _pointer.Value), _length));

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -509,6 +509,25 @@ namespace System
             return result;
         }
 
+        internal static string CreateFromSpan(ref char buffer, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0)
+            {
+                return Empty;
+            }
+
+            string result = FastAllocateString(length);
+
+            Buffer.Memmove(
+                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                destination: ref result._firstChar,
+                source: ref buffer);
+
+            return result;
+        }
+
         internal static unsafe void wstrcpy(char* dmem, char* smem, int charCount)
         {
             Buffer.Memmove((byte*)dmem, (byte*)smem, ((uint)charCount) * 2);


### PR DESCRIPTION
The current `{ReadOnly}Span<T>.ToString` method calls `new string(ReadOnlySpan<char>)`. However, due to quirks with how the JIT special-cases the `string` constructor, we can't really optimize that call site from its normal behavior of spilling the span onto the stack and passing the reference to the receiving `Ctor` method. I previously spoke with @davidwrighton about this but apparently it's a non-trivial exercise to address this.

Additionally, due to the amount of IL in the existing `Span<T>.ToString` method, it's not a candidate for inlining, even though most of it is pruned away at JIT time.

This PR introduces a "faster" factory that doesn't use the existing string constructors, and it wires the `{ReadOnly}Span<char>.ToString` specialization to use that factory. It also marks `ToString` as inlineable when _T = char_.

```cs
// sample method to demonstrate codegen improvements
public string SpanToString()
{
    char[] data = _data;
    _ = data.Length; // so JIT can elide null checks

    Span<char> span = new Span<char>(data);
    span = span.Slice(5); // actually use the span to mimic doing work
    return span.ToString();
}
```

### Old codegen

```asm
; Benchmark.SpanToString method (above)
00007ffd`ce1da320 4883ec38        sub     rsp,38h
00007ffd`ce1da324 33c0            xor     eax,eax
00007ffd`ce1da326 4889442428      mov     qword ptr [rsp+28h],rax ; stack initialization due to later spillage
00007ffd`ce1da32b 4889442430      mov     qword ptr [rsp+30h],rax
00007ffd`ce1da330 488b4908        mov     rcx,qword ptr [rcx+8]
00007ffd`ce1da334 8b4108          mov     eax,dword ptr [rcx+8]
00007ffd`ce1da337 4883c110        add     rcx,10h
00007ffd`ce1da33b 48894c2428      mov     qword ptr [rsp+28h],rcx
00007ffd`ce1da340 89442430        mov     dword ptr [rsp+30h],eax
00007ffd`ce1da344 837c243005      cmp     dword ptr [rsp+30h],5
00007ffd`ce1da349 7229            jb      ConsoleAppBenchmark!ConsoleAppBenchmark.SpanToStringRunner.SpanToString()+0x1d34 (00007ffd`ce1da374)
00007ffd`ce1da34b 488b4c2428      mov     rcx,qword ptr [rsp+28h]
00007ffd`ce1da350 8b442430        mov     eax,dword ptr [rsp+30h]
00007ffd`ce1da354 83c0fb          add     eax,0FFFFFFFBh
00007ffd`ce1da357 4883c10a        add     rcx,0Ah
00007ffd`ce1da35b 48894c2428      mov     qword ptr [rsp+28h],rcx
00007ffd`ce1da360 89442430        mov     dword ptr [rsp+30h],eax
00007ffd`ce1da364 488d4c2428      lea     rcx,[rsp+28h]
00007ffd`ce1da369 e882c6d9ff      call    Span<char>.ToString ; not inlined
00007ffd`ce1da36e 90              nop
00007ffd`ce1da36f 4883c438        add     rsp,38h
00007ffd`ce1da373 c3              ret

; Span<char>.ToString
00007ffd`ce1d9e60 4883ec38        sub     rsp,38h
00007ffd`ce1d9e64 33c0            xor     eax,eax
00007ffd`ce1d9e66 4889442428      mov     qword ptr [rsp+28h],rax
00007ffd`ce1d9e6b 488b11          mov     rdx,qword ptr [rcx]
00007ffd`ce1d9e6e 8b4908          mov     ecx,dword ptr [rcx+8]
00007ffd`ce1d9e71 488d442428      lea     rax,[rsp+28h]
00007ffd`ce1d9e76 488910          mov     qword ptr [rax],rdx
00007ffd`ce1d9e79 894808          mov     dword ptr [rax+8],ecx
00007ffd`ce1d9e7c 488d542428      lea     rdx,[rsp+28h]
00007ffd`ce1d9e81 33c9            xor     ecx,ecx
00007ffd`ce1d9e83 e8d0aad8ff      call    String.Ctor(ReadOnlySpan<char>)
00007ffd`ce1d9e88 90              nop
00007ffd`ce1d9e89 4883c438        add     rsp,38h
00007ffd`ce1d9e8d c3              ret
```

### New codegen

```asm
; Benchmark.SpanToString method (above)
00007ffd`cd52a020 4883ec28        sub     rsp,28h
00007ffd`cd52a024 488b4908        mov     rcx,qword ptr [rcx+8]
00007ffd`cd52a028 8b5108          mov     edx,dword ptr [rcx+8]
00007ffd`cd52a02b 4883c110        add     rcx,10h
00007ffd`cd52a02f 83fa05          cmp     edx,5
00007ffd`cd52a032 7212            jb      ConsoleAppBenchmark!ConsoleAppBenchmark.SpanToStringRunner.SpanToString()+0x18a6 (00007ffd`cd52a046)
00007ffd`cd52a034 83c2fb          add     edx,0FFFFFFFBh
00007ffd`cd52a037 4883c10a        add     rcx,0Ah
00007ffd`cd52a03b e8a0a9d8ff      call    String.Create(ref char, int) ; direct call, no bouncing through Span<char>.ToString
00007ffd`cd52a040 90              nop
00007ffd`cd52a041 4883c428        add     rsp,28h
00007ffd`cd52a045 c3              ret
```

Aside from the obvious codegen changes, I'm not currently in a position where I can properly benchmark this change to gather raw numbers.