### PR TITLE
Fix Windows CoreRun.exe to work with CoreCLR/Mono using xplat hosting API.

### DIFF
--- a/src/coreclr/src/hosts/corerun/logger.cpp
+++ b/src/coreclr/src/hosts/corerun/logger.cpp
@@ -8,6 +8,7 @@
 #include <windows.h>
 #include <Logger.h>
 #include "palclr.h"
+#include "sstring.h"
 
 void Logger::Enable() {
     m_isEnabled = true;
@@ -229,6 +230,19 @@ Logger& Logger::operator<< (const wchar_t *val) {
     if (m_isEnabled) {
         EnsurePrefixIsPrinted();
         print(val);
+    }
+    return *this;
+}
+
+Logger& Logger::operator<< (const char *val) {
+    if (m_isEnabled) {
+        EnsurePrefixIsPrinted();
+
+        SString valUTF8(SString::Utf8Literal, val);
+        SmallStackSString valUnicode;
+        valUTF8.ConvertToUnicode(valUnicode);
+
+        print(valUnicode);
     }
     return *this;
 }

--- a/src/coreclr/src/hosts/corerun/logger.h
+++ b/src/coreclr/src/hosts/corerun/logger.h
@@ -42,6 +42,7 @@ public:
     Logger& operator<< (double val);
     Logger& operator<< (long double val);
     Logger& operator<< (const wchar_t* val);
+    Logger& operator<< (const char* val);
     Logger& operator<< (Logger& ( *pf )(Logger&));
     static Logger& endl ( Logger& log );
     static Logger& hresult ( Logger& log);


### PR DESCRIPTION
CoreRun.exe is shared between both CoreCLR and Mono. On Windows, CoreRun.exe is still using ICLRRuntimeHost4 hosting API but Mono doesn't implement that API, just the xplat hosting API. Fix change CoreRun.exe on Windows to use xplat hosting API, so it works with both CoreCLR and Mono on Windows. CoreRun on Unix already used xplat hosting API.

Behaviour on CoreRun.exe Windows CoreCLR should be identical, since implementation of xplat hosting API on CoreCLR uses ICLRRuntimeHost4 internally and calls to CreateAppDomainWithManager, ExecuteAssembly, UnloadAppDomain2 and Stop look identical to what done in CoreRun.exe before this fix.