### PR TITLE
Mono: Fix/quash more warnings.

### DIFF
--- a/src/mono/mono/eglib/gfile-win32.c
+++ b/src/mono/mono/eglib/gfile-win32.c
@@ -88,10 +88,6 @@ g_mkdtemp (char *tmp_template)
 	g_free (utf16_template);
 	return NULL;
 }
-	     
-#ifdef _MSC_VER
-#pragma warning(disable:4701)
-#endif
 
 gboolean
 g_file_test (const gchar *filename, GFileTest test)

--- a/src/mono/mono/eglib/test/driver.c
+++ b/src/mono/mono/eglib/test/driver.c
@@ -111,7 +111,7 @@ gint run_tests_main(gint argc, gchar **argv)
 gint main(gint argc, gchar **argv)
 #endif
 {
-	gint i, j, c, iterations = 1;
+	gint j, iterations = 1;
 	StringArray *tests_to_run = NULL;
 	gdouble time_start;
 	gboolean report_time = FALSE;
@@ -121,6 +121,8 @@ gint main(gint argc, gchar **argv)
 	gboolean debug = FALSE;
 
 #if HAVE_GETOPT_H
+	int c;
+	int i;
 	static struct option long_options [] = {
 		{"help",       no_argument,       0, 'h'},
 		{"time",       no_argument,       0, 't'},

--- a/src/mono/mono/eglib/test/spawn.c
+++ b/src/mono/mono/eglib/test/spawn.c
@@ -13,6 +13,12 @@
 #define close _close
 #endif
 
+#if _MSC_VER
+// Two warnings for this significant error.
+#pragma warning(disable:4022) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
+#pragma warning(disable:4047) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
+#endif
+
 static RESULT
 test_spawn_sync (void)
 {

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2532,7 +2532,7 @@ mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataC
 
 	guint32 idx = custom_attrs_idx_from_class (klass);
 
-	return metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
+	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
 }
 
 static void

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -53,6 +53,10 @@
 #include "external-only.h"
 #include "icall-decl.h"
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 typedef struct DomainFinalizationReq {
 	gint32 ref;
 	MonoDomain *domain;
@@ -1080,7 +1084,7 @@ mono_gc_cleanup (void)
 					ret = guarded_wait (gc_thread->handle, MONO_INFINITE_WAIT, FALSE);
 					g_assert (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0);
 
-					mono_threads_add_joinable_thread ((gpointer)(MONO_UINT_TO_NATIVE_THREAD_ID (gc_thread->tid)));
+					mono_threads_add_joinable_thread ((gpointer)(gsize)MONO_UINT_TO_NATIVE_THREAD_ID (gc_thread->tid));
 					break;
 				}
 

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -120,6 +120,10 @@
 #include "mono/metadata/icall-signatures.h"
 #include "mono/utils/mono-signal-handler.h"
 
+#if _MSC_VER
+#pragma warning(disable:4047) // FIXME differs in levels of indirection
+#endif
+
 //#define MONO_DEBUG_ICALLARRAY
 
 #ifdef MONO_DEBUG_ICALLARRAY

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -599,7 +599,7 @@ free_method_jit_info (MonoDebugMethodJitInfo *jit, gboolean stack)
 void
 mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit)
 {
-	return free_method_jit_info (jit, FALSE);
+	free_method_jit_info (jit, FALSE);
 }
 
 static MonoDebugMethodJitInfo *

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -60,6 +60,10 @@
 #include "icall-decl.h"
 #include "icall-signatures.h"
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 // If no symbols in an object file in a static library are referenced, its exports will not be exported.
 // There are a few workarounds:
 // 1. Link to .o/.obj files directly on the link command line,

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -39,6 +39,10 @@
 #include "icall-signatures.h"
 #include "mono/utils/mono-tls-inline.h"
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 #ifdef HEAVY_STATISTICS
 static guint64 stat_wbarrier_set_arrayref = 0;
 static guint64 stat_wbarrier_value_copy = 0;
@@ -2160,7 +2164,7 @@ mono_gc_thread_detach (SgenThreadInfo *info)
 void
 mono_gc_thread_detach_with_lock (SgenThreadInfo *info)
 {
-	return sgen_thread_detach_with_lock (info);
+	sgen_thread_detach_with_lock (info);
 }
 
 void
@@ -2615,7 +2619,7 @@ mono_gc_make_descr_for_string (gsize *bitmap, int numbits)
 void
 mono_gc_register_obj_with_weak_fields (void *obj)
 {
-	return sgen_register_obj_with_weak_fields ((MonoObject*)obj);
+	sgen_register_obj_with_weak_fields ((MonoObject*)obj);
 }
 
 void*

--- a/src/mono/mono/metadata/sgen-stw.c
+++ b/src/mono/mono/metadata/sgen-stw.c
@@ -28,6 +28,10 @@
 #include "utils/mono-threads.h"
 #include "utils/mono-threads-debug.h"
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 #define TV_DECLARE SGEN_TV_DECLARE
 #define TV_GETTIME SGEN_TV_GETTIME
 #define TV_ELAPSED SGEN_TV_ELAPSED
@@ -419,7 +423,7 @@ sgen_unified_suspend_stop_world (void)
 
 		stopped_ip = (gpointer) (MONO_CONTEXT_GET_IP (&info->client_info.ctx));
 
-		sgen_binary_protocol_thread_suspend ((gpointer) mono_thread_info_get_tid (info), stopped_ip);
+		sgen_binary_protocol_thread_suspend ((gpointer)(gsize)mono_thread_info_get_tid (info), stopped_ip);
 
 		THREADS_STW_DEBUG ("[GC-STW-SUSPEND-END] thread %p is suspended, stopped_ip = %p, stack = %p -> %p\n",
 			mono_thread_info_get_tid (info), stopped_ip, info->client_info.stack_start, info->client_info.stack_start ? info->client_info.info.stack_end : NULL);

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -68,6 +68,10 @@
 
 #include <signal.h>
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 #if defined(HOST_WIN32)
 #include <objbase.h>
 #include <sys/timeb.h>
@@ -910,7 +914,7 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	if (thread_static_info.offset || thread_static_info.idx > 0) {
 		/* get the current allocated size */
 		guint32 offset = MAKE_SPECIAL_STATIC_OFFSET (thread_static_info.idx, thread_static_info.offset, 0);
-		mono_alloc_static_data (&internal->static_data, offset, (void *) MONO_UINT_TO_NATIVE_THREAD_ID (internal->tid), TRUE);
+		mono_alloc_static_data (&internal->static_data, offset, (void*)(gsize)MONO_UINT_TO_NATIVE_THREAD_ID (internal->tid), TRUE);
 	}
 
 	mono_threads_unlock ();
@@ -1836,13 +1840,13 @@ mono_sleep_internal (gint32 ms, MonoBoolean allow_interruption, MonoError *error
 void
 ves_icall_System_Threading_Thread_Sleep_internal (gint32 ms, MonoBoolean allow_interruption, MonoError *error)
 {
-	return mono_sleep_internal (ms, allow_interruption, error);
+	mono_sleep_internal (ms, allow_interruption, error);
 }
 #else
 void
 ves_icall_System_Threading_Thread_Sleep_internal (gint32 ms, MonoError *error)
 {
-	return mono_sleep_internal (ms, TRUE, error);
+	mono_sleep_internal (ms, TRUE, error);
 }
 
 void

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -114,6 +114,10 @@
 
 #define THREAD_TO_INTERNAL(thread) (thread)->internal_thread
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 typedef struct {
 	gboolean enabled;
 	char *transport;
@@ -2757,7 +2761,7 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 	if (mono_thread_internal_is_current (thread) || tls->terminated)
 		return;
 
-	DEBUG_PRINTF (1, "[%p] Interrupting %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)tid);
+	DEBUG_PRINTF (1, "[%p] Interrupting %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)(gsize)tid);
 
 	/* This is _not_ equivalent to mono_thread_internal_abort () */
 	InterruptData interrupt_data = { 0 };

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -79,10 +79,6 @@
 #endif
 #include <mono/metadata/icall-decl.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable:4102) // label' : unreferenced label
-#endif
-
 /* Arguments that are passed when invoking only a finally/filter clause from the frame */
 struct FrameClauseArgs {
 	/* Where we start the frame execution from */

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -57,6 +57,9 @@
 
 #endif
 
+#if _MSC_VER
+#pragma warning(disable:4293) // FIXME negative shift is undefined
+#endif
 
 /* If the bank is mirrored return the true logical bank that the register in the
  * physical register bank is allocated to.

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2684,7 +2684,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					msg = g_strdup ("(System.Exception.Message property not available)");
 				}
 			}
-			g_print ("[%p:] EXCEPTION handling: %s.%s: %s\n", (void*)mono_native_thread_id_get (), m_class_get_name_space (mono_object_class (obj)), m_class_get_name (mono_object_class (obj)), msg);
+			g_print ("[%p:] EXCEPTION handling: %s.%s: %s\n", (void*)(gsize)mono_native_thread_id_get (), m_class_get_name_space (mono_object_class (obj)), m_class_get_name (mono_object_class (obj)), msg);
 			g_free (msg);
 			if (mono_ex && mono_trace_eval_exception (mono_object_class (mono_ex)))
 				mono_print_thread_dump_from_ctx (ctx);

--- a/src/mono/mono/mini/trace.c
+++ b/src/mono/mono/mini/trace.c
@@ -27,6 +27,10 @@
 #include "trace.h"
 #include <mono/metadata/callspec.h>
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 #if defined (HOST_ANDROID) || (defined (TARGET_IOS) && defined (TARGET_IOS))
 #  undef printf
 #  define printf(...) g_log("mono", G_LOG_LEVEL_MESSAGE, __VA_ARGS__)

--- a/src/mono/mono/profiler/log.c
+++ b/src/mono/mono/profiler/log.c
@@ -4083,7 +4083,7 @@ create_profiler (const char *args, const char *filename, GPtrArray *filters)
 
 	//If filename begin with +, append the pid at the end
 	if (filename && *filename == '+')
-		filename = g_strdup_printf ("%s.%d", filename + 1, getpid ());
+		filename = g_strdup_printf ("%s.%d", filename + 1, (int)process_id ());
 
 	if (!filename) {
 		if (log_config.do_report)

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -26,6 +26,9 @@
 #include "mono/sgen/sgen-pinning.h"
 #include "mono/sgen/sgen-client.h"
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
 
 #ifndef DISABLE_SGEN_DEBUG_HELPERS
 
@@ -516,7 +519,7 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 			mword w = *ctxcurrent;
 
 			if (w >= (mword)obj && w < (mword)obj + size)
-				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)mono_thread_info_get_tid (info));
+				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)(gsize)mono_thread_info_get_tid (info));
 		}
 	} FOREACH_THREAD_END
 #endif

--- a/src/mono/mono/sgen/sgen-internal.c
+++ b/src/mono/mono/sgen/sgen-internal.c
@@ -264,8 +264,8 @@ sgen_dump_internal_mem_usage (FILE *heap_dump_file)
 void
 sgen_report_internal_mem_usage (void)
 {
-	int i G_GNUC_UNUSED;
 #ifdef HEAVY_STATISTICS
+	int i;
 	printf ("size -> # allocations\n");
 	for (i = 0; i < NUM_ALLOCATORS; ++i)
 		printf ("%d -> %d\n", allocator_sizes [i], allocator_sizes_stats [i]);

--- a/src/mono/mono/sgen/sgen-thread-pool.c
+++ b/src/mono/mono/sgen/sgen-thread-pool.c
@@ -307,7 +307,7 @@ sgen_thread_pool_shutdown (void)
 	mono_os_cond_destroy (&done_cond);
 
 	for (int i = 0; i < threads_num; i++) {
-		mono_threads_add_joinable_thread ((gpointer)threads [i]);
+		mono_threads_add_joinable_thread ((gpointer)(gsize)threads [i]);
 	}
 }
 

--- a/src/mono/mono/tests/libtest.c
+++ b/src/mono/mono/tests/libtest.c
@@ -838,6 +838,8 @@ mono_test_marshal_byref_class (simplestruct2 **ssp)
 	return 0;
 }
 
+MONO_DISABLE_WARNING (4172) // returning address of local
+
 static void *
 get_sp (void)
 {
@@ -848,6 +850,8 @@ get_sp (void)
 	p = &i;
 	return p;
 }
+
+MONO_RESTORE_WARNING
 
 LIBTEST_API int STDCALL 
 reliable_delegate (int a)

--- a/src/mono/mono/utils/hazard-pointer.c
+++ b/src/mono/mono/utils/hazard-pointer.c
@@ -26,6 +26,10 @@
 #include <mono/utils/mono-counters.h>
 #endif
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 typedef struct {
 	gpointer p;
 	MonoHazardousFreeFunc free_func;
@@ -119,7 +123,7 @@ mono_thread_small_id_alloc (void)
 		int num_pages = (hazard_table_size * sizeof (MonoThreadHazardPointers) + pagesize - 1) / pagesize;
 
 		if (hazard_table == NULL) {
-			hazard_table = (MonoThreadHazardPointers *volatile) mono_valloc (NULL,
+			hazard_table = (MonoThreadHazardPointers*) mono_valloc (NULL,
 				sizeof (MonoThreadHazardPointers) * HAZARD_TABLE_MAX_SIZE,
 				table_prot, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
 		}

--- a/src/mono/mono/utils/lock-free-queue.c
+++ b/src/mono/mono/utils/lock-free-queue.c
@@ -58,9 +58,9 @@
 
 #include <mono/utils/lock-free-queue.h>
 
-#define INVALID_NEXT	((MonoLockFreeQueueNode *volatile)-1)
-#define END_MARKER	((MonoLockFreeQueueNode *volatile)-2)
-#define FREE_NEXT	((MonoLockFreeQueueNode *volatile)-3)
+#define INVALID_NEXT	((MonoLockFreeQueueNode*)-1)
+#define END_MARKER	((MonoLockFreeQueueNode*)-2)
+#define FREE_NEXT	((MonoLockFreeQueueNode*)-3)
 
 /*
  * Initialize a lock-free queue in-place at @q.

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -41,6 +41,10 @@
 #include <mono/utils/mach-support.h>
 #endif
 
+#if _MSC_VER
+#pragma warning(disable:4312) // FIXME pointer cast to different size
+#endif
+
 /*
 Mutex that makes sure only a single thread can be suspending others.
 Suspend is a very racy operation since it requires restarting until
@@ -1682,8 +1686,8 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 #endif
 		} while (1);
 	} else {
-		int ret;
 #if defined (HAVE_CLOCK_NANOSLEEP) && !defined(__PASE__)
+		int ret;
 		struct timespec start, target;
 
 		/* Use clock_nanosleep () to prevent time drifting problems when nanosleep () is interrupted by signals */
@@ -1704,6 +1708,7 @@ mono_thread_info_sleep (guint32 ms, gboolean *alerted)
 #elif HOST_WIN32
 		Sleep (ms);
 #else
+		int ret;
 		struct timespec req, rem;
 
 		req.tv_sec = ms / 1000;

--- a/src/mono/msvc/msvc-disabled-warnings.h
+++ b/src/mono/msvc/msvc-disabled-warnings.h
@@ -4,31 +4,31 @@
 
 // FIXME This is all questionable but the logs are flooded and nothing else is fixing them.
 #define _CRT_SECURE_NO_WARNINGS 1
-#pragma warning(disable:4013) // function undefined; assuming extern returning int
+#pragma warning(  error:4013) // function undefined; assuming extern returning int
 #pragma warning(disable:4018) // signed/unsigned mismatch
-#pragma warning(disable:4022) // call and prototype disagree
-#pragma warning(disable:4047) // call and prototype disagree
+#pragma warning(  error:4022) // call and prototype disagree
+#pragma warning(  error:4047) // differs in level of indirection
 #pragma warning(disable:4090) // const problem
-#pragma warning(disable:4098) // void return returns a value
+#pragma warning(  error:4098) // void return returns a value
 #pragma warning(disable:4101) // unreferenced local variable
-#pragma warning(disable:4113) // call and prototype disagree
+#pragma warning(  error:4113) // call and prototype disagree
 #pragma warning(disable:4146) // unary minus operator applied to unsigned type, result still unsigned
-#pragma warning(disable:4172) // returning address of local variable or temporary
+#pragma warning(  error:4172) // returning address of local variable or temporary
 #pragma warning(disable:4189) // local variable is initialized but not referenced
-#pragma warning(disable:4197) // top-level volatile in cast is ignored
+#pragma warning(  error:4197) // top-level volatile in cast is ignored
 #pragma warning(disable:4244) // integer conversion, possible loss of data
 #pragma warning(disable:4245) // signed/unsigned mismatch
 #pragma warning(disable:4267) // integer conversion, possible loss of data
-#pragma warning(disable:4273) // inconsistent dll linkage
-#pragma warning(disable:4293) // shift count negative or too big, undefined behavior
+#pragma warning(  error:4273) // inconsistent dll linkage
+#pragma warning(  error:4293) // shift count negative or too big, undefined behavior
 #pragma warning(disable:4305) // truncation from 'double' to 'float'
-#pragma warning(disable:4312) // 'type cast': conversion from 'MonoNativeThreadId' to 'gpointer' of greater size
+#pragma warning(  error:4312) // 'type cast': conversion from 'MonoNativeThreadId' to 'gpointer' of greater size
 #pragma warning(disable:4389) // signed/unsigned mismatch
 #pragma warning(disable:4456) // declaration of 'j' hides previous local declaration
 #pragma warning(disable:4457) // declaration of 'text' hides function parameter
 #pragma warning(disable:4702) // unreachable code
 #pragma warning(disable:4706) // assignment within conditional expression
-#pragma warning(disable:4715) // 'keyword' not all control paths return a value
+#pragma warning(  error:4715) // 'keyword' not all control paths return a value
 #pragma warning(disable:4996) // deprecated function GetVersion GetVersionExW fopen inet_addr mktemp sprintf strcat strcpy strtok unlink etc.
 
 #endif


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18874,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Whittle away at warnings:
 Return address of local (deliberate).
 Pointer cast to different size (need to go back and fix them all).
 Function parameter and declaration badly mismatch (pid_t vs. void*). (need to come back and fix it).
 Unused locals.
 Top level volatile is ignored.
 Negative shift undefined.
 Call to undeclared function (getpid).

Some are fixed, some are disabled temporarily.