### PR TITLE
Fix createdump failures on alpine in diagnostics repo tests

### DIFF
--- a/src/coreclr/src/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/src/debug/createdump/crashinfo.cpp
@@ -415,14 +415,7 @@ CrashInfo::GetDSOInfo()
     int phnum = m_auxvValues[AT_PHNUM];
     assert(m_auxvValues[AT_PHENT] == sizeof(Phdr));
     assert(phnum != PN_XNUM);
-
-    if (!PopulateELFInfo(phdrAddr, phnum)) {
-        return false;
-    }
-    if (!EnumerateLinkMapEntries()) {
-        return false;
-    }
-    return true;
+    return EnumerateElfInfo(phdrAddr, phnum); 
 }
 
 //
@@ -443,13 +436,13 @@ CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
             // Now populate the elfreader with the runtime module info and
             // lookup the DAC table symbol to ensure that all the memory
             // necessary is in the core dump.
-            if (PopulateELFInfo(baseAddress)) {
+            if (PopulateForSymbolLookup(baseAddress)) {
                 uint64_t symbolOffset;
                 TryLookupSymbol("g_dacTable", &symbolOffset);
             }
         }
     }
-    EnumerateProgramHeaders(baseAddress, nullptr);
+    EnumerateProgramHeaders(baseAddress);
 }
 
 //

--- a/src/coreclr/src/debug/dbgutil/CMakeLists.txt
+++ b/src/coreclr/src/debug/dbgutil/CMakeLists.txt
@@ -9,6 +9,10 @@ include_directories(${CLR_DIR}/src/inc/llvm)
 
 add_definitions(-DPAL_STDCPP_COMPAT)
 
+if(CLR_CMAKE_TARGET_ALPINE_LINUX)
+    add_definitions(-DTARGET_ALPINE_LINUX)
+endif(CLR_CMAKE_TARGET_ALPINE_LINUX)
+
 set(DBGUTIL_SOURCES
     dbgutil.cpp
 )

--- a/src/coreclr/src/debug/dbgutil/elfreader.h
+++ b/src/coreclr/src/debug/dbgutil/elfreader.h
@@ -2,34 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include <windows.h>
-#include <clrdata.h>
-#include <cor.h>
-#include <cordebug.h>
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
 #include <elf.h>
 #ifdef HOST_UNIX
 #include <link.h>
 #endif // HOST_UNIX
 #include <string>
 #include <vector>
-
-#if TARGET_64BIT
-#define PRIx PRIx64
-#define PRIu PRIu64
-#define PRId PRId64
-#define PRIA "016"
-#define PRIxA PRIA PRIx
-#define TARGET_WORDSIZE 64
-#else
-#define PRIx PRIx32
-#define PRIu PRIu32
-#define PRId PRId32
-#define PRIA "08"
-#define PRIxA PRIA PRIx
-#define TARGET_WORDSIZE 32
-#endif
 
 #ifndef ElfW
 /* We use this macro to refer to ELF types independent of the native wordsize.
@@ -49,7 +27,6 @@ typedef struct {
 class ElfReader
 {
 private:
-    void* m_rdebugAddr;                     // DT_DEBUG
     void* m_gnuHashTableAddr;               // DT_GNU_HASH
     void* m_stringTableAddr;                // DT_STRTAB
     int m_stringTableSize;                  // DT_STRSIZ
@@ -62,14 +39,12 @@ private:
 public:
     ElfReader();
     virtual ~ElfReader();
-    bool PopulateELFInfo(uint64_t baseAddress);
-    bool PopulateELFInfo(ElfW(Phdr)* phdrAddr, int phnum);
-    bool TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset);
 #ifdef HOST_UNIX
-     bool EnumerateLinkMapEntries();
+    bool EnumerateElfInfo(ElfW(Phdr)* phdrAddr, int phnum);
 #endif
-    bool EnumerateProgramHeaders(uint64_t baseAddress, ElfW(Dyn)** pdynamicAddr);
-    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, ElfW(Dyn)** pdynamicAddr);
+    bool PopulateForSymbolLookup(uint64_t baseAddress);
+    bool TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset);
+    bool EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias = nullptr, ElfW(Dyn)** pdynamicAddr = nullptr);
 
 private:
     bool GetSymbol(int32_t index, ElfW(Sym)* symbol);
@@ -78,7 +53,10 @@ private:
     uint32_t Hash(const std::string& symbolName);
     bool GetChain(int index, int32_t* chain);
     bool GetStringAtIndex(int index, std::string& result);
-    bool EnumerateDynamicEntries(ElfW(Dyn)* dynamicAddr);
+#ifdef HOST_UNIX
+    bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
+#endif
+    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;


### PR DESCRIPTION
Add "loadbias" to dynamic entries RVAs on Alpine Linux.

Move the Windows includes files and other defines from elfreader.h to elfreader.cpp.

Make the two ways the ElfReader is used more clear by renaming and cleanup some
function names:
    1) PopulateForSymbolLookup (was PopulateElfInfo) for looking up symbols and caches
       symbol/string table state in the ElfReader class.
    2) EnumerateElfInfo (was PopulateElfInfo also) which is used by createdump to enumerate
       all the native modules and their program headers and doesn't depend on or caches any state.