### PR TITLE
[wip] fix handling of TLS session tickets on Linux servers

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -57,7 +57,7 @@ internal static partial class Interop
             // Always use SSLv23_method, regardless of protocols.  It supports negotiating to the highest
             // mutually supported version and can thus handle any of the set protocols, and we then use
             // SetProtocolOptions to ensure we only allow the ones requested.
-            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(Ssl.SslMethods.SSLv23_method))
+            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(Ssl.SslMethods.SSLv23_method, sslAuthenticationOptions.IsServer))
             {
                 if (innerContext.IsInvalid)
                 {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         internal unsafe delegate int SslCtxSetAlpnCallback(IntPtr ssl, out byte* outp, out byte outlen, byte* inp, uint inlen, IntPtr arg);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCreate")]
-        internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method);
+        internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method,  [MarshalAs(UnmanagedType.Bool)] bool isServer);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxDestroy")]
         internal static extern void SslCtxDestroy(IntPtr ctx);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -467,6 +467,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     FALLBACK_FUNCTION(SSL_CTX_set_options) \
     FALLBACK_FUNCTION(SSL_CTX_set_security_level) \
     REQUIRED_FUNCTION(SSL_CTX_set_verify) \
+    REQUIRED_FUNCTION(SSL_CTX_set_session_id_context) \
     REQUIRED_FUNCTION(SSL_CTX_use_certificate) \
     REQUIRED_FUNCTION(SSL_CTX_use_PrivateKey) \
     REQUIRED_FUNCTION(SSL_do_handshake) \
@@ -861,6 +862,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_CTX_set_quiet_shutdown SSL_CTX_set_quiet_shutdown_ptr
 #define SSL_CTX_set_security_level SSL_CTX_set_security_level_ptr
 #define SSL_CTX_set_verify SSL_CTX_set_verify_ptr
+#define SSL_CTX_set_session_id_context SSL_CTX_set_session_id_context_ptr
 #define SSL_CTX_use_certificate SSL_CTX_use_certificate_ptr
 #define SSL_CTX_use_PrivateKey SSL_CTX_use_PrivateKey_ptr
 #define SSL_do_handshake SSL_do_handshake_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -27,9 +27,9 @@ static void EnsureLibSsl10Initialized()
 #endif
 
 // Master encryption key for RFC5077 TLS session tickets.
-static unsigned char *s_sessionTicketsMasterKey = NULL;
+static unsigned char* s_sessionTicketsMasterKey = NULL;
 static long s_sessionTicketsMasterKeyLength = 0;
-static void * s_sessionContextId = &s_sessionTicketsMasterKeyLength; // actual value does not matter.
+static void* s_sessionContextId = &s_sessionTicketsMasterKeyLength; // actual value does not matter.
 
 void CryptoNative_EnsureLibSslInitialized()
 {
@@ -55,7 +55,7 @@ void CryptoNative_EnsureLibSslInitialized()
         if (s_sessionTicketsMasterKeyLength > 0)
         {
             s_sessionTicketsMasterKey = malloc((size_t)s_sessionTicketsMasterKeyLength);
-            if (RAND_bytes(s_sessionTicketsMasterKey, (int)s_sessionTicketsMasterKeyLength) != 1)
+            if (s_sessionTicketsMasterKey != NULL && RAND_bytes(s_sessionTicketsMasterKey, (int)s_sessionTicketsMasterKeyLength) != 1)
             {
                 free(s_sessionTicketsMasterKey);
                 s_sessionTicketsMasterKey = NULL;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -26,7 +26,7 @@ static void EnsureLibSsl10Initialized()
 }
 #endif
 
-// Master encryption key for TLS session tickets.
+// Master encryption key for RFC5077 TLS session tickets.
 static unsigned char *s_sessionTicketsMasterKey = NULL;
 static long s_sessionTicketsMasterKeyLength = 0;
 static void * s_sessionContextId = &s_sessionTicketsMasterKeyLength; // actual value does not matter.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.h
@@ -144,7 +144,7 @@ Shims the SSL_CTX_new method.
 
 Returns the new SSL_CTX instance.
 */
-PALEXPORT SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method);
+PALEXPORT SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method, int32_t isServer);
 
 /*
 Sets the specified protocols in the SSL_CTX options.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
@@ -37,7 +37,7 @@ namespace System.Net.Security
                 throw new PlatformNotSupportedException(SR.net_ssl_ciphersuites_policy_not_supported);
             }
 
-            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(Ssl.SslMethods.SSLv23_method))
+            using (SafeSslContextHandle innerContext = Ssl.SslCtxCreate(Ssl.SslMethods.SSLv23_method, false))
             {
                 if (innerContext.IsInvalid)
                 {


### PR DESCRIPTION
There are two mechanisms on how to do TLS resume. With session IDs both sides maintain cache and can use the ID to pick session parameters without a full handshake. With RFC5077, all the responsibility is pushed to the client and there is no state that the server needs to maintain. It uses an internal master key to encrypt session parameters and later client can present such a ticket and TLS can be resumed. 

This is supported on Windows as well as OpenSSL enables session tickets (and server cache by default). One can observe this by doing TLS handshake from Windows client (or not SslStream) to Kestrel (or SslStream) server on Linux. 

The reason why the resume does not work on Linux, is because all needed information is kept in SSL_CTX structure. Normally, one would create context and then individual SSL states for each connection. However, we create new SSL_CTX for each connection and that generates a new session (and session cache unless disabled). So even if the server creates a session ticket and the client presents it back (as current code), we would fail to decrypt it so full handshake happens instead.  

One way how to fix this is by sharing SSL_CTX among SslStreams with the same parameters. 
I'm not sure if that would have any side-effects. So instead of this, this change sets session master key so session tickets can be used across different contexts. 

Since this is not applicable to client-side, I added a new parameter to SslCtxCreate() to do extra work only for server context. 

This change impacts only server-side as handling session tickets on the client is more complicated. For that reason, microbenchmark shows no improvement as we will fail to resume when using SslStream as a client on Linux. However, that works nicely if an independent implementation is used. I get 80%ish improvement in end-to-end test with `Kestrel` and `wrk` client in `ConnectionClose` scenario.

asp-perf-lin & asp-perf-load (-n ConnectionClose  -j ../Benchmarks/benchmarks.plaintext.json --scheme=https)

| Description |   RPS | CPU (%) | Memory (MB) | Avg. Latency (ms) | Startup (ms) | Build Time (ms) | Published Size (KB) | First Request (ms) | Latency (ms) | Errors | Ratio |
| ----------- | ----- | ------- | ----------- | ----------------- | ------------ | --------------- | ------------------- | ------------------ | ------------ | ------ | ----- |
|  Baseline   | 4,063 |      96 |         320 |             17.58 |          386 |            4502 |              119119 |             164.61 |         6.36 |      0 |  1.00 |
|  TLS Resume | 7,658 |      93 |         277 |             11.15 |          389 |            6502 |              119119 |             220.77 |         7.52 |      0 |  1.88 |


cc: @sebastienros @Tratcher 

contributes to #22977