### PR TITLE
Fix build without FEATURE_EVENT_TRACE

### DIFF
--- a/src/coreclr/clrdefinitions.cmake
+++ b/src/coreclr/clrdefinitions.cmake
@@ -117,6 +117,8 @@ add_definitions(-DFEATURE_DEFAULT_INTERFACES)
 if(FEATURE_EVENT_TRACE)
     add_compile_definitions($<$<NOT:$<BOOL:$<TARGET_PROPERTY:CROSSGEN_COMPONENT>>>:FEATURE_EVENT_TRACE>)
     add_definitions(-DFEATURE_PERFTRACING)
+else(FEATURE_EVENT_TRACE)
+    add_custom_target(eventing_headers) # add a dummy target to avoid checking for FEATURE_EVENT_TRACE in multiple places
 endif(FEATURE_EVENT_TRACE)
 if(FEATURE_GDBJIT)
     add_definitions(-DFEATURE_GDBJIT)

--- a/src/coreclr/src/gc/env/etmdummy.h
+++ b/src/coreclr/src/gc/env/etmdummy.h
@@ -47,7 +47,7 @@
 #define FireEtwGCMarkHandles(HeapNum, ClrInstanceID) 0
 #define FireEtwGCMarkOlderGenerationRoots(HeapNum, ClrInstanceID) 0
 #define FireEtwFinalizeObject(TypeID, ObjectID, ClrInstanceID) 0
-#define FireEtwSetGCHandle(HandleID, ObjectID, Kind, Generation, ClrInstanceID) 0
+#define FireEtwSetGCHandle(HandleID, ObjectID, Kind, Generation, DomainAddr, ClrInstanceID) 0
 #define FireEtwDestroyGCHandle(HandleID, ClrInstanceID) 0
 #define FireEtwGCSampledObjectAllocationLow(Address, TypeID, ObjectCountForTypeSample, TotalSizeForTypeSample, ClrInstanceID) 0
 #define FireEtwPinObjectAtGCTime(HandleID, ObjectID, ObjectSize, TypeName, ClrInstanceID) 0
@@ -376,7 +376,7 @@
 #define FireEtwFailFast(FailFastUserMessage, FailedEIP, OSExitCode, ClrExitCode, ClrInstanceID) 0
 #define FireEtwPrvFinalizeObject(TypeID, ObjectID, ClrInstanceID, TypeName) 0
 #define FireEtwCCWRefCountChange(HandleID, ObjectID, COMInterfacePointer, NewRefCount, AppDomainID, ClassName, NameSpace, Operation, ClrInstanceID) 0
-#define FireEtwPrvSetGCHandle(HandleID, ObjectID, Kind, Generation, ClrInstanceID) 0
+#define FireEtwPrvSetGCHandle(HandleID, ObjectID, Kind, Generation, DomainAddr, ClrInstanceId) 0
 #define FireEtwPrvDestroyGCHandle(HandleID, ClrInstanceID) 0
 #define FireEtwFusionMessageEvent(ClrInstanceID, Prepend, Message) 0
 #define FireEtwFusionErrorCodeEvent(ClrInstanceID, Category, ErrorCode) 0
@@ -398,3 +398,13 @@
 #define FireEtwBeginCreateManagedReference(ClrInstanceID) 0
 #define FireEtwEndCreateManagedReference(ClrInstanceID) 0
 #define FireEtwObjectVariantMarshallingToManaged(TypeName, Int1, ClrInstanceID) 0
+#define FireEtwGCDynamicEvent(EventName, PayloadSize, Payload, ClrInstanceId) 0
+#define FireEtwBGC1stSweepEnd(GenNumber, ClrInstanceId) 0
+#define FireEtwResolutionAttempted(ClrInstanceId, asmName, stage, assemblyLoadContextName, result, resultAsmName, resultAsmPath, errMsg) 0
+#define FireEtwResolutionAttempted(ClrInstanceId, asmName, event, alcName, result, resultAsmName, resultAsmPath, errMsg) 0
+#define FireEtwKnownPathProbed(ClrInstanceId, path, source, hr) 0
+#define FireEtwContentionStop_V1(managedContention, ClrInstanceId, elapsedTimeInNanosecond) 0
+#define FireEtwAssemblyLoadContextResolvingHandlerInvoked(ClrInstanceId, assemblyName, handlerName, alcName, resultAssemblyName, resultAssemblyPath) 0
+#define FireEtwAppDomainAssemblyResolveHandlerInvoked(ClrInstanceId, assemblyName, handlerName, resultAssemblyName, resultAssemblyPath) 0
+#define FireEtwAssemblyLoadFromResolveHandlerInvoked(ClrInstanceId, assemblyName, isTrackedAssembly, requestingAssemblyPath, requestedAssemblyPath) 0
+#define FireEtwEventSource(eventID, eventName, eventSourceName, payload) 0

--- a/src/coreclr/src/scripts/genEventing.py
+++ b/src/coreclr/src/scripts/genEventing.py
@@ -635,12 +635,11 @@ typedef struct _DOTNET_TRACE_CONTEXT
         clrproviders = os.path.join(incDir, "clrproviders.h")
         with open_for_update(clrproviders) as Clrproviders:
             Clrproviders.write("""
-    typedef struct _EVENT_DESCRIPTOR
-    {
-        int const Level;
-        ULONGLONG const Keyword;
-    } EVENT_DESCRIPTOR;
-    """)
+typedef struct _EVENT_DESCRIPTOR
+{
+    int const Level;
+    ULONGLONG const Keyword;
+} EVENT_DESCRIPTOR;""")
 
             if not is_windows:
                 Clrproviders.write(eventpipe_trace_context_typedef)  # define EVENTPIPE_TRACE_CONTEXT

--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -7062,14 +7062,14 @@ HRESULT ProfToEEInterfaceImpl::EventPipeCreateProvider(const WCHAR *szName, EVEN
     EX_CATCH_HRESULT(hr);
 
     return hr;
-#elif // FEATURE_PERFTRACING
+#else // FEATURE_PERFTRACING
     return E_NOTIMPL;
 #endif // FEATURE_PERFTRACING
 }
 
 HRESULT ProfToEEInterfaceImpl::EventPipeDefineEvent(
     EVENTPIPE_PROVIDER provHandle,
-    const WCHAR *szName, 
+    const WCHAR *szName,
     UINT32 eventID,
     UINT64 keywords,
     UINT32 eventVersion,
@@ -7112,7 +7112,7 @@ HRESULT ProfToEEInterfaceImpl::EventPipeDefineEvent(
                       && sizeof(EventPipeParameterDesc) == sizeof(COR_PRF_EVENTPIPE_PARAM_DESC),
             "Layouts of EventPipeParameterDesc type and COR_PRF_EVENTPIPE_PARAM_DESC type do not match!");
         EventPipeParameterDesc *params = reinterpret_cast<EventPipeParameterDesc *>(pParamDescs);
-        
+
         size_t metadataLength;
         NewArrayHolder<BYTE> pMetadata = EventPipeMetadataGenerator::GenerateEventMetadata(
             eventID,
@@ -7139,7 +7139,7 @@ HRESULT ProfToEEInterfaceImpl::EventPipeDefineEvent(
     EX_CATCH_HRESULT(hr);
 
     return hr;
-#elif // FEATURE_PERFTRACING
+#else // FEATURE_PERFTRACING
     return E_NOTIMPL;
 #endif // FEATURE_PERFTRACING
 }
@@ -7174,14 +7174,14 @@ HRESULT ProfToEEInterfaceImpl::EventPipeWriteEvent(
 
     static_assert(offsetof(EventData, Ptr) == offsetof(COR_PRF_EVENT_DATA, ptr)
                     && offsetof(EventData, Size) == offsetof(COR_PRF_EVENT_DATA, size)
-                    && sizeof(EventData) == sizeof(COR_PRF_EVENT_DATA), 
+                    && sizeof(EventData) == sizeof(COR_PRF_EVENT_DATA),
         "Layouts of EventData type and COR_PRF_EVENT_DATA type do not match!");
 
     EventData *pEventData = reinterpret_cast<EventData *>(data);
     EventPipe::WriteEvent(*pEvent, pEventData, cData, pActivityId, pRelatedActivityId);
 
     return S_OK;
-#elif // FEATURE_PERFTRACING
+#else // FEATURE_PERFTRACING
     return E_NOTIMPL;
 #endif // FEATURE_PERFTRACING
 }


### PR DESCRIPTION
* Add dummy target `eventing_headers`
* Add missing events in `etmdummy.h` and fix include paths to it in two other sources 
* Fix the invalid `#elif // FEATUREE_EVENT_TRACE` (supposed to be `#else`)
* Minor formatting fixes

Tested with Ubuntu 18 and Android NDK v r21 (and API v28) in rootfs.