### PR TITLE
Add StatusCode to HttpRequestException

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -128,9 +128,9 @@ namespace System.Net.Http
         protected HttpContent() { }
         public System.Net.Http.Headers.HttpContentHeaders Headers { get { throw null; } }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream stream) { throw null; }
-        public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream stream, System.Net.TransportContext context) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream stream, System.Net.TransportContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected virtual System.Threading.Tasks.Task<System.IO.Stream> CreateContentReadStreamAsync() { throw null; }
         protected virtual System.Threading.Tasks.Task<System.IO.Stream> CreateContentReadStreamAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public void Dispose() { }
@@ -186,6 +186,8 @@ namespace System.Net.Http
         public HttpRequestException() { }
         public HttpRequestException(string message) { }
         public HttpRequestException(string message, System.Exception inner) { }
+        public HttpRequestException(string message, System.Exception inner, System.Net.HttpStatusCode? statusCode) { }
+        public System.Net.HttpStatusCode? StatusCode { get { throw null; } }
     }
     public partial class HttpRequestMessage : System.IDisposable
     {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -28,12 +28,21 @@ namespace System.Net.Http
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestException" /> class with a specific message that describes the current exception, an inner exception, and an HTTP status code.
+        /// </summary>
+        /// <param name="message">A message that describes the current exception.</param>
+        /// <param name="inner">The inner exception.</param>
+        /// <param name="statusCode">The HTTP status code.</param>
         public HttpRequestException(string message, Exception inner, HttpStatusCode? statusCode)
             : this(message, inner)
         {
             StatusCode = statusCode;
         }
 
+        /// <summary>
+        /// The HTTP status code to be returned with the exception.
+        /// </summary>
         public HttpStatusCode? StatusCode { get; }
 
         // This constructor is used internally to indicate that a request was not successfully sent due to an IOException,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -41,8 +41,11 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// The HTTP status code to be returned with the exception.
+        /// Gets the HTTP status code to be returned with the exception.
         /// </summary>
+        /// <value>
+        /// An HTTP status code if the exception represents a non-successful result, otherwise <c>null</c>.
+        /// </value>
         public HttpStatusCode? StatusCode { get; }
 
         // This constructor is used internally to indicate that a request was not successfully sent due to an IOException,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -28,6 +28,14 @@ namespace System.Net.Http
             }
         }
 
+        public HttpRequestException(string message, Exception inner, HttpStatusCode? statusCode)
+            : this(message, inner)
+        {
+            StatusCode = statusCode;   
+        }
+
+        public HttpStatusCode? StatusCode { get; }
+
         // This constructor is used internally to indicate that a request was not successfully sent due to an IOException,
         // and the exception occurred early enough so that the request may be retried on another connection.
         internal HttpRequestException(string message, Exception inner, RequestRetryType allowRetry)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http
         public HttpRequestException(string message, Exception inner, HttpStatusCode? statusCode)
             : this(message, inner)
         {
-            StatusCode = statusCode;   
+            StatusCode = statusCode;
         }
 
         public HttpStatusCode? StatusCode { get; }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -175,7 +175,7 @@ namespace System.Net.Http
                         SR.net_http_message_not_success_statuscode,
                         (int)_statusCode,
                         ReasonPhrase),
-                    null,
+                    inner: null,
                     _statusCode);
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -169,11 +169,14 @@ namespace System.Net.Http
         {
             if (!IsSuccessStatusCode)
             {
-                throw new HttpRequestException(SR.Format(
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    SR.net_http_message_not_success_statuscode,
-                    (int)_statusCode,
-                    ReasonPhrase));
+                throw new HttpRequestException(
+                    SR.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        SR.net_http_message_not_success_statuscode,
+                        (int)_statusCode,
+                        ReasonPhrase),
+                    null,
+                    _statusCode);
             }
 
             return this;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -192,9 +192,16 @@ namespace System.Net.Http.Functional.Tests
                     Content = withResponseContent ? new ByteArrayContent(new byte[1]) : null
                 }))))
             {
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(CreateFakeUri()));
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetByteArrayAsync(CreateFakeUri()));
-                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync(CreateFakeUri()));
+                HttpRequestException ex;
+
+                ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStringAsync(CreateFakeUri()));
+                Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+
+                ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetByteArrayAsync(CreateFakeUri()));
+                Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+
+                ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetStreamAsync(CreateFakeUri()));
+                Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -105,12 +105,14 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var m = new HttpResponseMessage(HttpStatusCode.MultipleChoices))
             {
-                Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+                var ex = Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+                Assert.Equal(HttpStatusCode.MultipleChoices, ex.StatusCode);
             }
 
             using (var m = new HttpResponseMessage(HttpStatusCode.BadGateway))
             {
-                Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+                var ex = Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+                Assert.Equal(HttpStatusCode.BadGateway, ex.StatusCode);
             }
 
             using (var response = new HttpResponseMessage(HttpStatusCode.OK))

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
@@ -18,6 +18,12 @@ namespace System.Net.Http.Tests
         {
             var exception = new HttpRequestException();
             Assert.Null(exception.StatusCode);
+            
+            exception = new HttpRequestException("message");
+            Assert.Null(exception.StatusCode);
+            
+            exception = new HttpRequestException("message", new InvalidOperationException());
+            Assert.Null(exception.StatusCode);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net.Http;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Net.Http.Tests
 {

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpRequestExceptionTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Tests
+{
+    public class HttpRequestExceptionTests
+    {
+        [Fact]
+        public void DefaultConstructors_HasNoStatusCode()
+        {
+            var exception = new HttpRequestException();
+            Assert.Null(exception.StatusCode);
+        }
+
+        [Fact]
+        public void StoresStatusCode()
+        {
+            var exception = new HttpRequestException("message", null, HttpStatusCode.InternalServerError);
+            Assert.Equal(HttpStatusCode.InternalServerError, exception.StatusCode);
+        }
+
+        [Fact]
+        public void StoresNonStandardStatusCode()
+        {
+            var statusCode = (HttpStatusCode)999;
+
+            var exception = new HttpRequestException("message", null, statusCode);
+            Assert.Equal(statusCode, exception.StatusCode);
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -415,6 +415,7 @@
     <Compile Include="MockContent.cs" />
     <Compile Include="StreamToStreamCopyTest.cs" />
     <Compile Include="HttpEnvironmentProxyTest.cs" />
+    <Compile Include="HttpRequestExceptionTests.cs" />
     <Compile Include="HttpWindowsProxyTest.cs" />
     <Compile Include="SystemProxyInfoTest.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs">


### PR DESCRIPTION
Implements #911.

TODO:

Code:
- [X] Add property and constructor, as approved, to Exception object.
- [X] Add to reference assembly
- [X] Add tests that it's set when it should be and not when it's not.
- [ ] ~~Add tests that the property is persisted when the exception is serialized.~~
- [X] Update callsites to include this when constructing the exception
- [X] Add tests for callsites to ensure that they do

Docs:
- [ ] Update docs for HttpRequestException to document the new property
- [ ] Update docs for EnsureSuccessStatusCode to point developers at the new property?

---

The exception doesn't seem to be marked as Serializable in any way, so I'm not sure if/how I should deal with exception serialization.