### PR TITLE
wip [checked-build] Assert if we safepoint while an OS mutex is locked

### DIFF
--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1223,6 +1223,12 @@ mono_assembly_get_alc (MonoAssembly *assm)
 	return mono_image_get_alc (assm->image);
 }
 
+static inline MonoType*
+mono_signature_get_return_type_internal (MonoMethodSignature *sig)
+{
+	return sig->ret;
+}
+
 /**
  * mono_type_get_type_internal:
  * \param type the \c MonoType operated on

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2517,11 +2517,11 @@ signature_in_image (MonoMethodSignature *sig, MonoImage *image)
 	gpointer iter = NULL;
 	MonoType *p;
 
-	while ((p = mono_signature_get_params (sig, &iter)) != NULL)
+	while ((p = mono_signature_get_params_internal (sig, &iter)) != NULL)
 		if (type_in_image (p, image))
 			return TRUE;
 
-	return type_in_image (mono_signature_get_return_type (sig), image);
+	return type_in_image (mono_signature_get_return_type_internal (sig), image);
 }
 
 static gboolean
@@ -2979,8 +2979,8 @@ collect_signature_images (MonoMethodSignature *sig, CollectData *data)
 	gpointer iter = NULL;
 	MonoType *p;
 
-	collect_type_images (mono_signature_get_return_type (sig), data);
-	while ((p = mono_signature_get_params (sig, &iter)) != NULL)
+	collect_type_images (mono_signature_get_return_type_internal (sig), data);
+	while ((p = mono_signature_get_params_internal (sig, &iter)) != NULL)
 		collect_type_images (p, data);
 }
 
@@ -5657,8 +5657,8 @@ mono_metadata_fnptr_equal (MonoMethodSignature *s1, MonoMethodSignature *s2, gbo
 		return FALSE;
 
 	while (TRUE) {
-		MonoType *t1 = mono_signature_get_params (s1, &iter1);
-		MonoType *t2 = mono_signature_get_params (s2, &iter2);
+		MonoType *t1 = mono_signature_get_params_internal (s1, &iter1);
+		MonoType *t2 = mono_signature_get_params_internal (s2, &iter2);
 
 		if (t1 == NULL || t2 == NULL)
 			return (t1 == t2);

--- a/src/mono/mono/metadata/metadata.h
+++ b/src/mono/mono/metadata/metadata.h
@@ -367,10 +367,10 @@ MONO_API mono_bool mono_type_is_pointer   (MonoType *type);
 MONO_API mono_bool mono_type_is_reference (MonoType *type);
 MONO_API mono_bool mono_type_is_generic_parameter (MonoType *type);
 
-MONO_API MonoType*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoType*
 mono_signature_get_return_type (MonoMethodSignature *sig);
 
-MONO_API MonoType*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoType*
 mono_signature_get_params      (MonoMethodSignature *sig, void **iter);
 
 MONO_API uint32_t

--- a/src/mono/mono/mini/mini-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-amd64-gsharedvt.c
@@ -300,8 +300,8 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 		gcinfo = caller_cinfo;
 	}
 
-	DEBUG_AMD64_GSHAREDVT_PRINT ("source sig: (%s) return (%s)\n", mono_signature_get_desc (caller_sig, FALSE), mono_type_full_name (mono_signature_get_return_type (caller_sig))); // Leak
-	DEBUG_AMD64_GSHAREDVT_PRINT ("dest sig: (%s) return (%s)\n", mono_signature_get_desc (callee_sig, FALSE), mono_type_full_name (mono_signature_get_return_type (callee_sig)));
+	DEBUG_AMD64_GSHAREDVT_PRINT ("source sig: (%s) return (%s)\n", mono_signature_get_desc (caller_sig, FALSE), mono_type_full_name (mono_signature_get_return_type_internal (caller_sig))); // Leak
+	DEBUG_AMD64_GSHAREDVT_PRINT ("dest sig: (%s) return (%s)\n", mono_signature_get_desc (callee_sig, FALSE), mono_type_full_name (mono_signature_get_return_type_internal (callee_sig)));
 
 	if (gcinfo->ret.storage == ArgGsharedvtVariableInReg) {
 		/*

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4389,6 +4389,7 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_thread_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
+	mono_threads_set_runtime_startup_finished ();
 
 #ifdef ENABLE_EXPERIMENT_TIERED
 	if (!mono_compile_aot) {

--- a/src/mono/mono/utils/mono-coop-mutex.h
+++ b/src/mono/mono/utils/mono-coop-mutex.h
@@ -49,7 +49,7 @@ static inline void
 mono_coop_mutex_lock (MonoCoopMutex *mutex)
 {
 	/* Avoid thread state switch if lock is not contended */
-	if (mono_os_mutex_trylock (&mutex->m) == 0)
+	if (mono_os_mutex_trylock_from_coop (&mutex->m) == 0)
 		return;
 
 	MONO_ENTER_GC_SAFE;
@@ -62,13 +62,13 @@ mono_coop_mutex_lock (MonoCoopMutex *mutex)
 static inline gint
 mono_coop_mutex_trylock (MonoCoopMutex *mutex)
 {
-	return mono_os_mutex_trylock (&mutex->m);
+	return mono_os_mutex_trylock_from_coop (&mutex->m);
 }
 
 static inline void
 mono_coop_mutex_unlock (MonoCoopMutex *mutex)
 {
-	mono_os_mutex_unlock (&mutex->m);
+	mono_os_mutex_unlock_from_coop (&mutex->m);
 }
 
 static inline void

--- a/src/mono/mono/utils/mono-threads-api.h
+++ b/src/mono/mono/utils/mono-threads-api.h
@@ -139,6 +139,12 @@ mono_threads_enter_no_safepoints_region (const char *func);
 void
 mono_threads_exit_no_safepoints_region (const char *func);
 
+int32_t
+mono_threads_enter_no_safepoints_region_if_unsafe (const char *func);
+
+void
+mono_threads_exit_no_safepoints_region_if_unsafe (const char *func);
+
 #if 0
 #define MONO_ENTER_NO_SAFEPOINTS						\
 	do {										\

--- a/src/mono/mono/utils/mono-threads-coop.h
+++ b/src/mono/mono/utils/mono-threads-coop.h
@@ -153,4 +153,17 @@ G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_unbalanced_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
+MONO_LLVM_INTERNAL_EXTERN_C_BEGIN
+extern char mono_threads_is_runtime_startup_finished_hidden_dont_modify MONO_LLVM_INTERNAL_NO_EXTERN_C;
+MONO_LLVM_INTERNAL_EXTERN_C_END
+
+static inline gboolean
+mono_threads_is_runtime_startup_finished (void)
+{
+	return mono_threads_is_runtime_startup_finished_hidden_dont_modify != 0;
+}
+
+void
+mono_threads_set_runtime_startup_finished (void);
+
 #endif

--- a/src/mono/mono/utils/mono-threads-state-machine.c
+++ b/src/mono/mono/utils/mono-threads-state-machine.c
@@ -832,12 +832,20 @@ retry_state_change:
 		 * cases where we would be in ASYNC_SUSPEND_REQUESTED with
 		 * no_safepoints set, since those are polling points.
 		 */
-		/* WISH: make this fatal. Unfortunately in that case, if a
-		 * thread asserts somewhere because no_safepoints was set when it
-		 * shouldn't have been, we get a second assertion here while
-		 * unwinding. */
-		if (no_safepoints)
-			g_warning ("Warning: no_safepoints = TRUE, but should be FALSE in state RUNNING with ABORT_BLOCKING");
+		if (no_safepoints) {
+			/* reset the state to no safepoints and then abort. If a
+			 * thread asserts somewhere because no_safepoints was set when it
+			 * shouldn't have been, we would get a second assertion here while
+			 * unwinding if we hadn't reset the no_safepoints flag.
+			 */
+			if (thread_state_cas (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count, FALSE), raw_state) != raw_state)
+				goto retry_state_change;
+
+			/* record the current transition, in order to grab a backtrace */
+			trace_state_change_with_func ("ABORT_BLOCKING", info, raw_state, STATE_RUNNING, FALSE, 0, func);
+
+			mono_fatal_with_history ("no_safepoints = TRUE, but should be FALSE in state RUNNING with ABORT_BLOCKING");
+		}
 		trace_state_change_sigsafe ("ABORT_BLOCKING", info, raw_state, cur_state, no_safepoints, 0, func);
 		return AbortBlockingIgnore;
 
@@ -872,7 +880,7 @@ STATE_BLOCKING_SELF_SUSPENDED: This is an exit state of done blocking, can't hap
 STATE_BLOCKING_ASYNC_SUSPENDED: This is an exit state of abort blocking, can't happen here.
 */
 	default:
-		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with ABORT_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
 }
 
@@ -881,7 +889,8 @@ Set the no_safepoints flag on an executing GC Unsafe thread.
 The no_safepoints bit prevents polling (hence self-suspending) and transitioning from GC Unsafe to GC Safe.
 Thus the thread will not be (cooperatively) interrupted while the bit is set.
 
-We don't allow nesting no_safepoints regions, so the flag must be initially unset.
+If nesting_ok is false, we don't allow nesting no_safepoints regions, so the flag must be initially unset,
+otherwise we return a result that indicates whether we performed the transition or not.
 
 Since a suspend initiator may at any time request that a thread should suspend,
 ASYNC_SUSPEND_REQUESTED is allowed to have the no_safepoints bit set, too.
@@ -889,8 +898,8 @@ ASYNC_SUSPEND_REQUESTED is allowed to have the no_safepoints bit set, too.
 thread to poll and retry the transition since if we enter here in the
 ASYNC_SUSPEND_REQUESTED state).
  */
-void
-mono_threads_transition_begin_no_safepoints (MonoThreadInfo *info, const char *func)
+static MonoNoSafepointsNestedResult
+mono_threads_transition_begin_no_safepoints_internal (MonoThreadInfo *info, const char *func, gboolean nesting_ok)
 {
 	int raw_state, cur_state, suspend_count;
 	gboolean no_safepoints;
@@ -900,13 +909,16 @@ retry_state_change:
 	switch (cur_state) {
 	case STATE_RUNNING:
 	case STATE_ASYNC_SUSPEND_REQUESTED:
-		/* Maybe revisit this.  But for now, don't allow nesting. */
-		if (no_safepoints)
-			mono_fatal_with_history ("no_safepoints = TRUE, but should be FALSE with BEGIN_NO_SAFEPOINTS.  Can't nest no safepointing regions");
+		if (no_safepoints) {
+			if (!nesting_ok)
+				mono_fatal_with_history ("no_safepoints = TRUE, but should be FALSE with BEGIN_NO_SAFEPOINTS.  Can't nest no safepointing regions");
+			else
+				return NoSafepointsNestedIgnored;
+		}
 		if (thread_state_cas (&info->thread_state, build_thread_state (cur_state, suspend_count, TRUE), raw_state) != raw_state)
 			goto retry_state_change;
 		trace_state_change_with_func ("BEGIN_NO_SAFEPOINTS", info, raw_state, cur_state, TRUE, 0, func);
-		return;
+		return NoSafepointsNestedOk;
 /*
 STATE_STARTING:
 STATE_DETACHED:
@@ -921,6 +933,35 @@ STATE_BLOCKING_SUSPEND_REQUESTED:
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with BEGIN_NO_SAFEPOINTS", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
+}
+
+/*
+Set the no_safepoints flag on an executing GC Unsafe thread.
+The no_safepoints bit prevents polling (hence self-suspending) and transitioning from GC Unsafe to GC Safe.
+Thus the thread will not be (cooperatively) interrupted while the bit is set.
+
+We don't allow nesting no_safepoints regions, so the flag must be initially unset.
+ */
+void
+mono_threads_transition_begin_no_safepoints (MonoThreadInfo *info, const char *func)
+{
+	(void)mono_threads_transition_begin_no_safepoints_internal (info, func, FALSE);
+}
+
+/*
+Set the no_safepoints flag on an executing GC Unsafe thread.
+The no_safepoints bit prevents polling (hence self-suspending) and transitioning from GC Unsafe to GC Safe.
+Thus the thread will not be (cooperatively) interrupted while the bit is set.
+
+We allow nesting calls to begin_no_safepoints_nested - if the flag is already
+set, the return value will be NoSafepointsNestedIgnored.  The return value
+should direct whether mono_threads_transition_end_no_safepoints will need to be
+called.
+ */
+MonoNoSafepointsNestedResult
+mono_threads_transition_begin_no_safepoints_nested (MonoThreadInfo *info, const char *func)
+{
+	return mono_threads_transition_begin_no_safepoints_internal (info, func, TRUE);
 }
 
 /*
@@ -951,7 +992,7 @@ retry_state_change:
 			mono_fatal_with_history ("no_safepoints = FALSE, but should be TRUE with END_NO_SAFEPOINTS.  Unbalanced no safepointing region");
 		if (thread_state_cas (&info->thread_state, build_thread_state (cur_state, suspend_count, FALSE), raw_state) != raw_state)
 			goto retry_state_change;
-		trace_state_change_with_func ("END_NO_SAFEPOINTS", info, raw_state, cur_state, TRUE, 0, func);
+		trace_state_change_with_func ("END_NO_SAFEPOINTS", info, raw_state, cur_state, FALSE, 0, func);
 		return;
 /*
 STATE_STARTING:

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -734,6 +734,10 @@ typedef enum {
 	AbortBlockingWait, //Abort worked, but should wait for resume
 } MonoAbortBlockingResult;
 
+typedef enum {
+	NoSafepointsNestedIgnored, // was already in no safepoints region
+	NoSafepointsNestedOk // ok, did a transition to no safepoints
+} MonoNoSafepointsNestedResult;
 
 void mono_threads_transition_attach (THREAD_INFO_TYPE* info);
 gboolean mono_threads_transition_detach (THREAD_INFO_TYPE *info);
@@ -748,6 +752,7 @@ MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* 
 MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char* func);
 gboolean mono_threads_transition_peek_blocking_suspend_requested (THREAD_INFO_TYPE* info);
 void mono_threads_transition_begin_no_safepoints (THREAD_INFO_TYPE* info, const char *func);
+MonoNoSafepointsNestedResult mono_threads_transition_begin_no_safepoints_nested (THREAD_INFO_TYPE *info, const char *func);
 void mono_threads_transition_end_no_safepoints (THREAD_INFO_TYPE* info, const char *func);
 
 G_EXTERN_C // due to THREAD_INFO_TYPE varying


### PR DESCRIPTION
!! This PR is a copy of mono/mono#18995,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Suppose two threads both try to lock an OS mutex while in GC Unsafe mode.  If one of them locks the mutex and then hits a safepoint and suspends, the other thread will block and wait for the mutex while in GC Unsafe (cooperative) mode. As a result, the suspend initiator (the GC) will deadlock and wait for the thread forever.

This PR adds a "no safepoints" state machine transition when we lock an OS mutex in checked builds (set `MONO_CHECK_MODE=thread`). That will cause an assertion if a thread attempt to safepoint while holding an OS mutex.

---

If the runtime is still starting up (and the main thread isn't attached yet), ignore the no safepoints transitions, as we don't expect to interact with suspension at all yet.

---

With recursive mutexes, we need to switch to no safepoints mode only once at the outermost mutex lock.  Add a counter cookie to the mutex struct to keep track of whether we need a transition.

The cookie logic is:
* initialize the cookie to 0 when we create the OS mutex.
* When locking:
   * if the cookie is 0 when we lock the mutex:
      *  if we did a transition - set the cookie to 1 - this lock will be responsible for doing the exit transition.
      * if we did not do a transition (because another os mutex higher up the call stack did it) - leave the cookie at 0 - this lock will not be responsible for doing the exit transition.
   * if the cookie is positive when we lock the mutex: increment the cookie.
* on unlock:
   *  if the cookie is positive: decrement the cookie, if it is now 0 do the exit transition.
   *  if the cookie is zero: do nothing

Suppose we have OS recursive mutexes m1 and m2 and we do:

```
// m1.cookie == m2.cookie == 0
lock (m1); // enter no safepoints mode; m1.cookie == 1
lock (m2); // already in safepoints mode; m2.cookie == 0
lock (m1); // cookie is positive; increment; m1.cookie == 2

unlock (m1); // decrement cookie; m1.cookie == 1
unlock (m2); // do nothing; m2.cookie == 0
unlock (m1); // decrement cookie; do exit transition ; m1.cookie == 0
```

---

If we call unlock from a coop mutex, don't do the exit no safepoints transition.

If we call `trylock` from a coop mutex (which doesn't do cookie management), don't do the no safepoints transition, since `unlock` for a coop mutex won't do the reverse transition.

`mono_coop_mutex_lock` slowpath calls `mono_os_mutex_lock` from inside a GC Safe region, so it already won't do the "no safepoints" transition, so there's no `_from_coop` version.

---

Condition variables:

save/restore cookie in `mono_os_cond_wait` and `mono_os_cond_timedwait`

When the mutex is unlocked and the thread waits on the condition variable, the cookie will belong to another thread.  When the current thread reacquires the mutex, it will restore the cookie state