### PR TITLE
Update tests to deserialize char so that they align better with the behavior being tested.

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -161,10 +161,11 @@ namespace System.Text.Json.Serialization.Tests
         public static void NullReadTestChar()
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("null"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>(""));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("1234"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>(""));   // Empty JSON is invalid
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("1234")); // Can't convert a JSON number to JSON string/char
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"stringTooLong\""));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"\u0059\"B"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"\u0059B\""));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"\uD800\uDC00\""));
             Assert.Equal('a', JsonSerializer.Deserialize<char>("\"a\""));
             Assert.Equal('Y', JsonSerializer.Deserialize<char>("\"\u0059\""));


### PR DESCRIPTION
Found a couple of corrections that we should make to the tests that deserialize JSON into char.
We were testing empty JSON payload rather than a non-empty payload containing an empty JSON string. Similarly, the quotes on one of the case was misplaced (resulting in invalid JSON), which wasn't the intent of this test.

These tests were added in https://github.com/dotnet/runtime/pull/528