### PR TITLE
Cleanup g_spawn_async_with_pipes, g_spawn_command_line_sync (gspawn.c).

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -5109,13 +5109,11 @@ case $host in
     PATHSEP='\\'
     SEARCHSEP=';'
     OS="WIN32"
-    PIDTYPE='void *'
     ;;
 *)
     PATHSEP='/'
     SEARCHSEP=':'
     OS="UNIX"
-    PIDTYPE='int'
     ;;
 esac
 
@@ -5145,7 +5143,6 @@ AC_SUBST(ORDER)
 AC_SUBST(PATHSEP)
 AC_SUBST(SEARCHSEP)
 AC_SUBST(OS)
-AC_SUBST(PIDTYPE)
 
 # Defined for all targets/platforms using classic Windows API support.
 AC_DEFINE(HAVE_CLASSIC_WINAPI_SUPPORT, 1, [Use classic Windows API support])

--- a/src/mono/mono/eglib/Makefile.am
+++ b/src/mono/mono/eglib/Makefile.am
@@ -15,7 +15,8 @@ win_files  = \
 
 unix_files = \
 	gdate-unix.c  gdir-unix.c  gfile-unix.c  gmisc-unix.c	\
-	gmodule-unix.c gtimer-unix.c gmodule-aix.c
+	gmodule-unix.c gtimer-unix.c gmodule-aix.c \
+	gspawn.c
 
 if HOST_WIN32
 os_files = $(win_files)
@@ -44,7 +45,6 @@ libeglib_la_SOURCES = \
 	gqueue.c	\
 	gpath.c		\
 	gshell.c	\
-	gspawn.c	\
 	gfile.c		\
 	gfile-posix.c	\
 	gpattern.c	\

--- a/src/mono/mono/eglib/eglib-config.h.in
+++ b/src/mono/mono/eglib/eglib-config.h.in
@@ -38,6 +38,10 @@ typedef @GSSIZE@ gssize;
 #define G_BREAKPOINT() do { printf ("MONO: BREAKPOINT\n"); abort (); } while (0)
 #endif
 
-typedef @PIDTYPE@ GPid;
+/* Define to 1 if you have the `fork' function. */
+#undef HAVE_FORK
+
+/* Define to 1 if you have the `execv' function. */
+#undef HAVE_EXECV
 
 #endif

--- a/src/mono/mono/eglib/eglib-config.hw
+++ b/src/mono/mono/eglib/eglib-config.hw
@@ -62,9 +62,19 @@ typedef int pid_t;
 /* disable the following warnings 
  * C4100: The formal parameter is not referenced in the body of the function. The unreferenced parameter is ignored. 
  * C4127: conditional expression is constant
+FIXME msvc-disabled-warnings.h instead.
 */
 #pragma warning(disable:4100 4127)
 #endif
 
-typedef void * GPid;
+/* Define to 1 if you have the `fork' function. */
+#undef HAVE_FORK
+
+/* Define to 1 if you have the `execv' function. */
+/* Windows does have it, but mono does not use it on Windows. */
+#undef HAVE_EXECV
+
+/* Define to 1 if you have the `getdtablesize' function. */
+#undef HAVE_GETDTABLESIZE
+
 #endif

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <inttypes.h>
+
 #ifdef _MSC_VER
 #include <eglib-config.hw>
 #else
@@ -1048,6 +1049,10 @@ gboolean  g_shell_parse_argv (const gchar *command_line, gint *argcp, gchar ***a
 gchar    *g_shell_unquote    (const gchar *quoted_string, GError **gerror);
 gchar    *g_shell_quote      (const gchar *unquoted_string);
 
+//#if defined (HAVE_FORK) && defined (HAVE_EXECV)
+
+//#define HAVE_G_SPAWN 1
+
 /*
  * Spawn
  */
@@ -1063,9 +1068,31 @@ typedef enum {
 
 typedef void (*GSpawnChildSetupFunc) (gpointer user_data);
 
+// Visual C++ runtime provides int getpid () and int _getpid ().
+// Win32 provides DWORD GetCurrentProcessId () (32bit unsigned long).
+// Posix provides pid_t.
+// g_spawn_async_with_pipes wants to return a HANDLE, i.e. void*.
+//
+// This is not really used.
+#ifdef G_OS_WIN32
+typedef void* GPid;
+#else
+#include <unistd.h>
+typedef pid_t GPid;
+#endif
+
 gboolean g_spawn_command_line_sync (const gchar *command_line, gchar **standard_output, gchar **standard_error, gint *exit_status, GError **gerror);
+
 gboolean g_spawn_async_with_pipes  (const gchar *working_directory, gchar **argv, gchar **envp, GSpawnFlags flags, GSpawnChildSetupFunc child_setup,
 				gpointer user_data, GPid *child_pid, gint *standard_input, gint *standard_output, gint *standard_error, GError **gerror);
+
+//#else
+
+// Win32 could implement these functions easily enough if needed.
+
+//#define HAVE_G_SPAWN 0
+
+//#endif
 
 int eg_getdtablesize (void);
 

--- a/src/mono/mono/eglib/gspawn.c
+++ b/src/mono/mono/eglib/gspawn.c
@@ -25,6 +25,13 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+#ifdef _WIN32
+
+#error Remove gspawn.c from the Win32 build definition.
+
+#else
+
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -60,6 +67,9 @@
 #ifdef G_OS_WIN32
 #include <io.h>
 #include <winsock2.h>
+#endif
+
+#if HAVE_G_SPAWN
 #define open _open
 #define close _close
 #define read _read
@@ -72,7 +82,13 @@
 #define set_error_cond(cond,msg, ...) do { if ((cond) && gerror != NULL) *gerror = g_error_new (G_LOG_DOMAIN, 1, msg, __VA_ARGS__); } while (0)
 #define set_error_status(status,msg, ...) do { if (gerror != NULL) *gerror = g_error_new (G_LOG_DOMAIN, status, msg, __VA_ARGS__); } while (0)
 #define NO_INTR(var,cmd) do { (var) = (cmd); } while ((var) == -1 && errno == EINTR)
-#define CLOSE_PIPE(p) do { close (p [0]); close (p [1]); } while (0)
+
+static void
+mono_close_pipe (int pipes [2])
+{
+	close (pipes [0]);
+	close (pipes [1]);
+}
 
 #if defined(__APPLE__)
 #if defined (TARGET_OSX)
@@ -88,6 +104,7 @@ G_END_DECLS
 static char *mono_environ[1] = { NULL };
 #define environ mono_environ
 #endif /* defined (TARGET_OSX) */
+
 #elif defined(_MSC_VER)
 /* MS defines this in stdlib.h */
 #else
@@ -96,7 +113,6 @@ extern char **environ;
 G_END_DECLS
 #endif
 
-#if !defined (G_OS_WIN32) && defined (HAVE_FORK) && defined (HAVE_EXECV)
 static int
 safe_read (int fd, gchar *buffer, gint count, GError **gerror)
 {
@@ -215,9 +231,11 @@ write_all (int fd, const void *vbuf, size_t n)
 	
 	return nwritten;
 }
-#endif /* !defined (G_OS_WIN32) && defined (HAVE_FORK) && defined (HAVE_EXECV) */
 
-#if !defined(G_OS_WIN32) && defined(HAVE_GETDTABLESIZE)
+#endif // HAVE_G_SPAWN
+
+#if defined (HAVE_GETDTABLESIZE)
+
 int
 eg_getdtablesize (void)
 {
@@ -232,13 +250,12 @@ eg_getdtablesize (void)
 	return getdtablesize ();
 #endif
 }
-#else
-int
-eg_getdtablesize (void)
-{
-	g_error ("Should not be called");
-}
+
 #endif
+
+#if HAVE_G_SPAWN
+
+// This code is presently not used, except to test it.
 
 gboolean
 g_spawn_command_line_sync (const gchar *command_line,
@@ -247,12 +264,6 @@ g_spawn_command_line_sync (const gchar *command_line,
 				gint *exit_status,
 				GError **gerror)
 {
-#ifdef G_OS_WIN32
-	return TRUE;
-#elif !defined (HAVE_FORK) || !defined (HAVE_EXECV)
-	fprintf (stderr, "g_spawn_command_line_sync not supported on this platform\n");
-	return FALSE;
-#else
 	pid_t pid;
 	gchar **argv;
 	gint argc;
@@ -269,7 +280,7 @@ g_spawn_command_line_sync (const gchar *command_line,
 
 	if (standard_error && !create_pipe (stderr_pipe, gerror)) {
 		if (standard_output) {
-			CLOSE_PIPE (stdout_pipe);
+			mono_close_pipe (stdout_pipe);
 		}
 		return FALSE;
 	}
@@ -306,6 +317,7 @@ g_spawn_command_line_sync (const gchar *command_line,
 	}
 
 	g_strfreev (argv);
+
 	if (standard_output)
 		close (stdout_pipe [1]);
 
@@ -327,13 +339,11 @@ g_spawn_command_line_sync (const gchar *command_line,
 		*exit_status = WEXITSTATUS (status);
 	}
 	return TRUE;
-#endif
 }
 
-/*
- * This is the only use we have in mono/metadata
-!g_spawn_async_with_pipes (NULL, (char**)addr_argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, &child_pid, &ch_in, &ch_out, NULL, NULL)
-*/
+// This function is used only in test code and in the reduced form:
+// mini/debugger-agent.c(1090): res = g_spawn_async_with_pipes (NULL, argv, NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
 gboolean
 g_spawn_async_with_pipes (const gchar *working_directory,
 			gchar **argv,
@@ -347,12 +357,6 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 			gint *standard_error,
 			GError **gerror)
 {
-#ifdef G_OS_WIN32
-	return TRUE;
-#elif !defined (HAVE_FORK) || !defined (HAVE_EXECVE)
-	fprintf (stderr, "g_spawn_async_with_pipes is not supported on this platform\n");
-	return FALSE;
-#else
 	pid_t pid;
 	int info_pipe [2];
 	int in_pipe [2] = { -1, -1 };
@@ -366,29 +370,29 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 		return FALSE;
 
 	if (standard_output && !create_pipe (out_pipe, gerror)) {
-		CLOSE_PIPE (info_pipe);
+		mono_close_pipe (info_pipe);
 		return FALSE;
 	}
 
 	if (standard_error && !create_pipe (err_pipe, gerror)) {
-		CLOSE_PIPE (info_pipe);
-		CLOSE_PIPE (out_pipe);
+		mono_close_pipe (info_pipe);
+		mono_close_pipe (out_pipe);
 		return FALSE;
 	}
 
 	if (standard_input && !create_pipe (in_pipe, gerror)) {
-		CLOSE_PIPE (info_pipe);
-		CLOSE_PIPE (out_pipe);
-		CLOSE_PIPE (err_pipe);
+		mono_close_pipe (info_pipe);
+		mono_close_pipe (out_pipe);
+		mono_close_pipe (err_pipe);
 		return FALSE;
 	}
 
 	pid = fork ();
 	if (pid == -1) {
-		CLOSE_PIPE (info_pipe);
-		CLOSE_PIPE (out_pipe);
-		CLOSE_PIPE (err_pipe);
-		CLOSE_PIPE (in_pipe);
+		mono_close_pipe (info_pipe);
+		mono_close_pipe (out_pipe);
+		mono_close_pipe (err_pipe);
+		mono_close_pipe (in_pipe);
 		set_error ("%s", "Error in fork ()");
 		return FALSE;
 	}
@@ -483,10 +487,10 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 		/* Wait for the first child if two are created */
 		NO_INTR (w, waitpid (pid, &status, 0));
 		if (status == 1 || w == -1) {
-			CLOSE_PIPE (info_pipe);
-			CLOSE_PIPE (out_pipe);
-			CLOSE_PIPE (err_pipe);
-			CLOSE_PIPE (in_pipe);
+			mono_close_pipe (info_pipe);
+			mono_close_pipe (out_pipe);
+			mono_close_pipe (err_pipe);
+			mono_close_pipe (in_pipe);
 			set_error ("Error in fork (): %d", status);
 			return FALSE;
 		}
@@ -522,5 +526,9 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 	if (standard_error)
 		*standard_error = err_pipe [0];
 	return TRUE;
-#endif
 }
+
+#endif // HAVE_G_SPAWN
+
+extern const char mono_eglib_quash_empty_file_warning_gspawn;
+extern const char mono_eglib_quash_empty_file_warning_gspawn = 0;

--- a/src/mono/mono/eglib/test/spawn.c
+++ b/src/mono/mono/eglib/test/spawn.c
@@ -13,15 +13,10 @@
 #define close _close
 #endif
 
-#if _MSC_VER
-// Two warnings for this significant error.
-#pragma warning(disable:4022) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
-#pragma warning(disable:4047) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
-#endif
-
 static RESULT
 test_spawn_sync (void)
 {
+#if HAVE_G_SPAWN
 	gchar *out;
 	gchar *err;
 	gint status = -1;
@@ -38,12 +33,14 @@ test_spawn_sync (void)
 
 	g_free (out);
 	g_free (err);
+#endif // HAVE_G_SPAWN
 	return OK;
 }
 
 static RESULT
 test_spawn_async (void)
 {
+#if HAVE_G_SPAWN
 	/*
 gboolean
 g_spawn_async_with_pipes (const gchar *working_directory,
@@ -60,7 +57,7 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 	char *argv [15];
 	int stdout_fd = -1;
 	char buffer [512];
-	pid_t child_pid = 0;
+	GPid child_pid = 0;
 
 	memset (argv, 0, 15 * sizeof (char *));
 	argv [0] = (char*)"ls";
@@ -73,7 +70,7 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 
 	while (read (stdout_fd, buffer, 512) > 0);
 	close (stdout_fd);
-
+#endif // HAVE_G_SPAWN
 	return OK;
 }
 

--- a/src/mono/winconfig.h
+++ b/src/mono/winconfig.h
@@ -273,6 +273,15 @@
 /* Version number of package */
 #define VERSION "#MONO_VERSION#"
 
+/* Define to 1 if you have the `execv' function. */
+#undef HAVE_EXECV
+
+/* Define to 1 if you have the `fork' function. */
+#undef HAVE_FORK
+
+/* Define to 1 if you have the `getdtablesize' function. */
+#undef HAVE_GETDTABLESIZE
+
 #else
 
 /* Not building under MSVC, use autogen.sh generated config.h */


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19025,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>There are a few problems here.

The main one, that drew me here, is that the GPid typedef
is wrong. If the code was actually live, Win32 would
corrupt memory or use uninitialized memory.
This resulted in two warnings on Windows builds that really
should be errors.

But more so, the function is not used on Windows, except sort of for testing.
and much of the functionality is not used on Unix.

On Windows, #if out the function. GPid ends up unused.
On Unix, leave it alone, mostly -- the unused parameters
and unused flags remain.

Move configuration of GPid from configure.ac and hardcoded
to eglib-config.h, correcting it even on Windows, where it not used.

Use the Posix specified pid_t instead of int.
 Probably the same thing. Maybe missing on some platforms.
 But if so, try to autoconf it better.

Note that the unused functionality is easy to implement on Windows.

CLOSE_PIPE is unnecessarily a macro, make it a function.
 Creating a processa and doing I/O is not going to be faster
 by inlining close.

Move Win32 toward the more general #ifdef configured_feature
instead of #ifdef Win32. Minor and arguable. It ends up hardcoded
in winconfig.h and eglib-config.hw anyway (these should probably be combined).