### PR TITLE
Bump DependencyModel reference to Text.Json to 4.7.1

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -70,8 +70,11 @@ if ($vs) {
 
   # Microsoft.DotNet.CoreSetup.sln is special - hosting tests are currently meant to run on the
   # bootstrapped .NET Core, not on the live-built runtime.
-  if ([System.IO.Path]::GetFileName($vs) -ieq "Microsoft.DotNet.CoreSetup.sln") {
+  if (([System.IO.Path]::GetFileName($vs) -ieq "Microsoft.DotNet.CoreSetup.sln") -or ($vs -ieq "Microsoft.DotNet.CoreSetup")) {
     if (-Not (Test-Path $vs)) {
+      if (-Not ( $vs.endswith(".sln"))) {
+          $vs = "$vs.sln"
+      }
       $vs = Join-Path "$PSScriptRoot\..\src\installer" $vs
     }
 

--- a/src/installer/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/installer/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -25,7 +25,7 @@
     -->
     <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+        <PackageReference Include="System.Text.Json" Version="4.7.1" />
       </ItemGroup>
       <ItemGroup>
         <Compile Remove="DependencyContextJsonReader.JsonTextReader.cs" />

--- a/src/installer/test/Microsoft.Extensions.DependencyModel.Tests/EnvironmentMockBuilder.cs
+++ b/src/installer/test/Microsoft.Extensions.DependencyModel.Tests/EnvironmentMockBuilder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.Extensions.DependencyModel.Tests
 {

--- a/src/installer/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.csproj
+++ b/src/installer/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Microsoft.DotNet.Tools.Tests.Utilities Class Library</Description>
     <TargetFramework>$(TestInfraTargetFramework)</TargetFramework>
-    <AssemblyName>Microsoft.Extensions.DependencyModel.Tests</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Microsoft.Extensions.DependencyModel.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
@@ -15,11 +12,7 @@
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Moq" Version="4.7.142" />
-    <PackageReference Include="NuGet.Versioning" Version="4.0.0" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="1.0.0-rc2-002702" />
-    <PackageReference Include="System.Text.Json" Version="4.7.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.0" />
-    <ProjectReference Include="..\..\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
     <ProjectReference Include="..\..\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
We shipped DependencyModel v3.1.2 that references Text.Json 4.7.1. We shouldn't ship a new version that downgrades that reference.

Also do some clean up in the Tests.