### PR TITLE
Add support in crossgen2 for 32-byte alignment

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -229,6 +229,8 @@ namespace Internal.JitInterface
                 _compilation.NodeFactory.Target.MinimumFunctionAlignment :
                 _compilation.NodeFactory.Target.OptimumFunctionAlignment;
 
+            alignment = Math.Max(alignment, _codeAlignment);
+
             var objectData = new ObjectNode.ObjectData(_code,
                                                        relocs,
                                                        alignment,
@@ -2516,6 +2518,7 @@ namespace Internal.JitInterface
 
         private byte[] _code;
         private byte[] _coldCode;
+        private int _codeAlignment;
 
         private byte[] _roData;
 
@@ -2535,11 +2538,25 @@ namespace Internal.JitInterface
             if (coldCodeSize != 0)
                 coldCodeBlock = (void*)GetPin(_coldCode = new byte[coldCodeSize]);
 
+            _codeAlignment = -1;
+            if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+            {
+                _codeAlignment = 32;
+            }
+            else if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
+            {
+                _codeAlignment = 16;
+            }
+
             if (roDataSize != 0)
             {
                 int alignment = 8;
 
-                if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN) != 0)
+                if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN) != 0)
+                {
+                    alignment = 32;
+                }
+                else if ((flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN) != 0)
                 {
                     alignment = 16;
                 }


### PR DESCRIPTION
What's in this pull request won't take effect in crossgen2 right now because crossgen2 doesn't set the Tier-1 flag. This pull request is more of a discussion point that will either see another commit, or will be closed.

32-byte alignment was added in #2249, affecting Tier-1 code only. One of the other pull requests that are open right now was discussing `compCodeOpt` and that made me realize this might be worth revisiting: I wanted to switch the check in JIT from `emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1)` to `compCodeOpt() == FAST_CODE` (so that this takes effect for crossgen2 as well), only to find out that compCodeOpt is currently hardcoded to return BLENDED.

Do we have an issue tracking what we want to do with `compCodeOpt`? There are customers who rely solely on R2R and giving them a knob that says "give me fastest code possible" might be useful for them. Crossgen2 has that knob, it just seems like it doesn't do anything.

Alternatively, we could turn on the Tier-1 flag in crossgen2 when the user requests optimizing for time.

Cc @dotnet/crossgen-contrib @AndyAyersMS 