### PR TITLE
Add missing MONO_LLVM_INTERNAL to mono_marshal_get_native_wrapper

### DIFF
--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -459,7 +459,7 @@ mono_marshal_get_aot_init_wrapper_name (MonoAotInitSubtype subtype);
 MONO_LLVM_INTERNAL MonoMethod *
 mono_marshal_get_llvm_func_wrapper (MonoLLVMFuncWrapperSubtype subtype);
 
-MonoMethod *
+MONO_LLVM_INTERNAL MonoMethod *
 mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, gboolean aot);
 
 MonoMethod *


### PR DESCRIPTION
It was missed due to a glitch in the GitHub API that caused the mirror to not get the latest version of the diff.