### PR TITLE
[threading] Switch domain assemblies lock from OS to Coop

### DIFF
--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -465,7 +465,7 @@ mono_domain_create (void)
 
 	mono_coop_mutex_init_recursive (&domain->lock);
 
-	mono_os_mutex_init_recursive (&domain->assemblies_lock);
+	mono_coop_mutex_init_recursive (&domain->assemblies_lock);
 	mono_os_mutex_init_recursive (&domain->jit_code_hash_lock);
 	mono_os_mutex_init_recursive (&domain->finalizable_objects_hash_lock);
 
@@ -1301,7 +1301,7 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 #endif
 
 	mono_os_mutex_destroy (&domain->finalizable_objects_hash_lock);
-	mono_os_mutex_destroy (&domain->assemblies_lock);
+	mono_coop_mutex_destroy (&domain->assemblies_lock);
 	mono_os_mutex_destroy (&domain->jit_code_hash_lock);
 
 	mono_coop_mutex_destroy (&domain->lock);


### PR DESCRIPTION
I don't think you can create a root domain without reaching the thread info attach call, so this should be safe to change outright.

Fixes #32177 

We should complete https://github.com/mono/mono/issues/18915 and then convert over other locks as needed, but this fixes the immediate CI hang.