### PR TITLE
Add Fedora 33 runtime ids

### DIFF
--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -970,6 +970,38 @@
     "any",
     "base"
   ],
+  "fedora.33": [
+    "fedora.33",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.33-arm64": [
+    "fedora.33-arm64",
+    "fedora.33",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.33-x64": [
+    "fedora.33-x64",
+    "fedora.33",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -499,6 +499,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.33": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.33-arm64": {
+      "#import": [
+        "fedora.33",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.33-x64": {
+      "#import": [
+        "fedora.33",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -48,7 +48,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora 32 is gearing up for release[1], and in-development version of
Fedora has been offically labelled as being Fedora 33:

    $ docker run -it fedora:33 cat /etc/os-release
    NAME=Fedora
    VERSION="33 (Container Image)"
    ID=fedora
    VERSION_ID=33
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f33"
    PRETTY_NAME="Fedora 33 (Container Image)"
    ANSI_COLOR="0;34"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:33"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
    VARIANT="Container Image"
    VARIANT_ID=container

[1] https://fedorapeople.org/groups/schedule/f-32/f-32-key-tasks.html