### PR TITLE
Update required SDK to 3.1.101

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100",
+    "version": "3.1.101",
     "allowPrerelease": true,
     "rollForward": "major"
   },


### PR DESCRIPTION
The toolset package requires at least a 3.1.101 SDK, therefore updating the minimum required version.

Fixes https://github.com/dotnet/runtime/issues/32775