### PR TITLE
Remove CreditManager from Http2Stream

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -12,7 +12,6 @@
   <PropertyGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <DefineConstants>$(DefineConstants);SYSNETHTTP_NO_OPENSSL</DefineConstants>
   </PropertyGroup>
-  <!-- Common -->
   <ItemGroup>
     <Compile Include="System\Net\Http\ByteArrayContent.cs" />
     <Compile Include="System\Net\Http\ByteArrayHelpers.cs" />
@@ -44,11 +43,6 @@
     <Compile Include="System\Net\Http\NetEventSource.Http.cs" />
     <Compile Include="System\Net\Http\ReadOnlyMemoryContent.cs" />
     <Compile Include="System\Net\Http\RequestRetryType.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3Connection.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ConnectionException.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ProtocolException.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3RequestStream.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthority.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />
@@ -94,7 +88,6 @@
     <Compile Include="System\Net\Http\Headers\UriHeaderParser.cs" />
     <Compile Include="System\Net\Http\Headers\ViaHeaderValue.cs" />
     <Compile Include="System\Net\Http\Headers\WarningHeaderValue.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="$(CommonPath)System\IO\StreamHelpers.CopyValidation.cs">
       <Link>Common\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
@@ -140,15 +133,22 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\ContentLengthWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\CookieHelper.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\CreditManager.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\CreditWaiter.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\DecompressionHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\EmptyReadStream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\FailedProxyCache.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Connection.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ConnectionException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ProtocolErrorCode.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ProtocolException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Stream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2StreamException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3Connection.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ConnectionException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3ProtocolException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http3RequestStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthenticatedConnectionHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthority.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpBaseStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnection.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnectionBase.cs" />
@@ -162,12 +162,12 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpTrace.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\FailedProxyCache.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IMultiWebProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\MultiProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="$(CommonPath)System\Net\NTAuthentication.Common.cs">
       <Link>Common\System\Net\NTAuthentication.Common.cs</Link>
     </Compile>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditWaiter.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditWaiter.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace System.Net.Http
+{
+    /// <summary>Represents a waiter for credit.</summary>
+    internal class CreditWaiter : IValueTaskSource<int>
+    {
+        public int Amount;
+        public CreditWaiter Next;
+        protected ManualResetValueTaskSourceCore<int> _source;
+
+        public CreditWaiter() => _source.RunContinuationsAsynchronously = true;
+
+        public ValueTask<int> AsValueTask() => new ValueTask<int>(this, _source.Version);
+
+        public bool IsPending => _source.GetStatus(_source.Version) == ValueTaskSourceStatus.Pending;
+
+        public bool TrySetResult(int result)
+        {
+            if (IsPending)
+            {
+                _source.SetResult(result);
+                return true;
+            }
+
+            return false;
+        }
+
+        public virtual void CleanUp() { }
+
+        public void Dispose()
+        {
+            CleanUp();
+            if (IsPending)
+            {
+                _source.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(CreditManager), SR.net_http_disposed_while_in_use)));
+            }
+        }
+
+        int IValueTaskSource<int>.GetResult(short token) =>
+            _source.GetResult(token);
+        ValueTaskSourceStatus IValueTaskSource<int>.GetStatus(short token) =>
+            _source.GetStatus(token);
+        void IValueTaskSource<int>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+            _source.OnCompleted(continuation, state, token, flags);
+    }
+
+    /// <summary>Represents a cancelable waiter for credit.</summary>
+    internal sealed class CancelableCreditWaiter : CreditWaiter
+    {
+        private readonly object _syncObj;
+        private CancellationTokenRegistration _registration;
+
+        public CancelableCreditWaiter(object syncObj, CancellationToken cancellationToken)
+        {
+            _syncObj = syncObj;
+            RegisterCancellation(cancellationToken);
+        }
+
+        public void ResetForAwait(CancellationToken cancellationToken)
+        {
+            Debug.Assert(Monitor.IsEntered(_syncObj));
+            Debug.Assert(!IsPending);
+            Debug.Assert(Next is null);
+            Debug.Assert(_registration == default);
+
+            _source.Reset();
+            RegisterCancellation(cancellationToken);
+        }
+
+        public override void CleanUp()
+        {
+            Monitor.IsEntered(_syncObj);
+            _registration.Dispose();
+            _registration = default;
+        }
+
+        private void RegisterCancellation(CancellationToken cancellationToken)
+        {
+            _registration = cancellationToken.UnsafeRegister(s =>
+            {
+                CancelableCreditWaiter thisRef = (CancelableCreditWaiter)s!;
+                lock (thisRef._syncObj)
+                {
+                    if (thisRef.IsPending)
+                    {
+                        thisRef._registration = default; // benign race with setting in the ctor
+                        thisRef._source.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new OperationCanceledException(thisRef._registration.Token)));
+
+                        // We don't remove it from the list as we lack a prev pointer that would enable us to do so correctly,
+                        // and it's not worth adding a prev pointer for the rare case of cancellation.  We instead just
+                        // check when completing a waiter whether it's already been canceled.  As such, we also do not
+                        // dispose it here.
+                    }
+                }
+            }, this);
+        }
+    }
+}


### PR DESCRIPTION
The CreditManager implementation supports multiple awaiters, but Http2Stream's CreditManager never has more than one waiter at a time.  We can instead just encode similar logic into Http2Stream, and make its waiter a reusable singleton, such that if we have to allocate it, we can just keep reusing it for all subsequent waits.  This means we avoid the CreditManager allocation per Http2Stream as well as the Waiter allocation per wait (other than the first).

cc: @scalablecory 