### PR TITLE
Fix/quash some warnings.

### DIFF
--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -2176,7 +2176,9 @@ handle_enum:
 		char *str;
 		guint32 slen;
 		if (!arg) {
+MONO_DISABLE_WARNING(4309) // truncation of constant
 			*p++ = 0xFF;
+MONO_RESTORE_WARNING
 			break;
 		}
 		str = mono_string_to_utf8_checked_internal ((MonoString*)arg, error);
@@ -2201,7 +2203,9 @@ handle_enum:
 		guint32 slen;
 		MonoType *arg_type;
 		if (!arg) {
+MONO_DISABLE_WARNING(4309) // truncation of constant
 			*p++ = 0xFF;
+MONO_RESTORE_WARNING
 			break;
 		}
 handle_type:
@@ -2229,7 +2233,9 @@ handle_type:
 		MonoClass *eclass, *arg_eclass;
 
 		if (!arg) {
+MONO_DISABLE_WARNING(4309) // truncation of constant
 			*p++ = 0xff; *p++ = 0xff; *p++ = 0xff; *p++ = 0xff;
+MONO_RESTORE_WARNING
 			break;
 		}
 		len = mono_array_length_internal ((MonoArray*)arg);
@@ -2283,7 +2289,9 @@ handle_type:
 
 		if (arg == NULL) {
 			*p++ = MONO_TYPE_STRING;	// It's same hack as MS uses
+MONO_DISABLE_WARNING(4309) // truncation of constant
 			*p++ = 0xFF;
+MONO_RESTORE_WARNING
 			break;
 		}
 		

--- a/src/mono/mono/mini/linear-scan.c
+++ b/src/mono/mono/mini/linear-scan.c
@@ -268,7 +268,7 @@ compare_by_interval_start_pos_func (gconstpointer a, gconstpointer b)
 #if 0
 #define LSCAN_DEBUG(a) do { a; } while (0)
 #else
-#define LSCAN_DEBUG(a)
+#define LSCAN_DEBUG(a) do { } while (0) /* non-empty to avoid warning */
 #endif
 
 /* FIXME: This is x86 only */

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -11815,6 +11815,7 @@ op_to_op_src2_membase (MonoCompile *cfg, int load_opcode, int opcode)
 int
 mono_op_to_op_imm_noemul (int opcode)
 {
+MONO_DISABLE_WARNING(4065) // switch with default but no case
 	switch (opcode) {
 #if SIZEOF_REGISTER == 4 && !defined(MONO_ARCH_NO_EMULATE_LONG_SHIFT_OPS)
 	case OP_LSHR:
@@ -11836,6 +11837,7 @@ mono_op_to_op_imm_noemul (int opcode)
 	default:
 		return mono_op_to_op_imm (opcode);
 	}
+MONO_RESTORE_WARNING
 }
 
 /**

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -516,7 +516,7 @@ gboolean mono_jit_map_is_enabled (void);
 #else
 #define mono_enable_jit_map()
 #define mono_emit_jit_map(ji)
-#define mono_emit_jit_tramp(s,z,d)
+#define mono_emit_jit_tramp(s,z,d) do { } while (0) /* non-empty to avoid warning */
 #define mono_jit_map_is_enabled() (0)
 #endif
 

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -1082,7 +1082,7 @@ compare_by_interval_start_pos_func (gconstpointer a, gconstpointer b)
 #if 0
 #define LSCAN_DEBUG(a) do { a; } while (0)
 #else
-#define LSCAN_DEBUG(a)
+#define LSCAN_DEBUG(a) do { } while (0) /* non-empty to avoid warning */
 #endif
 
 static gint32*

--- a/src/mono/mono/mini/type-checking.c
+++ b/src/mono/mono/mini/type-checking.c
@@ -164,7 +164,7 @@ mini_emit_interface_bitmap_check (MonoCompile *cfg, int intf_bit_reg, int base_r
 		MONO_EMIT_NEW_BIALU (cfg, OP_IAND, intf_bit_reg, ibitmap_byte_reg, iid_bit_reg);
 	} else {
 		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADI1_MEMBASE, ibitmap_byte_reg, ibitmap_reg, m_class_get_interface_id (klass) >> 3);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, intf_bit_reg, ibitmap_byte_reg, 1 << (m_class_get_interface_id (klass) & 7));
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, intf_bit_reg, ibitmap_byte_reg, ((target_mgreg_t)1) << (m_class_get_interface_id (klass) & 7));
 	}
 #endif
 }

--- a/src/mono/mono/utils/dtrace.h
+++ b/src/mono/mono/utils/dtrace.h
@@ -38,10 +38,10 @@
 #define MONO_VES_INIT_END_ENABLED() (0)
 
 
-#define MONO_PROBE_METHOD_COMPILE_BEGIN(method)
+#define MONO_PROBE_METHOD_COMPILE_BEGIN(method) do { } while (0) /* non-empty to avoid warning */
 #define MONO_METHOD_COMPILE_BEGIN_ENABLED() (0)
 
-#define MONO_PROBE_METHOD_COMPILE_END(method, success)
+#define MONO_PROBE_METHOD_COMPILE_END(method, success) do { } while (0) /* non-empty to avoid warning */
 #define MONO_METHOD_COMPILE_END_ENABLED() (0)
 
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18873,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>mini\mini.c(1253,59): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3100,43): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3273,49): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3281,49): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3480,51): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3490,49): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3626,48): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3664,48): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3722,48): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini.c(3944,47): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\mini-runtime.c(549,64): warning C4390:  ';': empty controlled statement found; is this the intent?
mini\method-to-ir.c(11838,2): warning C4065:  switch statement contains 'default' but no 'case ' labels
metadata\sre.c(2286,11): warning C4309:  '=': truncation of constant value
metadata\sre.c(2179,11): warning C4309:  '=': truncation of constant value
metadata\sre.c(2204,11): warning C4309:  '=': truncation of constant value
metadata\sre.c(2232,11): warning C4309:  '=': truncation of constant value
mini\method-to-ir.c(11838,2): warning C4065:  switch statement contains 'default' but no 'case
mini\type-checking.c(167,3): warning C4334:  '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)