### PR TITLE
RyuJIT: Optimize `obj.GetType() != typeof(X)` for sealed classes

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -12506,11 +12506,15 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
     // with `true` + null check.
     if (objCls != NO_CLASS_HANDLE &&
         // double check if it's final via impIsClassExact rather than pIsExact
-        impIsClassExact(objCls) && objCls == clsHnd)
+        impIsClassExact(objCls) && impIsClassExact(clsHnd))
     {
+        const bool typesAreEqual = objCls == clsHnd;
+        const bool operatorIsEQ = (oper == GT_EQ);
+        const int  compareResult = operatorIsEQ ^ typesAreEqual ? 0 : 1;
+
         GenTree* nullcheck = gtNewNullCheck(objOp, compCurBB);
         return gtNewOperNode(GT_COMMA, tree->TypeGet(), nullcheck,
-            gtNewIconNode((oper == GT_EQ) ? 1 : 0));
+            gtNewIconNode(compareResult));
     }
 
     GenTree* const objMT = gtNewOperNode(GT_IND, TYP_I_IMPL, objOp);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -12504,16 +12504,14 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
 
     // if both classes are "final" (e.g. System.String[]) we can replace the comparison
     // with `true/false` + null check.
-    if ((objCls != NO_CLASS_HANDLE) &&
-        // double check if it's final via impIsClassExact for arrays
-        (pIsExact || impIsClassExact(objCls)) && impIsClassExact(clsHnd))
+    if ((objCls != NO_CLASS_HANDLE) && (pIsExact || impIsClassExact(objCls)))
     {
         TypeCompareState tcs = info.compCompHnd->compareTypesForEquality(objCls, clsHnd);
         if (tcs != TypeCompareState::May)
         {
             const bool operatorIsEQ  = oper == GT_EQ;
             const bool typesAreEqual = tcs == TypeCompareState::Must;
-            GenTree* compareResult   = gtNewIconNode((operatorIsEQ ^ typesAreEqual) ? 0 : 1);
+            GenTree*   compareResult = gtNewIconNode((operatorIsEQ ^ typesAreEqual) ? 0 : 1);
 
             if (!pIsNonNull)
             {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -20654,7 +20654,7 @@ void Compiler::addExpRuntimeLookupCandidate(GenTreeCall* call)
 //    variance or similar.
 //
 // Note:
-//    We are conservative on arrays here, only array of sealed clases can
+//    We are conservative on arrays here, only arrays of sealed classes can
 //    be considered as final.
 
 bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
@@ -20666,7 +20666,7 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
     {
         return true;
     }
-    if ((flags & (CORINFO_FLG_VARIANCE | CORINFO_FLG_ARRAY)) == CORINFO_FLG_ARRAY)
+    if ((flags & flagsMask) == (CORINFO_FLG_FINAL | CORINFO_FLG_ARRAY))
     {
         CORINFO_CLASS_HANDLE arrayElementHandle = nullptr;
         if (info.compCompHnd->getChildType(classHnd, &arrayElementHandle) == CORINFO_TYPE_CLASS)

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -20668,8 +20668,7 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
     if ((flags & flagsMask) == (CORINFO_FLG_FINAL | CORINFO_FLG_ARRAY))
     {
         CORINFO_CLASS_HANDLE arrayElementHandle = nullptr;
-        CorInfoType          type
-            = info.compCompHnd->getChildType(classHnd, &arrayElementHandle);
+        CorInfoType          type               = info.compCompHnd->getChildType(classHnd, &arrayElementHandle);
 
         if ((type == CORINFO_TYPE_CLASS) || (type == CORINFO_TYPE_VALUECLASS))
         {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -20669,7 +20669,11 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
     if ((flags & flagsMask) == (CORINFO_FLG_FINAL | CORINFO_FLG_ARRAY))
     {
         CORINFO_CLASS_HANDLE arrayElementHandle = nullptr;
-        if (info.compCompHnd->getChildType(classHnd, &arrayElementHandle) == CORINFO_TYPE_CLASS)
+        CorInfoType          type
+            = info.compCompHnd->getChildType(classHnd, &arrayElementHandle);
+
+        if ((type == CORINFO_TYPE_CLASS) || (type == CORINFO_TYPE_VALUECLASS) ||
+            (type == CORINFO_TYPE_STRING))
         {
             return impIsClassExact(arrayElementHandle);
         }

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -20654,8 +20654,7 @@ void Compiler::addExpRuntimeLookupCandidate(GenTreeCall* call)
 //    variance or similar.
 //
 // Note:
-//    We are conservative on arrays here, only arrays of sealed classes can
-//    be considered as final.
+//    We are conservative on arrays of primitive types here.
 
 bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
 {
@@ -20672,8 +20671,7 @@ bool Compiler::impIsClassExact(CORINFO_CLASS_HANDLE classHnd)
         CorInfoType          type
             = info.compCompHnd->getChildType(classHnd, &arrayElementHandle);
 
-        if ((type == CORINFO_TYPE_CLASS) || (type == CORINFO_TYPE_VALUECLASS) ||
-            (type == CORINFO_TYPE_STRING))
+        if ((type == CORINFO_TYPE_CLASS) || (type == CORINFO_TYPE_VALUECLASS))
         {
             return impIsClassExact(arrayElementHandle);
         }


### PR DESCRIPTION
Motivation: https://github.com/dotnet/runtime/issues/29093#issuecomment-590616970

`impIsClassExact` now returns `true` for arrays of sealed classes, e.g. `String[]` (but returns `false` for arrays of other things including primitives and enums).

Also, optimizes `obj.GetType() == typeof(X)` to a const + nullcheck (can be eliminated later by Jit) if we can prove both types are sealed, e.g.:
```csharp
public static bool Check<T>(T[] array)
{
    // co-variance check, e.g. see Span<T>'s ctor
    return array.GetType() != typeof(T[]);
}
```
#### Old codegen for `Check<string>`:
```asm
       mov      rax, 0xD1FFAB1E
       cmp      qword ptr [rcx], rax 
       setne    al
       movzx    rax, al
       ret
```
#### New codegen for `Check<string>`:
```asm
       cmp      dword ptr [rcx], ecx  ;; null-check for array
       xor      eax, eax
       ret
```


#### Jit-diff (-f -pmi):
(Correct me if I am wrong but the diff should be way bigger once jit learns how to inline generics into shared methods -- because `Span<T>` uses that check a lot)
```
Found 5 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -363 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
        -135 : System.Private.CoreLib.dasm (-0.00% of base)
        -129 : System.IO.FileSystem.Watcher.dasm (-0.84% of base)
         -75 : System.Net.Http.dasm (-0.01% of base)
         -24 : System.Text.RegularExpressions.dasm (-0.01% of base)

4 total files with Code Size differences (4 improved, 0 regressed), 158 unchanged.

Top method improvements (bytes):
         -87 (-55.41% of base) : System.Private.CoreLib.dasm - System.Text.UTF32Encoding:get_Preamble():System.ReadOnlySpan`1[Byte]:this
         -65 (-10.38% of base) : System.IO.FileSystem.Watcher.dasm - ImmutableStringList:Insert(int,System.String):this
         -64 (-10.83% of base) : System.IO.FileSystem.Watcher.dasm - ImmutableStringList:RemoveAt(int):this
         -48 (-3.48% of base) : System.Private.CoreLib.dasm - System.Threading.WaitHandle:WaitMultiple(System.ReadOnlySpan`1[[System.Threading.WaitHandle, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],bool,int):int
         -25 (-2.34% of base) : System.Net.Http.dasm - System.Net.Http.Http2Connection:WriteHeaderCollection(System.Net.Http.Headers.HttpHeaders):this
         -25 (-1.43% of base) : System.Net.Http.dasm - System.Net.Http.Http3RequestStream:BufferHeaderCollection(System.Net.Http.Headers.HttpHeaders):this
         -25 (-5.94% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpHeaders:GetValuesAsStrings(System.Net.Http.Headers.HeaderDescriptor,HeaderStoreItemInfo,System.Object):System.String[]
         -24 (-9.80% of base) : System.Text.RegularExpressions.dasm - System.Text.RegularExpressions.Regex:GetGroupNames():System.String[]:this

Top method improvements (percentages):
         -87 (-55.41% of base) : System.Private.CoreLib.dasm - System.Text.UTF32Encoding:get_Preamble():System.ReadOnlySpan`1[Byte]:this
         -64 (-10.83% of base) : System.IO.FileSystem.Watcher.dasm - ImmutableStringList:RemoveAt(int):this
         -65 (-10.38% of base) : System.IO.FileSystem.Watcher.dasm - ImmutableStringList:Insert(int,System.String):this
         -24 (-9.80% of base) : System.Text.RegularExpressions.dasm - System.Text.RegularExpressions.Regex:GetGroupNames():System.String[]:this
         -25 (-5.94% of base) : System.Net.Http.dasm - System.Net.Http.Headers.HttpHeaders:GetValuesAsStrings(System.Net.Http.Headers.HeaderDescriptor,HeaderStoreItemInfo,System.Object):System.String[]
         -48 (-3.48% of base) : System.Private.CoreLib.dasm - System.Threading.WaitHandle:WaitMultiple(System.ReadOnlySpan`1[[System.Threading.WaitHandle, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],bool,int):int
         -25 (-2.34% of base) : System.Net.Http.dasm - System.Net.Http.Http2Connection:WriteHeaderCollection(System.Net.Http.Headers.HttpHeaders):this
         -25 (-1.43% of base) : System.Net.Http.dasm - System.Net.Http.Http3RequestStream:BufferHeaderCollection(System.Net.Http.Headers.HttpHeaders):this

8 total methods with Code Size differences (8 improved, 0 regressed), 305673 unchanged.

1 files had text diffs but no metric diffs.
System.Runtime.Serialization.Formatters.dasm had 66 diffs
```
Will add tests later.

cc @AndyAyersMS 