### PR TITLE
Prep CompareInfo for spanification

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -40,7 +40,7 @@ internal static partial class Interop
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern int LocaleNameToLCID(string lpName, uint dwFlags);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int LCMapStringEx(
                     string? lpLocaleName,
                     uint dwMapFlags,
@@ -52,7 +52,7 @@ internal static partial class Interop
                     void* lpReserved,
                     IntPtr sortHandle);
 
-        [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx")]
+        [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx", SetLastError = true)]
         internal static extern int FindNLSStringEx(
                     char* lpLocaleName,
                     uint dwFindNLSStringFlags,
@@ -85,7 +85,7 @@ internal static partial class Interop
                     int cchCount2,
                     bool bIgnoreCase);
 
-        [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal")]
+        [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal", SetLastError = true)]
         internal static extern int FindStringOrdinal(
                     uint dwFindStringOrdinalFlags,
                     char* lpStringSource,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -9,6 +9,15 @@ internal static partial class Interop
 {
     internal static unsafe partial class Kernel32
     {
+        // Under debug mode only, we'll want to check the error codes
+        // of some of the p/invokes we make.
+
+#if DEBUG
+        private const bool SetLastErrorForDebug = true;
+#else
+        private const bool SetLastErrorForDebug = false;
+#endif
+
         internal const uint LOCALE_ALLOW_NEUTRAL_NAMES  = 0x08000000; // Flag to allow returning neutral names/lcids for name conversion
         internal const uint LOCALE_ILANGUAGE            = 0x00000001;
         internal const uint LOCALE_SUPPLEMENTAL         = 0x00000002;
@@ -40,7 +49,7 @@ internal static partial class Interop
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern int LocaleNameToLCID(string lpName, uint dwFlags);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern int LCMapStringEx(
                     string? lpLocaleName,
                     uint dwMapFlags,
@@ -52,7 +61,7 @@ internal static partial class Interop
                     void* lpReserved,
                     IntPtr sortHandle);
 
-        [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx", SetLastError = true)]
+        [DllImport("kernel32.dll", EntryPoint = "FindNLSStringEx", SetLastError = SetLastErrorForDebug)]
         internal static extern int FindNLSStringEx(
                     char* lpLocaleName,
                     uint dwFindNLSStringFlags,
@@ -85,7 +94,7 @@ internal static partial class Interop
                     int cchCount2,
                     bool bIgnoreCase);
 
-        [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal", SetLastError = true)]
+        [DllImport("kernel32.dll", EntryPoint = "FindStringOrdinal", SetLastError = SetLastErrorForDebug)]
         internal static extern int FindStringOrdinal(
                     uint dwFindStringOrdinalFlags,
                     char* lpStringSource,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -101,7 +101,7 @@ internal static partial class Interop
                     int cchSource,
                     char* lpStringValue,
                     int cchValue,
-                    int bIgnoreCase);
+                    bool bIgnoreCase);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern bool IsNLSDefinedString(

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -101,7 +101,7 @@ internal static partial class Interop
                     int cchSource,
                     char* lpStringValue,
                     int cchValue,
-                    bool bIgnoreCase);
+                    BOOL bIgnoreCase);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern bool IsNLSDefinedString(

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
@@ -243,7 +243,7 @@ namespace System.Globalization
                 }
             }
 
-            return new SortKey(Name, source, options, keyData);
+            return new SortKey(this, source, options, keyData);
         }
 
         private static void InvariantCreateSortKeyOrdinal(ReadOnlySpan<char> source, Span<byte> sortKey)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -836,7 +836,7 @@ namespace System.Globalization
                 }
             }
 
-            return new SortKey(Name, source, options, keyData);
+            return new SortKey(this, source, options, keyData);
         }
 
         private static unsafe bool IsSortable(char *text, int length)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -43,63 +43,21 @@ namespace System.Globalization
             }
         }
 
-        internal static unsafe int IndexOfOrdinalCore(string source, string value, int startIndex, int count, bool ignoreCase)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-
-            Debug.Assert(source != null);
-            Debug.Assert(value != null);
-
-            if (value.Length == 0)
-            {
-                return startIndex;
-            }
-
-            if (count < value.Length)
-            {
-                return -1;
-            }
-
-            if (ignoreCase)
-            {
-                fixed (char* pSource = source)
-                {
-                    int index = Interop.Globalization.IndexOfOrdinalIgnoreCase(value, value.Length, pSource + startIndex, count, findLast: false);
-                    return index != -1 ?
-                        startIndex + index :
-                        -1;
-                }
-            }
-
-            int endIndex = startIndex + (count - value.Length);
-            for (int i = startIndex; i <= endIndex; i++)
-            {
-                int valueIndex, sourceIndex;
-
-                for (valueIndex = 0, sourceIndex = i;
-                     valueIndex < value.Length && source[sourceIndex] == value[valueIndex];
-                     valueIndex++, sourceIndex++) ;
-
-                if (valueIndex == value.Length)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
         internal static unsafe int IndexOfOrdinalCore(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase, bool fromBeginning)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(!value.IsEmpty);
 
-            Debug.Assert(source.Length != 0);
-            Debug.Assert(value.Length != 0);
+            // Ordinal (non-linguistic) comparisons require the length of the target string to be no greater
+            // than the length of the search space. Since our caller already checked for empty target strings,
+            // the below check also handles the case of empty search space strings.
 
             if (source.Length < value.Length)
             {
                 return -1;
             }
+
+            Debug.Assert(!source.IsEmpty);
 
             if (ignoreCase)
             {
@@ -199,9 +157,14 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
+            Debug.Assert(count1 > 0);
+            Debug.Assert(count2 > 0);
+
             fixed (char* char1 = &string1)
             fixed (char* char2 = &string2)
             {
+                Debug.Assert(char1 != null);
+                Debug.Assert(char2 != null);
                 return Interop.Globalization.CompareStringOrdinalIgnoreCase(char1, count1, char2, count2);
             }
         }
@@ -215,6 +178,9 @@ namespace System.Globalization
             Debug.Assert(string2 != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
+            // Unlike NLS, ICU (ucol_getSortKey) allows passing nullptr for either of the source arguments
+            // as long as the corresponding length parameter is 0.
+
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &string2.GetRawStringData())
             {
@@ -226,6 +192,9 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
+
+            // Unlike NLS, ICU (ucol_getSortKey) allows passing nullptr for either of the source arguments
+            // as long as the corresponding length parameter is 0.
 
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
@@ -540,7 +509,6 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!prefix.IsEmpty);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
@@ -553,7 +521,7 @@ namespace System.Globalization
             }
             else
             {
-                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                fixed (char* pSource = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
                 fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
                 {
                     return Interop.Globalization.StartsWith(_sortHandle, pPrefix, prefix.Length, pSource, source.Length, options);
@@ -565,13 +533,12 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!prefix.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
 
             int length = Math.Min(source.Length, prefix.Length);
 
-            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* ap = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
             fixed (char* bp = &MemoryMarshal.GetReference(prefix))
             {
                 char* a = ap;
@@ -636,13 +603,12 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!prefix.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
 
             int length = Math.Min(source.Length, prefix.Length);
 
-            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* ap = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
             fixed (char* bp = &MemoryMarshal.GetReference(prefix))
             {
                 char* a = ap;
@@ -696,7 +662,6 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!suffix.IsEmpty);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
@@ -709,7 +674,7 @@ namespace System.Globalization
             }
             else
             {
-                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                fixed (char* pSource = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
                 fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
                 {
                     return Interop.Globalization.EndsWith(_sortHandle, pSuffix, suffix.Length, pSource, source.Length, options);
@@ -721,13 +686,12 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!suffix.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
 
             int length = Math.Min(source.Length, suffix.Length);
 
-            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* ap = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
             fixed (char* bp = &MemoryMarshal.GetReference(suffix))
             {
                 char* a = ap + source.Length - 1;
@@ -773,13 +737,12 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!suffix.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
 
             int length = Math.Min(source.Length, suffix.Length);
 
-            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* ap = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
             fixed (char* bp = &MemoryMarshal.GetReference(suffix))
             {
                 char* a = ap + source.Length - 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -549,7 +549,7 @@ namespace System.Globalization
                 }
             }
 
-            return new SortKey(Name, source, options, keyData);
+            return new SortKey(this, source, options, keyData);
         }
 
         private static unsafe bool IsSortable(char* text, int length)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -44,33 +44,6 @@ namespace System.Globalization
 
         private static unsafe int FindStringOrdinal(
             uint dwFindStringOrdinalFlags,
-            string stringSource,
-            int offset,
-            int cchSource,
-            string value,
-            int cchValue,
-            bool bIgnoreCase)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-            Debug.Assert(stringSource != null);
-            Debug.Assert(value != null);
-
-            fixed (char* pSource = stringSource)
-            fixed (char* pValue = value)
-            {
-                int ret = Interop.Kernel32.FindStringOrdinal(
-                            dwFindStringOrdinalFlags,
-                            pSource + offset,
-                            cchSource,
-                            pValue,
-                            cchValue,
-                            bIgnoreCase ? 1 : 0);
-                return ret < 0 ? ret : ret + offset;
-            }
-        }
-
-        private static unsafe int FindStringOrdinal(
-            uint dwFindStringOrdinalFlags,
             ReadOnlySpan<char> source,
             ReadOnlySpan<char> value,
             bool bIgnoreCase)
@@ -82,6 +55,9 @@ namespace System.Globalization
             fixed (char* pSource = &MemoryMarshal.GetReference(source))
             fixed (char* pValue = &MemoryMarshal.GetReference(value))
             {
+                Debug.Assert(pSource != null);
+                Debug.Assert(pValue != null);
+
                 int ret = Interop.Kernel32.FindStringOrdinal(
                             dwFindStringOrdinalFlags,
                             pSource,
@@ -89,18 +65,15 @@ namespace System.Globalization
                             pValue,
                             value.Length,
                             bIgnoreCase ? 1 : 0);
+
+                Debug.Assert(ret >= -1 && ret <= source.Length);
+                if (ret < 0 && Marshal.GetLastWin32Error() != Interop.Errors.ERROR_SUCCESS)
+                {
+                    throw new ArgumentException(SR.Arg_ExternalException);
+                }
+
                 return ret;
             }
-        }
-
-        internal static int IndexOfOrdinalCore(string source, string value, int startIndex, int count, bool ignoreCase)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-
-            Debug.Assert(source != null);
-            Debug.Assert(value != null);
-
-            return FindStringOrdinal(FIND_FROMSTART, source, startIndex, count, value, value.Length, ignoreCase);
         }
 
         internal static int IndexOfOrdinalCore(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase, bool fromBeginning)
@@ -121,7 +94,13 @@ namespace System.Globalization
             Debug.Assert(source != null);
             Debug.Assert(value != null);
 
-            return FindStringOrdinal(FIND_FROMEND, source, startIndex - count + 1, count, value, value.Length, ignoreCase);
+            int offset = startIndex - count + 1;
+            int result = FindStringOrdinal(FIND_FROMEND, source.AsSpan(offset, count), value, ignoreCase);
+            if (result >= 0)
+            {
+                result += offset;
+            }
+            return result;
         }
 
         private unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options)
@@ -192,11 +171,22 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
+            Debug.Assert(count1 > 0);
+            Debug.Assert(count2 > 0);
+
             fixed (char* char1 = &string1)
             fixed (char* char2 = &string2)
             {
+                Debug.Assert(char1 != null);
+                Debug.Assert(char2 != null);
+
                 // Use the OS to compare and then convert the result to expected value by subtracting 2
-                return Interop.Kernel32.CompareStringOrdinal(char1, count1, char2, count2, true) - 2;
+                int result = Interop.Kernel32.CompareStringOrdinal(char1, count1, char2, count2, bIgnoreCase: true);
+                if (result == 0)
+                {
+                    throw new ArgumentException(SR.Arg_ExternalException);
+                }
+                return result - 2;
             }
         }
 
@@ -211,11 +201,22 @@ namespace System.Globalization
 
             string? localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
+            // CompareStringEx may try to dereference the first character of its input, even if an explicit
+            // length of 0 is specified. To work around potential AVs we'll always ensure zero-length inputs
+            // are normalized to a null-terminated empty string.
+
+            if (string1.IsEmpty)
+            {
+                string1 = string.Empty;
+            }
+
             fixed (char* pLocaleName = localeName)
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
-            fixed (char* pString2 = &string2.GetRawStringData())
+            fixed (char* pString2 = &string2.GetPinnableReference())
             {
-                Debug.Assert(pString1 != null);
+                Debug.Assert(*pString1 >= 0); // assert that we can always dereference this
+                Debug.Assert(*pString2 >= 0); // assert that we can always dereference this
+
                 int result = Interop.Kernel32.CompareStringEx(
                                     pLocaleName,
                                     (uint)GetNativeCompareFlags(options),
@@ -244,12 +245,27 @@ namespace System.Globalization
 
             string? localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
+            // CompareStringEx may try to dereference the first character of its input, even if an explicit
+            // length of 0 is specified. To work around potential AVs we'll always ensure zero-length inputs
+            // are normalized to a null-terminated empty string.
+
+            if (string1.IsEmpty)
+            {
+                string1 = string.Empty;
+            }
+
+            if (string2.IsEmpty)
+            {
+                string2 = string.Empty;
+            }
+
             fixed (char* pLocaleName = localeName)
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
-                Debug.Assert(pString1 != null);
-                Debug.Assert(pString2 != null);
+                Debug.Assert(*pString1 >= 0); // assert that we can always dereference this
+                Debug.Assert(*pString2 >= 0); // assert that we can always dereference this
+
                 int result = Interop.Kernel32.CompareStringEx(
                                     pLocaleName,
                                     (uint)GetNativeCompareFlags(options),
@@ -278,63 +294,48 @@ namespace System.Globalization
                     int* pcchFound)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
-            Debug.Assert(!lpStringSource.IsEmpty);
             Debug.Assert(!lpStringValue.IsEmpty);
 
             string? localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
+
+            // FindNLSStringEx disallows passing an explicit 0 for cchSource or cchValue.
+            // The caller should've already checked that 'lpStringValue' isn't empty,
+            // but it's possible for 'lpStringSource' to be empty. In this case we'll
+            // substitute an empty null-terminated string and pass -1 so that the NLS
+            // function uses the implicit string length.
+
+            int lpStringSourceLength = lpStringSource.Length;
+            if (lpStringSourceLength == 0)
+            {
+                lpStringSource = string.Empty;
+                lpStringSourceLength = -1;
+            }
 
             fixed (char* pLocaleName = localeName)
             fixed (char* pSource = &MemoryMarshal.GetReference(lpStringSource))
             fixed (char* pValue = &MemoryMarshal.GetReference(lpStringValue))
             {
-                return Interop.Kernel32.FindNLSStringEx(
+                Debug.Assert(pSource != null && pValue != null);
+
+                int result = Interop.Kernel32.FindNLSStringEx(
                                     pLocaleName,
                                     dwFindNLSStringFlags,
                                     pSource,
-                                    lpStringSource.Length,
+                                    lpStringSourceLength,
                                     pValue,
                                     lpStringValue.Length,
                                     pcchFound,
                                     null,
                                     null,
                                     _sortHandle);
-            }
-        }
 
-        private unsafe int FindString(
-            uint dwFindNLSStringFlags,
-            string lpStringSource,
-            int startSource,
-            int cchSource,
-            string lpStringValue,
-            int startValue,
-            int cchValue,
-            int* pcchFound)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-            Debug.Assert(lpStringSource != null);
-            Debug.Assert(lpStringValue != null);
+                Debug.Assert(result >= -1 && result <= lpStringSource.Length);
+                if (result < 0 && Marshal.GetLastWin32Error() != Interop.Errors.ERROR_SUCCESS)
+                {
+                    throw new ArgumentException(SR.Arg_ExternalException);
+                }
 
-            string? localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
-
-            fixed (char* pLocaleName = localeName)
-            fixed (char* pSource = lpStringSource)
-            fixed (char* pValue = lpStringValue)
-            {
-                char* pS = pSource + startSource;
-                char* pV = pValue + startValue;
-
-                return Interop.Kernel32.FindNLSStringEx(
-                                    pLocaleName,
-                                    dwFindNLSStringFlags,
-                                    pS,
-                                    cchSource,
-                                    pV,
-                                    cchValue,
-                                    pcchFound,
-                                    null,
-                                    null,
-                                    _sortHandle);
+                return result;
             }
         }
 
@@ -342,13 +343,11 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(source != null);
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
             Debug.Assert((options & CompareOptions.Ordinal) == 0);
 
-            int retValue = FindString(FIND_FROMSTART | (uint)GetNativeCompareFlags(options), source, startIndex, count,
-                                                            target, 0, target.Length, matchLengthPtr);
+            int retValue = FindString(FIND_FROMSTART | (uint)GetNativeCompareFlags(options), source.AsSpan(startIndex, count), target, matchLengthPtr);
             if (retValue >= 0)
             {
                 return retValue + startIndex;
@@ -361,7 +360,6 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(source.Length != 0);
             Debug.Assert(target.Length != 0);
             Debug.Assert(options == CompareOptions.None || options == CompareOptions.IgnoreCase);
 
@@ -373,7 +371,6 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
 
@@ -386,8 +383,7 @@ namespace System.Globalization
             }
             else
             {
-                int retValue = FindString(FIND_FROMEND | (uint)GetNativeCompareFlags(options), source, startIndex - count + 1,
-                                                               count, target, 0, target.Length, null);
+                int retValue = FindString(FIND_FROMEND | (uint)GetNativeCompareFlags(options), source.AsSpan(startIndex - count + 1, count), target, null);
 
                 if (retValue >= 0)
                 {
@@ -396,18 +392,6 @@ namespace System.Globalization
             }
 
             return -1;
-        }
-
-        private unsafe bool StartsWith(string source, string prefix, CompareOptions options)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-
-            Debug.Assert(!string.IsNullOrEmpty(source));
-            Debug.Assert(!string.IsNullOrEmpty(prefix));
-            Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
-
-            return FindString(FIND_STARTSWITH | (uint)GetNativeCompareFlags(options), source, 0, source.Length,
-                                                   prefix, 0, prefix.Length, null) >= 0;
         }
 
         private unsafe bool StartsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options)
@@ -421,23 +405,10 @@ namespace System.Globalization
             return FindString(FIND_STARTSWITH | (uint)GetNativeCompareFlags(options), source, prefix, null) >= 0;
         }
 
-        private unsafe bool EndsWith(string source, string suffix, CompareOptions options)
-        {
-            Debug.Assert(!GlobalizationMode.Invariant);
-
-            Debug.Assert(!string.IsNullOrEmpty(source));
-            Debug.Assert(!string.IsNullOrEmpty(suffix));
-            Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
-
-            return FindString(FIND_ENDSWITH | (uint)GetNativeCompareFlags(options), source, 0, source.Length,
-                                                   suffix, 0, suffix.Length, null) >= 0;
-        }
-
         private unsafe bool EndsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            Debug.Assert(!source.IsEmpty);
             Debug.Assert(!suffix.IsEmpty);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -64,7 +64,7 @@ namespace System.Globalization
                             source.Length,
                             pValue,
                             value.Length,
-                            bIgnoreCase ? 1 : 0);
+                            bIgnoreCase);
 
                 Debug.Assert(ret >= -1 && ret <= source.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -67,10 +67,9 @@ namespace System.Globalization
                             bIgnoreCase ? 1 : 0);
 
                 Debug.Assert(ret >= -1 && ret <= source.Length);
-                if (ret < 0 && Marshal.GetLastWin32Error() != Interop.Errors.ERROR_SUCCESS)
-                {
-                    throw new ArgumentException(SR.Arg_ExternalException);
-                }
+
+                // SetLastError is only performed under debug builds.
+                Debug.Assert(ret >= 0 || Marshal.GetLastWin32Error() == Interop.Errors.ERROR_SUCCESS);
 
                 return ret;
             }
@@ -330,10 +329,9 @@ namespace System.Globalization
                                     _sortHandle);
 
                 Debug.Assert(result >= -1 && result <= lpStringSource.Length);
-                if (result < 0 && Marshal.GetLastWin32Error() != Interop.Errors.ERROR_SUCCESS)
-                {
-                    throw new ArgumentException(SR.Arg_ExternalException);
-                }
+
+                // SetLastError is only performed under debug builds.
+                Debug.Assert(result >= 0 || Marshal.GetLastWin32Error() == Interop.Errors.ERROR_SUCCESS);
 
                 return result;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -64,7 +64,7 @@ namespace System.Globalization
                             source.Length,
                             pValue,
                             value.Length,
-                            bIgnoreCase);
+                            bIgnoreCase ? Interop.BOOL.TRUE : Interop.BOOL.FALSE);
 
                 Debug.Assert(ret >= -1 && ret <= source.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -1112,23 +1112,35 @@ namespace System.Globalization
 
         internal static int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
+            Debug.Assert(source != null);
+            Debug.Assert(value != null);
+            Debug.Assert((uint)startIndex <= (uint)source.Length);
+            Debug.Assert((uint)count <= (uint)(source.Length - startIndex));
+
+            int result;
+
             if (!ignoreCase)
             {
-                int result = SpanHelpers.IndexOf(
+                result = SpanHelpers.IndexOf(
                     ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
                     count,
                     ref value.GetRawStringData(),
                     value.Length);
-
-                return (result >= 0 ? startIndex : 0) + result;
             }
-
-            if (GlobalizationMode.Invariant)
+            else if (GlobalizationMode.Invariant)
             {
-                return InvariantIndexOf(source, value, startIndex, count, ignoreCase);
+                result = InvariantIndexOf(source.AsSpan(startIndex, count), value, ignoreCase, fromBeginning: true);
+            }
+            else
+            {
+                result = IndexOfOrdinalCore(source.AsSpan(startIndex, count), value, ignoreCase, fromBeginning: true);
             }
 
-            return IndexOfOrdinalCore(source, value, startIndex, count, ignoreCase);
+            if (result >= 0)
+            {
+                result += startIndex;
+            }
+            return result;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -1117,6 +1117,21 @@ namespace System.Globalization
             Debug.Assert((uint)startIndex <= (uint)source.Length);
             Debug.Assert((uint)count <= (uint)(source.Length - startIndex));
 
+            // For ordinal (non-linguistic) comparisons, an empty target string is always
+            // found at the beginning of the search space, and a non-empty target string
+            // can never be found within an empty search space. This assumption is not
+            // valid for linguistic comparisons, including InvariantCulture comparisons.
+
+            if (value.Length == 0)
+            {
+                return startIndex;
+            }
+
+            if (count == 0)
+            {
+                return -1;
+            }
+
             int result;
 
             if (!ignoreCase)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/SortKey.cs
@@ -11,7 +11,7 @@ namespace System.Globalization
     /// </summary>
     public sealed partial class SortKey
     {
-        private readonly string _localeName;
+        private readonly CompareInfo _compareInfo;
         private readonly CompareOptions _options;
         private readonly string _string;
         private readonly byte[] _keyData;
@@ -20,10 +20,10 @@ namespace System.Globalization
         /// The following constructor is designed to be called from CompareInfo to get the
         /// the sort key of specific string for synthetic culture
         /// </summary>
-        internal SortKey(string localeName, string str, CompareOptions options, byte[] keyData)
+        internal SortKey(CompareInfo compareInfo, string str, CompareOptions options, byte[] keyData)
         {
             _keyData = keyData;
-            _localeName = localeName;
+            _compareInfo = compareInfo;
             _options = options;
             _string = str;
         }
@@ -75,13 +75,12 @@ namespace System.Globalization
 
         public override int GetHashCode()
         {
-            // keep this in sync with CompareInfo.GetHashCodeOfString
-            return Marvin.ComputeHash32(_keyData, Marvin.DefaultSeed);
+            return _compareInfo.GetHashCode(_string, _options);
         }
 
         public override string ToString()
         {
-            return "SortKey - " + _localeName + ", " + _options + ", " + _string;
+            return "SortKey - " + _compareInfo.Name + ", " + _options + ", " + _string;
         }
     }
 }


### PR DESCRIPTION
This removes many (not all, see https://github.com/dotnet/runtime/issues/8890) of the string-based p/invoke wrappers in `CompareInfo` and replaces them with span-based wrappers.

There's a little more error checking around the actual p/invokes themselves, but otherwise the intent of this PR is that there's no behavioral change to the existing surface area, and there's no new API being exposed.

This PR serves as the shared foundation for upcoming work such as https://github.com/dotnet/runtime/issues/25428, https://github.com/dotnet/runtime/issues/27912, and https://github.com/dotnet/runtime/issues/27935.

This PR also reverts a small optimization we did to `SortKey` in https://github.com/dotnet/runtime/pull/31779, since I was already touching `SortKey`-related code paths here.