### PR TITLE
Prefer StringBuilder.Append(char) over Append(string)

### DIFF
--- a/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeGenerator.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeGenerator.cs
@@ -379,7 +379,7 @@ namespace Microsoft.VisualBasic
         {
             b.Append("&Global.Microsoft.VisualBasic.ChrW(");
             b.Append(((int)value).ToString(CultureInfo.InvariantCulture));
-            b.Append(")");
+            b.Append(')');
         }
 
         protected override void ProcessCompilerOutputLine(CompilerResults results, string line)

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ContractNameServices.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ContractNameServices.cs
@@ -91,7 +91,7 @@ namespace System.ComponentModel.Composition
 
             WriteTypeWithNamespace(methodNameStringBuilder, method.ReturnType, formatGenericName);
 
-            methodNameStringBuilder.Append("(");
+            methodNameStringBuilder.Append('(');
 
             ParameterInfo[] parameters = method.GetParameters();
 
@@ -99,12 +99,12 @@ namespace System.ComponentModel.Composition
             {
                 if (i != 0)
                 {
-                    methodNameStringBuilder.Append(",");
+                    methodNameStringBuilder.Append(',');
                 }
 
                 WriteTypeWithNamespace(methodNameStringBuilder, parameters[i].ParameterType, formatGenericName);
             }
-            methodNameStringBuilder.Append(")");
+            methodNameStringBuilder.Append(')');
 
             return methodNameStringBuilder.ToString();
         }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/TypeCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/TypeCatalog.cs
@@ -378,7 +378,7 @@ namespace System.ComponentModel.Composition.Hosting
                 if (builder.Length > 0)
                 {
                     builder.Append(CultureInfo.CurrentCulture.TextInfo.ListSeparator);
-                    builder.Append(" ");
+                    builder.Append(' ');
                 }
 
                 builder.Append(definition.GetPartType().GetDisplayName());

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
@@ -1246,9 +1246,9 @@ namespace System.Configuration
                         {
                             if (sb.Length != 0)
                                 sb.Append(", ");
-                            sb.Append("'");
+                            sb.Append('\'');
                             sb.Append(validProp.Name);
-                            sb.Append("'");
+                            sb.Append('\'');
                         }
                     }
                     else
@@ -1257,9 +1257,9 @@ namespace System.Configuration
                         {
                             if (sb.Length != 0)
                                 sb.Append(", ");
-                            sb.Append("'");
+                            sb.Append('\'');
                             sb.Append(validProp.Name);
-                            sb.Append("'");
+                            sb.Append('\'');
                         }
                     }
                 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/XmlUtil.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/XmlUtil.cs
@@ -834,22 +834,22 @@ namespace System.Configuration
 
             // Start with element tag name
             StringBuilder element = new StringBuilder(64);
-            element.Append("<");
+            element.Append('<');
             element.Append(Reader.Name);
 
             // Add attributes
             while (Reader.MoveToNextAttribute())
             {
-                element.Append(" ");
+                element.Append(' ');
                 element.Append(Reader.Name);
-                element.Append("=");
+                element.Append('=');
                 element.Append('\"');
                 element.Append(Reader.Value);
                 element.Append('\"');
             }
 
             // Now close the element tag
-            element.Append(">");
+            element.Append('>');
 
             return element.ToString();
         }

--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
@@ -132,7 +132,7 @@ namespace System.Data.Common
 
             if ((0 < builder.Length) && (';' != builder[builder.Length - 1]))
             {
-                builder.Append(";");
+                builder.Append(';');
             }
 
             if (useOdbcRules)
@@ -143,7 +143,7 @@ namespace System.Data.Common
             {
                 builder.Append(keyName.Replace("=", "=="));
             }
-            builder.Append("=");
+            builder.Append('=');
 
             if (null != keyValue)
             { // else <keyword>=;

--- a/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
@@ -193,7 +193,7 @@ namespace System.Data.Common
 
             if ((0 < builder.Length) && (';' != builder[builder.Length - 1]))
             {
-                builder.Append(";");
+                builder.Append(';');
             }
 
             if (useOdbcRules)
@@ -204,7 +204,7 @@ namespace System.Data.Common
             {
                 builder.Append(keyName.Replace("=", "=="));
             }
-            builder.Append("=");
+            builder.Append('=');
 
             if (null != keyValue)
             { // else <keyword>=;

--- a/src/libraries/System.Data.OleDb/src/OleDbConnectionString.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbConnectionString.cs
@@ -416,9 +416,9 @@ namespace System.Data.OleDb
 
                         StringBuilder builder = new StringBuilder();
                         builder.Append(KEY.Ole_DB_Services);
-                        builder.Append("=");
+                        builder.Append('=');
                         builder.Append(_oledbServices.ToString(CultureInfo.InvariantCulture));
-                        builder.Append(";");
+                        builder.Append(';');
                         builder.Append(connectionString);
                         connectionString = builder.ToString();
                     }

--- a/src/libraries/System.Data.OleDb/src/OleDbMetaDataFactory.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbMetaDataFactory.cs
@@ -218,7 +218,7 @@ namespace System.Data.OleDb
                 compositeSeparatorPattern.Append(patternEscaped.ToString());
                 if ((schemaSeparatorPattern != null) && (schemaSeparatorPattern != catalogSeparatorPattern))
                 {
-                    compositeSeparatorPattern.Append("|");
+                    compositeSeparatorPattern.Append('|');
                     patternEscaped.Length = 0;
                     ADP.EscapeSpecialCharacters(schemaSeparatorPattern, patternEscaped);
                     compositeSeparatorPattern.Append(patternEscaped.ToString());

--- a/src/libraries/System.Data.OleDb/src/OleDb_Util.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDb_Util.cs
@@ -700,7 +700,7 @@ namespace System.Data.OleDb
             }
             builder.Append("(0x");
             builder.Append(((int)hr).ToString("X8", CultureInfo.InvariantCulture));
-            builder.Append(")");
+            builder.Append(')');
             return builder.ToString();
         }
 

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -158,9 +158,9 @@ namespace System.Diagnostics
                         {
                             if (i != 0)
                                 msgBuf.Append(", ");
-                            msgBuf.Append("'");
+                            msgBuf.Append('\'');
                             msgBuf.Append(strings[i]);
-                            msgBuf.Append("'");
+                            msgBuf.Append('\'');
                         }
 
                         msg = msgBuf.ToString();
@@ -420,7 +420,7 @@ namespace System.Diagnostics
                         result.Append(owner.MachineName);
                         result.Append(@"\");
                         result.Append(fileNames[i][0]);
-                        result.Append("$");
+                        result.Append('$');
                         result.Append(fileNames[i], 2, fileNames[i].Length - 2);
                         result.Append(';');
                     }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -418,7 +418,7 @@ namespace System.Diagnostics
                     {
                         result.Append(@"\\");
                         result.Append(owner.MachineName);
-                        result.Append(@"\");
+                        result.Append('\\');
                         result.Append(fileNames[i][0]);
                         result.Append('$');
                         result.Append(fileNames[i], 2, fileNames[i].Length - 2);

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -691,7 +691,7 @@ namespace System.Diagnostics
 
             if (!string.IsNullOrEmpty(arguments))
             {
-                commandLine.Append(" ");
+                commandLine.Append(' ');
                 commandLine.Append(arguments);
             }
 

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
@@ -201,11 +201,11 @@ namespace System.Diagnostics
         {
             StringBuilder failMessage = new StringBuilder();
             failMessage.Append(SR.TraceListenerFail);
-            failMessage.Append(" ");
+            failMessage.Append(' ');
             failMessage.Append(message);
             if (detailMessage != null)
             {
-                failMessage.Append(" ");
+                failMessage.Append(' ');
                 failMessage.Append(detailMessage);
             }
 

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADAMStoreCtx.cs
@@ -333,7 +333,7 @@ namespace System.DirectoryServices.AccountManagement
                         {
                             filter.Append("(objectClass=");
                             filter.Append(objectClass);
-                            filter.Append(")");
+                            filter.Append(')');
                         }
 
                         _cachedBindableObjectFilter = filter.ToString();

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -1049,22 +1049,22 @@ namespace System.DirectoryServices.AccountManagement
 
                 foreach (string ldapAttribute in ldapAttributes)
                 {
-                    ldapFilter.Append("(");
+                    ldapFilter.Append('(');
 
                     switch (matchType)
                     {
                         case MatchType.Equals:
                             ldapFilter.Append(ldapAttribute);
-                            ldapFilter.Append("=");
+                            ldapFilter.Append('=');
                             ldapFilter.Append(ldapValue);
                             break;
 
                         case MatchType.NotEquals:
                             ldapFilter.Append("!(");
                             ldapFilter.Append(ldapAttribute);
-                            ldapFilter.Append("=");
+                            ldapFilter.Append('=');
                             ldapFilter.Append(ldapValue);
-                            ldapFilter.Append(")");
+                            ldapFilter.Append(')');
                             break;
 
                         case MatchType.GreaterThanOrEquals:
@@ -1080,24 +1080,24 @@ namespace System.DirectoryServices.AccountManagement
                             break;
 
                         case MatchType.GreaterThan:
-                            ldapFilter.Append("&");
+                            ldapFilter.Append('&');
 
                             // Greater-than-or-equals (or less-than-or-equals))
-                            ldapFilter.Append("(");
+                            ldapFilter.Append('(');
                             ldapFilter.Append(ldapAttribute);
                             ldapFilter.Append(matchType == MatchType.GreaterThan ? ">=" : "<=");
                             ldapFilter.Append(ldapValue);
-                            ldapFilter.Append(")");
+                            ldapFilter.Append(')');
 
                             // And not-equal
                             ldapFilter.Append("(!(");
                             ldapFilter.Append(ldapAttribute);
-                            ldapFilter.Append("=");
+                            ldapFilter.Append('=');
                             ldapFilter.Append(ldapValue);
                             ldapFilter.Append("))");
 
                             // And exists (need to include because of tristate LDAP logic)
-                            ldapFilter.Append("(");
+                            ldapFilter.Append('(');
                             ldapFilter.Append(ldapAttribute);
                             ldapFilter.Append("=*)");
                             break;
@@ -1110,7 +1110,7 @@ namespace System.DirectoryServices.AccountManagement
                             break;
                     }
 
-                    ldapFilter.Append(")");
+                    ldapFilter.Append(')');
                 }
 
                 ldapFilter.Append("))");

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -628,13 +628,13 @@ namespace System.DirectoryServices.AccountManagement
                                 innerLdapFilter.Append(filterVal);
                     }
 
-                    innerLdapFilter.Append(")");
+                    innerLdapFilter.Append(')');
 
                     ldapFilter.Append(innerLdapFilter.ToString());
                 }
 
                 // Wrap off the filter
-                ldapFilter.Append(")");
+                ldapFilter.Append(')');
 
                 ds.Filter = ldapFilter.ToString();
                 GlobalDebug.WriteLineIf(GlobalDebug.Info, "ADStoreCtx", "FindPrincipalByIdentRefHelper: using LDAP filter {0}", ds.Filter);
@@ -1244,7 +1244,7 @@ namespace System.DirectoryServices.AccountManagement
                 // Preexisting values that have not been removed.
                 // This also includes inserted values.
                 sb.Append(value);
-                sb.Append(",");
+                sb.Append(',');
             }
 
             // We have an extra comma at the end (assuming we added any values to the string).  Remove it.

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_Query.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_Query.cs
@@ -172,7 +172,7 @@ namespace System.DirectoryServices.AccountManagement
                 //
                 // Wrap off the filter
                 //
-                ldapFilter.Append(")");
+                ldapFilter.Append(')');
             }
 
             // We don't need any attributes returned, since we're just going to get a DirectoryEntry
@@ -211,7 +211,7 @@ namespace System.DirectoryServices.AccountManagement
                 StringBuilder SB = new StringBuilder();
                 SB.Append("(&(objectClass=");
                 SB.Append(objClass);
-                SB.Append(")");
+                SB.Append(')');
                 ldapFilter = SB.ToString();
             }
 
@@ -330,12 +330,12 @@ namespace System.DirectoryServices.AccountManagement
 
             if (filter.Value != null)
             {
-                sb.Append("(");
+                sb.Append('(');
                 sb.Append(suggestedAdProperty);
-                sb.Append("=");
+                sb.Append('=');
                 sb.Append(ADUtils.PAPIQueryToLdapQueryString((string)filter.Value));
 
-                sb.Append(")");
+                sb.Append(')');
             }
             else
             {
@@ -355,11 +355,11 @@ namespace System.DirectoryServices.AccountManagement
 
             if (filter.Value != null)
             {
-                sb.Append("(");
+                sb.Append('(');
                 sb.Append(suggestedAdProperty);
-                sb.Append("=");
+                sb.Append('=');
                 sb.Append(!(bool)filter.Value ? "TRUE" : "FALSE");
-                sb.Append(")");
+                sb.Append(')');
             }
             else
             {
@@ -390,17 +390,17 @@ namespace System.DirectoryServices.AccountManagement
                     sb.Append(suggestedAdProperty);
                     sb.Append("=*)(");
                     sb.Append(suggestedAdProperty);
-                    sb.Append("=");
+                    sb.Append('=');
                     sb.Append((bool)filter.Value ? "TRUE" : "FALSE");
                     sb.Append(")))");
                 }
                 else
                 {
-                    sb.Append("(");
+                    sb.Append('(');
                     sb.Append(suggestedAdProperty);
-                    sb.Append("=");
+                    sb.Append('=');
                     sb.Append((bool)filter.Value ? "TRUE" : "FALSE");
-                    sb.Append(")");
+                    sb.Append(')');
                 }
             }
             else
@@ -419,11 +419,11 @@ namespace System.DirectoryServices.AccountManagement
 
                     if (filter.Value != null)
                     {
-                        sb.Append("(");
+                        sb.Append('(');
                         sb.Append(suggestedAdProperty);
-                        sb.Append("=");
+                        sb.Append('=');
                         sb.Append( (bool)filter.Value ? "TRUE" : "FALSE" );
-                        sb.Append(")");
+                        sb.Append(')');
                     }
                     else
                     {
@@ -441,12 +441,12 @@ namespace System.DirectoryServices.AccountManagement
 
             if (filter.Value != null)
             {
-                sb.Append("(");
+                sb.Append('(');
                 sb.Append(suggestedAdProperty);
                 sb.Append("=*");
                 sb.Append(ADUtils.PAPIQueryToLdapQueryString((string)filter.Value));
-                sb.Append("*");
-                sb.Append(")");
+                sb.Append('*');
+                sb.Append(')');
             }
             else
             {
@@ -510,13 +510,13 @@ namespace System.DirectoryServices.AccountManagement
 
                     sb.Append(ldapHexGuid);
 
-                    sb.Append(")");
+                    sb.Append(')');
                     break;
 
                 case UrnScheme.DistinguishedNameScheme:
                     sb.Append("(distinguishedName=");
                     sb.Append(ADUtils.EscapeRFC2254SpecialChars(identity));
-                    sb.Append(")");
+                    sb.Append(')');
                     break;
 
                 case UrnScheme.SidScheme:
@@ -543,19 +543,19 @@ namespace System.DirectoryServices.AccountManagement
 
                     sb.Append("(samAccountName=");
                     sb.Append(ADUtils.EscapeRFC2254SpecialChars(samAccountName));
-                    sb.Append(")");
+                    sb.Append(')');
                     break;
 
                 case UrnScheme.NameScheme:
                     sb.Append("(name=");
                     sb.Append(ADUtils.EscapeRFC2254SpecialChars(identity));
-                    sb.Append(")");
+                    sb.Append(')');
                     break;
 
                 case UrnScheme.UpnScheme:
                     sb.Append("(userPrincipalName=");
                     sb.Append(ADUtils.EscapeRFC2254SpecialChars(identity));
-                    sb.Append(")");
+                    sb.Append(')');
                     break;
 
                 default:
@@ -646,7 +646,7 @@ namespace System.DirectoryServices.AccountManagement
             {
                 filter.Append("(objectSid=");
                 filter.Append(ldapHexSid);
-                filter.Append(")");
+                filter.Append(')');
             }
 
             return true;
@@ -663,7 +663,7 @@ namespace System.DirectoryServices.AccountManagement
 
             sb.Append("(userCertificate=");
             sb.Append(ADUtils.EscapeBinaryValue(rawCertificate));
-            sb.Append(")");
+            sb.Append(')');
 
             return sb.ToString();
         }
@@ -759,9 +759,9 @@ namespace System.DirectoryServices.AccountManagement
 
             if (filter.Value != null)
             {
-                sb.Append("(");
+                sb.Append('(');
                 sb.Append(suggestedAdProperty);
-                sb.Append("=");
+                sb.Append('=');
                 sb.Append(ADUtils.EscapeBinaryValue((byte[])filter.Value));
             }
             else
@@ -771,7 +771,7 @@ namespace System.DirectoryServices.AccountManagement
                 sb.Append("=*))");
             }
 
-            sb.Append(")");
+            sb.Append(')');
 
             return sb.ToString();
         }
@@ -793,7 +793,7 @@ namespace System.DirectoryServices.AccountManagement
             {
                 sb.Append("(accountExpires=");
                 sb.Append(ADUtils.DateTimeToADString(date.Value));
-                sb.Append(")");
+                sb.Append(')');
             }
 
             return sb.ToString();
@@ -824,7 +824,7 @@ namespace System.DirectoryServices.AccountManagement
 
                 sb.Append(ldapHexGuid);
 
-                sb.Append(")");
+                sb.Append(')');
             }
 
             return sb.ToString();
@@ -874,7 +874,7 @@ namespace System.DirectoryServices.AccountManagement
             sb.Append("(|");
             sb.Append(DateTimeFilterBuilder("lastLogon", (DateTime)qmt.Value, LdapConstants.defaultUtcTime, false, qmt.Match));
             sb.Append(DateTimeFilterBuilder("lastLogonTimestamp", (DateTime)qmt.Value, LdapConstants.defaultUtcTime, true, qmt.Match));
-            sb.Append(")");
+            sb.Append(')');
 
             return (sb.ToString());
         }
@@ -952,16 +952,16 @@ namespace System.DirectoryServices.AccountManagement
             {
                 case MatchType.Equals:
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapSearchValue);
                     break;
 
                 case MatchType.NotEquals:
                     ldapFilter.Append("!(");
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapSearchValue);
-                    ldapFilter.Append(")");
+                    ldapFilter.Append(')');
                     break;
 
                 case MatchType.GreaterThanOrEquals:
@@ -977,24 +977,24 @@ namespace System.DirectoryServices.AccountManagement
                     break;
 
                 case MatchType.GreaterThan:
-                    ldapFilter.Append("&");
+                    ldapFilter.Append('&');
 
                     // Greater-than-or-equals (or less-than-or-equals))
-                    ldapFilter.Append("(");
+                    ldapFilter.Append('(');
                     ldapFilter.Append(attributeName);
                     ldapFilter.Append(mt == MatchType.GreaterThan ? ">=" : "<=");
                     ldapFilter.Append(ldapSearchValue);
-                    ldapFilter.Append(")");
+                    ldapFilter.Append(')');
 
                     // And not-equal
                     ldapFilter.Append("(!(");
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapSearchValue);
                     ldapFilter.Append("))");
 
                     // And exists (need to include because of tristate LDAP logic)
-                    ldapFilter.Append("(");
+                    ldapFilter.Append('(');
                     ldapFilter.Append(attributeName);
                     ldapFilter.Append("=*)");
                     break;
@@ -1003,29 +1003,29 @@ namespace System.DirectoryServices.AccountManagement
                     goto case MatchType.GreaterThan;
             }
 
-            ldapFilter.Append(")");
+            ldapFilter.Append(')');
             bool closeFilter = false;
 
             if (defaultNeeded)
             {
                 ldapFilter.Append("(!");
                 ldapFilter.Append(attributeName);
-                ldapFilter.Append("=");
+                ldapFilter.Append('=');
                 ldapFilter.Append(ldapDefaultValue);
-                ldapFilter.Append(")");
+                ldapFilter.Append(')');
                 closeFilter = true;
             }
 
             if (mt == MatchType.NotEquals && requirePresence)
             {
-                ldapFilter.Append("(");
+                ldapFilter.Append('(');
                 ldapFilter.Append(attributeName);
                 ldapFilter.Append("=*)");
                 closeFilter = true;
             }
 
             if (closeFilter)
-                ldapFilter.Append(")");
+                ldapFilter.Append(')');
 
             return (ldapFilter.ToString());
         }
@@ -1065,16 +1065,16 @@ namespace System.DirectoryServices.AccountManagement
             {
                 case MatchType.Equals:
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapValue);
                     break;
 
                 case MatchType.NotEquals:
                     ldapFilter.Append("!(");
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapValue);
-                    ldapFilter.Append(")");
+                    ldapFilter.Append(')');
                     break;
 
                 case MatchType.GreaterThanOrEquals:
@@ -1090,24 +1090,24 @@ namespace System.DirectoryServices.AccountManagement
                     break;
 
                 case MatchType.GreaterThan:
-                    ldapFilter.Append("&");
+                    ldapFilter.Append('&');
 
                     // Greater-than-or-equals (or less-than-or-equals))
-                    ldapFilter.Append("(");
+                    ldapFilter.Append('(');
                     ldapFilter.Append(attributeName);
                     ldapFilter.Append(mt == MatchType.GreaterThan ? ">=" : "<=");
                     ldapFilter.Append(ldapValue);
-                    ldapFilter.Append(")");
+                    ldapFilter.Append(')');
 
                     // And not-equal
                     ldapFilter.Append("(!(");
                     ldapFilter.Append(attributeName);
-                    ldapFilter.Append("=");
+                    ldapFilter.Append('=');
                     ldapFilter.Append(ldapValue);
                     ldapFilter.Append("))");
 
                     // And exists (need to include because of tristate LDAP logic)
-                    ldapFilter.Append("(");
+                    ldapFilter.Append('(');
                     ldapFilter.Append(attributeName);
                     ldapFilter.Append("=*)");
                     break;
@@ -1116,7 +1116,7 @@ namespace System.DirectoryServices.AccountManagement
                     goto case MatchType.GreaterThan;
             }
 
-            ldapFilter.Append(")");
+            ldapFilter.Append(')');
 
             return ldapFilter.ToString();
         }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADUtils.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADUtils.cs
@@ -79,7 +79,7 @@ namespace System.DirectoryServices.AccountManagement
             int startingIndex = 0;
             if (dnComponent[0] == ' ' || dnComponent[0] == '#')
             {
-                sb.Append(@"\");
+                sb.Append('\\');
                 sb.Append(dnComponent[0]);
                 startingIndex++;
             }
@@ -284,7 +284,7 @@ namespace System.DirectoryServices.AccountManagement
 
             foreach (byte b in bytes)
             {
-                sb.Append(@"\");
+                sb.Append('\\');
                 sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
             }
 
@@ -343,7 +343,7 @@ namespace System.DirectoryServices.AccountManagement
                 if (((firstChar >= '0' && firstChar <= '9') || (firstChar >= 'A' && firstChar <= 'F') || (firstChar >= 'a' && firstChar <= 'f')) &&
                      ((secondChar >= '0' && secondChar <= '9') || (secondChar >= 'A' && secondChar <= 'F') || (secondChar >= 'a' && secondChar <= 'f')))
                 {
-                    sb.Append(@"\");
+                    sb.Append('\\');
                     sb.Append(firstChar);
                     sb.Append(secondChar);
                 }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/TokenGroupsSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/TokenGroupsSet.cs
@@ -56,7 +56,7 @@ namespace System.DirectoryServices.AccountManagement
 
                     SidBindingString.Append("<SID=");
                     SidBindingString.Append(Utils.SecurityIdentifierToLdapHexBindingString(_currentSID));
-                    SidBindingString.Append(">");
+                    SidBindingString.Append('>');
 
                     DirectoryEntry currentDE = SDSUtils.BuildDirectoryEntry(
                                                 BuildPathFromDN(SidBindingString.ToString()),

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMMembersSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMMembersSet.cs
@@ -154,7 +154,7 @@ namespace System.DirectoryServices.AccountManagement
 
                         // Build the "WinNT://machineName/" portion of the new path
                         adsPath.Append(_storeCtx.MachineUserSuppliedName);
-                        adsPath.Append("/");
+                        adsPath.Append('/');
 
                         // Build the "WinNT://machineName/foo" portion of the new path
                         int cElements = pathName.GetNumElements();
@@ -166,7 +166,7 @@ namespace System.DirectoryServices.AccountManagement
                         for (int i = cElements - 2; i >= 0; i--)
                         {
                             adsPath.Append(pathName.GetElement(i));
-                            adsPath.Append("/");
+                            adsPath.Append('/');
                         }
 
                         adsPath.Remove(adsPath.Length - 1, 1);  // remove the trailing "/"

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -950,9 +950,9 @@ namespace System.DirectoryServices.Protocols
             // encode Target if it is not null
             if (Target.Length != 0)
             {
-                seq.Append("t");
+                seq.Append('t');
                 objList.Add(0x80 | 0x1);
-                seq.Append("o");
+                seq.Append('o');
                 objList.Add(Target);
             }
             else
@@ -962,17 +962,17 @@ namespace System.DirectoryServices.Protocols
                 seq.Append("ii");
                 objList.Add(Offset);
                 objList.Add(EstimateCount);
-                seq.Append("}");
+                seq.Append('}');
             }
 
             // encode the contextID if present
             if (ContextId.Length != 0)
             {
-                seq.Append("o");
+                seq.Append('o');
                 objList.Add(ContextId);
             }
 
-            seq.Append("}");
+            seq.Append('}');
             object[] values = new object[objList.Count];
             for (int i = 0; i < objList.Count; i++)
             {

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -205,7 +205,7 @@ namespace System.DirectoryServices.Protocols
                         temp.Append(servers[i]);
                         if (i < servers.Length - 1)
                         {
-                            temp.Append(" ");
+                            temp.Append(' ');
                         }
                     }
                 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -889,7 +889,7 @@ namespace System.DirectoryServices.Protocols
 
                 var target = new StringBuilder();
                 target.Append(HostName);
-                target.Append(":");
+                target.Append(':');
                 target.Append(PortNumber);
                 var identifier = new LdapDirectoryIdentifier(target.ToString());
 
@@ -956,7 +956,7 @@ namespace System.DirectoryServices.Protocols
 
                 var target = new StringBuilder();
                 target.Append(hostName);
-                target.Append(":");
+                target.Append(':');
                 target.Append(portNumber);
                 var identifier = new LdapDirectoryIdentifier(target.ToString());
 

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
@@ -144,7 +144,7 @@ namespace System.DirectoryServices.Interop
                             string s = bytes[i].ToString("X", CultureInfo.InvariantCulture);
                             if (s.Length == 1)
                             {
-                                binaryPart.Append("0");
+                                binaryPart.Append('0');
                             }
 
                             binaryPart.Append(s);
@@ -152,9 +152,9 @@ namespace System.DirectoryServices.Interop
 
                         strb.Append("B:");
                         strb.Append(binaryPart.Length);
-                        strb.Append(":");
+                        strb.Append(':');
                         strb.Append(binaryPart.ToString());
-                        strb.Append(":");
+                        strb.Append(':');
                         strb.Append(Marshal.PtrToStringUni(dnb.pszDNString));
 
                         return strb.ToString();
@@ -169,9 +169,9 @@ namespace System.DirectoryServices.Interop
                         var strb = new StringBuilder();
                         strb.Append("S:");
                         strb.Append(strValue.Length);
-                        strb.Append(":");
+                        strb.Append(':');
                         strb.Append(strValue);
-                        strb.Append(":");
+                        strb.Append(':');
                         strb.Append(Marshal.PtrToStringUni(dns.pszDNString));
 
                         return strb.ToString();

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchema.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchema.cs
@@ -358,21 +358,21 @@ namespace System.DirectoryServices.ActiveDirectory
 
             if (((int)type & (int)PropertyTypes.Indexed) != 0)
             {
-                str.Append("(");
+                str.Append('(');
                 str.Append(PropertyManager.SearchFlags);
                 str.Append(":1.2.840.113556.1.4.804:=");
                 str.Append((int)SearchFlags.IsIndexed);
-                str.Append(")");
+                str.Append(')');
             }
 
             if (((int)type & (int)PropertyTypes.InGlobalCatalog) != 0)
             {
-                str.Append("(");
+                str.Append('(');
                 str.Append(PropertyManager.IsMemberOfPartialAttributeSet);
                 str.Append("=TRUE)");
             }
 
-            str.Append(")"); // end filter
+            str.Append(')'); // end filter
             return GetAllProperties(context, _schemaEntry, str.ToString());
         }
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchemaClass.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchemaClass.cs
@@ -1178,7 +1178,7 @@ namespace System.DirectoryServices.ActiveDirectory
             str.Append("(&(");
             str.Append(PropertyManager.ObjectCategory);
             str.Append("=classSchema)");
-            str.Append("(");
+            str.Append('(');
             if (!isDefunctOnServer)
             {
                 str.Append(PropertyManager.LdapDisplayName);
@@ -1187,16 +1187,16 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 str.Append(PropertyManager.Cn);
             }
-            str.Append("=");
+            str.Append('=');
             str.Append(Utils.GetEscapedFilterValue(name));
-            str.Append(")");
+            str.Append(')');
             if (!isDefunctOnServer)
             {
                 str.Append("(!(");
             }
             else
             {
-                str.Append("(");
+                str.Append('(');
             }
             str.Append(PropertyManager.IsDefunct);
             if (!isDefunctOnServer)
@@ -1325,15 +1325,15 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
                 foreach (string ldapDisplayName in ldapDisplayNames)
                 {
-                    str.Append("(");
+                    str.Append('(');
                     str.Append(PropertyManager.LdapDisplayName);
-                    str.Append("=");
+                    str.Append('=');
                     str.Append(Utils.GetEscapedFilterValue(ldapDisplayName));
-                    str.Append(")");
+                    str.Append(')');
                 }
                 if (ldapDisplayNames.Count > 1)
                 {
-                    str.Append(")");
+                    str.Append(')');
                 }
 
                 string filter = "(&(" + PropertyManager.ObjectCategory + "=classSchema)" + str.ToString() + "(!(" + PropertyManager.IsDefunct + "=TRUE)))";
@@ -1403,15 +1403,15 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
                 foreach (string ldapDisplayName in ldapDisplayNames)
                 {
-                    str.Append("(");
+                    str.Append('(');
                     str.Append(PropertyManager.LdapDisplayName);
-                    str.Append("=");
+                    str.Append('=');
                     str.Append(Utils.GetEscapedFilterValue(ldapDisplayName));
-                    str.Append(")");
+                    str.Append(')');
                 }
                 if (ldapDisplayNames.Count > 1)
                 {
-                    str.Append(")");
+                    str.Append(')');
                 }
 
                 string filter = "(&(" + PropertyManager.ObjectCategory + "=attributeSchema)" + str.ToString() + "(!(" + PropertyManager.IsDefunct + "=TRUE)))";

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchemaProperty.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySchemaProperty.cs
@@ -1217,7 +1217,7 @@ namespace System.DirectoryServices.ActiveDirectory
             str.Append("(&(");
             str.Append(PropertyManager.ObjectCategory);
             str.Append("=attributeSchema)");
-            str.Append("(");
+            str.Append('(');
             if (!isDefunctOnServer)
             {
                 str.Append(PropertyManager.LdapDisplayName);
@@ -1226,16 +1226,16 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 str.Append(PropertyManager.Cn);
             }
-            str.Append("=");
+            str.Append('=');
             str.Append(Utils.GetEscapedFilterValue(name));
-            str.Append(")");
+            str.Append(')');
             if (!isDefunctOnServer)
             {
                 str.Append("(!(");
             }
             else
             {
-                str.Append("(");
+                str.Append('(');
             }
             str.Append(PropertyManager.IsDefunct);
             if (!isDefunctOnServer)

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
@@ -987,10 +987,10 @@ namespace System.DirectoryServices.ActiveDirectory
                         str.Append("(fromServer=");
                         str.Append("CN=NTDS Settings,");
                         str.Append(Utils.GetEscapedFilterValue((string)val.Key));
-                        str.Append(")");
+                        str.Append(')');
                     }
                     if (nonBridgHeadTable.Count > 1)
-                        str.Append(")");
+                        str.Append(')');
                     ADSearcher adSearcher = new ADSearcher(serverEntry,
                                                           "(&(objectClass=nTDSConnection)(objectCategory=NTDSConnection)" + str.ToString() + ")",
                                                           new string[] { "fromServer", "distinguishedName" },

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ApplicationPartition.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ApplicationPartition.cs
@@ -225,7 +225,7 @@ namespace System.DirectoryServices.ActiveDirectory
             str.Append((int)SystemFlag.SystemFlagNtdsDomain);
             str.Append("))(");
             str.Append(PropertyManager.NCName);
-            str.Append("=");
+            str.Append('=');
             str.Append(Utils.GetEscapedFilterValue(distinguishedName));
             str.Append("))");
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ConfigSet.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ConfigSet.cs
@@ -447,11 +447,11 @@ namespace System.DirectoryServices.ActiveDirectory
                 str.Append("(&(");
                 str.Append(PropertyManager.ObjectCategory);
                 str.Append("=serviceConnectionPoint)");
-                str.Append("(");
+                str.Append('(');
                 str.Append(PropertyManager.Keywords);
                 str.Append("=1.2.840.113556.1.4.1851)(");
                 str.Append(PropertyManager.Keywords);
-                str.Append("=");
+                str.Append('=');
                 str.Append(Utils.GetEscapedFilterValue(context.Name)); // target = config set name
                 str.Append("))");
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Domain.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Domain.cs
@@ -1146,7 +1146,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 str.Append((int)SystemFlag.SystemFlagNtdsDomain);
                 str.Append(")(");
                 str.Append(PropertyManager.DnsRoot);
-                str.Append("=");
+                str.Append('=');
                 str.Append(Utils.GetEscapedFilterValue(partitionName));
                 str.Append("))");
 
@@ -1241,7 +1241,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 str.Append((int)SystemFlag.SystemFlagNtdsDomain);
                 str.Append(")(");
                 str.Append(PropertyManager.TrustParent);
-                str.Append("=");
+                str.Append('=');
                 str.Append(Utils.GetEscapedFilterValue(_crossRefDN));
                 str.Append("))");
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -754,7 +754,7 @@ namespace System.DirectoryServices.ActiveDirectory
             str.Append((int)SystemFlag.SystemFlagNtdsDomain);
             str.Append("))(");
             str.Append(PropertyManager.NCName);
-            str.Append("=");
+            str.Append('=');
             str.Append(Utils.GetEscapedFilterValue(partitionName));
             str.Append("))");
 
@@ -1306,32 +1306,32 @@ namespace System.DirectoryServices.ActiveDirectory
 
                     foreach (string replicaLocation in replicaLocations)
                     {
-                        ntdsaFilter.Append("(");
+                        ntdsaFilter.Append('(');
                         ntdsaFilter.Append(PropertyManager.DistinguishedName);
-                        ntdsaFilter.Append("=");
+                        ntdsaFilter.Append('=');
                         ntdsaFilter.Append(Utils.GetEscapedFilterValue(replicaLocation));
-                        ntdsaFilter.Append(")");
+                        ntdsaFilter.Append(')');
 
-                        serverFilter.Append("(");
+                        serverFilter.Append('(');
                         serverFilter.Append(PropertyManager.DistinguishedName);
-                        serverFilter.Append("=");
+                        serverFilter.Append('=');
                         serverFilter.Append(Utils.GetEscapedFilterValue(Utils.GetPartialDN(replicaLocation, 1)));
-                        serverFilter.Append(")");
+                        serverFilter.Append(')');
                     }
 
                     foreach (string roReplicaLocation in roReplicaLocations)
                     {
-                        roNtdsaFilter.Append("(");
+                        roNtdsaFilter.Append('(');
                         roNtdsaFilter.Append(PropertyManager.DistinguishedName);
-                        roNtdsaFilter.Append("=");
+                        roNtdsaFilter.Append('=');
                         roNtdsaFilter.Append(Utils.GetEscapedFilterValue(roReplicaLocation));
-                        roNtdsaFilter.Append(")");
+                        roNtdsaFilter.Append(')');
 
-                        roServerFilter.Append("(");
+                        roServerFilter.Append('(');
                         roServerFilter.Append(PropertyManager.DistinguishedName);
-                        roServerFilter.Append("=");
+                        roServerFilter.Append('=');
                         roServerFilter.Append(Utils.GetEscapedFilterValue(Utils.GetPartialDN(roReplicaLocation, 1)));
-                        roServerFilter.Append(")");
+                        roServerFilter.Append(')');
                     }
                 }
                 catch (COMException e)
@@ -1608,16 +1608,16 @@ namespace System.DirectoryServices.ActiveDirectory
 
                             foreach (string name in ntdsaNamesForRangeRetrieval)
                             {
-                                str.Append("(");
+                                str.Append('(');
                                 str.Append(PropertyManager.NCName);
-                                str.Append("=");
+                                str.Append('=');
                                 str.Append(Utils.GetEscapedFilterValue(name));
-                                str.Append(")");
+                                str.Append(')');
                             }
 
                             if (ntdsaNamesForRangeRetrieval.Count > 1)
                             {
-                                str.Append(")");
+                                str.Append(')');
                             }
 
                             // Clear it for the next round of range retrieval

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -47,7 +47,7 @@ namespace System.Linq.Expressions.Compiler
             StringBuilder sb = new StringBuilder(name);
 
             int index = Interlocked.Increment(ref _index);
-            sb.Append("$");
+            sb.Append('$');
             sb.Append(index);
 
             // An unhandled Exception: System.Runtime.InteropServices.COMException (0x80131130): Record not found on lookup.

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -505,7 +505,7 @@ namespace System.Net.Mail
                 {
                     if (oneSet)
                     {
-                        s.Append(",");
+                        s.Append(',');
                     }
                     s.Append("FAILURE");
                     oneSet = true;
@@ -514,7 +514,7 @@ namespace System.Net.Mail
                 {
                     if (oneSet)
                     {
-                        s.Append(",");
+                        s.Append(',');
                     }
                     s.Append("DELAY");
                 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -244,7 +244,7 @@ namespace System.Net
             {
                 if (cookie.Domain[0] == '.')
                 {
-                    uriSb.Append("0"); // URI cctor should consume this faked host.
+                    uriSb.Append('0'); // URI cctor should consume this faked host.
                 }
             }
             uriSb.Append(cookie.Domain);
@@ -253,7 +253,7 @@ namespace System.Net
             // Either keep Port as implicit or set it according to original cookie.
             if (cookie.PortList != null)
             {
-                uriSb.Append(":").Append(cookie.PortList[0]);
+                uriSb.Append(':').Append(cookie.PortList[0]);
             }
 
             // Path must be present, set to root by default.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -5296,7 +5296,7 @@ namespace System.Diagnostics.Tracing
             sb.AppendLine(" <instrumentation xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:win=\"http://manifests.microsoft.com/win/2004/08/windows/events\">");
             sb.AppendLine("  <events xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">");
             sb.Append("<provider name=\"").Append(providerName).
-               Append("\" guid=\"{").Append(providerGuid.ToString()).Append("}");
+               Append("\" guid=\"{").Append(providerGuid.ToString()).Append('}');
             if (dllName != null)
                 sb.Append("\" resourceFileName=\"").Append(dllName).Append("\" messageFileName=\"").Append(dllName);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -120,9 +120,9 @@ namespace Microsoft.Internal
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append("(");
+            sb.Append('(');
             sb.Append(m_Item1);
-            sb.Append(")");
+            sb.Append(')');
             return sb.ToString();
         }
 
@@ -153,11 +153,11 @@ namespace Microsoft.Internal
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append("(");
+            sb.Append('(');
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
-            sb.Append(")");
+            sb.Append(')');
             return sb.ToString();
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -845,7 +845,7 @@ namespace System
                         break;
                     case DateTimeKind.Utc:
                         // The 'Z' constant is a marker for a UTC date
-                        result.Append("Z");
+                        result.Append('Z');
                         return;
                     default:
                         // If the kind is unspecified, we output nothing here

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1524,12 +1524,12 @@ namespace System.Runtime.Serialization
                 {
                     Type genParam = genParams[i];
                     if (isTypeOpenGeneric)
-                        localName.Append("{").Append(i).Append("}");
+                        localName.Append('{').Append(i).Append('}');
                     else
                     {
                         XmlQualifiedName qname = DataContract.GetStableName(genParam);
                         localName.Append(qname.Name);
-                        namespaces.Append(" ").Append(qname.Namespace);
+                        namespaces.Append(' ').Append(qname.Namespace);
                         if (parametersFromBuiltInNamespaces)
                             parametersFromBuiltInNamespaces = IsBuiltInNamespace(qname.Namespace);
                     }
@@ -2244,7 +2244,7 @@ namespace System.Runtime.Serialization
         {
             StringBuilder namespaces = new StringBuilder();
             for (int j = 0; j < GetParameterCount(); j++)
-                namespaces.Append(" ").Append(GetStableName(j).Namespace);
+                namespaces.Append(' ').Append(GetStableName(j).Namespace);
             return namespaces.ToString();
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNodeReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNodeReader.cs
@@ -249,7 +249,7 @@ namespace System.Xml
                     {
                         strb.Append(decNodeAttributes[i].name + "=\"" + decNodeAttributes[i].value + "\"");
                         if (i != (_nDeclarationAttrCount - 1))
-                            strb.Append(" ");
+                            strb.Append(' ');
                     }
                     retValue = strb.ToString();
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/ConstraintStruct.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/ConstraintStruct.cs
@@ -505,7 +505,7 @@ namespace System.Xml.Schema
             sb.Append(_ks[0].ToString());
             for (int i = 1; i < _ks.Length; i++)
             {
-                sb.Append(" ");
+                sb.Append(' ');
                 sb.Append(_ks[i].ToString());
             }
             return sb.ToString();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
@@ -581,7 +581,7 @@ namespace System.Xml.Schema
 
             while (true)
             {
-                bb.Append("(");
+                bb.Append('(');
                 if (this_.LeftChild is SequenceNode)
                 {
                     nodeStack.Push(this_);
@@ -593,7 +593,7 @@ namespace System.Xml.Schema
             ProcessRight:
                 bb.Append(", ");
                 this_.RightChild.Dump(bb, symbols, positions);
-                bb.Append(")");
+                bb.Append(')');
                 if (nodeStack.Count == 0)
                     break;
 
@@ -664,7 +664,7 @@ namespace System.Xml.Schema
 
             while (true)
             {
-                bb.Append("(");
+                bb.Append('(');
                 if (this_.LeftChild is ChoiceNode)
                 {
                     nodeStack.Push(this_);
@@ -676,7 +676,7 @@ namespace System.Xml.Schema
             ProcessRight:
                 bb.Append(" | ");
                 this_.RightChild.Dump(bb, symbols, positions);
-                bb.Append(")");
+                bb.Append(')');
                 if (nodeStack.Count == 0)
                     break;
 
@@ -707,7 +707,7 @@ namespace System.Xml.Schema
         public override void Dump(StringBuilder bb, SymbolsDictionary symbols, Positions positions)
         {
             LeftChild.Dump(bb, symbols, positions);
-            bb.Append("+");
+            bb.Append('+');
         }
 #endif
     }
@@ -728,7 +728,7 @@ namespace System.Xml.Schema
         public override void Dump(StringBuilder bb, SymbolsDictionary symbols, Positions positions)
         {
             LeftChild.Dump(bb, symbols, positions);
-            bb.Append("?");
+            bb.Append('?');
         }
 #endif
     }
@@ -753,7 +753,7 @@ namespace System.Xml.Schema
         public override void Dump(StringBuilder bb, SymbolsDictionary symbols, Positions positions)
         {
             LeftChild.Dump(bb, symbols, positions);
-            bb.Append("*");
+            bb.Append('*');
         }
 #endif
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
@@ -156,7 +156,7 @@ namespace System.Xml.Schema
                 if (_firstPattern == true)
                 {
                     _regStr = new StringBuilder();
-                    _regStr.Append("(");
+                    _regStr.Append('(');
                     _regStr.Append(facet.Value);
                     _pattern_facet = facet;
                     _firstPattern = false;
@@ -357,12 +357,12 @@ namespace System.Xml.Schema
                     }
                     try
                     {
-                        _regStr.Append(")");
+                        _regStr.Append(')');
                         string tempStr = _regStr.ToString();
                         if (tempStr.Contains('|'))
                         { // ordinal compare
-                            _regStr.Insert(0, "(");
-                            _regStr.Append(")");
+                            _regStr.Insert(0, '(');
+                            _regStr.Append(')');
                         }
                         _derivedRestriction.Patterns.Add(new Regex(Preprocess(_regStr.ToString())));
                     }
@@ -701,7 +701,7 @@ namespace System.Xml.Schema
             private static string Preprocess(string pattern)
             {
                 StringBuilder bufBld = new StringBuilder();
-                bufBld.Append("^");
+                bufBld.Append('^');
 
                 char[] source = pattern.ToCharArray();
                 int length = pattern.Length;
@@ -739,7 +739,7 @@ namespace System.Xml.Schema
                     bufBld.Append(source, copyPosition, length - copyPosition);
                 }
 
-                bufBld.Append("$");
+                bufBld.Append('$');
                 return bufBld.ToString();
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/NamespaceList.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/NamespaceList.cs
@@ -138,7 +138,7 @@ namespace System.Xml.Schema
                         }
                         else
                         {
-                            sb.Append(" ");
+                            sb.Append(' ');
                         }
                         if (s == _targetNamespace)
                         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -2430,14 +2430,14 @@ namespace System.Xml.Schema
             }
             else if (particle is XmlSchemaAny)
             {
-                sb.Append("<");
+                sb.Append('<');
                 sb.Append(((XmlSchemaAny)particle).NamespaceList.ToString());
-                sb.Append(">");
+                sb.Append('>');
             }
             else if (particle is XmlSchemaAll)
             {
                 XmlSchemaAll all = (XmlSchemaAll)particle;
-                sb.Append("[");
+                sb.Append('[');
                 bool first = true;
                 for (int i = 0; i < all.Items.Count; ++i)
                 {
@@ -2453,15 +2453,15 @@ namespace System.Xml.Schema
                     sb.Append(localElement.QualifiedName.Name);
                     if (localElement.MinOccurs == decimal.Zero)
                     {
-                        sb.Append("?");
+                        sb.Append('?');
                     }
                 }
-                sb.Append("]");
+                sb.Append(']');
             }
             else if (particle is XmlSchemaGroupBase)
             {
                 XmlSchemaGroupBase gb = (XmlSchemaGroupBase)particle;
-                sb.Append("(");
+                sb.Append('(');
                 string delimeter = (particle is XmlSchemaChoice) ? " | " : ", ";
                 bool first = true;
                 for (int i = 0; i < gb.Items.Count; ++i)
@@ -2476,7 +2476,7 @@ namespace System.Xml.Schema
                     }
                     DumpContentModelTo(sb, (XmlSchemaParticle)gb.Items[i]);
                 }
-                sb.Append(")");
+                sb.Append(')');
             }
             else
             {
@@ -2489,15 +2489,15 @@ namespace System.Xml.Schema
             }
             else if (particle.MinOccurs == decimal.Zero && particle.MaxOccurs == decimal.One)
             {
-                sb.Append("?");
+                sb.Append('?');
             }
             else if (particle.MinOccurs == decimal.Zero && particle.MaxOccurs == decimal.MaxValue)
             {
-                sb.Append("*");
+                sb.Append('*');
             }
             else if (particle.MinOccurs == decimal.One && particle.MaxOccurs == decimal.MaxValue)
             {
-                sb.Append("+");
+                sb.Append('+');
             }
             else
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAny.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAny.cs
@@ -73,7 +73,7 @@ namespace System.Xml.Schema
                             sb.Append(wildcardNS + ":*");
                             if (i < _namespaceList.Enumerate.Count)
                             {
-                                sb.Append(" ");
+                                sb.Append(' ');
                             }
                             i++;
                         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaDataType.cs
@@ -191,7 +191,7 @@ namespace System.Xml.Schema
                 IEnumerator enumerator = (value as IEnumerable).GetEnumerator();
                 if (enumerator.MoveNext())
                 {
-                    bldr.Append("{");
+                    bldr.Append('{');
                     object cur = enumerator.Current;
                     if (cur is IFormattable)
                     {
@@ -214,7 +214,7 @@ namespace System.Xml.Schema
                             bldr.Append(cur.ToString());
                         }
                     }
-                    bldr.Append("}");
+                    bldr.Append('}');
                     stringValue = bldr.ToString();
                 }
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
@@ -2656,7 +2656,7 @@ namespace System.Xml.Schema
             builder.Append(expected[0].ToString());
             for (int i = 1; i < expected.Count; ++i)
             {
-                builder.Append(" ");
+                builder.Append(' ');
                 builder.Append(expected[i].ToString());
             }
             builder.Append(Quote);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -179,7 +179,7 @@ namespace System.Xml.Serialization
             if (t.DeclaringType != null && t.DeclaringType != t)
             {
                 index = GetCSharpName(t.DeclaringType, parameters, index, sb);
-                sb.Append(".");
+                sb.Append('.');
             }
             string name = t.Name;
             int nameEnd = name.IndexOf('`');
@@ -190,17 +190,17 @@ namespace System.Xml.Serialization
             if (nameEnd > 0)
             {
                 EscapeKeywords(name.Substring(0, nameEnd), sb);
-                sb.Append("<");
+                sb.Append('<');
                 int arguments = int.Parse(name.Substring(nameEnd + 1), CultureInfo.InvariantCulture) + index;
                 for (; index < arguments; index++)
                 {
                     sb.Append(GetCSharpName(parameters[index]));
                     if (index < arguments - 1)
                     {
-                        sb.Append(",");
+                        sb.Append(',');
                     }
                 }
-                sb.Append(">");
+                sb.Append('>');
             }
             else
             {
@@ -226,7 +226,7 @@ namespace System.Xml.Serialization
                 for (int i = 0; i < parts.Length; i++)
                 {
                     EscapeKeywords(parts[i], sb);
-                    sb.Append(".");
+                    sb.Append('.');
                 }
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -270,7 +270,7 @@ namespace System.Xml.Serialization
             for (int i = 0; i < list.Count; i++)
             {
                 sb.Append(list[i].ToString());
-                sb.Append(",");
+                sb.Append(',');
             }
 
             return sb.ToString();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
@@ -1139,7 +1139,7 @@ namespace System.Xml.Serialization
                             if (s.TargetNamespace != null && s.TargetNamespace.Length > 0)
                             {
                                 if (anyNamespaces.Length > 0)
-                                    anyNamespaces.Append(" ");
+                                    anyNamespaces.Append(' ');
                                 anyNamespaces.Append(s.TargetNamespace);
                             }
                         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -839,7 +839,7 @@ namespace System.Xml.Serialization
                                 {
                                     if (shouldAppendWhitespace)
                                     {
-                                        sb.Append(" ");
+                                        sb.Append(' ');
                                     }
 
                                     sb.Append(stringValue);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SchemaObjectWriter.cs
@@ -159,19 +159,19 @@ namespace System.Xml.Serialization
         {
             for (int i = 0; i < _indentLevel; i++)
             {
-                _w.Append(" ");
+                _w.Append(' ');
             }
         }
         protected void WriteAttribute(string localName, string ns, string value)
         {
             if (value == null || value.Length == 0)
                 return;
-            _w.Append(",");
+            _w.Append(',');
             _w.Append(ns);
             if (ns != null && ns.Length != 0)
-                _w.Append(":");
+                _w.Append(':');
             _w.Append(localName);
-            _w.Append("=");
+            _w.Append('=');
             _w.Append(value);
         }
         protected void WriteAttribute(string localName, string ns, XmlQualifiedName value)
@@ -190,7 +190,7 @@ namespace System.Xml.Serialization
         }
         protected void WriteEndElement()
         {
-            _w.Append("]");
+            _w.Append(']');
             _indentLevel--;
         }
         protected void NewLine()
@@ -256,7 +256,7 @@ namespace System.Xml.Serialization
                         }
                         else
                         {
-                            sb.Append(" ");
+                            sb.Append(' ');
                         }
                         if (s.Length == 0)
                         {
@@ -602,14 +602,14 @@ namespace System.Xml.Serialization
                 }
                 list.Sort(new QNameComparer());
 
-                _w.Append(",");
+                _w.Append(',');
                 _w.Append("memberTypes=");
 
                 for (int i = 0; i < list.Count; i++)
                 {
                     XmlQualifiedName q = (XmlQualifiedName)list[i];
                     _w.Append(q.ToString());
-                    _w.Append(",");
+                    _w.Append(',');
                 }
             }
             Write5_XmlSchemaAnnotation((XmlSchemaAnnotation)o.@Annotation);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -1004,7 +1004,7 @@ namespace System.Xml.Serialization
                 }
                 /*
                 if (ns.Length > 0) {
-                    typeName.Append("_");
+                    typeName.Append('_');
                     typeName.Append(GetHash(ns.ToString()));
                 }
                 */

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlMembersMapping.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlMembersMapping.cs
@@ -21,14 +21,14 @@ namespace System.Xml.Serialization
         {
             MembersMapping mapping = (MembersMapping)accessor.Mapping;
             StringBuilder key = new StringBuilder();
-            key.Append(":");
+            key.Append(':');
             _mappings = new XmlMemberMapping[mapping.Members.Length];
             for (int i = 0; i < _mappings.Length; i++)
             {
                 if (mapping.Members[i].TypeDesc.Type != null)
                 {
                     key.Append(GenerateKey(mapping.Members[i].TypeDesc.Type, null, null));
-                    key.Append(":");
+                    key.Append(':');
                 }
                 _mappings[i] = new XmlMemberMapping(mapping.Members[i]);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -1824,7 +1824,7 @@ namespace System.Xml.Serialization
                 sb.Append(obj);
                 sb.Append(".@");
                 sb.Append(methodName);
-                sb.Append("(");
+                sb.Append('(');
             }
             for (int i = 0; i < args.Length; i++)
             {
@@ -1835,7 +1835,7 @@ namespace System.Xml.Serialization
             if (useReflection)
                 sb.Append("})");
             else
-                sb.Append(")");
+                sb.Append(')');
             return sb.ToString();
         }
 
@@ -1948,9 +1948,9 @@ namespace System.Xml.Serialization
             StringBuilder createInstance = new StringBuilder();
             if (cast != null && cast.Length > 0)
             {
-                createInstance.Append("(");
+                createInstance.Append('(');
                 createInstance.Append(cast);
-                createInstance.Append(")");
+                createInstance.Append(')');
             }
             createInstance.Append(typeof(Activator).FullName);
             createInstance.Append(".CreateInstance(");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Xmlcustomformatter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Xmlcustomformatter.cs
@@ -188,7 +188,7 @@ namespace System.Xml.Serialization
                 if ((ids[i] & originalValue) == ids[i])
                 {
                     if (sb.Length != 0)
-                        sb.Append(" ");
+                        sb.Append(' ');
                     sb.Append(vals[i]);
                     val &= ~ids[i];
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathMultyIterator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathMultyIterator.cs
@@ -66,7 +66,7 @@ namespace MS.Internal.Xml.XPath
         string Dump(ResetableIterator it) {
             it = (ResetableIterator) it.Clone();
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
-            sb.Append("(");
+            sb.Append('(');
             do {
                 XPathNavigator nav = it.Current.Clone();
                 nav.MoveToAttribute("id1", "");
@@ -74,7 +74,7 @@ namespace MS.Internal.Xml.XPath
                 sb.Append(", ");
             } while (it.MoveNext());
             sb.Length = sb.Length - 2;
-            sb.Append(")");
+            sb.Append(')');
             return sb.ToString();
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
@@ -406,7 +406,7 @@ namespace System.Xml.Xsl
                 for (int i = 0; i < Count; i++)
                 {
                     if (i != 0)
-                        sb.Append("|");
+                        sb.Append('|');
                     sb.Append(this[i].TypeCode.ToString());
                 }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/NumberAction.cs
@@ -577,7 +577,7 @@ namespace System.Xml.Xsl.XsltOld
                 {
                     if (i != 0)
                     {
-                        result.Append(".");
+                        result.Append('.');
                     }
                     result.Append(numberingFormat.FormatItem(numberlist[i]));
                 }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualMethodBase.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualMethodBase.cs
@@ -135,9 +135,9 @@ namespace System.Reflection.Context.Virtual
             var sb = new StringBuilder();
 
             sb.Append(ReturnType.ToString());
-            sb.Append(" ");
+            sb.Append(' ');
             sb.Append(Name);
-            sb.Append("(");
+            sb.Append('(');
 
             Type[] parameterTypes = GetParameterTypes();
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -359,17 +359,17 @@ namespace System.Runtime.Serialization
                 return type.FullName!;
             }
 
-            var builder = new StringBuilder(type.GetGenericTypeDefinition().FullName).Append("[");
+            var builder = new StringBuilder(type.GetGenericTypeDefinition().FullName).Append('[');
 
             bool hasTypeForwardedFrom;
             foreach (Type genericArgument in type.GetGenericArguments())
             {
-                builder.Append("[").Append(GetClrTypeFullName(genericArgument)).Append(", ");
+                builder.Append('[').Append(GetClrTypeFullName(genericArgument)).Append(", ");
                 builder.Append(GetClrAssemblyName(genericArgument, out hasTypeForwardedFrom)).Append("],");
             }
 
             //remove the last comma and close typename for generic with a close bracket
-            return builder.Remove(builder.Length - 1, 1).Append("]").ToString();
+            return builder.Remove(builder.Length - 1, 1).Append(']').ToString();
         }
     }
 

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography.Xml
             {
                 anc.GetNamespacesToRender(this, attrListToRender, nsListToRender, nsLocallyDeclared);
 
-                strBuilder.Append("<" + Name);
+                strBuilder.Append('<').Append(Name);
                 foreach (object attr in nsListToRender.GetKeyList())
                 {
                     (attr as CanonicalXmlAttribute).Write(strBuilder, docPos, anc);
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.Xml
                 {
                     (attr as CanonicalXmlAttribute).Write(strBuilder, docPos, anc);
                 }
-                strBuilder.Append(">");
+                strBuilder.Append('>');
             }
 
             anc.EnterElementContext();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -227,9 +227,9 @@ namespace System.Text.Json
                     // Once all elements are read, the exception is not within the array.
                     if (frame.ObjectState < StackFrameObjectState.ReadElements)
                     {
-                        sb.Append(@"[");
+                        sb.Append('[');
                         sb.Append(GetCount(enumerable));
-                        sb.Append(@"]");
+                        sb.Append(']');
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -309,7 +309,7 @@ namespace System.Text.RegularExpressions
                 case Notoneloopatomic:
                 case Onelazy:
                 case Notonelazy:
-                    sb.Append("'").Append(RegexCharClass.CharDescription((char)Codes[offset + 1])).Append("'");
+                    sb.Append('\'').Append(RegexCharClass.CharDescription((char)Codes[offset + 1])).Append('\'');
                     break;
 
                 case Set:


### PR DESCRIPTION
The char overload has a much simpler/faster implementation.  And if nothing else this increases our consistency across the codebase, as we already use the char overload in a bunch of places.