### PR TITLE
Fix Platform setting in mono nuget Directory.Build.props

### DIFF
--- a/src/mono/netcore/nuget/Directory.Build.props
+++ b/src/mono/netcore/nuget/Directory.Build.props
@@ -181,14 +181,14 @@
     <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
     <BuildRID Include="$(PackageRID)"
               Condition="'$(_isSupportedOSGroup)' == 'true'">
-      <Platform Condition="'$(ArchGroup)' == 'x64'">amd64</Platform>
+      <Platform Condition="'$(ArchGroup)' == 'x64'">x64</Platform>
       <Platform Condition="'$(ArchGroup)' != 'x64'">$(ArchGroup)</Platform>
     </BuildRID>
   </ItemGroup>
 
   <ItemGroup>
     <_project Include="@(BuildRID)">
-      <Platform Condition="'%(Platform)' == ''">amd64</Platform>
+      <Platform Condition="'%(Platform)' == ''">x64</Platform>
       <PackageTargetRuntime>%(Identity)</PackageTargetRuntime>
       <AdditionalProperties>PackageTargetRuntime=%(Identity);Platform=%(Platform)</AdditionalProperties>
     </_project>


### PR DESCRIPTION
Otherwise doing `./mono.sh -pack` didn't work since it'd use amd64 instead of x64.
We copied much of this logic from coreclr so I assume this is specific to their build, but I still don't fully understand every bit.

I assume it only worked on CI because we explicitly pass Platform=x64 there which overrides this setting.