### PR TITLE
Use ILLink Assembly path defined in its package

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -9,9 +9,6 @@
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->
   <PropertyGroup>
-    <ILLinkTasksDir>$([MSBuild]::NormalizeDirectory('$(PkgILLink_Tasks)', 'tools'))</ILLinkTasksDir>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' and '$(MSBuildRuntimeType)' == 'core'">$(ILLinkTasksDir)netcoreapp3.0/ILLink.Tasks.dll</ILLinkTasksPath>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' and '$(MSBuildRuntimeType)' != 'core'">$(ILLinkTasksDir)$(NetFrameworkCurrent)/ILLink.Tasks.dll</ILLinkTasksPath>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
     <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
@@ -62,7 +59,7 @@
        Examines the "input assembly" for IL that is unreachable from public API and trims that,
        rewriting the assembly to an "output assembly"
   -->
-  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksPath)" />
+  <UsingTask TaskName="ILLink" Condition="'$(LinkTaskDllPath)' != ''" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'">
     <PropertyGroup>
       <ILLinkArgs>$(ILLinkArgs)-r $(TargetName)</ILLinkArgs>

--- a/src/coreclr/src/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
+++ b/src/coreclr/src/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
@@ -1,5 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+<Project>
   <PropertyGroup>
     <CompileDependsOn>_CreateILLinkRuntimeRootDescriptorFile;$(CompileDependsOn)</CompileDependsOn>
   </PropertyGroup>
@@ -11,9 +10,6 @@
     <_CortypeFilePath Condition=" '$(_CortypeFilePath)' == '' ">$(MSBuildThisFileDirectory)..\inc\cortypeinfo.h</_CortypeFilePath>
     <_RexcepFilePath Condition=" '$(_RexcepFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\rexcep.h</_RexcepFilePath>
     <_ILLinkTrimXmlFilePath Condition=" '$(_ILLinkTrimXmlFilePath)' == '' ">$(MSBuildThisFileDirectory)ILLinkTrim.xml</_ILLinkTrimXmlFilePath>
-    <_ILLinkTasksToolsDir>$(PkgILLink_Tasks)/tools</_ILLinkTasksToolsDir>
-    <_ILLinkTasksDir>$(_ILLinkTasksToolsDir)/$(NetFrameworkCurrent)/</_ILLinkTasksDir>
-    <_ILLinkTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_ILLinkTasksToolsDir)/netcoreapp3.0/</_ILLinkTasksDir>
   </PropertyGroup>
 
   <!--
@@ -24,7 +20,7 @@
         of child processes, and attach a debugger to msbuild. After that you can set a bp on the exception
         you are seeing.
   -->
-  <UsingTask TaskName="CreateRuntimeRootILLinkDescriptorFile" AssemblyFile="$(_ILLinkTasksDir)ILLink.Tasks.dll" />
+  <UsingTask TaskName="CreateRuntimeRootILLinkDescriptorFile" Condition="'$(LinkTaskDllPath)' != ''" AssemblyFile="$(LinkTaskDllPath)" />
   <Target Name="_CreateILLinkRuntimeRootDescriptorFile"
           Inputs="$(_NamespaceFilePath);$(_MscorlibFilePath);$(_CortypeFilePath);$(_RexcepFilePath);$(_ILLinkTrimXmlFilePath)"
           Outputs="$(_ILLinkRuntimeRootDescriptorFilePath)">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32453
Remove the duplication of the path construction and use the paths that
are defined in the nuget package's targets file.