### PR TITLE
Restore test 10127, it should work now.

### DIFF
--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -1110,11 +1110,6 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 # see https://github.com/mono/mono/issues/9739
 PLATFORM_DISABLED_TESTS += verbose.exe
 
-if ENABLE_CXX
-# see https://github.com/mono/mono/issues/18827
-PLATFORM_DISABLED_TESTS += bug-10127.exe
-endif
-
 endif
 
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18942,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Restore test 10127, it should work now.

This is a redo of messy https://github.com/mono/mono/pull/18894.

Note that other stuff was done to attempt to workaround this, that should be considered to be undone. Specifically e8527db725696e06a3b221474b39973a735dccf0 or part of it (leave configure.ac).

To properly debug this however:

 - Rollback a few changes, to before e8527db725696e06a3b221474b39973a735dccf0
   Or just reset --hard e8527db725696e06a3b221474b39973a735dccf0~1.

 - Confirm a reasonable repro rate.

 - Confirm the problem is a deadlock around locks
   being held by suspended threads that running threads are waiting for.

 - If the problem isn't obvious, consder adding in-memory logging,
   like maybe around THREADS_STW_DEBUG,
   THREADS_SUSPEND_DEBUG, THREADS_STATE_MACHINE_DEBUG

 - Also, tweak the size of the struct back and forth, without changing anything else (leave the reads/writes absent to minimize diff, though they are in driver, not runtime).

Some of what changes in the meantime is:
 - Some `#if __cplusplus` removed -- since the failure *appears* to be C++ specific, and the changes were fairly reasonable, making the code clearer or neater.
 - Non-recursive locks changed to SRWLOCK for efficiency.

However the struct size, if it is a factor somehow, would be smaller than the rest and easier to do A/B testing of.

Note that appverifier changes locking behavior and caused or exacerbated deadlock.
And taking a reverse debugging record caused a seemingly different hang.
So those debugging tools do not likely apply.