### PR TITLE
Nullability of BaseDirectory fix

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -30,7 +30,7 @@ namespace System
 
         public static AppDomain CurrentDomain => s_domain;
 
-        public string? BaseDirectory => AppContext.BaseDirectory;
+        public string BaseDirectory => AppContext.BaseDirectory;
 
         public string? RelativeSearchPath => null;
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -110,7 +110,7 @@ namespace System
     public sealed partial class AppDomain : System.MarshalByRefObject
     {
         internal AppDomain() { }
-        public string? BaseDirectory { get { throw null; } }
+        public string BaseDirectory { get { throw null; } }
         public static System.AppDomain CurrentDomain { get { throw null; } }
         public string? DynamicDirectory { get { throw null; } }
         public string FriendlyName { get { throw null; } }


### PR DESCRIPTION
BaseDirectory is never null. Not sure if you want to keep it this way as a protection against the future API changes?