### PR TITLE
Add back System.Json to mono-profiler-coverage.suppression

### DIFF
--- a/src/mono/mono/profiler/mono-profiler-coverage.suppression
+++ b/src/mono/mono/profiler/mono-profiler-coverage.suppression
@@ -86,6 +86,7 @@ System.Interactive.Async
 System.Interactive.Providers
 System.IO.Compression
 System.IO.Compression.FileSystem
+System.Json
 System.Json.Microsoft
 System.Management
 System.Messaging


### PR DESCRIPTION
It was removed in https://github.com/dotnet/runtime/pull/32329 but this file contains assemblies that apply to mono/mono.