### PR TITLE
IsInst handles nullable without boxing

### DIFF
--- a/src/coreclr/src/inc/corinfo.h
+++ b/src/coreclr/src/inc/corinfo.h
@@ -1925,9 +1925,10 @@ const int MAX_EnC_HANDLER_NESTING_LEVEL = 6;
 // Results from type comparison queries
 enum class TypeCompareState
 {
-    MustNot = -1, // types are not equal
-    May = 0,      // types may be equal (must test at runtime)
-    Must = 1,     // type are equal
+    MustNot = -1,     // types are not equal
+    May = 0,          // types may be equal (must test at runtime)
+    Must = 1,         // types are equal,
+    MustNullable = 2, // types represent nullable and underlying
 };
 
 //

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -4469,6 +4469,11 @@ TypeCompareState CEEInfo::compareTypesForCast(
     {
         result = TypeCompareState::May;
     }
+    // If casting from Nullable<T> to T, try to optimizze
+    else if (Nullable::IsNullableForTypeNoGC(fromHnd, toHnd.GetMethodTable()))
+    {
+        result = TypeCompareState::MustNullable;
+    }
     // If the types are not shared, we can check directly.
     else if (!fromHnd.IsCanonicalSubtype() && !toHnd.IsCanonicalSubtype())
     {


### PR DESCRIPTION
@AndyAyersMS this is what I did for #12568 and the change should optimize boxing with the following `isinst`. Unfortunately, wasn't able to build it yet, but will do. Optimization of the `unbox.any` will come later when I finish with this.