### PR TITLE
Added some parenthesis and a cast to control order of operations.

### DIFF
--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2639,7 +2639,7 @@ mono_gc_get_allocated_bytes_for_current_thread (void)
 	info = mono_thread_info_current ();
 
 	/*There are some more allocated bytes in the current tlab that have not been recorded yet */
-	return info->total_bytes_allocated + info->tlab_next - info->tlab_start;
+	return info->total_bytes_allocated + (ptrdiff_t)(info->tlab_next - info->tlab_start);
 }
 
 guint64


### PR DESCRIPTION
This fixes https://github.com/mono/mono/issues/17140; intermittent negative values from GetTotalBytesAllocated for current thread. uint64_t and a pointer difference are not the same type/width on all architectures, so incorrect results can happen with out the parenthesis. 