### PR TITLE
Should fix https://github.com/mono/mono/issues/18827.

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -71,6 +71,12 @@
 #   include <sys/resource.h>
 #endif
 
+#ifdef ENABLE_NETCORE
+gboolean mono_enable_netcore = TRUE;
+#else
+gboolean mono_enable_netcore;
+#endif
+
 static FILE *mini_stats_fd;
 
 static void mini_usage (void);
@@ -200,9 +206,8 @@ static gboolean
 parse_debug_options (const char* p)
 {
 	MonoDebugOptions *opt = mini_get_debug_options ();
-#ifdef ENABLE_NETCORE
-	opt->enabled = TRUE;
-#endif
+	if (mono_enable_netcore)
+		opt->enabled = TRUE;
 
 	do {
 		if (!*p) {
@@ -219,11 +224,9 @@ parse_debug_options (const char* p)
 		} else if (!strncmp (p, "gdb", 3)) {
 			opt->gdb = TRUE;
 			p += 3;
-#ifdef ENABLE_NETCORE
-		} else if (!strncmp (p, "ignore", 6)) {
+		} else if (mono_enable_netcore && !strncmp (p, "ignore", 6)) {
 			opt->enabled = FALSE;
 			p += 6;
-#endif
 		} else {
 			fprintf (stderr, "Invalid debug option `%s', use --help-debug for details\n", p);
 			return FALSE;

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -263,9 +263,7 @@ typedef struct MonoDebugOptions {
 	 */
 	gboolean top_runtime_invoke_unhandled;
 
-#ifdef ENABLE_NETCORE
 	gboolean enabled;
-#endif
 } MonoDebugOptions;
 
 /*

--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -1109,12 +1109,6 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
-
-if ENABLE_CXX
-# see https://github.com/mono/mono/issues/18827
-PLATFORM_DISABLED_TESTS += bug-10127.exe
-endif
-
 endif
 
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18894,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fix https://github.com/mono/mono/issues/18827 by making the C++ and C more the same.
 There is not a complete explanation here, but circumstantially it makes some sense.
 This is an area that had #if __cplusplus.
 The prior construct was confusing.
 The new construct is clearer albeit a little more repititious.
 I never really liked extern "C" without braces, always found it confusing,
  because extern on its own means something, is not redundant for data,
  is redundant for functions. The braces serve to give each extern its own
  place and let them coexist unambiguously.

i.e.

```
extern "C" {
1   extern void function(); // redundant but clear
                        // same as void function();
2   extern int data; // not redundant, and clear
}
```

vs.
```
3   extern "C" void function(); // I guess clear.
4   extern "C" int data; // unclear -- is it extern or extern "C" or both?
```

This PR in particular turns 4 into 2.
2 is clearly a declaration, not a definition.
4 is unclear as to if it is a declaration or definition.

Repro was:
```
C:\s\mono2>more \s\1.cmd
for /l %%a in (1 1 9999) do echo %%a && C:\s\mono2\msvc\build\sgen\x64\bin\Release\mono-sgen.exe \s\mono2\mono\tests\bug-10127.exe
```

which would sometimes hang.

It remains confusing to me that we suspend/resume threads
that are busy acquiring/releasing locks, which is not atomic,
but perhaps indeed there is no preexisting race or deadlock condition.