### PR TITLE
Fix CrstTypeTool to target the right header file on non-Windows platform

### DIFF
--- a/src/coreclr/src/inc/CrstTypeTool.cs
+++ b/src/coreclr/src/inc/CrstTypeTool.cs
@@ -65,7 +65,7 @@ class CrstTypeTool
         {
             // Calculate the filenames of the input and output files.
             string inputFile = "CrstTypes.def";
-            string outputFile = "CrstTypes.h";
+            string outputFile = "crsttypes.h";
 
             // A common error is to forget to check out the CrstTypes.h file first. Handle this case specially
             // so we can give a good error message.


### PR DESCRIPTION
When I run CrstTypeTool on Linux, I found that it doesn't update the crst type header file and instead creates another file because on Linux, the uppercase letters of "CrstTypes.h" mismatches with the name of the file we have checked in (crsttypes.h). 

This fixes CrstTypeTool to actually target the correct header file when used on non-Windows platforms.  