### PR TITLE
Improve Expression.Lambda<TDelegate> performance

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -687,7 +687,11 @@ namespace System.Linq.Expressions
         {
             ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
             ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
-            return (Expression<TDelegate>)CreateLambda(typeof(TDelegate), body, name, tailCall, parameterList);
+#if FEATURE_COMPILE
+            return Expression<TDelegate>.Create(body, name, tailCall, parameterList);
+#else
+            return ExpressionCreator<TDelegate>.CreateExpressionFunc(body, name, tailCall, parameterList);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Unnecessary cache call in Expression.Lambda<TDelegate>
(with reflection in worst scenario) has been removed.

Fix #32767

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=5.0.100-preview.2.20120.11
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.11909, CoreFX 5.0.20.11909), X64 RyuJIT
  Job-OOGNGR : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT
  Job-ZDXXHT : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT
  Job-AZQMMA : .NET Framework 4.8 (4.8.4121.0), X64 RyuJIT
  Job-MHZNLL : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT
  Job-THTYGA : .NET Core 5.0.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT

Server=True  InvocationCount=1  IterationCount=1  
LaunchCount=1  RunStrategy=ColdStart  UnrollFactor=1  
WarmupCount=1  

```
|                      Method |        EnvironmentVariables |              Toolchain |     Mean | Error |      Min |      Max | Ratio |       Gen 0 |     Gen 1 | Gen 2 | Allocated | Allocated native memory | Native memory leak |
|---------------------------- |---------------------------- |----------------------- |---------:|------:|---------:|---------:|------:|------------:|----------:|------:|----------:|------------------------:|-------------------:|
| Expression_Lambda_TDelegate | COMPlus_TieredCompilation=0 |           netcoreapp50 | 905.8 ms |    NA | 905.8 ms | 905.8 ms |  1.97 |  20000.0000 | 1000.0000 |     - | 164.21 MB |                 1.13 MB |               0 MB |
| Expression_Lambda_TDelegate | COMPlus_TieredCompilation=0 | netcoreapp50_vchirikov | 172.6 ms |    NA | 172.6 ms | 172.6 ms |  0.38 |  11000.0000 |         - |     - |  94.58 MB |                 0.62 MB |               0 MB |
| Expression_Lambda_TDelegate |                       Empty |                  net48 | 459.2 ms |    NA | 459.2 ms | 459.2 ms |  1.00 | 143000.0000 |         - |     - | 226.48 MB |                 0.43 MB |            0.01 MB |
| Expression_Lambda_TDelegate |                       Empty |           netcoreapp50 | 883.4 ms |    NA | 883.4 ms | 883.4 ms |  1.92 |  20000.0000 | 1000.0000 |     - | 164.14 MB |                 1.55 MB |            0.22 MB |
| Expression_Lambda_TDelegate |                       Empty | netcoreapp50_vchirikov | 202.2 ms |    NA | 202.2 ms | 202.2 ms |  0.44 |  11000.0000 |         - |     - |  94.73 MB |                 1.02 MB |            0.22 MB |

[More information](https://github.com/dotnet/runtime/issues/32767)
