### PR TITLE
Fix an assert error in crossgen2 on ARM

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1449,6 +1449,8 @@ namespace Internal.JitInterface
 
             pResult->methodFlags = getMethodAttribsInternal(methodToCall);
 
+            pResult->wrapperDelegateInvoke = false;
+
             Get_CORINFO_SIG_INFO(methodToCall, &pResult->sig, useInstantiatingStub);
         }
 


### PR DESCRIPTION
- Initialize wrapperDelegateInvoke of CORINFO_CALL_INFO in ARM.