### PR TITLE
Use simd for small prolog zeroing (ia32/x64)

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6490,7 +6490,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
             // Output count of bytes to clear
             inst_RV_IV(INS_mov, REG_ECX, blkSize / sizeof(int), EA_4BYTE);
             // Subtract the unaligned already cleared
-            emit->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_ECX, REG_EAX);
+            emit->emitIns_R_R(INS_sub, EA_PTRSIZE, REG_ECX, REG_EAX);
 #else  // !TARGET_64BIT
             emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_EDI, frameReg, untrLclLo);
 #endif // TARGET_64BIT


### PR DESCRIPTION
rep stosd has a low throughput if the memory is not 32byte aligned; however it is a compact code size.

Use faster throughput SIMD instructions when the amount to zero in the prologue is low; moving back to rep stosd when it becomes too many instructions.

Also align `rep stosd` to 32 bytes when it is used.

Best checked with ignore whitespace (due to new `if`/`else` indenting)

Contributes to https://github.com/dotnet/runtime/issues/8890

/cc @erozenfeld not entirely sure what I'm doing :)