### PR TITLE
[loader] Add check to mono_domain_ensure_entry_assembly for AOT

### DIFF
--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -1026,7 +1026,7 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 void
 mono_domain_ensure_entry_assembly (MonoDomain *domain, MonoAssembly *assembly)
 {
-	if (!domain->entry_assembly && assembly) {
+	if (!mono_runtime_get_no_exec () && !domain->entry_assembly && assembly) {
 		gchar *str;
 		ERROR_DECL (error);
 


### PR DESCRIPTION
Fixes a crash with AOT because domain->setup is NULL here