### PR TITLE
Fix issue #32466

### DIFF
--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2833,12 +2833,13 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         // Absolute addresses marked as contained should fit within the base of addr mode.
         assert(memBase->AsIntConCommon()->FitsInAddrBase(emitComp));
 
-        // Either not generating relocatable code, or addr must be an icon handle, or the
-        // constant is zero (which we won't generate a relocation for).
-        //
-        // On x86 we can have an indirection of a non-handle int constant without a reloc.
-        // The return value of FitsInAddrBase determines whether we mark the int constant node
-        // as contained or not (see Lowering::ContainCheckIndir)
+        // If we reach here, either:
+        // - we are not generating relocatable code, (typically the non-AOT JIT case)
+        // - the base address is a handle represented by an integer constant,
+        // - the base address is a constant zero, or
+        // - the base address is a constant that fits into the memory instruction (this can happen on x86).
+        //   This last case is captured in the FitsInAddrBase method which is used by Lowering to determine that it can
+        //   be contained.
         //
         assert(!emitComp->opts.compReloc || memBase->IsIconHandle() || memBase->IsIntegralConst(0) ||
                memBase->AsIntConCommon()->FitsInAddrBase(emitComp));

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2835,7 +2835,13 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
 
         // Either not generating relocatable code, or addr must be an icon handle, or the
         // constant is zero (which we won't generate a relocation for).
-        assert(!emitComp->opts.compReloc || memBase->IsIconHandle() || memBase->IsIntegralConst(0));
+        //
+        // On x86 we can have an indirection of a non-handle int constant without a reloc.
+        // The return value of FitsInAddrBase determines whether we mark the int constant node
+        // as contained or not (see Lowering::ContainCheckIndir)
+        //
+        assert(!emitComp->opts.compReloc || memBase->IsIconHandle() || memBase->IsIntegralConst(0) ||
+               memBase->AsIntConCommon()->FitsInAddrBase(emitComp));
 
         if (memBase->AsIntConCommon()->AddrNeedsReloc(emitComp))
         {


### PR DESCRIPTION
Fixes outerloop leg: R2R Windows_NT x86 Checked no_tiered_compilation @ Windows.10.Amd64.Open

Fixes issue #32466