### PR TITLE
Change abort to use byte instead of bool

### DIFF
--- a/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
@@ -310,9 +310,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         [StructLayout(LayoutKind.Explicit)]
         internal struct StreamEventDataSendComplete
         {
-            [FieldOffset(7)]
+            [FieldOffset(0)]
             internal byte Canceled;
-            [FieldOffset(8)]
+            [FieldOffset(1)]
             internal IntPtr ClientContext;
 
             internal bool IsCanceled()
@@ -321,24 +321,21 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             }
         }
 
-        [StructLayout(LayoutKind.Explicit)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct StreamEventDataPeerSendAbort
         {
-            [FieldOffset(0)]
-            internal ulong ErrorCode;
+            internal long ErrorCode;
         }
 
-        [StructLayout(LayoutKind.Explicit)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct StreamEventDataPeerRecvAbort
         {
-            [FieldOffset(0)]
-            internal ulong ErrorCode;
+            internal long ErrorCode;
         }
 
-        [StructLayout(LayoutKind.Explicit)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct StreamEventDataSendShutdownComplete
         {
-            [FieldOffset(0)]
             internal byte Graceful;
         }
 

--- a/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/Interop/MsQuicNativeMethods.cs
@@ -304,7 +304,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal ulong TotalBufferLength;
             internal QuicBuffer* Buffers;
             internal uint BufferCount;
-            internal byte Flags;
+            internal uint Flags;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -321,22 +321,25 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             }
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Explicit)]
         internal struct StreamEventDataPeerSendAbort
         {
-            internal long ErrorCode;
+            [FieldOffset(0)]
+            internal ulong ErrorCode;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Explicit)]
         internal struct StreamEventDataPeerRecvAbort
         {
-            internal long ErrorCode;
+            [FieldOffset(0)]
+            internal ulong ErrorCode;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Explicit)]
         internal struct StreamEventDataSendShutdownComplete
         {
-            internal bool Graceful;
+            [FieldOffset(0)]
+            internal byte Graceful;
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -101,6 +101,8 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             get
             {
+                ThrowIfDisposed();
+
                 if (_streamId == -1)
                 {
                     _streamId = GetStreamId();
@@ -390,6 +392,8 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override void Shutdown()
         {
+            ThrowIfDisposed();
+
             MsQuicApi.Api.StreamShutdownDelegate(_ptr, (uint)QUIC_STREAM_SHUTDOWN_FLAG.GRACEFUL, errorCode: 0);
         }
 
@@ -613,7 +617,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldComplete = true;
                 }
                 _sendState = SendState.Aborted;
-                _sendErrorCode = evt.Data.PeerSendAbort.ErrorCode;
+                _sendErrorCode = (long)evt.Data.PeerSendAbort.ErrorCode;
             }
 
             if (shouldComplete)
@@ -726,7 +730,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldComplete = true;
                 }
                 _readState = ReadState.Aborted;
-                _readErrorCode = evt.Data.PeerSendAbort.ErrorCode;
+                _readErrorCode = (long)evt.Data.PeerSendAbort.ErrorCode;
             }
 
             if (shouldComplete)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -617,7 +617,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldComplete = true;
                 }
                 _sendState = SendState.Aborted;
-                _sendErrorCode = (long)evt.Data.PeerSendAbort.ErrorCode;
+                _sendErrorCode = evt.Data.PeerSendAbort.ErrorCode;
             }
 
             if (shouldComplete)
@@ -730,7 +730,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldComplete = true;
                 }
                 _readState = ReadState.Aborted;
-                _readErrorCode = (long)evt.Data.PeerSendAbort.ErrorCode;
+                _readErrorCode = evt.Data.PeerSendAbort.ErrorCode;
             }
 
             if (shouldComplete)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -93,7 +93,7 @@ namespace System.Net.Quic.Tests
                 byte[] buffer = new byte[100];
                 QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => serverStream.ReadAsync(buffer).AsTask());
                 Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
-            }).TimeoutAfter(millisecondsTimeout: 500_000);
+            }).TimeoutAfter(millisecondsTimeout: 5_000);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/32050")]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -67,11 +67,10 @@ namespace System.Net.Quic.Tests
                 select new object[] { readSize, writeSize };
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32049")]
         [Fact]
         public async Task Read_StreamAborted_Throws()
         {
-            const int ExpectedErrorCode = 1234;
+            const int ExpectedErrorCode = 0xfffffff;
 
             await Task.Run(async () =>
             {
@@ -94,7 +93,7 @@ namespace System.Net.Quic.Tests
                 byte[] buffer = new byte[100];
                 QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => serverStream.ReadAsync(buffer).AsTask());
                 Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
-            }).TimeoutAfter(millisecondsTimeout: 5_000);
+            }).TimeoutAfter(millisecondsTimeout: 500_000);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/32050")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32049.

This is a peculiar one. I have the following union with the following defintions:
```c#
        [StructLayout(LayoutKind.Explicit)]
        internal struct StreamEventDataUnion
        {
            [FieldOffset(0)]
            internal StreamEventDataRecv Recv;
            [FieldOffset(0)]
            internal StreamEventDataSendComplete SendComplete;
            [FieldOffset(0)]
            internal StreamEventDataPeerSendAbort PeerSendAbort;
            [FieldOffset(0)]
            internal StreamEventDataPeerRecvAbort PeerRecvAbort;
            [FieldOffset(0)]
            internal StreamEventDataSendShutdownComplete SendShutdownComplete;
        }

        [StructLayout(LayoutKind.Sequential)]
        internal struct StreamEventDataRecv
        {
            internal ulong AbsoluteOffset;
            internal ulong TotalBufferLength;
            internal QuicBuffer* Buffers;
            internal uint BufferCount;
            internal uint Flags;
        }

        [StructLayout(LayoutKind.Explicit)]
        internal struct StreamEventDataSendComplete
        {
            [FieldOffset(0)]
            internal byte Canceled;
            [FieldOffset(1)]
            internal IntPtr ClientContext;

            internal bool IsCanceled()
            {
                return Canceled != 0;
            }
        }

        [StructLayout(LayoutKind.Sequential)]
        internal struct StreamEventDataPeerSendAbort
        {
            internal long ErrorCode;
        }

        [StructLayout(LayoutKind.Sequential)]
        internal struct StreamEventDataPeerRecvAbort
        {
            internal long ErrorCode;
        }

        [StructLayout(LayoutKind.Sequential)]
        internal struct StreamEventDataSendShutdownComplete
        {
            internal byte Graceful; //Where bug is if byte is instead bool
        }
```

Where the comment is where the bug occurs. When Graceful was defined as a bool, it reinterpreted the lowest byte of the union and interpreted it as either 1 or 0. 