### PR TITLE
Make X509Certificate.Export non-null-returning

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -158,10 +158,10 @@ namespace System.Security.Cryptography.X509Certificates
         protected virtual void Dispose(bool disposing) { }
         public override bool Equals(object? obj) { throw null; }
         public virtual bool Equals(System.Security.Cryptography.X509Certificates.X509Certificate? other) { throw null; }
-        public virtual byte[]? Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public virtual byte[]? Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, System.Security.SecureString? password) { throw null; }
-        public virtual byte[]? Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string? password) { throw null; }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, System.Security.SecureString? password) { throw null; }
+        public virtual byte[] Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string? password) { throw null; }
         protected static string FormatDate(System.DateTime date) { throw null; }
         public virtual byte[] GetCertHash() { throw null; }
         public virtual byte[] GetCertHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePalCore.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/ICertificatePalCore.cs
@@ -29,6 +29,6 @@ namespace Internal.Cryptography
         DateTime NotAfter { get; }
         DateTime NotBefore { get; }
         byte[] RawData { get; }
-        byte[]? Export(X509ContentType contentType, SafePasswordHandle password);
+        byte[] Export(X509ContentType contentType, SafePasswordHandle password);
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
@@ -141,7 +141,7 @@ namespace Internal.Cryptography.Pal
             public DateTime NotAfter => _realPal.NotAfter;
             public DateTime NotBefore => _realPal.NotBefore;
             public byte[] RawData => _realPal.RawData;
-            public byte[]? Export(X509ContentType contentType, SafePasswordHandle password) =>
+            public byte[] Export(X509ContentType contentType, SafePasswordHandle password) =>
                 _realPal.Export(contentType, password);
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -623,11 +623,13 @@ namespace Internal.Cryptography.Pal
             sb.AppendLine("[Private Key]");
         }
 
-        public byte[]? Export(X509ContentType contentType, SafePasswordHandle password)
+        public byte[] Export(X509ContentType contentType, SafePasswordHandle password)
         {
             using (IExportPal storePal = StorePal.FromCertificate(this))
             {
-                return storePal.Export(contentType, password);
+                byte[]? exported = storePal.Export(contentType, password);
+                Debug.Assert(exported != null);
+                return exported;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -769,11 +769,13 @@ namespace Internal.Cryptography.Pal
             throw new CryptographicException();
         }
 
-        public byte[]? Export(X509ContentType contentType, SafePasswordHandle password)
+        public byte[] Export(X509ContentType contentType, SafePasswordHandle password)
         {
             using (IExportPal storePal = StorePal.FromCertificate(this))
             {
-                return storePal.Export (contentType, password);
+                byte[]? exported = storePal.Export(contentType, password);
+                Debug.Assert(exported != null);
+                return exported;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -537,11 +537,13 @@ namespace Internal.Cryptography.Pal
             _certContext = certContext;
         }
 
-        public byte[]? Export(X509ContentType contentType, SafePasswordHandle password)
+        public byte[] Export(X509ContentType contentType, SafePasswordHandle password)
         {
             using (IExportPal storePal = StorePal.FromCertificate(this))
             {
-                return storePal.Export(contentType, password);
+                byte[]? exported = storePal.Export(contentType, password);
+                Debug.Assert(exported != null);
+                return exported;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -271,12 +271,12 @@ namespace System.Security.Cryptography.X509Certificates
             return true;
         }
 
-        public virtual byte[]? Export(X509ContentType contentType)
+        public virtual byte[] Export(X509ContentType contentType)
         {
             return Export(contentType, (string?)null);
         }
 
-        public virtual byte[]? Export(X509ContentType contentType, string? password)
+        public virtual byte[] Export(X509ContentType contentType, string? password)
         {
             VerifyContentType(contentType);
 
@@ -290,7 +290,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         [System.CLSCompliantAttribute(false)]
-        public virtual byte[]? Export(X509ContentType contentType, SecureString? password)
+        public virtual byte[] Export(X509ContentType contentType, SecureString? password)
         {
             VerifyContentType(contentType);
 


### PR DESCRIPTION
Single-cert export can't return null; only empty collection export can.

Since single certs always make non-empty collections, they don't export as null.