### PR TITLE
Additional SuperIlc fixes for running composite R2R images

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -23,6 +23,8 @@ namespace ReadyToRun.SuperIlc
             "clrjit",
             "mscorrc",
             "mscorrc.debug",
+            "mscordaccore",
+            "mscordbi",
         };
 
         private List<string> _compilationInputFiles;

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -12,6 +12,19 @@ namespace ReadyToRun.SuperIlc
 {
     public class BuildFolder
     {
+        private static string[] s_runtimeExecutables =
+        {
+            "corerun"
+        };
+
+        private static string[] s_runtimeLibraries =
+        {
+            "coreclr",
+            "clrjit",
+            "mscorrc",
+            "mscorrc.debug",
+        };
+
         private List<string> _compilationInputFiles;
 
         private List<string> _mainExecutables;
@@ -132,6 +145,21 @@ namespace ReadyToRun.SuperIlc
             if (compilationInputFiles.Count == 0)
             {
                 return null;
+            }
+
+            if (options.Composite)
+            {
+                // In composite mode we copy the native runtime to the app folder and pretend that is CORE_ROOT,
+                // otherwise CoreRun picks up the original MSIL versions of framework assemblies from CORE_ROOT
+                // instead of the rewritten ones next to the app.
+                foreach (string exe in s_runtimeExecutables)
+                {
+                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, exe.OSExeSuffix()));
+                }
+                foreach (string lib in s_runtimeLibraries)
+                {
+                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, lib.OSDllSuffix()));
+                }
             }
 
             foreach (CompilerRunner runner in compilerRunners)

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -154,11 +154,11 @@ namespace ReadyToRun.SuperIlc
                 // instead of the rewritten ones next to the app.
                 foreach (string exe in s_runtimeExecutables)
                 {
-                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, exe.OSExeSuffix()));
+                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, exe.AppendOSExeSuffix()));
                 }
                 foreach (string lib in s_runtimeLibraries)
                 {
-                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, lib.OSDllSuffix()));
+                    passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, lib.AppendOSDllSuffix()));
                 }
             }
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -111,7 +111,7 @@ namespace ReadyToRun.SuperIlc
         public string CoreRunPath(CompilerIndex index, bool isFramework)
         {
             string coreRunDir = CoreRootOutputPath(index, isFramework);
-            string coreRunExe = "corerun".OSExeSuffix();
+            string coreRunExe = "corerun".AppendOSExeSuffix();
             string coreRunPath = Path.Combine(coreRunDir, coreRunExe);
             if (!File.Exists(coreRunPath))
             {

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -187,10 +187,21 @@ namespace ReadyToRun.SuperIlc
                 processParameters.Arguments = "-c " + scriptToRun;
             }
 
+            string coreRootDir;
+            if (_options.Composite)
+            {
+                coreRootDir = GetOutputPath(outputRoot);
+            }
+            else
+            {
+                coreRootDir = _options.CoreRootOutputPath(Index, isFramework: false);
+            }
+
             processParameters.InputFileNames = new string[] { scriptToRun };
             processParameters.OutputFileName = scriptToRun;
             processParameters.LogPath = scriptToRun + ".log";
-            processParameters.EnvironmentOverrides["CORE_ROOT"] = _options.CoreRootOutputPath(Index, isFramework: false);
+            processParameters.EnvironmentOverrides["CORE_ROOT"] = coreRootDir;
+
             return processParameters;
         }
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -19,7 +19,7 @@ namespace ReadyToRun.SuperIlc
 
         protected override string CompilerRelativePath => "crossgen2";
 
-        protected override string CompilerFileName => "crossgen2".OSExeSuffix();
+        protected override string CompilerFileName => "crossgen2".AppendOSExeSuffix();
 
         private List<string> _resolvedReferences;
 

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -19,7 +19,7 @@ namespace ReadyToRun.SuperIlc
 
         protected override string CompilerRelativePath => ".";
 
-        protected override string CompilerFileName => "crossgen".OSExeSuffix();
+        protected override string CompilerFileName => "crossgen".AppendOSExeSuffix();
 
         protected override string CompilerPath
         {

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -32,6 +32,9 @@ static class PathExtensions
 
     internal static string OSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
 
+    internal static string OSDllSuffix(this string path) => path +
+        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so");
+
     internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);
 
     internal static string ToAbsoluteDirectoryPath(this string argValue) => argValue.ToAbsolutePath().StripTrailingDirectorySeparators();

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -30,9 +30,9 @@ static class PathExtensions
     /// </summary>
     const int DirectoryDeletionBackoffMilliseconds = 500;
 
-    internal static string OSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
+    internal static string AppendOSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
 
-    internal static string OSDllSuffix(this string path) => path +
+    internal static string AppendOSDllSuffix(this string path) => path +
         (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so");
 
     internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);


### PR DESCRIPTION
As an expedite way to run "non-shared" composite R2R images
(including the frameworK) I have added support to SuperIlc to
copy corerun, coreclr, clrjit and mscorrc next to the compiled
composite executable and supplying that as the CORE_ROOT
folder; otherwise corerun in the normal Tests/Core_Root
automatically grabs the framework next to it, not the composite
rewritten versions.

Thanks

Tomas