### PR TITLE
Use xmm for stack prolog zeroing rather than rep stos

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -71,14 +71,14 @@ private:
     // Generates SSE41 code for the given tree as a round operation
     void genSSE41RoundOp(GenTreeOp* treeNode);
 
-    inline instruction simdAlignedMovIns()
+    instruction simdAlignedMovIns()
     {
-        // We use movaps at R2R because it is a smaller instruction; however at JIT time
+        // We use movaps when non-VEX because it is a smaller instruction;
         // however the VEX version vmovaps would be used which is the same size as vmovdqa;
         // also vmovdqa has more available CPU ports on older processors so we switch to that
         return compiler->canUseVexEncoding() ? INS_movdqa : INS_movaps;
     }
-    inline instruction simdUnalignedMovIns()
+    instruction simdUnalignedMovIns()
     {
         // We use movups when non-VEX because it is a smaller instruction;
         // however the VEX version vmovups would be used which is the same size as vmovdqu;

--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -70,6 +70,21 @@ private:
 
     // Generates SSE41 code for the given tree as a round operation
     void genSSE41RoundOp(GenTreeOp* treeNode);
+
+    inline instruction simdAlignedMovIns()
+    {
+        // We use movaps at R2R because it is a smaller instruction; however at JIT time
+        // however the VEX version vmovaps would be used which is the same size as vmovdqa;
+        // also vmovdqa has more available CPU ports on older processors so we switch to that
+        return compiler->canUseVexEncoding() ? INS_movdqa : INS_movaps;
+    }
+    inline instruction simdUnalignedMovIns()
+    {
+        // We use movups when non-VEX because it is a smaller instruction;
+        // however the VEX version vmovups would be used which is the same size as vmovdqu;
+        // but vmovdqu has more available CPU ports on older processors so we switch to that
+        return compiler->canUseVexEncoding() ? INS_movdqu : INS_movups;
+    }
 #endif // defined(TARGET_XARCH)
 
     void genPrepForCompiler();

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6361,8 +6361,8 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
         }
         else
         {
-        // Grab a non-argument, non-callee saved XMM reg
-        CLANG_FORMAT_COMMENT_ANCHOR;
+            // Grab a non-argument, non-callee saved XMM reg
+            CLANG_FORMAT_COMMENT_ANCHOR;
 #ifdef UNIX_AMD64_ABI
             // System V x64 first temp reg is xmm8
             regNumber zeroSIMDReg = genRegNumFromMask(RBM_XMM8);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6336,7 +6336,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
             simdMov = simdUnalignedMovIns();
         }
 #else // !defined(TARGET_AMD64)
-        // We aren't going to try and align on 32bit or if there are no guarantees on SIMD alignment
+        // We aren't going to try and align on x86
         instruction simdMov      = simdUnalignedMovIns();
         int         alignedLclLo = untrLclLo;
 #endif
@@ -6361,7 +6361,8 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
         }
         else
         {
-// Grab a non-argument, non-callee saved XMM reg
+        // Grab a non-argument, non-callee saved XMM reg
+        CLANG_FORMAT_COMMENT_ANCHOR;
 #ifdef UNIX_AMD64_ABI
             // System V x64 first temp reg is xmm8
             regNumber zeroSIMDReg = genRegNumFromMask(RBM_XMM8);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6379,7 +6379,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
             zeroReg = genGetZeroReg(initReg, pInitRegZeroed);
 
             int i = 0;
-            for (; i < blkSize; i += REGSIZE_BYTES)
+            for (; i + REGSIZE_BYTES <= blkSize; i += REGSIZE_BYTES)
             {
                 emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, untrLclLo + i);
             }
@@ -6424,7 +6424,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                 zeroReg = genGetZeroReg(initReg, pInitRegZeroed);
 
                 int i = 0;
-                for (; i < alignmentLoBlkSize; i += REGSIZE_BYTES)
+                for (; i + REGSIZE_BYTES <= alignmentLoBlkSize; i += REGSIZE_BYTES)
                 {
                     emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, untrLclLo + i);
                 }
@@ -6541,7 +6541,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                 zeroReg = genGetZeroReg(initReg, pInitRegZeroed);
 
                 int i = 0;
-                for (; i < alignmentHiBlkSize; i += REGSIZE_BYTES)
+                for (; i + REGSIZE_BYTES <= alignmentHiBlkSize; i += REGSIZE_BYTES)
                 {
                     emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, alignedLclHi + i);
                 }

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6112,18 +6112,17 @@ regNumber CodeGen::genGetZeroReg(regNumber initReg, bool* pInitRegZeroed)
 #endif // !TARGET_ARM64
 }
 
-/*-----------------------------------------------------------------------------
- *
- * Do we have any untracked pointer locals at all,
- * or do we need to initialize memory for locspace?
- *
- * untrLclHi      - (Untracked locals High-Offset)   The upper bound offset at which the zero init code will end
- * initializing memory (not inclusive).
- * untrLclLo      - (Untracked locals Low-Offset)    The lower bound at which the zero init code will start zero
- * initializing memory.
- * initReg        - A scratch register (that gets set to zero on some platforms).
- * pInitRegZeroed - Sets a flag that tells the callee whether or not the initReg register got zeroed.
- */
+//-----------------------------------------------------------------------------
+// genZeroInitFrame: Zero any untracked pointer locals and/or initialize memory for locspace
+//
+// Arguments:
+//    untrLclHi      - (Untracked locals High-Offset)  The upper bound offset at which the zero init
+//                                                     code will end initializing memory (not inclusive).
+//    untrLclLo      - (Untracked locals Low-Offset)   The lower bound at which the zero init code will
+//                                                     start zero initializing memory.
+//    initReg        - A scratch register (that gets set to zero on some platforms).
+//    pInitRegZeroed - Sets a flag that tells the callee whether or not the initReg register got zeroed.
+//
 void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, bool* pInitRegZeroed)
 {
     assert(compiler->compGeneratingProlog);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -4797,39 +4797,6 @@ void CodeGen::genCheckUseBlockInit()
             maskCalleeRegArgMask &= ~RBM_SECRET_STUB_PARAM;
         }
 
-#ifdef TARGET_XARCH
-        // If we're going to use "REP STOS", remember that we will trash EDI
-        // For fastcall we will have to save ECX, EAX
-        // so reserve two extra callee saved
-        // This is better than pushing eax, ecx, because we in the later
-        // we will mess up already computed offsets on the stack (for ESP frames)
-        regSet.rsSetRegsModified(RBM_EDI);
-
-#ifdef UNIX_AMD64_ABI
-        // For register arguments we may have to save ECX (and RDI on Amd64 System V OSes.)
-        // In such case use R12 and R13 registers.
-        if (maskCalleeRegArgMask & RBM_RCX)
-        {
-            regSet.rsSetRegsModified(RBM_R12);
-        }
-
-        if (maskCalleeRegArgMask & RBM_RDI)
-        {
-            regSet.rsSetRegsModified(RBM_R13);
-        }
-#else  // !UNIX_AMD64_ABI
-        if (maskCalleeRegArgMask & RBM_ECX)
-        {
-            regSet.rsSetRegsModified(RBM_ESI);
-        }
-#endif // !UNIX_AMD64_ABI
-
-        if (maskCalleeRegArgMask & RBM_EAX)
-        {
-            regSet.rsSetRegsModified(RBM_EBX);
-        }
-
-#endif // TARGET_XARCH
 #ifdef TARGET_ARM
         //
         // On the Arm if we are using a block init to initialize, then we

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -4774,7 +4774,7 @@ void CodeGen::genCheckUseBlockInit()
 
     // We can clear using aligned SIMD so the threshold is lower,
     // and clears in order which is better for auto-prefetching
-    genUseBlockInit = genInitStkLclCnt > (largeGcStructs + 4);
+    genUseBlockInit = (genInitStkLclCnt > (largeGcStructs + 4));
 
 #else // !defined(TARGET_AMD64)
 
@@ -6329,7 +6329,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
         // Aligning low we want to move up to next boundary
         int alignedLclLo = (untrLclLo + (XMM_REGSIZE_BYTES - 1)) & -XMM_REGSIZE_BYTES;
 
-        if (untrLclLo != alignedLclLo && blkSize < 2 * XMM_REGSIZE_BYTES)
+        if ((untrLclLo != alignedLclLo) && (blkSize < 2 * XMM_REGSIZE_BYTES))
         {
             // If unaligned and smaller then 2 x SIMD size we won't bother trying to align
             assert((alignedLclLo - untrLclLo) < XMM_REGSIZE_BYTES);
@@ -6350,7 +6350,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                 emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, untrLclLo + i);
             }
 #if defined(TARGET_AMD64)
-            assert(i == blkSize || (i + sizeof(int) == blkSize));
+            assert((i == blkSize) || (i + sizeof(int) == blkSize));
             if (i != blkSize)
             {
                 emit->emitIns_AR_R(ins_Store(TYP_INT), EA_4BYTE, zeroReg, frameReg, untrLclLo + i);
@@ -6375,7 +6375,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
             int       alignedLclHi;
             int       alignmentHiBlkSize;
 
-            if (blkSize < 2 * XMM_REGSIZE_BYTES || untrLclLo == alignedLclLo)
+            if ((blkSize < 2 * XMM_REGSIZE_BYTES) || (untrLclLo == alignedLclLo))
             {
                 // Either aligned or smaller then 2 x SIMD size so we won't try to align
                 // However, we still want to zero anything that is not in a 16 byte chunk at end
@@ -6411,7 +6411,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                 {
                     emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, untrLclLo + i);
                 }
-                assert(i == alignmentLoBlkSize || (i + sizeof(int) == alignmentLoBlkSize));
+                assert((i == alignmentLoBlkSize) || (i + sizeof(int) == alignmentLoBlkSize));
                 if (i != alignmentLoBlkSize)
                 {
                     emit->emitIns_AR_R(ins_Store(TYP_INT), EA_4BYTE, zeroReg, frameReg, untrLclLo + i);
@@ -6432,7 +6432,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
 #endif
             // The loop is unrolled 3 times so we do not move to the loop block until it
             // will loop at least once so the threshold is 6.
-            if (blkSize < 6 * XMM_REGSIZE_BYTES)
+            if (blkSize < (6 * XMM_REGSIZE_BYTES))
             {
                 // Generate the following code:
                 //
@@ -6529,7 +6529,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                     emit->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, zeroReg, frameReg, alignedLclHi + i);
                 }
 #if defined(TARGET_AMD64)
-                assert(i == alignmentHiBlkSize || (i + sizeof(int) == alignmentHiBlkSize));
+                assert((i == alignmentHiBlkSize) || (i + sizeof(int) == alignmentHiBlkSize));
                 if (i != alignmentHiBlkSize)
                 {
                     emit->emitIns_AR_R(ins_Store(TYP_INT), EA_4BYTE, zeroReg, frameReg, alignedLclHi + i);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6365,8 +6365,9 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
         if (untrLclLo != alignedLclLo)
         {
             // If unaligned and smaller then 1.5 x SIMD size we won't bother trying to align
-            assert((alignedLclLo - untrLclLo) <= REGSIZE_BYTES);
-            minSimdSize = XMM_REGSIZE_BYTES + REGSIZE_BYTES;
+            assert((alignedLclLo - untrLclLo) < XMM_REGSIZE_BYTES);
+            minSimdSize = ((alignedLclLo - untrLclLo) > REGSIZE_BYTES) ? 2 * XMM_REGSIZE_BYTES
+                                                                       : XMM_REGSIZE_BYTES + REGSIZE_BYTES;
         }
 #else // !defined(TARGET_AMD64)
         // We aren't going to try and align on 32bit or if there are no guarantees on SIMD alignment

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6464,7 +6464,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
                 int i = 0;
                 for (; i < blkSize; i += XMM_REGSIZE_BYTES)
                 {
-                    emit->emitIns_AR_R(simdMov, EA_ATTR(regSize), zeroSIMDReg, frameReg, alignedLclLo + i);
+                    emit->emitIns_AR_R(simdMov, EA_ATTR(XMM_REGSIZE_BYTES), zeroSIMDReg, frameReg, alignedLclLo + i);
                 }
 
                 assert(i == blkSize);

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3004,11 +3004,11 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         {
             if (dstLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_S_R(INS_movdqu, EA_ATTR(regSize), srcXmmReg, dstLclNum, dstOffset);
+                emit->emitIns_S_R(INS_movups, EA_ATTR(regSize), srcXmmReg, dstLclNum, dstOffset);
             }
             else
             {
-                emit->emitIns_ARX_R(INS_movdqu, EA_ATTR(regSize), srcXmmReg, dstAddrBaseReg, dstAddrIndexReg,
+                emit->emitIns_ARX_R(INS_movups, EA_ATTR(regSize), srcXmmReg, dstAddrBaseReg, dstAddrIndexReg,
                                     dstAddrIndexScale, dstOffset);
             }
         }
@@ -3203,21 +3203,21 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         {
             if (srcLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_R_S(INS_movdqu, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
+                emit->emitIns_R_S(INS_movups, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
             }
             else
             {
-                emit->emitIns_R_ARX(INS_movdqu, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
+                emit->emitIns_R_ARX(INS_movups, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
                                     srcAddrIndexScale, srcOffset);
             }
 
             if (dstLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_S_R(INS_movdqu, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
+                emit->emitIns_S_R(INS_movups, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
             }
             else
             {
-                emit->emitIns_ARX_R(INS_movdqu, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
+                emit->emitIns_ARX_R(INS_movups, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
                                     dstAddrIndexScale, dstOffset);
             }
         }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -3000,15 +3000,16 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 #endif
         }
 
+        instruction simdMov = simdUnalignedMovIns();
         for (unsigned regSize = XMM_REGSIZE_BYTES; size >= regSize; size -= regSize, dstOffset += regSize)
         {
             if (dstLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_S_R(INS_movups, EA_ATTR(regSize), srcXmmReg, dstLclNum, dstOffset);
+                emit->emitIns_S_R(simdMov, EA_ATTR(regSize), srcXmmReg, dstLclNum, dstOffset);
             }
             else
             {
-                emit->emitIns_ARX_R(INS_movups, EA_ATTR(regSize), srcXmmReg, dstAddrBaseReg, dstAddrIndexReg,
+                emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), srcXmmReg, dstAddrBaseReg, dstAddrIndexReg,
                                     dstAddrIndexScale, dstOffset);
             }
         }
@@ -3198,26 +3199,27 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     {
         regNumber tempReg = node->GetSingleTempReg(RBM_ALLFLOAT);
 
+        instruction simdMov = simdUnalignedMovIns();
         for (unsigned regSize = XMM_REGSIZE_BYTES; size >= regSize;
              size -= regSize, srcOffset += regSize, dstOffset += regSize)
         {
             if (srcLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_R_S(INS_movups, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
+                emit->emitIns_R_S(simdMov, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
             }
             else
             {
-                emit->emitIns_R_ARX(INS_movups, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
+                emit->emitIns_R_ARX(simdMov, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
                                     srcAddrIndexScale, srcOffset);
             }
 
             if (dstLclNum != BAD_VAR_NUM)
             {
-                emit->emitIns_S_R(INS_movups, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
+                emit->emitIns_S_R(simdMov, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
             }
             else
             {
-                emit->emitIns_ARX_R(INS_movups, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
+                emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
                                     dstAddrIndexScale, dstOffset);
             }
         }

--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -4159,7 +4159,13 @@ bool Compiler::fgVarNeedsExplicitZeroInit(LclVarDsc* varDsc, bool bbInALoop, boo
 // all struct fields. If the logic for block initialization in CodeGen::genCheckUseBlockInit()
 // changes, these conditions need to be updated.
 #ifdef TARGET_64BIT
+#if defined(TARGET_AMD64)
+        // We can clear using aligned SIMD so the threshold is lower,
+        // and clears in order which is better for auto-prefetching
+        if (roundUp(varDsc->lvSize(), TARGET_POINTER_SIZE) / sizeof(int) > 4)
+#else // !defined(TARGET_AMD64)
         if (roundUp(varDsc->lvSize(), TARGET_POINTER_SIZE) / sizeof(int) > 8)
+#endif
 #else
         if (roundUp(varDsc->lvSize(), TARGET_POINTER_SIZE) / sizeof(int) > 4)
 #endif

--- a/src/coreclr/src/jit/emit.cpp
+++ b/src/coreclr/src/jit/emit.cpp
@@ -4322,14 +4322,12 @@ void emitter::emitCheckFuncletBranch(instrDesc* jmp, insGroup* jmpIG)
     }
 #endif
 
-#ifdef TARGET_ARMARCH
     if (jmp->idAddr()->iiaHasInstrCount())
     {
         // Too hard to figure out funclets from just an instruction count
         // You're on your own!
         return;
     }
-#endif // TARGET_ARMARCH
 
 #ifdef TARGET_ARM64
     // No interest if it's not jmp.

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -808,8 +808,6 @@ protected:
             bool iiaIsJitDataOffset() const;
             int  iiaGetJitDataOffset() const;
 
-#ifdef TARGET_ARMARCH
-
             // iiaEncodedInstrCount and its accessor functions are used to specify an instruction
             // count for jumps, instead of using a label and multiple blocks. This is used in the
             // prolog as well as for IF_LARGEJMP pseudo-branch instructions.
@@ -829,6 +827,8 @@ protected:
                 assert(abs(count) < 10);
                 iiaEncodedInstrCount = (count << iaut_SHIFT) | iaut_INST_COUNT;
             }
+
+#ifdef TARGET_ARMARCH
 
             struct
             {

--- a/src/coreclr/src/jit/emitxarch.h
+++ b/src/coreclr/src/jit/emitxarch.h
@@ -62,7 +62,7 @@ BYTE* emitOutputIV(BYTE* dst, instrDesc* id);
 
 BYTE* emitOutputRRR(BYTE* dst, instrDesc* id);
 
-BYTE* emitOutputLJ(BYTE* dst, instrDesc* id);
+BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 
 unsigned emitOutputRexOrVexPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);


### PR DESCRIPTION
Use `xmm` registers to clear prolog blocks rather than `rep stosd`.

`rep stos` does have a shallower growth rate so it will eventually overtake; however unlikely in the size range for the stack clearance:

![image](https://user-images.githubusercontent.com/1142958/75546014-9b0c9300-5a1f-11ea-8a41-b8314659d3ef.png)


Also its variability based on small changes in stack changes is problematic as just adding an extra variable to a method (with no other changes) could add or remove 9ns from its running time. Whereas the xmm clear in this PR is much smoother and more expected changes.

Focusing in on the more common <= 256 range

![image](https://user-images.githubusercontent.com/1142958/75546245-0bb3af80-5a20-11ea-8356-b2c578c22ecc.png)

And throughput


![image](https://user-images.githubusercontent.com/1142958/75598661-53285300-5a95-11ea-8491-ace0942f13d5.png)


As the prolog doesn't support `jmp` labels; I have taught the x86/x64 Jit to understand relative `jmp`s by instruction count (as per Arm) for the prolog.

e.g. output prolog  for a 1024 byte stack leap method:
```asm
G_M1845_IG01:
       push     rdi
       push     rsi
       sub      rsp, 0x408
       mov      rax, -0x3F0
       vxorps   xmm4, xmm4
       vmovups  xmmword ptr [rsp], xmm4
       vmovups  xmmword ptr [rsp+rax+400H], xmm4
       vmovups  xmmword ptr [rsp+rax+410H], xmm4
       vmovups  xmmword ptr [rsp+rax+420H], xmm4
       add      rax, 48
       jne      SHORT  -5 instr
```

Switch to `movups` rather than `movdqu` as is shorter encoding with same functionality to reduce code size regressions.

```
Top file regressions (bytes):
        2195 : System.Private.CoreLib.dasm (0.07% of base)
```

Contributes to #8890
Resolves https://github.com/dotnet/runtime/issues/32396