### PR TITLE
Use VS2019 Preview for libraries build which contains a newer CMake

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -25,11 +25,6 @@ jobs:
     variables:
     - ${{ each variable in parameters.variables }}:
       - ${{insert}}: ${{ variable }}
-    - name: noWarnAsErrorArg
-      value: ''
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - name: noWarnAsErrorArg
-        value: -warnAsError:0
 
     steps:
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
@@ -45,7 +40,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(noWarnAsErrorArg) ${{ parameters.buildArgs }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} ${{ parameters.buildArgs }}
       displayName: Build product
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -25,6 +25,11 @@ jobs:
     variables:
     - ${{ each variable in parameters.variables }}:
       - ${{insert}}: ${{ variable }}
+    - name: noWarnAsErrorArg
+      value: ''
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - name: noWarnAsErrorArg
+        value: -warnAsError:0
 
     steps:
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
@@ -40,7 +45,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} ${{ parameters.buildArgs }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(noWarnAsErrorArg) ${{ parameters.buildArgs }}
       displayName: Build product
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -89,13 +89,24 @@ jobs:
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+          ${{ if eq(parameters.jobParameters.useVsPreviewPool, true) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+
+          ${{ if ne(parameters.jobParameters.useVsPreviewPool, true) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019
 
         # Public Windows Build Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          ${{ if eq(parameters.jobParameters.useVsPreviewPool, true) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+
+          ${{ if ne(parameters.jobParameters.useVsPreviewPool, true) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Open
+
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -104,7 +104,7 @@ jobs:
             queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
 
           ${{ if ne(parameters.jobParameters.useVsPreviewPool, true) }}:
-            name: NetCoreInternal-Pool
+            name: NetCorePublic-Pool
             queue: BuildPool.Windows.10.Amd64.VS2019.Open
 
 

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -90,12 +90,12 @@ jobs:
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
           name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
 
         # Public Windows Build Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
           name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Open
+          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -52,7 +52,7 @@ jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
     buildConfig: release
     platforms:
     - Linux_x64
@@ -60,6 +60,20 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       testGroup: perf
+      useVsPreviewPool: false
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    jobParameters:
+      useVsPreviewPool: true
+      liveRuntimeBuildConfig: Release
+
     
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -65,7 +65,7 @@ jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: release
+    buildConfig: Release
     platforms:
     - Linux_x64
     - Windows_NT_x64

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -72,7 +72,7 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       useVsPreviewPool: true
-      liveRuntimeBuildConfig: Release
+      liveRuntimeBuildConfig: release
 
     
 - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -102,8 +102,6 @@ jobs:
         # Windows variables
         - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
           - _runtimeOSArg: /p:RuntimeOS=win10
-          # Remove when: https://github.com/dotnet/runtime/issues/31888 is fixed.
-          - _warnAsErrorArg: -warnAsError:0
 
         # Non-Windows variables
         - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -326,6 +326,7 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       liveRuntimeBuildConfig: release
+      useVsPreviewPool: true
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -339,6 +340,7 @@ jobs:
     - Windows_NT_x64
     jobParameters:
       liveRuntimeBuildConfig: release
+      useVsPreviewPool: true
 #
 # Libraries Build that only run when libraries is changed
 #
@@ -352,6 +354,7 @@ jobs:
       - Windows_NT_x86
     jobParameters:
       liveRuntimeBuildConfig: release
+      useVsPreviewPool: true
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -367,6 +370,7 @@ jobs:
       - Windows_NT_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: true
       isFullMatrix: ${{ variables.isFullMatrix }}
       framework: net472
       runTests: true
@@ -384,6 +388,7 @@ jobs:
     - Windows_NT_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: true
       isFullMatrix: ${{ variables.isFullMatrix }}
       framework: allConfigurations
       runTests: true

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -137,6 +137,7 @@ jobs:
     - Windows_NT_arm64
     jobParameters:
       testGroup: innerloop
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -154,6 +155,7 @@ jobs:
     - OSX_x64
     jobParameters:
       testGroup: innerloop
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -180,6 +182,7 @@ jobs:
     - Windows_NT_arm
     - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       testGroup: innerloop
 
 #
@@ -193,6 +196,7 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     jobParameters:
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -219,6 +223,7 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -246,6 +251,7 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -274,6 +280,7 @@ jobs:
     # - Windows_NT_arm64
     jobParameters:
       llvm: true
+      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -301,6 +308,7 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       llvm: true
       condition: >-
         or(
@@ -413,6 +421,7 @@ jobs:
       - Windows_NT_arm
       - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: Release
 
@@ -426,6 +435,7 @@ jobs:
       - Linux_musl_x64
       - Windows_NT_x64
     jobParameters:
+      useVsPreviewPool: false
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
@@ -442,6 +452,7 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     jobParameters:
+      useVsPreviewPool: false
       isOfficialBuild: false
       liveRuntimeBuildConfig: release
       testScope: innerloop
@@ -465,6 +476,7 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       liveLibrariesBuildConfig: Release
       condition: >-
         or(
@@ -485,6 +497,7 @@ jobs:
     - Windows_NT_arm
     - Windows_NT_arm64
     jobParameters:
+      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
       condition: >-
@@ -506,6 +519,7 @@ jobs:
     - Linux_arm64
     - Windows_NT_x64
     jobParameters:
+      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       condition: >-
@@ -529,6 +543,7 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
       condition: >-
@@ -548,6 +563,7 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       condition: >-
@@ -571,6 +587,7 @@ jobs:
     - Linux_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -595,6 +612,7 @@ jobs:
     - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -627,6 +645,7 @@ jobs:
       - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
+      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -652,6 +671,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
+      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
@@ -672,6 +692,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
+      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
@@ -694,6 +715,7 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
+      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/31888

This re-enable warnaserror on Windows as it was before.

The reason why I just updated it for Libraries is because coreclr was failing because of the newer Windows SDK when building the tests. It seems like the toolset changed so I’ll follow up with @MattGal and when I’m back update to use the same pool and toolset for the whole repo. Also because of that I can’t enable warnaserror in the live local CI build but we get enough coverage with the regular CI build with this change now.

cc: @dotnet/runtime-infrastructure @stephentoub 