### PR TITLE
R2RDump fixes

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -237,7 +237,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         code.NextFrameOffset = (int)offset * 16;
                         if ((UnwindCodeArray[i].FrameOffset & 0xF0000000) != 0)
                         {
-                            Console.WriteLine("Warning: Illegal unwindInfo unscaled offset: too large");
+                            throw new BadImageFormatException("Warning: Illegal unwindInfo unscaled offset: too large");
                         }
                     }
                     break;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 var sectionType = (ReadyToRunSectionType)type;
                 if (!Enum.IsDefined(typeof(ReadyToRunSectionType), type))
                 {
-                    Console.WriteLine("Warning: Invalid ReadyToRun section type");
+                    throw new BadImageFormatException("Warning: Invalid ReadyToRun section type");
                 }
                 int sectionStartRva = NativeReader.ReadInt32(image, ref curOffset);
                 int sectionLength = NativeReader.ReadInt32(image, ref curOffset);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -381,8 +381,17 @@ namespace ILCompiler.Reflection.ReadyToRun
             return false;
         }
 
-        private MetadataReader GetSystemModuleMetadataReader() =>
-            _systemModuleReader ??= _assemblyResolver.FindAssembly(SystemModuleName, Filename);
+        private MetadataReader GetSystemModuleMetadataReader()
+        {
+            if (_systemModuleReader == null)
+            {
+                if (_assemblyResolver != null)
+                {
+                    _systemModuleReader = _assemblyResolver.FindAssembly(SystemModuleName, Filename);
+                }
+            }
+            return _systemModuleReader;
+        }
 
         public MetadataReader GetGlobalMetadataReader()
         {
@@ -630,7 +639,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     if (_composite)
                     {
                         // The only types that don't have module overrides on them in composite images are primitive types within the system module
-                        mdReader ??= GetSystemModuleMetadataReader();
+                        mdReader = GetSystemModuleMetadataReader();
                     }
                     owningType = decoder.ReadTypeSignatureNoEmit();
                 }


### PR DESCRIPTION
Fixes #966

This is just a reaction on a recent change to `R2RDump` that makes it fits for the ILSpy scenario.

1. Avoid `Console.WriteLine()` in `ILCompiler.Reflection.ReadyToRun`. I am pretty sure these should be thrown as an exception instead. 
2. Avoid using the null coalescing assignment operator. The operator is only available in C# 8.0, which is not fully compatible with .NET standard 2.0 as required by ILSpy's use.

There are a few reasons why I think it is a good idea to make warning exceptions instead:

1. When we see unexpected input, it is unclear if moving on will generate any good output.
2. R2RDump output tends to be verbose, a warning hidden in the output file often go unnoticeable.
3. Making it exception forces whoever broke it to fix it fast.
4. We do not want to see `Console.WriteLine` in ILSpy.