### PR TITLE
Use double.Parse on span instead of string in Unix ping

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -156,8 +156,8 @@ namespace System.Net.NetworkInformation
             int afterTime = timeIndex + "time=".Length;
             int msIndex = pingOutput.IndexOf("ms", afterTime, StringComparison.Ordinal);
             int numLength = msIndex - afterTime - 1;
-            string timeSubstring = pingOutput.Substring(afterTime, numLength);
-            double parsedRtt = double.Parse(timeSubstring, CultureInfo.InvariantCulture);
+            ReadOnlySpan<char> timeSubstring = pingOutput.AsSpan(afterTime, numLength);
+            double parsedRtt = double.Parse(timeSubstring, provider: CultureInfo.InvariantCulture);
             return (long)Math.Round(parsedRtt);
         }
     }


### PR DESCRIPTION
Avoids a string allocation.
cc: @wfurt