### PR TITLE
Sync shared code with aspnetcore for HTTP/3

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
@@ -340,7 +340,6 @@ namespace System.Net.Http.QPack
             return true;
         }
 
-        // TODO these are fairly hard coded for the first two bytes to be zero.
         public bool BeginEncode(IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
         {
             _enumerator = headers.GetEnumerator();
@@ -351,7 +350,11 @@ namespace System.Net.Http.QPack
             buffer[0] = 0;
             buffer[1] = 0;
 
-            return Encode(buffer.Slice(2), out length);
+            bool doneEncode = Encode(buffer.Slice(2), out length);
+
+            // Add two for the first two bytes.
+            length += 2;
+            return doneEncode;
         }
 
         public bool BeginEncode(int statusCode, IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -142,12 +142,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             //   error code mapping when creating exceptions.
 
             OperatingSystem ver = Environment.OSVersion;
-
-            if (ver.Platform == PlatformID.Win32NT && ver.Version < new Version(10, 0, 19041, 0))
-            {
-                IsQuicSupported = false;
-                return;
-            }
 
             // TODO: try to initialize TLS 1.3 in SslStream.
 


### PR DESCRIPTION
@scalablecory / @Tratcher I removed the OS check for IsQuicSupport for now; I was hitting issues where the version in aspnetcore didn't match the version in runtime. @Tratcher also had pushback on this check in general. We can discuss what we'd like to do here.