### PR TITLE
Fix minor issue in debugging.md

### DIFF
--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -16,7 +16,7 @@ Debugging CoreCLR on Windows
 5. Select Configuration Properties->Debugging from the left side tree control
 6. Set Command=`$(SolutionDir)\..\..\..\bin\coreclr\Windows_NT.$(Platform).$(Configuration)\corerun.exe`
     1. This points to the folder where the built runtime binaries are present.
-7. Set Command Arguments=`<managed app you wish to run>` (e.g. HelloWorld.exe)
+7. Set Command Arguments=`<managed app you wish to run>` (e.g. HelloWorld.dll)
 8. Set Working Directory=`$(SolutionDir)\..\..\..\bin\coreclr\Windows_NT.$(Platform).$(Configuration)`
     1. This points to the folder containing CoreCLR binaries.
 9. Press F11 to start debugging at wmain in corerun (or set a breakpoint in source and press F5 to run to it)


### PR DESCRIPTION
It might be misleading since nowadays `.exe` is jut a native launcher (e.g. for ConsoleApp) and the `INSTALL` target actually expects a path to a managed library.
