### PR TITLE
[interp] Make newobj_vtst_fast not recursive.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -301,14 +301,6 @@ static gboolean interp_init_done = FALSE;
 
 static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args, MonoError *error);
 
-static MONO_NEVER_INLINE void
-interp_exec_method_newobj_vtst_fast (InterpFrame *frame, ThreadContext *context, MonoError *error)
-// This function makes WebAsssembly stacks clearer, so you can see which recursion
-// is occuring, in the absence of line numbers in the debugger.
-{
-	interp_exec_method_full (frame, context, NULL, error);
-}
-
 static InterpMethod* lookup_method_pointer (gpointer addr);
 
 typedef void (*ICallMethod) (InterpFrame *frame);
@@ -3223,36 +3215,6 @@ mono_interp_leave (InterpFrame* child_frame)
 	return (MonoException*)tmp_sp.data.p;
 }
 
-static MONO_NEVER_INLINE void
-mono_interp_newobj_vt (
-	// Parameters are sorted by name and parameter list is minimized
-	// to reduce stack use in caller, on e.g. NT/AMD64 (up to 4 parameters
-	// use no stack in caller).
-	InterpFrame* child_frame,
-	ThreadContext* context,
-	MonoError* error)
-{
-	stackval* const sp = child_frame->stack_args;
-
-	stackval valuetype_this;
-
-	memset (&valuetype_this, 0, sizeof (stackval));
-	sp->data.p = &valuetype_this;
-
-	// FIXME remove recursion
-	//
-	// FIXME It is unfortunate to outline a recursive case as it
-	// increases its stack usage. We do this however as it conserves
-	// stack for all the other recursive cases.
-	interp_exec_method (child_frame, context, error);
-
-	CHECK_RESUME_STATE (context);
-
-	*sp = valuetype_this;
-resume:
-	;
-}
-
 static MONO_NEVER_INLINE MonoException*
 mono_interp_newobj (
 	// Parameters are sorted by name and parameter list is minimized
@@ -5079,51 +5041,49 @@ call:;
 			} else {
 				cmethod = (InterpMethod*)frame->imethod->data_items [imethod_index];
 				frame->ip = ip - 4;
-				is_void = TRUE;
-				retval = NULL;
-				++sp; // Point sp at this, after return value.
-				goto call;
+				goto call_newobj;
 			}
 
 			MINT_IN_BREAK;
 		}
+
 		MINT_IN_CASE(MINT_NEWOBJ_VT_FAST)
 		MINT_IN_CASE(MINT_NEWOBJ_VTST_FAST) {
-			int dummy;
-			// This is split up to:
-			//  - conserve stack
-			//  - keep exception handling and resume mostly in the main function
 
 			frame->ip = ip;
-			child_frame = alloc_frame (context, &dummy, frame, (InterpMethod*) frame->imethod->data_items [ip [1]], NULL, NULL);
+			cmethod = (InterpMethod*)frame->imethod->data_items [ip [1]];
 			guint16 const param_count = ip [2];
 
+			// Make room for extra parameter and result.
 			if (param_count) {
 				sp -= param_count;
-				memmove (sp + 1, sp, param_count * sizeof (stackval));
+				memmove (sp + 2, sp, param_count * sizeof (stackval));
 			}
-			child_frame->stack_args = sp;
+
 			gboolean const vtst = *ip == MINT_NEWOBJ_VTST_FAST;
 			if (vtst) {
 				memset (vt_sp, 0, ip [3]);
-				sp->data.p = vt_sp;
 				ip += 4;
-
-				// FIXME remove recursion
-				interp_exec_method_newobj_vtst_fast (child_frame, context, error);
-
-				CHECK_RESUME_STATE (context);
-				sp->data.p = vt_sp;
-
+				// Put extra parameter and result on stack, before other parameters,
+				// and point stack to extra parameter, after result.
+				// This pattern occurs for newobj_vt_fast and newobj_fast.
+				sp [1].data.p = vt_sp;
+				sp [0].data.p = vt_sp;
 			} else {
 				ip += 3;
-				// FIXME remove recursion
-				mono_interp_newobj_vt (child_frame, context, error);
-				CHECK_RESUME_STATE (context);
+				// Like newobj_fast, add valuetype_this parameter
+				// and result and point stack to this after result.
+				memset (sp, 0, sizeof (*sp));
+				sp [1].data.p = &sp [0].data; // valuetype_this == result
 			}
-			++sp;
-			MINT_IN_BREAK;
-		}
+			}
+			// call_newobj captures the pattern where the return value is placed
+			// on the stack before the call, instead of the call forming it.
+call_newobj:
+			++sp; // Point sp at added extra param, after return value.
+			is_void = TRUE;
+			retval = NULL;
+			goto call;
 
 		MINT_IN_CASE(MINT_NEWOBJ) {
 			int dummy;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18902,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>[interp] Make newobj_vtst_fast and newobj_vt_fast not recursive.
    
This is builds upon https://github.com/mono/mono/pull/18875 which was newobj_vt_fast-only.
That was preceded by https://github.com/mono/mono/pull/18870 which did not handle the stack/GC perhaps as well.

Some notes:
 - This is a little gnarly in its stack manipulation in transform.c and interp.c. Please review carefully.
 - This is *not* known to contribute to WebAssembly/Blazor failures (which are suspected fixed via earlier fixes already). Leaving it alone is an option. Not my favorate, but I understand.
  - There are expected to be improvements on the Apple side as well, further strengthening the previous point. Still not my preference, but again I understand.