### PR TITLE
Fix Version.Details.xml merge failure

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -50,7 +50,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f83aa9749a531bf771a98e5bdace55b31a9bb2b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20117.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20121.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f83aa9749a531bf771a98e5bdace55b31a9bb2b2</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -50,6 +50,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f83aa9749a531bf771a98e5bdace55b31a9bb2b2</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20117.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f83aa9749a531bf771a98e5bdace55b31a9bb2b2</Sha>
     </Dependency>


### PR DESCRIPTION
Broken by https://github.com/dotnet/runtime/commit/9a085069d0b36f7b6711f5b9fb41bf5c2d882d19.
Missing <Dependency> tag.