### PR TITLE
Update dependencies ILLink.Tasks

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -166,9 +166,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>e793fcc19797f407a1b7e98d5f81b04e25a551c3</Sha>
     </Dependency>
-    <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.20117.1">
+    <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.20122.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>72551f41d5925198262c1f3c2d06dfecd2596a4e</Sha>
+      <Sha>e06788800df2d0431c0821e1116406ff3a67226a</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Use darc commands to include the latest commit from the linker in the runtime and see how it behaves in CI. This is a follow up from https://github.com/dotnet/runtime/pull/1804 after some linker fixes.