### PR TITLE
Make MONO_API_DATA clearer.

### DIFF
--- a/src/mono/mono/metadata/opcodes.h
+++ b/src/mono/mono/metadata/opcodes.h
@@ -67,7 +67,9 @@ typedef struct {
 	unsigned short opval;
 } MonoOpcode;
 
+MONO_BEGIN_DECLS
 MONO_API_DATA const MonoOpcode mono_opcodes [];
+MONO_END_DECLS
 
 MONO_API const char*
 mono_opcode_name (int opcode);

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -371,14 +371,18 @@ extern gboolean mono_compile_aot;
 extern gboolean mono_aot_only;
 extern gboolean mono_llvm_only;
 extern MonoAotMode mono_aot_mode;
+MONO_BEGIN_DECLS
 MONO_API_DATA const char *mono_build_date;
+MONO_END_DECLS
 extern gboolean mono_do_signal_chaining;
 extern gboolean mono_do_crash_chaining;
+MONO_BEGIN_DECLS
 MONO_API_DATA gboolean mono_use_llvm;
 MONO_API_DATA gboolean mono_use_fast_math;
 MONO_API_DATA gboolean mono_use_interpreter;
 MONO_API_DATA MonoCPUFeatures mono_cpu_features_enabled;
 MONO_API_DATA MonoCPUFeatures mono_cpu_features_disabled;
+MONO_END_DECLS
 extern const char* mono_interp_opts_string;
 extern gboolean mono_do_single_method_regression;
 extern guint32 mono_single_method_regression_opt;

--- a/src/mono/mono/utils/mono-logger-internals.h
+++ b/src/mono/mono/utils/mono-logger-internals.h
@@ -31,8 +31,10 @@ typedef enum {
 	MONO_TRACE_TIERED             = 1 << 18,
 } MonoTraceMask;
 
+MONO_BEGIN_DECLS
 MONO_API_DATA GLogLevelFlags mono_internal_current_level;
 MONO_API_DATA MonoTraceMask mono_internal_current_mask;
+MONO_END_DECLS
 
 MONO_API void
 mono_trace_init (void);

--- a/src/mono/mono/utils/mono-publib.h
+++ b/src/mono/mono/utils/mono-publib.h
@@ -75,15 +75,8 @@ typedef unsigned __int64	uint64_t;
 
 #define MONO_API MONO_EXTERN_C MONO_API_NO_EXTERN_C
 
-// extern "C" extern int c; // warning: duplicate 'extern' declaration specifier [-Wduplicate-decl-specifier]
-//
-// Therefore, remove extern on functions as always meaningless/redundant,
-// and provide MONO_API_DATA for data, that always has one and only one extern.
-#ifdef __cplusplus
-#define MONO_API_DATA MONO_API
-#else
-#define MONO_API_DATA extern MONO_API
-#endif
+// Should (but not must) wrap in extern "C" (MONO_BEGIN_DECLS, MONO_END_DECLS).
+#define MONO_API_DATA MONO_API_NO_EXTERN_C extern
 
 typedef int32_t		mono_bool;
 typedef uint8_t		mono_byte;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18897,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Make MONO_API_DATA clearer, its old form -- MONO_API extern.
extern "C" { } should be added around it not within it, for clarity.
I've always found extern "C" without braces unclear, esp. for data.

i.e.

```
 extern "C" {
1   extern void function(); // redundant but clear
                            // same as void function();
2   extern int data; // not redundant, and clear
}
```

vs.
```
3   extern "C" void function(); // I guess clear.
4   extern "C" int data; // unclear -- is it extern or extern "C" or both?
```

This PR in particular turns 4 into 2.
2 is clearly a declaration, not a definition.
4 is unclear as to if it is a declaration or definition.

I was looking into https://github.com/mono/mono/issues/18827.

This does not actually change anything but makes things clearer.