### PR TITLE
Fix warnings: GPid vs. pid_t function signature mixup in glib test code.

### DIFF
--- a/src/mono/mono/eglib/test/spawn.c
+++ b/src/mono/mono/eglib/test/spawn.c
@@ -13,12 +13,6 @@
 #define close _close
 #endif
 
-#if _MSC_VER
-// Two warnings for this significant error.
-#pragma warning(disable:4022) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
-#pragma warning(disable:4047) // FIXME severe parameter mismatch with regard to g_spawn_async_with_pipes GPid
-#endif
-
 static RESULT
 test_spawn_sync (void)
 {
@@ -60,7 +54,7 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 	char *argv [15];
 	int stdout_fd = -1;
 	char buffer [512];
-	pid_t child_pid = 0;
+	GPid child_pid = 0;
 
 	memset (argv, 0, 15 * sizeof (char *));
 	argv [0] = (char*)"ls";


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19028,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Extracted from https://github.com/mono/mono/pull/19025.