### PR TITLE
[debugger] Enable reading embedded ppdb

### DIFF
--- a/src/mono/mono/metadata/Makefile.am
+++ b/src/mono/mono/metadata/Makefile.am
@@ -130,13 +130,11 @@ libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" 
 #
 # Support is a separate library because it is not valid C++.
 #
-if !ENABLE_NETCORE
 support_libraries = libmonoruntime-support.la
 
 libmonoruntime_support_la_SOURCES = support.c
 libmonoruntime_support_la_LDFLAGS = $(Z_LIBS)
 libmonoruntime_support_la_CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @ZLIB_CFLAGS@
-endif
 
 #
 # This library contains the icall tables if the runtime was configured with --disable-icall-tables

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -172,8 +172,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		return NULL;
 	}
 
-// Temporarily disabled to unblock Roslyn
-#if HOST_WIN32 || HOST_WASM
+#if HOST_WIN32 || HOST_WASM || HAVE_SYS_ZLIB
 	if (ppdb_data) {
 		/* Embedded PPDB data */
 		/* ppdb_size is the uncompressed size */
@@ -436,7 +435,8 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	}
 
 	location = g_new0 (MonoDebugSourceLocation, 1);
-	location->source_file = docname;
+	if (docname && docname [0])
+		location->source_file = docname;
 	location->row = start_line;
 	location->column = start_col;
 	location->il_offset = iloffset;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18895,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Running the debugger tests using embedded pdb as this will be used alot.
To fix the issue of enable reading embedded pdb everywhere the problem was that when the roslyn tests are compiling sources it creates embedded pdb with source file "", and before enable reading the embedded pdb we don't read this information, and now we read and our StackTrace corlib doesn't expect a source file "", it's okay if it's NULL but not "".
I could fix in corlib or in mono, I prefer to fix on mono because I don't know if there is any other place in corlib that doesn't expect source file "".
