### PR TITLE
Make mono_cond/mutex typesafe.

### DIFF
--- a/src/mono/mono/utils/mono-os-mutex.c
+++ b/src/mono/mono/utils/mono-os-mutex.c
@@ -41,7 +41,7 @@ mono_os_cond_timedwait (mono_cond_t *cond, mono_mutex_t *mutex, guint32 timeout_
 	ts.tv_sec = timeout_ms / 1000;
 	ts.tv_nsec = (timeout_ms % 1000) * 1000 * 1000;
 
-	res = pthread_cond_timedwait_relative_np (cond, mutex, &ts);
+	res = pthread_cond_timedwait_relative_np (&cond->pcond, &mutex->pmutex, &ts);
 	if (G_UNLIKELY (res != 0 && res != ETIMEDOUT)) {
 		g_print ("cond: %p mutex: %p\n", *(gpointer*)cond, *(gpointer*)mutex);
 		g_error ("%s: pthread_cond_timedwait_relative_np failed with \"%s\" (%d) %ld %ld %d", __func__, g_strerror (res), res, ts.tv_sec, ts.tv_nsec, timeout_ms);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18928,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>That is, disallow passing them directly to pthread or Win32 functions.

typedef is transparent and should not be used in the way it was used here,
if a strict layer separation is desired.

Unique types are produced by structs (or unions or classes).