### PR TITLE
AllowNatTraversal is properly set for stopped socket

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -354,7 +354,7 @@ namespace System.Net.Sockets
 
             if (_allowNatTraversal != null)
             {
-                SetIPProtectionLevel(_allowNatTraversal.Value);
+                SetIPProtectionLevel(_allowNatTraversal.GetValueOrDefault());
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -358,7 +358,7 @@ namespace System.Net.Sockets
             if (_allowNatTraversal != null)
             {
                 SetIPProtectionLevel(_allowNatTraversal.GetValueOrDefault());
-                _allowNatTraversal = null; //Reset value to avoid affecting more sockets
+                _allowNatTraversal = null; // Reset value to avoid affecting more sockets
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -121,9 +121,12 @@ namespace System.Net.Sockets
 
             if (_serverSocket != null)
             {
-                SetIPProtectionLevel(allowed);
+                SetIPProtectionLevel(allowed); // Set it only for the current socket to preserve existing behavior
             }
-            _allowNatTraversal = allowed;
+            else
+            {
+                _allowNatTraversal = allowed;
+            }
         }
 
         // Starts listening to network requests.
@@ -355,6 +358,7 @@ namespace System.Net.Sockets
             if (_allowNatTraversal != null)
             {
                 SetIPProtectionLevel(_allowNatTraversal.GetValueOrDefault());
+                _allowNatTraversal = null; //Reset value to avoid affecting more sockets
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -50,6 +50,7 @@ namespace System.Net.Sockets.Tests
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.AllowNatTraversal(true);
+            listener.Start();
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -52,7 +52,8 @@ namespace System.Net.Sockets.Tests
             listener.AllowNatTraversal(true);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void AllowNatTraversal_Started_ThrowsException()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -44,14 +44,14 @@ namespace System.Net.Sockets.Tests
             Assert.False(listener.Active);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void AllowNatTraversal_NotStarted_SetSuccessfully()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.AllowNatTraversal(true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void AllowNatTraversal_Started_ThrowsException()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
@@ -59,7 +59,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<InvalidOperationException>(() => listener.AllowNatTraversal(true));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void AllowNatTraversal_StartedAndStopped_SetSuccessfully()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -51,6 +51,7 @@ namespace System.Net.Sockets.Tests
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.AllowNatTraversal(true);
             listener.Start();
+            listener.Stop();
         }
 
         [Fact]
@@ -60,6 +61,7 @@ namespace System.Net.Sockets.Tests
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             Assert.Throws<InvalidOperationException>(() => listener.AllowNatTraversal(true));
+            listener.Stop();
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -44,7 +44,8 @@ namespace System.Net.Sockets.Tests
             Assert.False(listener.Active);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void AllowNatTraversal_NotStarted_SetSuccessfully()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -61,7 +61,8 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<InvalidOperationException>(() => listener.AllowNatTraversal(true));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void AllowNatTraversal_StartedAndStopped_SetSuccessfully()
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -45,6 +45,30 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public void AllowNatTraversal_NotStarted_SetSuccessfully()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.AllowNatTraversal(true);
+        }
+
+        [Fact]
+        public void AllowNatTraversal_Started_ThrowsException()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            Assert.Throws<InvalidOperationException>(() => listener.AllowNatTraversal(true));
+        }
+
+        [Fact]
+        public void AllowNatTraversal_StartedAndStopped_SetSuccessfully()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            listener.Stop();
+            listener.AllowNatTraversal(true);
+        }
+
+        [Fact]
         public void Start_InvalidArgs_Throws()
         {
             var listener = new DerivedTcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
If AllowNatTraversal is called on a stopped TcpListener when ```_serverSocket``` is null, ```allow``` value gets stored in a field. Subsequently, if a new socket is created on ```Start``` call, the saved value is read and the corresponding argument is passed to```SetIPProtectionLevel``` call.
Fixes #32551 