### PR TITLE
Fix nullable warnings on windows

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -74,7 +74,7 @@ namespace System.Diagnostics
             return PerformanceCounterLib.s_libraryTable.GetOrAdd((machineName, lcidString), (key) => new PerformanceCounterLib(key.machineName, key.lcidString));
         }
 
-        internal byte[] GetPerformanceData(string item)
+        internal byte[]? GetPerformanceData(string item)
         {
             if (_performanceMonitor == null)
             {
@@ -113,9 +113,9 @@ namespace System.Diagnostics
                     try
                     {
                         if (!isHelp)
-                            names = (string[])libraryKey.GetValue("Counter " + _perfLcid);
+                            names = (string[]?)libraryKey.GetValue("Counter " + _perfLcid);
                         else
-                            names = (string[])libraryKey.GetValue("Explain " + _perfLcid);
+                            names = (string[]?)libraryKey.GetValue("Explain " + _perfLcid);
 
                         if ((names == null) || (names.Length == 0))
                         {
@@ -225,7 +225,7 @@ namespace System.Diagnostics
             // we wait may not be sufficient if the Win32 code keeps running into this deadlock again
             // and again. A condition very rare but possible in theory. We would get back to the user
             // in this case with InvalidOperationException after the wait time expires.
-            internal byte[] GetData(string item)
+            internal byte[]? GetData(string item)
             {
 #if FEATURE_REGISTRY
                 int waitRetries = 17;   //2^16*10ms == approximately 10mins
@@ -237,7 +237,7 @@ namespace System.Diagnostics
                 {
                     try
                     {
-                        data = (byte[])_perfDataKey.GetValue(item);
+                        data = (byte[]?)_perfDataKey.GetValue(item);
                         return data;
                     }
                     catch (IOException e)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -360,7 +360,7 @@ namespace System.Diagnostics
             {
                 try
                 {
-                    byte[] dataPtr = library.GetPerformanceData(PerfCounterQueryString);
+                    byte[]? dataPtr = library.GetPerformanceData(PerfCounterQueryString);
                     processInfos = GetProcessInfos(library, ProcessPerfCounterId, ThreadPerfCounterId, dataPtr);
                 }
                 catch (Exception e)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Win32.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
                 if (string.IsNullOrEmpty(extension))
                     return Array.Empty<string>();
 
-                using (RegistryKey key = Registry.ClassesRoot.OpenSubKey(extension))
+                using (RegistryKey? key = Registry.ClassesRoot.OpenSubKey(extension))
                 {
                     if (key == null)
                         return Array.Empty<string>();
@@ -27,7 +27,7 @@ namespace System.Diagnostics
                     if (string.IsNullOrEmpty(value))
                         return Array.Empty<string>();
 
-                    using (RegistryKey subKey = Registry.ClassesRoot.OpenSubKey(value + "\\shell"))
+                    using (RegistryKey? subKey = Registry.ClassesRoot.OpenSubKey(value + "\\shell"))
                     {
                         if (subKey == null)
                             return Array.Empty<string>();


### PR DESCRIPTION
Due to: https://github.com/dotnet/runtime/issues/31888 we disabled warnAsError on Windows in CI and these warnings slip through. So local workflow is currently red when trying to build on Windows.

cc: @stephentoub @eiriktsarpalis @buyaa-n 