### PR TITLE
Move EventLog tests to not run on CI

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -10,6 +10,7 @@ namespace System.Diagnostics.Tests
     {
         private const string message = "EntryCollectionMessage";
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CopyingEventLogEntryCollection()
         {
@@ -44,6 +45,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckingEntryEqualityWithNull()
         {
@@ -69,6 +71,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckingEntryEqualityAndIndex()
         {
@@ -99,6 +102,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckingEntryInEquality()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -4,7 +4,7 @@
 
 using System.Threading;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -52,6 +52,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void EntryWrittenEventRaised()
         {
@@ -59,6 +60,7 @@ namespace System.Diagnostics.Tests
             Assert.NotEqual(0, eventCounter);
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void EntryWrittenEventRaiseDisable()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics.Tests
 {
     public class EventLogSourceCreationTests
     {
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32241")]
+        [Trait(XunitConstants.Category, "EventLog")] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckSourceExistenceAndDeletion()
         {
@@ -28,6 +28,7 @@ namespace System.Diagnostics.Tests
             Assert.False(EventLog.SourceExists(source));
         }
 
+        [Trait(XunitConstants.Category, "EventLog")] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetCore()
@@ -54,6 +55,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, "EventLog")] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetFramework()
@@ -142,6 +144,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => EventLog.CreateEventSource(null));
         }
 
+        [Trait(XunitConstants.Category, "EventLog")] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void SourceAlreadyExistsWhenCreatingSource()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -22,6 +22,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void ClearLog()
         {
@@ -57,6 +58,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void DeleteLog()
         {
@@ -128,6 +130,7 @@ namespace System.Diagnostics.Tests
             Assert.Contains(eventLogCollection, eventlog => eventlog.Log.Equals("System"));
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void GetMaxKilobytes_Set()
         {
@@ -162,6 +165,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void OverflowAndRetention_Set()
         {
@@ -190,6 +194,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void Overflow_OverWriteOlderAndRetention_Set()
         {
@@ -248,6 +253,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void RegisterDisplayLogName()
         {
@@ -314,6 +320,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => EventLog.DeleteEventSource("", ""));
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void LogDisplayNameDefault()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -4,7 +4,7 @@
 
 using System.ComponentModel;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -121,6 +121,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -153,6 +154,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -182,6 +184,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -211,6 +214,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -246,6 +250,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -302,6 +307,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => EventLog.WriteEntry("", message));
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]
@@ -328,6 +334,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -87,6 +87,7 @@ namespace System.Diagnostics.Tests
                 listener.Close(); // shouldn't fail.
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void WriteTest()
         {
@@ -113,7 +114,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/40224", TestPlatforms.Windows)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(TraceEventType.Information, EventLogEntryType.Information, ushort.MaxValue + 1, ushort.MaxValue)]
         [InlineData(TraceEventType.Error, EventLogEntryType.Error, ushort.MinValue - 1, ushort.MinValue)]
@@ -155,6 +156,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { new object[] { "one string + null", null } };
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [MemberData(nameof(GetTraceDataParams_MemberData))]
         public void TraceDataParamsData(object[] parameters)
@@ -195,7 +197,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { null, new object[] { "thanks, 00", "i like it...", 111 } };
         }
 
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/40224", TestPlatforms.Windows)]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [MemberData(nameof(GetTraceEventFormat_MemberData))]
         public void TraceEventFormatAndParams(string format, object[] parameters)
@@ -251,6 +253,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void TraceWithFilters()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -29,6 +29,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/corefx/issues/34547")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData("System")]

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.Security.Principal;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.Security.Principal;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -94,6 +94,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void RecordWrittenEventRaised()
         {
@@ -101,6 +102,7 @@ namespace System.Diagnostics.Tests
             Assert.NotEqual(0, eventCounter);
         }
 
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Unreliable Win32 API call
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void RecordWrittenEventRaiseDisable()
         {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -5,7 +5,7 @@
 using System.Diagnostics.Eventing.Reader;
 using System.Threading;
 using Xunit;
-using Microsoft.DotNet.XunitExtensions;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.Eventing.Reader;
 using System.Threading;
 using Xunit;
+using Microsoft.DotNet.XunitExtensions;
 
 namespace System.Diagnostics.Tests
 {


### PR DESCRIPTION
We are hitting Win32 API issues when calling specific EventLog features.
As the risk of changes in EventLog is low we decided to turn off some
tests in CI and run them manually before a release.

https://github.com/dotnet/runtime/pull/32403#issuecomment-587394723 for discussion.

