### PR TITLE
Optimize Uri.GetHashCode

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1512,7 +1512,7 @@ namespace System
                 MoreInfo moreInfo = (_info ??= new UriInfo()).MoreInfo ??= new MoreInfo();
                 if (moreInfo.Hash == 0)
                 {
-                    moreInfo.Hash = OriginalString.GetHashCode(StringComparison.OrdinalIgnoreCase);
+                    moreInfo.Hash = OriginalString.GetHashCode();
                 }
                 return moreInfo.Hash;
             }
@@ -1521,8 +1521,8 @@ namespace System
                 MoreInfo moreInfo = EnsureUriInfo().MoreInfo ??= new MoreInfo();
                 if (moreInfo.Hash == 0)
                 {
-                    string? chkString = moreInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
-                    moreInfo.Hash = chkString.GetHashCode(StringComparison.OrdinalIgnoreCase);
+                    string remoteUrl = moreInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
+                    moreInfo.Hash = remoteUrl.GetHashCode(IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
                 }
                 return moreInfo.Hash;
             }

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -149,7 +149,6 @@ namespace System
             public string? Query;
             public string? Fragment;
             public string? AbsoluteUri;
-            public int Hash;
             public string? RemoteUrl;
         };
 
@@ -1509,22 +1508,21 @@ namespace System
         {
             if (IsNotAbsoluteUri)
             {
-                MoreInfo moreInfo = (_info ??= new UriInfo()).MoreInfo ??= new MoreInfo();
-                if (moreInfo.Hash == 0)
-                {
-                    moreInfo.Hash = OriginalString.GetHashCode();
-                }
-                return moreInfo.Hash;
+                return OriginalString.GetHashCode();
             }
             else
             {
                 MoreInfo moreInfo = EnsureUriInfo().MoreInfo ??= new MoreInfo();
-                if (moreInfo.Hash == 0)
+                string remoteUrl = moreInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
+
+                if (IsUncOrDosPath)
                 {
-                    string remoteUrl = moreInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
-                    moreInfo.Hash = remoteUrl.GetHashCode(IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+                    return remoteUrl.GetHashCode(StringComparison.OrdinalIgnoreCase);
                 }
-                return moreInfo.Hash;
+                else
+                {
+                    return remoteUrl.GetHashCode();
+                }
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -396,7 +396,17 @@ namespace System.Tests
 
                 if (uri2 != null)
                 {
-                    Assert.Equal(expected, uri1.GetHashCode() == uri2.GetHashCode());
+                    bool hashCodesAreEqual = uri1.GetHashCode() == uri2.GetHashCode();
+
+                    if (expected)
+                    {
+                        Assert.True(hashCodesAreEqual);
+                    }
+
+                    if (!hashCodesAreEqual)
+                    {
+                        Assert.False(expected);
+                    }
                 }
             }
 

--- a/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -389,15 +389,17 @@ namespace System.Tests
         public void Equals(Uri uri1, object obj, bool expected)
         {
             Uri uri2 = obj as Uri;
+
             if (uri1 != null)
             {
                 Assert.Equal(expected, uri1.Equals(obj));
+
                 if (uri2 != null)
                 {
-                    bool onlyCaseDifference = string.Equals(uri1.OriginalString, uri2.OriginalString, StringComparison.OrdinalIgnoreCase);
-                    Assert.Equal(expected || onlyCaseDifference, uri1.GetHashCode().Equals(uri2.GetHashCode()));
+                    Assert.Equal(expected, uri1.GetHashCode() == uri2.GetHashCode());
                 }
             }
+
             if (!(obj is string))
             {
                 Assert.Equal(expected, uri1 == uri2);

--- a/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -394,19 +394,9 @@ namespace System.Tests
             {
                 Assert.Equal(expected, uri1.Equals(obj));
 
-                if (uri2 != null)
+                if (uri2 != null && expected)
                 {
-                    bool hashCodesAreEqual = uri1.GetHashCode() == uri2.GetHashCode();
-
-                    if (expected)
-                    {
-                        Assert.True(hashCodesAreEqual);
-                    }
-
-                    if (!hashCodesAreEqual)
-                    {
-                        Assert.False(expected);
-                    }
+                    Assert.Equal(uri1.GetHashCode(), uri2.GetHashCode());
                 }
             }
 


### PR DESCRIPTION
Use `text.GetHashCode(StringComparison.OrdinalIgnoreCase)` instead of `text.ToLowerInvariant().GetHashCode()`.

For relative Uris also cache the computed hash like we do for absolute Uris. This makes dictionary lookups on relative Uris perform 2-5000 times faster depending on length (field access instead of string allocation and hash computation).

For absolute Uris, cache the `RemoteUrl` we just computed instead of discarding it.