### PR TITLE
Preserve dep win rt

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.Uap.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.Uap.cs
@@ -51,7 +51,7 @@ namespace System.Threading
         // This is necessary because linker can't add new assemblies to the closure when recognizing Type.GetType
         // so even though the GetType call below is analyzable, the PreserveDependency is still necessary to actually include
         // the assembly in the trimmed closure.
-        [PreserveDependency(".ctor()", "System.Threading.WinRTSynchronizationContextFactory", "System.Runtime.WindowsRuntime")]
+        [PreserveDependency("Create", "System.Threading.WinRTSynchronizationContextFactory", "System.Runtime.WindowsRuntime")]
         private static SynchronizationContext GetWinRTSynchronizationContext(object dispatcher)
         {
             //

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.Uap.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.Uap.cs
@@ -48,6 +48,10 @@ namespace System.Threading
 
         private static Func<object, SynchronizationContext>? s_createSynchronizationContextDelegate;
 
+        // This is necessary because linker can't add new assemblies to the closure when recognizing Type.GetType
+        // so even though the GetType call below is analyzable, the PreserveDependency is still necessary to actually include
+        // the assembly in the trimmed closure.
+        [PreserveDependency(".ctor()", "System.Threading.WinRTSynchronizationContextFactory", "System.Runtime.WindowsRuntime")]
         private static SynchronizationContext GetWinRTSynchronizationContext(object dispatcher)
         {
             //

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.Uap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.Uap.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Globalization;
 using System.Reflection;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Internal.Resources;
 
 namespace System.Resources
@@ -57,6 +58,10 @@ namespace System.Resources
         // Since we can't directly reference System.Runtime.WindowsRuntime from System.Private.CoreLib, we have to get the type via reflection.
         // It would be better if we could just implement WindowsRuntimeResourceManager in System.Private.CoreLib, but we can't, because
         // we can do very little with WinRT in System.Private.CoreLib.
+        // The attribute is necessary because linker can't add new assemblies to the closure when recognizing Type.GetType
+        // so even though the GetType call below is analyzable, the PreserveDependency is still necessary to actually include
+        // the assembly in the trimmed closure.
+        [PreserveDependency(".ctor()", "System.Resources.WindowsRuntimeResourceManager", "System.Runtime.WindowsRuntime")]
         internal static WindowsRuntimeResourceManagerBase GetWinRTResourceManager()
         {
             Type WinRTResourceManagerType = Type.GetType("System.Resources.WindowsRuntimeResourceManager, System.Runtime.WindowsRuntime", throwOnError: true)!;


### PR DESCRIPTION
Both cases have type references to a different assembly and linker currently can't add a new assembly to the closure when analyzing `Type.GetType` - so `PreserveDepenency` attribute is necessary in this case.

This is necessary for correctness, but the downside is that the System.Runtime.WindowsRuntime.dll will pretty much always be included even for apps which are not WinRT apps. To fix this, the linker would need to be able to determine the value of `ApplicationModel.IsUap` and remove inaccessible branches in the code - since all of this code is hidden behind checks for the `IsUap`.