### PR TITLE
Replace MemoryMarshal calls to direct Unsafe calls

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -746,12 +746,7 @@ namespace System
         {
             if (BitConverter.IsLittleEndian)
             {
-                if (Unsafe.SizeOf<Guid>() > (uint)destination.Length)
-                {
-                    return false;
-                }
-                Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(destination), this);
-                return true;
+                return MemoryMarshal.TryWrite(destination, ref this);
             }
 
             // slower path for BigEndian


### PR DESCRIPTION
In that places we can call System.Runtime.CompilerServices.Unsafe directly instead of calling MemoryMarshal methods.