### PR TITLE
Removing configuration group from installer

### DIFF
--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Honor the generic RuntimeConfiguration property. -->
   <PropertyGroup>
-    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(ConfigurationGroup)</RuntimeConfiguration>
+    <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">$(Configuration)</RuntimeConfiguration>
     <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == '' AND ('$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Release')">$(Configuration)</RuntimeConfiguration>
     <RuntimeConfiguration Condition="'$(RuntimeConfiguration)' == ''">Debug</RuntimeConfiguration>
     <CoreCLRConfiguration Condition="'$(CoreCLRConfiguration)' == ''">$(RuntimeConfiguration)</CoreCLRConfiguration>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -52,7 +52,7 @@
 
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
     <ItemsToSign
-      Condition="'$(ConfigurationGroup)' == 'Release' and '$(TargetArchitecture)' == 'x86'"
+      Condition="'$(Configuration)' == 'Release' and '$(TargetArchitecture)' == 'x86'"
       Include="$(CoreCLRArtifactsPath)Redist\ucrt\DLLs\$(TargetArchitecture)\api-ms-win-core-xstate-l2-1-0.dll" />
 
     <!-- Sign libraries. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Paths used during restore -->
-    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and ('$(ConfigurationGroup)' == 'Release' or '$(Configuration)' == 'Release')">true</EnableNgenOptimization>
+    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(Configuration)' == 'Release'">true</EnableNgenOptimization>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <XmlDocDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'docs'))</XmlDocDir>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -138,7 +138,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "build"                { $arguments += " -build" }
     "buildtests"           { if ($build -eq $true) { $arguments += " /p:BuildTests=true" } else { $arguments += " -build /p:BuildTests=only" } }
     "test"                 { $arguments += " -test" }
-    "configuration"        { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " /p:ConfigurationGroup=$configuration -configuration $configuration" }
+    "configuration"        { $arguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])))" }
     "runtimeConfiguration" { $arguments += " /p:RuntimeConfiguration=$((Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])))" }
     "framework"            { $arguments += " /p:BuildTargetFramework=$($PSBoundParameters[$argument].ToLowerInvariant())" }
     "os"                   { $arguments += " /p:OSGroup=$($PSBoundParameters[$argument])" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -94,7 +94,7 @@ while [[ $# > 0 ]]; do
       ;;
      -configuration|-c)
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
-      arguments="$arguments /p:ConfigurationGroup=$val -configuration $val"
+      arguments="$arguments -configuration $val"
       shift 2
       ;;
      -framework|-f)

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -60,38 +60,13 @@
   a single binary folder and can have a similar experience between the command line and Visual Studio.
   -->
 
-  <!--
-  If Configuration is empty that means we are not being built in VS and so folks need to explicitly pass the different
-  values for $(ConfigurationGroup) or $(OSGroup) or accept the defaults for them.
-  -->
   <PropertyGroup>
     <OSGroup Condition="'$(OS)'=='Unix' AND Exists('/Applications')">OSX</OSGroup>
     <OSGroup Condition="'$(OSGroup)' == ''">$(OS)</OSGroup>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'==''">
-    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
-    <Configuration>$(ConfigurationGroup)</Configuration>
-    <Configuration>$(OSGroup)_$(Configuration)</Configuration>
-  </PropertyGroup>
-
-  <!--
-  If Configuration is set then someone explicitly passed it in or we building from VS. In either case
-  default $(ConfigurationGroup) or $(OSGroup) from the Configuration if they aren't
-  already explicitly set.
-  -->
-  <PropertyGroup Condition="'$(Configuration)'!=''">
-    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
-    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
-    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
-
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Windows'))">Windows_NT</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Unix'))">Unix</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('NetBSD'))">NetBSD</OSGroup>
-    <OSGroup Condition="'$(OSGroup)'==''">AnyOS</OSGroup>
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -106,14 +81,14 @@
 
   <!-- Set up Default symbol and optimization for Configuration -->
   <Choose>
-    <When Condition="'$(ConfigurationGroup)'=='Debug'">
+    <When Condition="'$(Configuration)'=='Debug'">
       <PropertyGroup>
         <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
         <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
         <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
       </PropertyGroup>
     </When>
-    <When Condition="'$(ConfigurationGroup)' == 'Release'">
+    <When Condition="'$(Configuration)' == 'Release'">
       <PropertyGroup>
         <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
         <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
@@ -122,7 +97,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown ConfigurationGroup [$(ConfigurationGroup)] specificed in your project.</ConfigurationErrorMsg>
+        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown Configuration [$(Configuration)] specificed in your project.</ConfigurationErrorMsg>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -157,7 +132,7 @@
 
   <!-- Set up the default output and intermediate paths -->
   <PropertyGroup>
-    <OSPlatformConfig>$(OutputRid).$(ConfigurationGroup)</OSPlatformConfig>
+    <OSPlatformConfig>$(OutputRid).$(Configuration)</OSPlatformConfig>
 
     <BaseOutputRootPath>$(ArtifactsBinDir)$(OSPlatformConfig)\</BaseOutputRootPath>
     <CrossGenRootPath>$(BaseOutputRootPath)crossgen\</CrossGenRootPath>
@@ -179,7 +154,7 @@
     <DisableCrossgen>false</DisableCrossgen>
     <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
     <DisableCrossgen Condition="'$(OSGroup)'=='FreeBSD'">true</DisableCrossgen>
-    <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(ConfigurationGroup)_version_badge.svg</OutputVersionBadge>
+    <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(Configuration)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -66,10 +66,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType>
   </PropertyGroup>
 

--- a/src/installer/corehost/build.proj
+++ b/src/installer/corehost/build.proj
@@ -27,7 +27,7 @@
     <PropertyGroup>
       <CMakeBuildDir>$(IntermediateOutputRootPath)corehost\cmake\</CMakeBuildDir>
 
-      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) -apphostver "$(AppHostVersion)" -hostver "$(HostVersion)" -fxrver "$(HostResolverVersion)" -policyver "$(HostPolicyVersion)" -commithash "$(LatestCommit)"</BuildArgs>
+      <BuildArgs>$(Configuration) $(TargetArchitecture) -apphostver "$(AppHostVersion)" -hostver "$(HostVersion)" -fxrver "$(HostResolverVersion)" -policyver "$(HostPolicyVersion)" -commithash "$(LatestCommit)"</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' != 'true'">$(BuildArgs) -portablebuild=false</BuildArgs>
       <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) -cross</BuildArgs>
       <BuildArgs Condition="'$(Compiler)' != ''">$(BuildArgs) $(Compiler)</BuildArgs>
@@ -84,7 +84,7 @@
         !Exists('$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity)\version_info.h')"/>
 
     <PropertyGroup>
-      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(OutputRid)</BuildArgs>
+      <BuildArgs>$(Configuration) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(OutputRid)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>
       <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>
       <BuildArgs>$(BuildArgs) rootdir $(RepoRoot)</BuildArgs>

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -33,7 +33,7 @@
       deb-tool" commands, after depending on InitializeDotnetDebTool target.
     -->
     <DebToolBinDir>$(ArtifactsBinDir)dotnet-deb-tool\</DebToolBinDir>
-    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppCurrent)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
+    <DebtoolAssemblyFile>$(DebToolBinDir)$(OSGroup)_$(Configuration)\$(NetCoreAppCurrent)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
     <DotnetDebToolSourceDir>$(RepoRoot)tools-local/dotnet-deb-tool/</DotnetDebToolSourceDir>
 
     <IsDebianBasedDistro

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -33,7 +33,7 @@
       deb-tool" commands, after depending on InitializeDotnetDebTool target.
     -->
     <DebToolBinDir>$(ArtifactsBinDir)dotnet-deb-tool\</DebToolBinDir>
-    <DebtoolAssemblyFile>$(DebToolBinDir)$(OSGroup)_$(Configuration)\$(NetCoreAppCurrent)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
+    <DebtoolAssemblyFile>$(DebToolBinDir)$(Configuration)\$(NetCoreAppCurrent)\dotnet-deb-tool.dll</DebtoolAssemblyFile>
     <DotnetDebToolSourceDir>$(RepoRoot)tools-local/dotnet-deb-tool/</DotnetDebToolSourceDir>
 
     <IsDebianBasedDistro

--- a/src/installer/test/Directory.Build.targets
+++ b/src/installer/test/Directory.Build.targets
@@ -79,7 +79,7 @@
       <TestContextVariable Include="TEST_TARGETRID=$(TestTargetRid)" />
       <TestContextVariable Include="BUILDRID=$(OutputRid)" />
       <TestContextVariable Include="BUILD_ARCHITECTURE=$(TargetArchitecture)" />
-      <TestContextVariable Include="BUILD_CONFIGURATION=$(ConfigurationGroup)" />
+      <TestContextVariable Include="BUILD_CONFIGURATION=$(Configuration)" />
       <TestContextVariable Include="MNA_VERSION=$(NETCoreAppRuntimePackageVersion)" />
       <TestContextVariable Include="MNA_TFM=$(NETCoreAppFramework)" />
       <TestContextVariable Include="DOTNET_SDK_PATH=$(DotNetRoot)" />
@@ -129,7 +129,7 @@
       <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(_HostRid)</TestTargetRid>
       <TestsOutputName Condition="'$(TestsOutputName)' == ''">$(MSBuildProjectName)</TestsOutputName>
 
-      <TestsOutputRootDir Condition="'$(TestsOutputRootDir)' == ''">$(ArtifactsDir)tests/$(ConfigurationGroup)/</TestsOutputRootDir>
+      <TestsOutputRootDir Condition="'$(TestsOutputRootDir)' == ''">$(ArtifactsDir)tests/$(Configuration)/</TestsOutputRootDir>
       <TestsOutputDir Condition="'$(TestsOutputDir)' == ''">$(TestsOutputRootDir)$(TestsOutputName)/</TestsOutputDir>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32506

The build passes locally. Testing it on CI.
Todo:- check behavior differences for the VS

Removing ConfigurationGroup and using Configuration instead. This will make the behavior similar to the libraries and coreclr subset.

I have pushed the change to internal mirror to test that official build is not broken