### PR TITLE
Cross compilation, check first if an env variable is defined

### DIFF
--- a/src/coreclr/src/pal/tools/gen-dactable-rva.sh
+++ b/src/coreclr/src/pal/tools/gen-dactable-rva.sh
@@ -1,1 +1,1 @@
-nm $1 | grep g_dacTable | cut -f 1 -d' ' | head -n 1 | awk '{ print "#define DAC_TABLE_RVA 0x" $1}' > $2
+${NM:-nm} $1 | grep g_dacTable | cut -f 1 -d' ' | head -n 1 | awk '{ print "#define DAC_TABLE_RVA 0x" $1}' > $2


### PR DESCRIPTION
Hello 

Is it possible to check if an environment variable is set before using nm?

nm is prohibited by our package manager due to cross compilation.

The binary is not the same depending on the architecture, so we use the environment variable ${NM} to indicate the path of the good binary.