### PR TITLE
R2RDump improvements in composite format support

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -84,8 +84,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         // ManifestReferences
         private MetadataReader _manifestReader;
         private List<AssemblyReferenceHandle> _manifestReferences;
-        private List<string> _manifestReferenceNames;
-        private Dictionary<string, int> _manifestReferenceIndices;
+        private Dictionary<string, int> _manifestReferenceAssemblies;
 
         // ExceptionInfo
         private Dictionary<int, EHInfo> _runtimeFunctionToEHInfo;
@@ -134,8 +133,8 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             get
             {
-                EnsureManifestReferenceNames();
-                return _manifestReferenceIndices;
+                EnsureManifestReferenceAssemblies();
+                return _manifestReferenceAssemblies;
             }
         }
 
@@ -558,20 +557,18 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
         }
 
-        private void EnsureManifestReferenceNames()
+        private void EnsureManifestReferenceAssemblies()
         {
-            if (_manifestReferenceNames != null)
+            if (_manifestReferenceAssemblies != null)
             {
                 return;
             }
             EnsureManifestReferences();
-            _manifestReferenceNames = new List<string>(_manifestReferences.Count);
-            _manifestReferenceIndices = new Dictionary<string, int>(_manifestReferences.Count);
+            _manifestReferenceAssemblies = new Dictionary<string, int>(_manifestReferences.Count);
             for (int assemblyIndex = 0; assemblyIndex < _manifestReferences.Count; assemblyIndex++)
             {
                 string assemblyName = ManifestReader.GetString(ManifestReader.GetAssemblyReference(_manifestReferences[assemblyIndex]).Name);
-                _manifestReferenceNames.Add(assemblyName);
-                _manifestReferenceIndices.Add(assemblyName, assemblyIndex);
+                _manifestReferenceAssemblies.Add(assemblyName, assemblyIndex);
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -130,16 +130,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// The list originates in the top-level R2R image and is copied
         /// to all reference assemblies for the sake of simplicity.
         /// </summary>
-        public IList<string> ManifestReferenceAssemblies
-        {
-            get
-            {
-                EnsureManifestReferenceNames();
-                return _manifestReferenceNames;
-            }
-        }
-
-        public Dictionary<string, int> ManifestReferenceIndices
+        public Dictionary<string, int> ManifestReferenceAssemblies
         {
             get
             {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -18,6 +18,7 @@ using Internal.Runtime;
 using Internal.ReadyToRunConstants;
 
 using Debug = System.Diagnostics.Debug;
+using System.Linq;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
@@ -83,12 +84,14 @@ namespace ILCompiler.Reflection.ReadyToRun
         // ManifestReferences
         private MetadataReader _manifestReader;
         private List<AssemblyReferenceHandle> _manifestReferences;
+        private List<string> _manifestReferenceNames;
+        private Dictionary<string, int> _manifestReferenceIndices;
 
         // ExceptionInfo
         private Dictionary<int, EHInfo> _runtimeFunctionToEHInfo;
 
         // Methods
-        private List<ReadyToRunMethod> _methods;
+        private Dictionary<ReadyToRunSection, List<ReadyToRunMethod>> _methods;
         private List<InstanceMethod> _instanceMethods;
 
         // ImportSections
@@ -96,7 +99,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         private Dictionary<int, string> _importCellNames;
 
         // AvailableType
-        private List<string> _availableTypes;
+        private Dictionary<ReadyToRunSection, List<string>> _availableTypes;
 
         // CompilerIdentifier
         private string _compilerIdentifier;
@@ -127,15 +130,21 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// The list originates in the top-level R2R image and is copied
         /// to all reference assemblies for the sake of simplicity.
         /// </summary>
-        public IEnumerable<string> ManifestReferenceAssemblies
+        public IList<string> ManifestReferenceAssemblies
         {
             get
             {
-                // TODO (refactoring) make this a IReadOnlyList<string> to be consistent with the rest of the interface
-                foreach (AssemblyReferenceHandle manifestReference in ManifestReferences)
-                {
-                    yield return ManifestReader.GetString(ManifestReader.GetAssemblyReference(manifestReference).Name);
-                }
+                EnsureManifestReferenceNames();
+                return _manifestReferenceNames;
+            }
+        }
+
+        public Dictionary<string, int> ManifestReferenceIndices
+        {
+            get
+            {
+                EnsureManifestReferenceNames();
+                return _manifestReferenceIndices;
             }
         }
 
@@ -224,7 +233,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// The runtime functions and method signatures of each method
         /// </summary>
-        public IReadOnlyList<ReadyToRunMethod> Methods
+        public Dictionary<ReadyToRunSection, List<ReadyToRunMethod>> Methods
         {
             get
             {
@@ -248,7 +257,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// The available types from READYTORUN_SECTION_AVAILABLE_TYPES
         /// </summary>
-        public IReadOnlyList<string> AvailableTypes
+        public Dictionary<ReadyToRunSection, List<string>> AvailableTypes
         {
 
             get
@@ -402,7 +411,8 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 return;
             }
-            _methods = new List<ReadyToRunMethod>();
+
+            _methods = new Dictionary<ReadyToRunSection, List<ReadyToRunMethod>>();
             _instanceMethods = new List<InstanceMethod>();
 
             if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.RuntimeFunctions, out ReadyToRunSection runtimeFunctionSection))
@@ -557,6 +567,23 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
         }
 
+        private void EnsureManifestReferenceNames()
+        {
+            if (_manifestReferenceNames != null)
+            {
+                return;
+            }
+            EnsureManifestReferences();
+            _manifestReferenceNames = new List<string>(_manifestReferences.Count);
+            _manifestReferenceIndices = new Dictionary<string, int>(_manifestReferences.Count);
+            for (int assemblyIndex = 0; assemblyIndex < _manifestReferences.Count; assemblyIndex++)
+            {
+                string assemblyName = ManifestReader.GetString(ManifestReader.GetAssemblyReference(_manifestReferences[assemblyIndex]).Name);
+                _manifestReferenceNames.Add(assemblyName);
+                _manifestReferenceIndices.Add(assemblyName, assemblyIndex);
+            }
+        }
+
         private unsafe void EnsureExceptionInfo()
         {
             if (_runtimeFunctionToEHInfo != null)
@@ -659,7 +686,12 @@ namespace ILCompiler.Reflection.ReadyToRun
                         throw new BadImageFormatException("EntryPointRuntimeFunctionId out of bounds");
                     }
                     isEntryPoint[method.EntryPointRuntimeFunctionId] = true;
-                    _methods.Add(method);
+                    if (!_methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+                    {
+                        sectionMethods = new List<ReadyToRunMethod>();
+                        _methods.Add(section, sectionMethods);
+                    }
+                    sectionMethods.Add(method);
                 }
             }
         }
@@ -744,7 +776,12 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     isEntryPoint[method.EntryPointRuntimeFunctionId] = true;
                 }
-                _methods.Add(method);
+                if (!Methods.TryGetValue(instMethodEntryPointSection, out List<ReadyToRunMethod> sectionMethods))
+                {
+                    sectionMethods = new List<ReadyToRunMethod>();
+                    Methods.Add(instMethodEntryPointSection, sectionMethods);
+                }
+                sectionMethods.Add(method);
                 _instanceMethods.Add(new InstanceMethod(curParser.LowHashcode, method));
                 curParser = allEntriesEnum.GetNext();
             }
@@ -752,7 +789,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private void CountRuntimeFunctions(bool[] isEntryPoint)
         {
-            foreach (ReadyToRunMethod method in _methods)
+            foreach (ReadyToRunMethod method in Methods.Values.SelectMany(sectionMethods => sectionMethods))
             {
                 int runtimeFunctionId = method.EntryPointRuntimeFunctionId;
                 if (runtimeFunctionId == -1)
@@ -778,7 +815,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 return;
             }
-            _availableTypes = new List<string>();
+            _availableTypes = new Dictionary<ReadyToRunSection, List<string>>();
             ReadyToRunSection availableTypesSection;
             if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.AvailableTypes, out availableTypesSection))
             {
@@ -820,13 +857,23 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     ExportedTypeHandle exportedTypeHandle = MetadataTokens.ExportedTypeHandle((int)rid);
                     string exportedTypeName = GetExportedTypeFullName(metadataReader, exportedTypeHandle);
-                    _availableTypes.Add("exported " + exportedTypeName);
+                    if (!AvailableTypes.TryGetValue(availableTypesSection, out List<string> sectionTypes))
+                    {
+                        sectionTypes = new List<string>();
+                        AvailableTypes.Add(availableTypesSection, sectionTypes);
+                    }
+                    sectionTypes.Add("exported " + exportedTypeName);
                 }
                 else
                 {
                     TypeDefinitionHandle typeDefHandle = MetadataTokens.TypeDefinitionHandle((int)rid);
                     string typeDefName = MetadataNameFormatter.FormatHandle(metadataReader, typeDefHandle);
-                    _availableTypes.Add(typeDefName);
+                    if (!AvailableTypes.TryGetValue(availableTypesSection, out List<string> sectionTypes))
+                    {
+                        sectionTypes = new List<string>();
+                        AvailableTypes.Add(availableTypesSection, sectionTypes);
+                    }
+                    sectionTypes.Add(typeDefName);
                 }
 
                 curParser = allEntriesEnum.GetNext();

--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -57,9 +57,54 @@ namespace R2RDump
             DiffR2RSections();
             DiffR2RMethods();
 
-            Dictionary<string, ReadyToRunMethod> leftMethods = new Dictionary<string, ReadyToRunMethod>(_leftDumper.Reader.Methods
+            if (!_leftDumper.Reader.ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out ReadyToRunSection leftSection))
+            {
+                leftSection = new ReadyToRunSection();
+            }
+            if (!_rightDumper.Reader.ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out ReadyToRunSection rightSection))
+            {
+                rightSection = new ReadyToRunSection();
+            }
+
+            DiffMethodsForModule(leftSection, rightSection);
+
+            if (_leftDumper.Reader.Composite && _rightDumper.Reader.Composite)
+            {
+                HashSet<string> allComponentAssemblies = new HashSet<string>(_leftDumper.Reader.ManifestReferenceAssemblies);
+                allComponentAssemblies.UnionWith(_rightDumper.Reader.ManifestReferenceAssemblies);
+                foreach (string assemblyName in allComponentAssemblies.OrderBy(name => name))
+                {
+                    int leftIndex = _leftDumper.Reader.ManifestReferenceIndices[assemblyName];
+                    int rightIndex = _rightDumper.Reader.ManifestReferenceIndices[assemblyName];
+
+                    if (leftIndex < 0 ||  _leftDumper.Reader.ReadyToRunAssemblyHeaders[leftIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out leftSection))
+                    {
+                        leftSection = new ReadyToRunSection();
+                    }
+                    if (rightIndex < 0 || !_rightDumper.Reader.ReadyToRunAssemblyHeaders[rightIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out rightSection))
+                    {
+                        rightSection = new ReadyToRunSection();
+                    }
+                    _writer.WriteLine($@"{assemblyName}: component method diff");
+                    DiffMethodsForModule(leftSection, rightSection);
+                }
+            }
+        }
+
+        private void DiffMethodsForModule(ReadyToRunSection leftSection, ReadyToRunSection rightSection)
+        {
+            if (!_leftDumper.Reader.Methods.TryGetValue(leftSection, out List<ReadyToRunMethod> leftSectionMethods))
+            {
+                leftSectionMethods = new List<ReadyToRunMethod>();
+            }
+            if (!_rightDumper.Reader.Methods.TryGetValue(leftSection, out List<ReadyToRunMethod> rightSectionMethods))
+            {
+                rightSectionMethods = new List<ReadyToRunMethod>();
+            }
+
+            Dictionary<string, ReadyToRunMethod> leftMethods = new Dictionary<string, ReadyToRunMethod>(leftSectionMethods
                 .Select(method => new KeyValuePair<string, ReadyToRunMethod>(method.SignatureString, method)));
-            Dictionary<string, ReadyToRunMethod> rightMethods = new Dictionary<string, ReadyToRunMethod>(_rightDumper.Reader.Methods
+            Dictionary<string, ReadyToRunMethod> rightMethods = new Dictionary<string, ReadyToRunMethod>(rightSectionMethods
                 .Select(method => new KeyValuePair<string, ReadyToRunMethod>(method.SignatureString, method)));
             Dictionary<string, MethodPair> commonMethods = new Dictionary<string, MethodPair>(leftMethods
                 .Select(kvp => new KeyValuePair<string, MethodPair>(kvp.Key,
@@ -69,8 +114,8 @@ namespace R2RDump
             {
                 commonMethods = new Dictionary<string, MethodPair>(HideMethodsWithSameDisassembly(commonMethods));
             }
-            DumpCommonMethods(_leftDumper, commonMethods);
-            DumpCommonMethods(_rightDumper, commonMethods);
+            DumpCommonMethods(_leftDumper, leftSection, commonMethods);
+            DumpCommonMethods(_rightDumper, rightSection, commonMethods);
         }
 
         /// <summary>
@@ -104,7 +149,40 @@ namespace R2RDump
         /// </summary>
         private void DiffR2RMethods()
         {
-            ShowDiff(GetR2RMethodMap(_leftDumper.Reader), GetR2RMethodMap(_rightDumper.Reader), "R2R methods");
+            DiffR2RMethodsForHeader(_leftDumper.Reader.ReadyToRunHeader, _rightDumper.Reader.ReadyToRunHeader);
+        }
+
+        private void DiffR2RMethodsForHeader(ReadyToRunCoreHeader leftHeader, ReadyToRunCoreHeader rightHeader)
+        {
+            if (!leftHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out ReadyToRunSection leftSection))
+            {
+                leftSection = new ReadyToRunSection();
+            }
+            if (!rightHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out ReadyToRunSection rightSection))
+            {
+                rightSection = new ReadyToRunSection();
+            }
+            ShowDiff(GetR2RMethodMap(_leftDumper.Reader, leftSection), GetR2RMethodMap(_rightDumper.Reader, rightSection), "R2R methods");
+
+            if (_leftDumper.Reader.Composite && _rightDumper.Reader.Composite)
+            {
+                HashSet<string> allComponentAssemblies = new HashSet<string>(_leftDumper.Reader.ManifestReferenceAssemblies);
+                allComponentAssemblies.UnionWith(_rightDumper.Reader.ManifestReferenceAssemblies);
+                foreach (string assemblyName in allComponentAssemblies.OrderBy(name => name))
+                {
+                    int leftIndex = _leftDumper.Reader.ManifestReferenceIndices[assemblyName];
+                    int rightIndex = _rightDumper.Reader.ManifestReferenceIndices[assemblyName];
+                    if (leftIndex < 0 || !_leftDumper.Reader.ReadyToRunAssemblyHeaders[leftIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out leftSection))
+                    {
+                        leftSection = new ReadyToRunSection();
+                    }
+                    if (rightIndex < 0 || !_rightDumper.Reader.ReadyToRunAssemblyHeaders[rightIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out rightSection))
+                    {
+                        rightSection = new ReadyToRunSection();
+                    }
+                    ShowDiff(GetR2RMethodMap(_leftDumper.Reader, leftSection), GetR2RMethodMap(_rightDumper.Reader, rightSection), $"{assemblyName}: component R2R methods");
+                }
+            }
         }
 
         /// <summary>
@@ -209,11 +287,16 @@ namespace R2RDump
         /// </summary>
         /// <param name="reader">R2R image to scan</param>
         /// <returns></returns>
-        private Dictionary<string, int> GetR2RMethodMap(ReadyToRunReader reader)
+        private Dictionary<string, int> GetR2RMethodMap(ReadyToRunReader reader, ReadyToRunSection section)
         {
             Dictionary<string, int> methodMap = new Dictionary<string, int>();
 
-            foreach (ReadyToRunMethod method in reader.Methods)
+            if (!reader.Methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+            {
+                sectionMethods = new List<ReadyToRunMethod>();
+            }
+
+            foreach (ReadyToRunMethod method in sectionMethods)
             {
                 int size = method.RuntimeFunctions.Sum(rf => rf.Size);
                 methodMap.Add(method.SignatureString, size);
@@ -227,11 +310,14 @@ namespace R2RDump
         /// </summary>
         /// <param name="dumper">Output dumper to use</param>
         /// <param name="signatureFilter">Set of common signatures of methods to dump</param>
-        private void DumpCommonMethods(Dumper dumper, Dictionary<string, MethodPair> signatureFilter)
+        private void DumpCommonMethods(Dumper dumper, ReadyToRunSection section, Dictionary<string, MethodPair> signatureFilter)
         {
-            IEnumerable<ReadyToRunMethod> filteredMethods = dumper
-                .Reader
-                .Methods
+            if (!dumper.Reader.Methods.TryGetValue(section, out List<ReadyToRunMethod> sectionMethods))
+            {
+                sectionMethods = new List<ReadyToRunMethod>();
+            }
+
+            IEnumerable<ReadyToRunMethod> filteredMethods = sectionMethods
                 .Where(method => signatureFilter.ContainsKey(method.SignatureString))
                 .OrderBy(method => method.SignatureString);
 

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -142,9 +142,9 @@ namespace R2RDump
             _options = options;
         }
 
-        public IEnumerable<ReadyToRunSection> NormalizedSections()
+        public IEnumerable<ReadyToRunSection> NormalizedSections(ReadyToRunCoreHeader header)
         {
-            IEnumerable<ReadyToRunSection> sections = _r2r.ReadyToRunHeader.Sections.Values;
+            IEnumerable<ReadyToRunSection> sections = header.Sections.Values;
             if (_options.Normalize)
             {
                 sections = sections.OrderBy((s) => s.Type);
@@ -154,7 +154,7 @@ namespace R2RDump
 
         public IEnumerable<ReadyToRunMethod> NormalizedMethods()
         {
-            IEnumerable<ReadyToRunMethod> methods = _r2r.Methods;
+            IEnumerable<ReadyToRunMethod> methods = _r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods);
             if (_options.Normalize)
             {
                 methods = methods.OrderBy((m) => m.SignatureString);
@@ -441,7 +441,7 @@ namespace R2RDump
         public IList<ReadyToRunMethod> FindMethod(ReadyToRunReader r2r, string query, bool exact)
         {
             List<ReadyToRunMethod> res = new List<ReadyToRunMethod>();
-            foreach (ReadyToRunMethod method in r2r.Methods)
+            foreach (ReadyToRunMethod method in r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods))
             {
                 if (Match(method, query, exact))
                 {
@@ -478,7 +478,7 @@ namespace R2RDump
         /// <param name="rtfQuery">The name or value to search for</param>
         public RuntimeFunction FindRuntimeFunction(ReadyToRunReader r2r, int rtfQuery)
         {
-            foreach (ReadyToRunMethod m in r2r.Methods)
+            foreach (ReadyToRunMethod m in r2r.Methods.Values.SelectMany(sectionMethods => sectionMethods))
             {
                 foreach (RuntimeFunction rtf in m.RuntimeFunctions)
                 {

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -85,15 +85,16 @@ namespace R2RDump
                 if (_r2r.Composite)
                 {
                     WriteDivider("Component Assembly Sections");
-                    for (int assemblyIndex = 0; assemblyIndex < _r2r.ReadyToRunAssemblyHeaders.Count; assemblyIndex++)
+                    int assemblyIndex = 0;
+                    foreach (string assemblyName in _r2r.ManifestReferenceAssemblies.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key))
                     {
-                        string assemblyName = _r2r.ManifestReferenceAssemblies[assemblyIndex];
                         WriteDivider($@"Component Assembly [{assemblyIndex}]: {assemblyName}");
                         ReadyToRunCoreHeader assemblyHeader = _r2r.ReadyToRunAssemblyHeaders[assemblyIndex];
                         foreach (ReadyToRunSection section in NormalizedSections(assemblyHeader))
                         {
                             DumpSection(section);
                         }
+                        assemblyIndex++;
                     }
 
                 }
@@ -420,9 +421,9 @@ namespace R2RDump
                         }
                     }
 
-                    _writer.WriteLine($"Manifest metadata AssemblyRef's ({_r2r.ManifestReferenceAssemblies.Count()} entries):");
+                    _writer.WriteLine($"Manifest metadata AssemblyRef's ({_r2r.ManifestReferenceAssemblies.Count} entries):");
                     int manifestAsmIndex = 0;
-                    foreach (string manifestReferenceAssembly in _r2r.ManifestReferenceAssemblies)
+                    foreach (string manifestReferenceAssembly in _r2r.ManifestReferenceAssemblies.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key))
                     {
                         _writer.WriteLine($"[ID 0x{manifestAsmIndex + assemblyRefCount + 2:X2}]: {manifestReferenceAssembly}");
                         manifestAsmIndex++;


### PR DESCRIPTION
1) Added back-translation table from component assembly names
to their indices;

2) Added clean split of available types and method entrypoints per
component module and modified the various dumps as appropriate;

3) Added dump of component header sections for composite files.

Thanks

Tomas