### PR TITLE
Reduce allocation in HTTP/2 requests by ~30%

### DIFF
--- a/src/libraries/Common/src/System/Net/CookieParser.cs
+++ b/src/libraries/Common/src/System/Net/CookieParser.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace System.Net
 {
@@ -39,7 +40,7 @@ namespace System.Net
     //
     // Used to split a single or multi-cookie (header) string into individual
     // tokens.
-    internal class CookieTokenizer
+    internal struct CookieTokenizer
     {
         private bool _eofCookie;
         private int _index;
@@ -54,7 +55,7 @@ namespace System.Net
         private int _cookieStartIndex;
         private int _cookieLength;
 
-        internal CookieTokenizer(string tokenStream)
+        internal CookieTokenizer(string tokenStream) : this()
         {
             _length = tokenStream.Length;
             _tokenStream = tokenStream;
@@ -506,14 +507,15 @@ namespace System.Net
     // CookieParser
     //
     // Takes a cookie header, makes cookies.
-    internal class CookieParser
+    internal struct CookieParser
     {
-        private readonly CookieTokenizer _tokenizer;
+        private CookieTokenizer _tokenizer;
         private Cookie _savedCookie;
 
         internal CookieParser(string cookieString)
         {
             _tokenizer = new CookieTokenizer(cookieString);
+            _savedCookie = null;
         }
 
 #if SYSTEM_NET_PRIMITIVES_DLL

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -62,14 +62,19 @@ namespace System.Net.Http.Headers
         {
             get
             {
-                if (ExpectCore.IsSpecialValueSet)
+                // ExpectCore will force the collection into existence, so avoid accessing it if possible.
+                if (_expectContinueSet || ContainsParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue))
                 {
-                    return true;
+                    if (ExpectCore.IsSpecialValueSet)
+                    {
+                        return true;
+                    }
+                    if (_expectContinueSet)
+                    {
+                        return false;
+                    }
                 }
-                if (_expectContinueSet)
-                {
-                    return false;
-                }
+
                 return null;
             }
             set

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -30,10 +30,10 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader AltSvc = new KnownHeader("Alt-Svc", HttpHeaderType.Response, AltSvcHeaderParser.Parser, http3StaticTableIndex: H3StaticTable.AltSvcClear);
         public static readonly KnownHeader AltUsed = new KnownHeader("Alt-Used", HttpHeaderType.Request, parser: null);
         public static readonly KnownHeader Authorization = new KnownHeader("Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, H2StaticTable.Authorization, H3StaticTable.Authorization);
-        public static readonly KnownHeader CacheControl = new KnownHeader("Cache-Control", HttpHeaderType.General | HttpHeaderType.NonTrailing, CacheControlHeaderParser.Parser, null, H2StaticTable.CacheControl, H3StaticTable.CacheControlMaxAge0);
+        public static readonly KnownHeader CacheControl = new KnownHeader("Cache-Control", HttpHeaderType.General | HttpHeaderType.NonTrailing, CacheControlHeaderParser.Parser, new string[] { "must-revalidate", "no-cache", "no-store", "no-transform", "private", "proxy-revalidate", "public" }, H2StaticTable.CacheControl, H3StaticTable.CacheControlMaxAge0);
         public static readonly KnownHeader Connection = new KnownHeader("Connection", HttpHeaderType.General, GenericHeaderParser.TokenListParser, new string[] { "close" });
-        public static readonly KnownHeader ContentDisposition = new KnownHeader("Content-Disposition", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentDispositionParser, null, H2StaticTable.ContentDisposition, H3StaticTable.ContentDisposition);
-        public static readonly KnownHeader ContentEncoding = new KnownHeader("Content-Encoding", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, new string[] { "gzip", "deflate" }, H2StaticTable.ContentEncoding, H3StaticTable.ContentEncodingBr);
+        public static readonly KnownHeader ContentDisposition = new KnownHeader("Content-Disposition", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.ContentDispositionParser, new string[] { "inline", "attachment" }, H2StaticTable.ContentDisposition, H3StaticTable.ContentDisposition);
+        public static readonly KnownHeader ContentEncoding = new KnownHeader("Content-Encoding", HttpHeaderType.Content | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser, new string[] { "gzip", "deflate", "br", "compress", "identity" }, H2StaticTable.ContentEncoding, H3StaticTable.ContentEncodingBr);
         public static readonly KnownHeader ContentLanguage = new KnownHeader("Content-Language", HttpHeaderType.Content, GenericHeaderParser.TokenListParser, null, H2StaticTable.ContentLanguage);
         public static readonly KnownHeader ContentLength = new KnownHeader("Content-Length", HttpHeaderType.Content | HttpHeaderType.NonTrailing, Int64NumberHeaderParser.Parser, null, H2StaticTable.ContentLength, H3StaticTable.ContentLength0);
         public static readonly KnownHeader ContentLocation = new KnownHeader("Content-Location", HttpHeaderType.Content | HttpHeaderType.NonTrailing, UriHeaderParser.RelativeOrAbsoluteUriParser, null, H2StaticTable.ContentLocation);
@@ -61,7 +61,7 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader MaxForwards = new KnownHeader("Max-Forwards", HttpHeaderType.Request | HttpHeaderType.NonTrailing, Int32NumberHeaderParser.Parser, null, H2StaticTable.MaxForwards);
         public static readonly KnownHeader Origin = new KnownHeader("Origin", http3StaticTableIndex: H3StaticTable.Origin);
         public static readonly KnownHeader P3P = new KnownHeader("P3P");
-        public static readonly KnownHeader Pragma = new KnownHeader("Pragma", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueParser);
+        public static readonly KnownHeader Pragma = new KnownHeader("Pragma", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueNameValueParser, new string[] { "no-cache" });
         public static readonly KnownHeader ProxyAuthenticate = new KnownHeader("Proxy-Authenticate", HttpHeaderType.Response | HttpHeaderType.NonTrailing, GenericHeaderParser.MultipleValueAuthenticationParser, null, H2StaticTable.ProxyAuthenticate);
         public static readonly KnownHeader ProxyAuthorization = new KnownHeader("Proxy-Authorization", HttpHeaderType.Request | HttpHeaderType.NonTrailing, GenericHeaderParser.SingleValueAuthenticationParser, null, H2StaticTable.ProxyAuthorization);
         public static readonly KnownHeader ProxyConnection = new KnownHeader("Proxy-Connection");
@@ -80,10 +80,10 @@ namespace System.Net.Http.Headers
         public static readonly KnownHeader SetCookie = new KnownHeader("Set-Cookie", HttpHeaderType.Custom | HttpHeaderType.NonTrailing, null, null, H2StaticTable.SetCookie, H3StaticTable.SetCookie);
         public static readonly KnownHeader SetCookie2 = new KnownHeader("Set-Cookie2", HttpHeaderType.Custom | HttpHeaderType.NonTrailing, null, null);
         public static readonly KnownHeader StrictTransportSecurity = new KnownHeader("Strict-Transport-Security", H2StaticTable.StrictTransportSecurity, H3StaticTable.StrictTransportSecurityMaxAge31536000);
-        public static readonly KnownHeader TE = new KnownHeader("TE", HttpHeaderType.Request | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueWithQualityParser);
+        public static readonly KnownHeader TE = new KnownHeader("TE", HttpHeaderType.Request | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueWithQualityParser, new string[] { "trailers", "compress", "deflate", "gzip" });
         public static readonly KnownHeader TSV = new KnownHeader("TSV");
         public static readonly KnownHeader Trailer = new KnownHeader("Trailer", HttpHeaderType.General | HttpHeaderType.NonTrailing, GenericHeaderParser.TokenListParser);
-        public static readonly KnownHeader TransferEncoding = new KnownHeader("Transfer-Encoding", HttpHeaderType.General | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueParser, new string[] { "chunked" }, H2StaticTable.TransferEncoding);
+        public static readonly KnownHeader TransferEncoding = new KnownHeader("Transfer-Encoding", HttpHeaderType.General | HttpHeaderType.NonTrailing, TransferCodingHeaderParser.MultipleValueParser, new string[] { "chunked", "compress", "deflate", "gzip", "identity" }, H2StaticTable.TransferEncoding);
         public static readonly KnownHeader Upgrade = new KnownHeader("Upgrade", HttpHeaderType.General, GenericHeaderParser.MultipleValueProductParser);
         public static readonly KnownHeader UpgradeInsecureRequests = new KnownHeader("Upgrade-Insecure-Requests", http3StaticTableIndex: H3StaticTable.UpgradeInsecureRequests1);
         public static readonly KnownHeader UserAgent = new KnownHeader("User-Agent", HttpHeaderType.Request, ProductInfoHeaderParser.MultipleValueParser, null, H2StaticTable.UserAgent, H3StaticTable.UserAgent);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1737,7 +1737,7 @@ namespace System.Net.Http
                 // complete before worrying about response headers completing.
                 if (requestBodyTask.IsCompleted ||
                     duplex == false ||
-                    requestBodyTask == await Task.WhenAny(requestBodyTask, responseHeadersTask).ConfigureAwait(false) ||
+                    await Task.WhenAny(requestBodyTask, responseHeadersTask).ConfigureAwait(false) == requestBodyTask ||
                     requestBodyTask.IsCompleted)
                 {
                     // The sending of the request body completed before receiving all of the request headers (or we're

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1049,7 +1049,10 @@ namespace System.Net.Http
             Debug.Assert(_headerBuffer.ActiveLength == 0);
 
             // HTTP2 does not support Transfer-Encoding: chunked, so disable this on the request.
-            request.Headers.TransferEncodingChunked = false;
+            if (request.HasHeaders && request.Headers.TransferEncodingChunked == true)
+            {
+                request.Headers.TransferEncodingChunked = false;
+            }
 
             HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -534,7 +534,10 @@ namespace System.Net.Http
             if (request.HasHeaders)
             {
                 // H3 does not support Transfer-Encoding: chunked.
-                request.Headers.TransferEncodingChunked = false;
+                if (request.HasHeaders && request.Headers.TransferEncodingChunked == true)
+                {
+                    request.Headers.TransferEncodingChunked = false;
+                }
 
                 BufferHeaderCollection(request.Headers);
             }
@@ -551,7 +554,10 @@ namespace System.Net.Http
             if (request.Content == null || request.Content.Headers.ContentLength == 0)
             {
                 // Expect 100 Continue requires content.
-                request.Headers.ExpectContinue = null;
+                if (request.HasHeaders && request.Headers.ExpectContinue != null)
+                {
+                    request.Headers.ExpectContinue = null;
+                }
 
                 if (normalizedMethod.MustHaveRequestBody)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -71,7 +71,10 @@ namespace System.Net.Http
 
                     request.Method = HttpMethod.Get;
                     request.Content = null;
-                    request.Headers.TransferEncodingChunked = false;
+                    if (request.Headers.TransferEncodingChunked == true)
+                    {
+                        request.Headers.TransferEncodingChunked = false;
+                    }
                 }
 
                 // Issue the redirected request.

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -200,8 +200,10 @@ namespace System.Net
             if (isStrict)
             {
                 int idx = 0;
-                foreach (Cookie c in m_list)
+                int listCount = m_list.Count;
+                for (int i = 0; i < listCount; i++)
                 {
+                    Cookie c = (Cookie)m_list[i];
                     if (CookieComparer.Compare(cookie, c) == 0)
                     {
                         ret = 0; // Will replace or reject

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -772,9 +772,10 @@ namespace System.Net
                 }
             }
 
-            foreach (Cookie c in cookies)
+            int cookiesCount = cookies.Count;
+            for (int i = 0; i < cookiesCount; i++)
             {
-                Add(c, isThrow);
+                Add((Cookie)cookies[i], isThrow);
             }
 
             return cookies;
@@ -880,14 +881,14 @@ namespace System.Net
 
                 lock (pathList.SyncRoot)
                 {
-                    // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
-                    IDictionaryEnumerator e = pathList.GetEnumerator();
-                    while (e.MoveNext())
+                    SortedList list = pathList.List;
+                    int listCount = list.Count;
+                    for (int e = 0; e < listCount; e++)
                     {
-                        string path = (string)e.Key;
+                        string path = (string)list.GetKey(e);
                         if (uri.AbsolutePath.StartsWith(CookieParser.CheckQuoted(path), StringComparison.Ordinal))
                         {
-                            CookieCollection cc = (CookieCollection)e.Value;
+                            CookieCollection cc = (CookieCollection)list.GetByIndex(e);
                             cc.TimeStamp(CookieCollection.Stamp.Set);
                             MergeUpdateCollections(ref cookies, cc, port, isSecure, matchOnlyPlainCookie);
                         }
@@ -1041,9 +1042,11 @@ namespace System.Net
             int count = 0;
             lock (SyncRoot)
             {
-                foreach (CookieCollection cc in m_list.Values)
+                IList list = m_list.GetValueList();
+                int listCount = list.Count;
+                for (int i = 0; i < listCount; i++)
                 {
-                    count += cc.Count;
+                    count += ((CookieCollection)list[i]).Count;
                 }
             }
             return count;
@@ -1091,6 +1094,8 @@ namespace System.Net
                 m_list.Remove(key);
             }
         }
+
+        internal SortedList List => m_list;
 
         internal object SyncRoot => m_list.SyncRoot;
 

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -204,80 +204,8 @@ namespace System
             return true;
         }
 
-        internal static unsafe string IdnEquivalent(string hostname)
-        {
-            bool allAscii = true;
-            string? bidiStrippedHost = null;
-            string idnEquivalent = IdnEquivalent(hostname, ref allAscii, ref bidiStrippedHost);
-
-            string strippedHost = (allAscii ? idnEquivalent : bidiStrippedHost!);
-
-            fixed (char* strippedHostPtr = strippedHost)
-            {
-                int length = strippedHost.Length;
-                int newPos = 0;
-                int curPos = 0;
-                bool foundAce = false;
-                bool checkedAce = false;
-                bool foundDot = false;
-
-                do
-                {
-                    foundAce = false;
-                    checkedAce = false;
-                    foundDot = false;
-
-                    //find the dot or hit the end
-                    newPos = curPos;
-                    while (newPos < length)
-                    {
-                        char c = strippedHostPtr[newPos];
-                        if (!checkedAce)
-                        {
-                            checkedAce = true;
-                            if ((newPos + 3 < length) && IsIdnAce(strippedHostPtr, newPos))
-                            {
-                                newPos += 4;
-                                foundAce = true;
-                                continue;
-                            }
-                        }
-
-                        if ((c == '.') || (c == '\u3002') ||    //IDEOGRAPHIC FULL STOP
-                            (c == '\uFF0E') ||                  //FULLWIDTH FULL STOP
-                            (c == '\uFF61'))                    //HALFWIDTH IDEOGRAPHIC FULL STOP
-                        {
-                            foundDot = true;
-                            break;
-                        }
-                        ++newPos;
-                    }
-
-                    if (foundAce)
-                    {
-                        // check ace validity
-                        try
-                        {
-                            s_idnMapping.GetUnicode(strippedHost, curPos, newPos - curPos);
-                            break;
-                        }
-                        catch (ArgumentException)
-                        {
-                            // not valid ace so treat it as a normal ascii label
-                        }
-                    }
-
-                    curPos = newPos + (foundDot ? 1 : 0);
-                } while (curPos < length);
-            }
-
-            return idnEquivalent;
-        }
-
-        //
-        // Will convert a host name into its idn equivalent
-        //
-        private static string IdnEquivalent(string hostname, ref bool allAscii, ref string? bidiStrippedHost)
+        /// <summary>Converts a host name into its idn equivalent.</summary>
+        internal static string IdnEquivalent(string hostname)
         {
             if (hostname.Length == 0)
             {
@@ -286,7 +214,7 @@ namespace System
 
             // check if only ascii chars
             // special case since idnmapping will not lowercase if only ascii present
-            allAscii = true;
+            bool allAscii = true;
             foreach (char c in hostname)
             {
                 if (c > 0x7F)
@@ -302,6 +230,7 @@ namespace System
                 return hostname.ToLowerInvariant();
             }
 
+            string bidiStrippedHost;
             unsafe
             {
                 fixed (char* hostnamePtr = hostname)


### PR DESCRIPTION
Reduces total number and size of allocations on my particular test by ~30%.  The test just repeatedly hits the microsoft.com en-us home page:
```C#
using System;
using System.IO;
using System.Net;
using System.Net.Http;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    static async Task Main()
    {
        var client = new HttpClient(new SocketsHttpHandler() { UseCookies = false })
        {
            Timeout = Timeout.InfiniteTimeSpan,
            DefaultRequestVersion = HttpVersion.Version20
        };
        var uri = new Uri("https://www.microsoft.com/en-us/");

        for (int i = 0; i < 1000; i++)
        {
            using (HttpResponseMessage r = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
            using (Stream s = await r.Content.ReadAsStreamAsync())
            {
                await s.CopyToAsync(Stream.Null);
            }
        }
    }
}
```

Primary changes:
- Adds a CopyToAsync override on the HTTP/2 response content stream.
- Stops forcing the Expect and TransferEncoding request headers into existence.  They should now only be allocated if the dev explicitly sets them on the request.
- Removes string allocations from Uri.IdnHost, while also reducing the amount of unsafe code used.
- Removes the Http2Connection.ReadAtLeastAsync method, putting the relevant logic into its sole caller, EnsureIncomingBytesAsync, without increasing its size (and reducing overall number of lines of code).
- Reduces the number of calls to ReadFrameAsync that actually need to yield, such that more complete synchronously and never need to allocate a state machine.
- Reduce the size of the Http2Connection.SendAsync state machine.
- Add additional common header values to KnownHeaders

Additionally:
- When first measuring, I neglected to disable cookies, and the microsoft.com home page triggers a bunch of related functionality.  Before disabling that in the test, I removed a bunch of temporarily allocations related to cookies, like unnecessary enumerator allocations, also removing some associated interface dispatch.

![image](https://user-images.githubusercontent.com/2642209/74610022-8b0ac000-50bd-11ea-8faa-322fd7d5aacf.png)

cc: @scalablecory, @davidsh, @MihaZupan, @JamesNK 
Contributes to https://github.com/dotnet/runtime/issues/31235