### PR TITLE
Add ConfigurationGroup back to entrypoints

### DIFF
--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Honor the generic RuntimeConfiguration property. -->
   <PropertyGroup>
-    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(Configuration)</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
     <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == '' AND ('$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release')">$(Configuration)</RuntimeConfiguration>
     <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">Debug</RuntimeConfiguration>
     <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -138,7 +138,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "build"                { $arguments += " -build" }
     "buildtests"           { if ($build -eq $true) { $arguments += " /p:BuildTests=true" } else { $arguments += " -build /p:BuildTests=only" } }
     "test"                 { $arguments += " -test" }
-    "configuration"        { $arguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])))" }
+    "configuration"        { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " /p:ConfigurationGroup=$configuration -configuration $configuration" }
     "runtimeConfiguration" { $arguments += " /p:RuntimeConfiguration=$((Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])))" }
     "framework"            { $arguments += " /p:BuildTargetFramework=$($PSBoundParameters[$argument].ToLowerInvariant())" }
     "os"                   { $arguments += " /p:OSGroup=$($PSBoundParameters[$argument])" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -94,7 +94,7 @@ while [[ $# > 0 ]]; do
       ;;
      -configuration|-c)
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
-      arguments="$arguments -configuration $val"
+      arguments="$arguments /p:ConfigurationGroup=$val -configuration $val"
       shift 2
       ;;
      -framework|-f)


### PR DESCRIPTION
ConfigurationGroup was removed but installer still uses and depends on
it. Bringing it back in the entrypoint build scripts and in the managed
msbuild Configurations.props file.

Fixes https://github.com/dotnet/runtime/issues/32741

cc @dotnet/runtime-infrastructure 