### PR TITLE
Remove unused LogSendPacketsBuffers method

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -348,28 +348,6 @@ namespace System.Net.Sockets
             }
         }
 
-        internal void LogSendPacketsBuffers(int size)
-        {
-            foreach (SendPacketsElement spe in _sendPacketsElements)
-            {
-                if (spe != null)
-                {
-                    if (spe.Buffer != null && spe.Count > 0)
-                    {
-                        NetEventSource.DumpBuffer(this, spe.Buffer, spe.Offset, Math.Min(spe.Count, size));
-                    }
-                    else if (spe.FilePath != null)
-                    {
-                        NetEventSource.NotLoggedFile(spe.FilePath, _currentSocket, _completedOperation);
-                    }
-                    else if (spe.FileStream != null)
-                    {
-                        NetEventSource.NotLoggedFile(spe.FileStream.Name, _currentSocket, _completedOperation);
-                    }
-                }
-            }
-        }
-
         private SocketError FinishOperationAccept(Internals.SocketAddress remoteSocketAddress)
         {
             System.Buffer.BlockCopy(_acceptBuffer, 0, remoteSocketAddress.Buffer, 0, _acceptAddressBufferCount);


### PR DESCRIPTION
This logging method used to be called, but it is no longer called.

https://github.com/dotnet/corefx/commit/7f22c8d8f7077c26fbe908c2fb8b1693d37f532f removed the call site to this method.

https://github.com/dotnet/corefx/commit/60179fb62ed6c1c74fb243921a7de4804868f883 removed the corresponding Windows method.