### PR TITLE
[mono] Remove CoreFX.issues_mac.rsp file

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -80,12 +80,11 @@
     <!-- TODO: remove when rsp files are removed: https://github.com/dotnet/runtime/issues/1980. -->
     <ItemGroup>
       <_rspFile Include="$(TestRspFile)" Condition="'$(TestRspFile)' != ''" />
-      <_rspFile Include="$(MonoProjectRoot)netcore\CoreFX.issues_mac.rsp" Condition="'$(TargetOS)' == 'OSX'" />
       <_rspFile Include="$(MonoProjectRoot)netcore\CoreFX.issues_linux.rsp" Condition="'$(TargetOS)' == 'Linux'" />
       <_rspFile Include="$(MonoProjectRoot)netcore\CoreFX.issues_windows.rsp" Condition="'$(TargetOS)' == 'Windows_NT'" />
     </ItemGroup>
     <ItemGroup>
-      <_rspFileContent Include="$([System.IO.File]::ReadAllText(%(_rspFile.Identity)))" />
+      <_rspFileContent Include="$([System.IO.File]::ReadAllText(%(_rspFile.Identity)))" Condition="'$(TargetOS)' != 'OSX'" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(MonoRspFile)" Lines="@(_rspFileContent)" Overwrite="true" />

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -262,8 +262,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/17547", TestPlatforms.OSX, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void DroppedWatcher_Collectible()
         {
             WeakReference watcher = CreateEnabledWatcher(TestDirectory);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -263,6 +263,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/mono/mono/issues/17547", TestPlatforms.OSX, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void DroppedWatcher_Collectible()
         {
             WeakReference watcher = CreateEnabledWatcher(TestDirectory);

--- a/src/mono/netcore/CoreFX.issues_mac.rsp
+++ b/src/mono/netcore/CoreFX.issues_mac.rsp
@@ -1,2 +1,0 @@
-# https://github.com/mono/mono/issues/17547
--nomethod System.IO.Tests.FileSystemWatcherTests_netstandard17.DroppedWatcher_Collectible


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/1980

The details about the only disabled test see in https://github.com/mono/mono/issues/17547