### PR TITLE
MulticastOption.Group no longer accepts null.

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
@@ -44,7 +44,7 @@ namespace System.Net.Sockets
 
         public override bool Equals(object comparand)
         {
-            return comparand is IPPacketInformation && this == (IPPacketInformation)comparand;
+            return comparand is IPPacketInformation other && this == other;
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
@@ -42,10 +42,8 @@ namespace System.Net.Sockets
             return !(packetInformation1 == packetInformation2);
         }
 
-        public override bool Equals(object comparand)
-        {
-            return comparand is IPPacketInformation other && this == other;
-        }
+        public override bool Equals(object comparand) =>
+            comparand is IPPacketInformation other && this == other;
 
         public override int GetHashCode()
         {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MulticastOption.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MulticastOption.cs
@@ -67,12 +67,7 @@ namespace System.Net.Sockets
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _group = value;
+                _group = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 
@@ -155,12 +150,7 @@ namespace System.Net.Sockets
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _group = value;
+                _group = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MulticastOption.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MulticastOption.cs
@@ -67,6 +67,11 @@ namespace System.Net.Sockets
             }
             set
             {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _group = value;
             }
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
@@ -71,12 +71,12 @@ namespace System.Net.Sockets
         /// <returns>true if obj is an instance of <see cref="UdpReceiveResult"/> and equals the value of the instance; otherwise, false</returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is UdpReceiveResult))
+            if (!(obj is UdpReceiveResult other))
             {
                 return false;
             }
 
-            return Equals((UdpReceiveResult)obj);
+            return Equals(other);
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
@@ -69,15 +69,8 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="obj">The object to compare with this instance</param>
         /// <returns>true if obj is an instance of <see cref="UdpReceiveResult"/> and equals the value of the instance; otherwise, false</returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is UdpReceiveResult other))
-            {
-                return false;
-            }
-
-            return Equals(other);
-        }
+        public override bool Equals(object obj) =>
+            obj is UdpReceiveResult other && Equals(other);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/MulticastOptionTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/MulticastOptionTest.cs
@@ -26,8 +26,7 @@ namespace System.Net.Sockets.Tests
             var option = new MulticastOption(IPAddress.Any);
             Assert.Same(IPAddress.Any, option.Group);
 
-            option.Group = null;
-            Assert.Null(option.Group);
+            Assert.Throws<ArgumentNullException>("value", () => option.Group = null);
 
             option.Group = IPAddress.Broadcast;
             Assert.Same(IPAddress.Broadcast, option.Group);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/MulticastOptionTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/MulticastOptionTest.cs
@@ -26,7 +26,7 @@ namespace System.Net.Sockets.Tests
             var option = new MulticastOption(IPAddress.Any);
             Assert.Same(IPAddress.Any, option.Group);
 
-            Assert.Throws<ArgumentNullException>("value", () => option.Group = null);
+            AssertExtensions.Throws<ArgumentNullException>("value", () => option.Group = null);
 
             option.Group = IPAddress.Broadcast;
             Assert.Same(IPAddress.Broadcast, option.Group);


### PR DESCRIPTION
MulticastOption.Group is not supposed to accept null. If someone sets it to null, we will NRE inside of the Sockets implementation.

I also fixed two small double-cast problems while I was in here.

Fix #32490

Note that this is a breaking change. I'm not sure all the ways I'm supposed to document this. If anyone has thoughts, please let me know.