### PR TITLE
Avoid Split(new char[]) inside loops

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapDirectoryIdentifier.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapDirectoryIdentifier.cs
@@ -35,7 +35,7 @@ namespace System.DirectoryServices.Protocols
                     if (servers[i] != null)
                     {
                         string trimmedName = servers[i].Trim();
-                        string[] result = trimmedName.Split(new char[] { ' ' });
+                        string[] result = trimmedName.Split(' ');
                         if (result.Length > 1)
                         {
                             throw new ArgumentException(SR.WhiteSpaceServerName);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
@@ -1003,7 +1003,7 @@ namespace System.DirectoryServices
                         _propertyCollection.valueTable.Remove(name);
 
                         // also need to consider the range retrieval case
-                        string[] results = name.Split(new char[] { ';' });
+                        string[] results = name.Split(';');
                         if (results.Length != 1)
                         {
                             string rangeName = "";


### PR DESCRIPTION
Taking @stephentoub suggestion on #32584. Had to make new pr due to branch deletion.
