### PR TITLE
Fix the guid for the transaction

### DIFF
--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -194,7 +194,7 @@ namespace System.Data.OleDb
             );
     }
 
-    [Guid("0c733a93-2a1c-11ce-ade5-00aa0044773d")]
+    [Guid("0c733a5f-2a1c-11ce-ade5-00aa0044773d")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComImport]
     internal unsafe interface ITransactionLocal : ITransaction

--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using static System.Data.Common.UnsafeNativeMethods;
 
 namespace System.Data.OleDb
 {
@@ -164,75 +165,6 @@ namespace System.Data.OleDb
             }
             return base.ReleaseHandle();
         }
-    }
-
-    [Guid("0fb15084-af41-11ce-bd2b-204c4f4f5020")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [ComImport]
-    internal interface ITransaction
-    {
-        [PreserveSig]
-        int Commit
-            (
-            [In] bool fRetaining,
-            [In] uint grfTC,
-            [In] uint grfRM
-            );
-
-        [PreserveSig]
-        int Abort
-            (
-            [In] IntPtr pboidReason,
-            [In]         bool fRetaining,
-            [In]         bool fAsync
-            );
-
-        [PreserveSig]
-        int GetTransactionInfo
-            (
-            [Out] IntPtr pinfo
-            );
-    }
-
-    [Guid("0c733a5f-2a1c-11ce-ade5-00aa0044773d")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [ComImport]
-    internal unsafe interface ITransactionLocal : ITransaction
-    {
-        [PreserveSig]
-        new int Commit
-            (
-            [In] bool fRetaining,
-            [In] uint grfTC,
-            [In] uint grfRM
-            );
-
-        [PreserveSig]
-        new int Abort
-            (
-            [In] IntPtr pboidReason,
-            [In]         bool fRetaining,
-            [In]         bool fAsync
-            );
-
-        [PreserveSig]
-        new int GetTransactionInfo
-            (
-            [Out] IntPtr pinfo
-            );
-
-        [PreserveSig]
-        int GetOptionsObject(
-            [Out, Optional] IntPtr ppOptions
-        );
-
-        [PreserveSig]
-        int StartTransaction(
-            [In] int isoLevel,
-            [In] uint isoFlags,
-            [In, Optional] IntPtr pOtherOptions,
-            [Out, Optional] uint* pulTransactionLevel
-        );
     }
 
     internal enum XACTTC

--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -678,6 +678,7 @@ namespace System.Data.OleDb
                 {
                     chapteredRowset = (System.Data.Common.UnsafeNativeMethods.IChapteredRowset)Marshal.GetObjectForIUnknown(pChapteredRowset);
                     hr = (OleDbHResult)chapteredRowset.ReleaseChapter(hchapter, out var refcount);
+                    Marshal.ReleaseComObject(chapteredRowset);
                     Marshal.Release(pChapteredRowset);
                 }
             }
@@ -699,6 +700,7 @@ namespace System.Data.OleDb
                 {
                     transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);
                     hr = (OleDbHResult)transactionLocal.Abort(IntPtr.Zero, false, false);
+                    Marshal.ReleaseComObject(transactionLocal);
                     Marshal.Release(pTransaction);
                 }
             }
@@ -720,6 +722,7 @@ namespace System.Data.OleDb
                 {
                     transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);
                     hr = (OleDbHResult)transactionLocal.Commit(false, (uint)XACTTC.XACTTC_SYNC_PHASETWO, 0);
+                    Marshal.ReleaseComObject(transactionLocal);
                     Marshal.Release(pTransaction);
                 }
             }

--- a/src/libraries/System.Data.OleDb/src/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Data.OleDb/src/UnsafeNativeMethods.cs
@@ -741,9 +741,21 @@ namespace System.Data.Common
         [Guid("0C733A5F-2A1C-11CE-ADE5-00AA0044773D"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport, SuppressUnmanagedCodeSecurity]
         internal interface ITransactionLocal
         {
-            [Obsolete("not used", true)] void Commit(/*deleted parameter signature*/);
+            [PreserveSig]
+            int Commit
+                (
+                [In] bool fRetaining,
+                [In] uint grfTC,
+                [In] uint grfRM
+                );
 
-            [Obsolete("not used", true)] void Abort(/*deleted parameter signature*/);
+            [PreserveSig]
+            int Abort
+                (
+                [In] IntPtr pboidReason,
+                [In] bool fRetaining,
+                [In] bool fAsync
+                );
 
             [Obsolete("not used", true)] void GetTransactionInfo(/*deleted parameter signature*/);
 

--- a/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
+++ b/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -356,6 +357,18 @@ namespace System.Data.OleDb.Tests
             Assert.Empty(connectionStringBuilder.FileName);
             Assert.True(connectionStringBuilder.Remove("Provider"));
             Assert.Empty(connectionStringBuilder.Provider);
+        }
+
+        [ConditionalFact(Helpers.IsDriverAvailable)]
+        public void TransactionRollBackTest()
+        {
+            using (OleDbConnection connection = new OleDbConnection(ConnectionString))
+            {
+                connection.Open();
+                OleDbTransaction transaction = connection.BeginTransaction();
+                // This call shouldn't throw
+                transaction.Rollback();
+            }
         }
     }
 }

--- a/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
+++ b/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Diagnostics;
 using System.IO;
 using Xunit;
 


### PR DESCRIPTION
The guid for `ITransactionLocal` was incorrectly coded. The change fixes the Guid and also adds a test to verify this. 

The test was throwing an exception before the fix. 

The guid was verified from oledb.h header and also was reported in https://github.com/dotnet/runtime/issues/32405


Fixes https://github.com/dotnet/runtime/issues/31177
Fixes https://github.com/dotnet/runtime/issues/32405

