### PR TITLE
Ensure Process.MainWindowHandle is refreshed

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -243,7 +243,7 @@ namespace System.Diagnostics
                     EnsureState(State.IsLocal | State.HaveId);
                     _mainWindowHandle = ProcessManager.GetMainWindowHandle(_processId);
 
-                    _haveMainWindow = true;
+                    _haveMainWindow = _mainWindowHandle != IntPtr.Zero;
                 }
                 return _mainWindowHandle;
             }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -116,6 +116,7 @@ namespace System.Diagnostics
         private void RefreshCore()
         {
             _signaled = false;
+            _haveMainWindow = false;
         }
 
         /// <summary>Additional logic invoked when the Process is closed.</summary>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1509,6 +1509,38 @@ namespace System.Diagnostics.Tests
             var process = new Process();
             Assert.Throws<InvalidOperationException>(() => process.MainWindowHandle);
         }
+        
+        [Fact(Skip = "Manual test")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MainWindowHandle_GetWithGui_ShouldRefresh_Windows()
+        {
+            const string exePath = "notepad.exe";
+            Assert.True(IsProgramInstalled(exePath));
+
+            using (Process process = Process.Start(exePath))
+            {
+                try
+                {
+                    for (int attempt = 0; attempt < 50; ++attempt)
+                    {
+                        process.Refresh();
+                        if (process.MainWindowHandle != IntPtr.Zero)
+                        {
+                            break;
+                        }
+
+                        Thread.Sleep(100);
+                    }
+
+                    Assert.NotEqual(IntPtr.Zero, process.MainWindowHandle);
+                }
+                finally
+                {
+                    process.Kill();
+                    Assert.True(process.WaitForExit(WaitInMS));
+                }
+            }
+        }
 
         [Fact]
         public void MainWindowTitle_NoWindow_ReturnsEmpty()

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
 using Xunit.Sdk;
@@ -1510,7 +1511,9 @@ namespace System.Diagnostics.Tests
             Assert.Throws<InvalidOperationException>(() => process.MainWindowHandle);
         }
         
-        [Fact(Skip = "Manual test")]
+        [Fact]
+        [OuterLoop]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Pops UI
         [PlatformSpecific(TestPlatforms.Windows)]
         public void MainWindowHandle_GetWithGui_ShouldRefresh_Windows()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1517,10 +1517,10 @@ namespace System.Diagnostics.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void MainWindowHandle_GetWithGui_ShouldRefresh_Windows()
         {
-            const string exePath = "notepad.exe";
-            Assert.True(IsProgramInstalled(exePath));
+            const string ExePath = "notepad.exe";
+            Assert.True(IsProgramInstalled(ExePath));
 
-            using (Process process = Process.Start(exePath))
+            using (Process process = Process.Start(ExePath))
             {
                 try
                 {


### PR DESCRIPTION
As discussed in #32690, this will set `_haveMainWindow` to true only if `_mainWindowHandle` is non-zero. It also forces the latter to be reset during a `Process.Refresh()` call, hence allowing the re-evaluation of both.

As suggested, the test I added is marked as manual due to needing to launch a UI (Notepad) as part of it. I did it this using `Fact(Skip = "Manual test")]` based on what I saw in [ProcessStartInfoTests.StartInfo_WebPage](https://github.com/dotnet/runtime/blob/d872a664488f773b98376365da93c2f3425e15bd/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs#L906).