### PR TITLE
Replace ushort usage with int

### DIFF
--- a/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
@@ -86,14 +86,13 @@ namespace System
         {
             for (int i = 0; i < NumberOfLabels; ++i)
             {
-
-                byte b = 0;
+                int b = 0;
                 char ch;
                 for (; (start < end) && (ch = name[start]) != '.' && ch != ':'; ++start)
                 {
-                    b = (byte)(b * 10 + (byte)(ch - '0'));
+                    b = (b * 10) + ch - '0';
                 }
-                numbers[i] = b;
+                numbers[i] = (byte)b;
                 ++start;
             }
             return numbers[0] == 127;

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -67,7 +67,7 @@ namespace System
         //           MUST NOT be used unless all input indexes are verified and trusted.
         //
 
-        internal static unsafe bool IsValid(char* name, ushort pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
+        internal static unsafe bool IsValid(char* name, int pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
         {
             char* curPos = name + pos;
             char* newPos = curPos;
@@ -124,7 +124,7 @@ namespace System
                 ++curPos;
             } while (curPos < end);
 
-            returnedEnd = (ushort)(end - name);
+            returnedEnd = (int)(end - name);
             return true;
         }
 
@@ -133,7 +133,7 @@ namespace System
         // There are pretty much no restrictions and we effectively return the end of the
         // domain name.
         //
-        internal static unsafe bool IsValidByIri(char* name, ushort pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
+        internal static unsafe bool IsValidByIri(char* name, int pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
         {
             char* curPos = name + pos;
             char* newPos = curPos;
@@ -200,7 +200,7 @@ namespace System
                 ++curPos;
             } while (curPos < end);
 
-            returnedEnd = (ushort)(end - name);
+            returnedEnd = (int)(end - name);
             return true;
         }
 

--- a/src/libraries/System.Private.Uri/src/System/UncNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UncNameHelper.cs
@@ -49,9 +49,9 @@ namespace System
         //
         // Assumption is the caller will check on the resulting name length
         // Remarks:  MUST NOT be used unless all input indexes are verified and trusted.
-        internal static unsafe bool IsValid(char* name, ushort start, ref int returnedEnd, bool notImplicitFile)
+        internal static unsafe bool IsValid(char* name, int start, ref int returnedEnd, bool notImplicitFile)
         {
-            ushort end = (ushort)returnedEnd;
+            int end = returnedEnd;
 
             if (start == end)
                 return false;
@@ -59,24 +59,25 @@ namespace System
             // First segment could consist of only '_' or '-' but it cannot be all digits or empty
             //
             bool validShortName = false;
-            ushort i = start;
+            int i = start;
             for (; i < end; ++i)
             {
-                if (name[i] == '/' || name[i] == '\\' || (notImplicitFile && (name[i] == ':' || name[i] == '?' || name[i] == '#')))
+                char c = name[i];
+                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
                 {
                     end = i;
                     break;
                 }
-                else if (name[i] == '.')
+                else if (c == '.')
                 {
                     ++i;
                     break;
                 }
-                if (char.IsLetter(name[i]) || name[i] == '-' || name[i] == '_')
+                if (char.IsLetter(c) || c == '-' || c == '_')
                 {
                     validShortName = true;
                 }
-                else if (name[i] < '0' || name[i] > '9')
+                else if (c < '0' || c > '9')
                     return false;
             }
 
@@ -89,24 +90,25 @@ namespace System
 
             for (; i < end; ++i)
             {
-                if (name[i] == '/' || name[i] == '\\' || (notImplicitFile && (name[i] == ':' || name[i] == '?' || name[i] == '#')))
+                char c = name[i];
+                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
                 {
                     end = i;
                     break;
                 }
-                else if (name[i] == '.')
+                else if (c == '.')
                 {
                     if (!validShortName || ((i - 1) >= start && name[i - 1] == '.'))
                         return false;
 
                     validShortName = false;
                 }
-                else if (name[i] == '-' || name[i] == '_')
+                else if (c == '-' || c == '_')
                 {
                     if (!validShortName)
                         return false;
                 }
-                else if (char.IsLetter(name[i]) || (name[i] >= '0' && name[i] <= '9'))
+                else if (char.IsLetter(c) || (c >= '0' && c <= '9'))
                 {
                     if (!validShortName)
                         validShortName = true;

--- a/src/libraries/System.Private.Uri/src/System/UncNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UncNameHelper.cs
@@ -62,22 +62,21 @@ namespace System
             int i = start;
             for (; i < end; ++i)
             {
-                char c = name[i];
-                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
+                if (name[i] == '/' || name[i] == '\\' || (notImplicitFile && (name[i] == ':' || name[i] == '?' || name[i] == '#')))
                 {
                     end = i;
                     break;
                 }
-                else if (c == '.')
+                else if (name[i] == '.')
                 {
                     ++i;
                     break;
                 }
-                if (char.IsLetter(c) || c == '-' || c == '_')
+                if (char.IsLetter(name[i]) || name[i] == '-' || name[i] == '_')
                 {
                     validShortName = true;
                 }
-                else if (c < '0' || c > '9')
+                else if (name[i] < '0' || name[i] > '9')
                     return false;
             }
 
@@ -90,25 +89,24 @@ namespace System
 
             for (; i < end; ++i)
             {
-                char c = name[i];
-                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
+                if (name[i] == '/' || name[i] == '\\' || (notImplicitFile && (name[i] == ':' || name[i] == '?' || name[i] == '#')))
                 {
                     end = i;
                     break;
                 }
-                else if (c == '.')
+                else if (name[i] == '.')
                 {
                     if (!validShortName || ((i - 1) >= start && name[i - 1] == '.'))
                         return false;
 
                     validShortName = false;
                 }
-                else if (c == '-' || c == '_')
+                else if (name[i] == '-' || name[i] == '_')
                 {
                     if (!validShortName)
                         return false;
                 }
-                else if (char.IsLetter(c) || (c >= '0' && c <= '9'))
+                else if (char.IsLetter(name[i]) || (name[i] >= '0' && name[i] <= '9'))
                 {
                     if (!validShortName)
                         validShortName = true;

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -411,7 +411,7 @@ namespace System
 
             fixed (char* str = _string)
             {
-                ushort idx = 0;
+                int idx = 0;
                 //
                 // For a relative Uri we only care about escaping and backslashes
                 //
@@ -422,7 +422,7 @@ namespace System
                     {
                         return false;
                     }
-                    return (CheckCanonical(str, ref idx, (ushort)_string.Length, c_EOL)
+                    return (CheckCanonical(str, ref idx, _string.Length, c_EOL)
                             & (Check.BackslashInPath | Check.EscapedCanonical)) == Check.EscapedCanonical;
                 }
 
@@ -471,7 +471,7 @@ namespace System
                 // checking on scheme:\\ or file:////
                 if (InFact(Flags.AuthorityFound))
                 {
-                    idx = (ushort)(_info.Offset.Scheme + _syntax.SchemeName.Length + 2);
+                    idx = _info.Offset.Scheme + _syntax.SchemeName.Length + 2;
                     if (idx >= _info.Offset.User || _string[idx - 1] == '\\' || _string[idx] == '\\')
                         return false;
 
@@ -510,7 +510,7 @@ namespace System
                 if ((_flags & Flags.CanonicalDnsHost) == 0 && HostType != Flags.IPv6HostType)
                 {
                     idx = _info.Offset.User;
-                    Check result = CheckCanonical(str, ref idx, (ushort)_info.Offset.Path, '/');
+                    Check result = CheckCanonical(str, ref idx, _info.Offset.Path, '/');
                     if (((result & (Check.ReservedFound | Check.BackslashInPath | Check.EscapedCanonical))
                         != Check.EscapedCanonical)
                         && (!_iriParsing || (_iriParsing
@@ -525,7 +525,7 @@ namespace System
                 if ((_flags & (Flags.SchemeNotCanonical | Flags.AuthorityFound))
                     == (Flags.SchemeNotCanonical | Flags.AuthorityFound))
                 {
-                    idx = (ushort)_syntax.SchemeName.Length;
+                    idx = _syntax.SchemeName.Length;
                     while (str[idx++] != ':');
                     if (idx + 1 >= _string.Length || str[idx] != '/' || str[idx + 1] != '/')
                         return false;
@@ -884,7 +884,7 @@ namespace System
                 {
                     fixed (char* otherPtr = other)
                     {
-                        return UriHelper.TestForSubPath(selfPtr, (ushort)self.Length, otherPtr, (ushort)other.Length,
+                        return UriHelper.TestForSubPath(selfPtr, self.Length, otherPtr, other.Length,
                             IsUncOrDosPath || uriLink.IsUncOrDosPath);
                     }
                 }

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -33,10 +33,10 @@ namespace System
         // ASSUMES that strings like http://host/Path/Path/MoreDir/../../  have been canonicalized before going to this method.
         // ASSUMES that back slashes already have been converted if applicable.
         //
-        internal static unsafe bool TestForSubPath(char* selfPtr, ushort selfLength, char* otherPtr, ushort otherLength,
+        internal static unsafe bool TestForSubPath(char* selfPtr, int selfLength, char* otherPtr, int otherLength,
             bool ignoreCase)
         {
-            ushort i = 0;
+            int i = 0;
             char chSelf;
             char chOther;
 


### PR DESCRIPTION
Uri code wastes cpu cycles by using ushort for indexes and lengths. This PR changes those to int.

Also removed `FindEndOfComponent`, as it was effectively a glorified and confusing `IndexOf`.