### PR TITLE
Update CodeAnalysis.ruleset to list every roslyn analyzers rule

### DIFF
--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,77 +1,214 @@
 ﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1000" Action="None" /> <!-- Do not declare static members on generic types -->
-    <Rule Id="CA1001" Action="None" /> <!-- Non disposable class owns disposable fields -->
-    <Rule Id="CA1010" Action="None" /> <!-- Collections should implement generic interface -->
-    <Rule Id="CA1028" Action="None" /> <!-- Enum storage should be Int32 -->
-    <Rule Id="CA1030" Action="None" /> <!-- Use events where appropriate -->
-    <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
-    <Rule Id="CA1032" Action="None" /> <!-- Implement standard exception constructors  -->
-    <Rule Id="CA1034" Action="None" /> <!-- Nested types should not be visible -->
-    <Rule Id="CA1036" Action="None" /> <!-- Overload comparison operators when implementing System.IComparable -->
-    <Rule Id="CA1041" Action="None" /> <!-- Provide ObsoleteAttribute message -->
-    <Rule Id="CA1043" Action="None" /> <!-- Use integral or string argument for indexers -->
-    <Rule Id="CA1044" Action="None" /> <!-- Properties should not be write only -->
-    <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
-    <Rule Id="CA1052" Action="None" /> <!-- Static holder types should be sealed -->
-    <Rule Id="CA1054" Action="None" /> <!-- URI parameters should not be strings -->
-    <Rule Id="CA1055" Action="None" /> <!-- URI return values should not be strings -->
-    <Rule Id="CA1056" Action="None" /> <!-- URI properties should not be strings -->
-    <Rule Id="CA1058" Action="None" /> <!-- Types should not extend certain base types -->
-    <Rule Id="CA1061" Action="None" /> <!-- Do not hide base class methods -->
-    <Rule Id="CA1062" Action="None" /> <!-- Validate arguments of public methods -->
-    <Rule Id="CA1063" Action="None" /> <!-- Implement IDisposable correctly -->
-    <Rule Id="CA1064" Action="None" /> <!-- Exceptions should be public -->
-    <Rule Id="CA1065" Action="None" /> <!-- Do not raise exceptions in unexpected locations -->
-    <Rule Id="CA1066" Action="None" /> <!-- Type should implement IEquatable -->
-    <Rule Id="CA1067" Action="None" /> <!-- Override Object.Equals(object) when implementing IEquatable -->
-    <Rule Id="CA1068" Action="None" /> <!-- CancellationToken parameters must come last -->
-    <Rule Id="CA1303" Action="None" /> <!-- Do not pass literals as localized parameters -->
-    <Rule Id="CA1304" Action="None" /> <!-- Specify CultureInfo -->
-    <Rule Id="CA1305" Action="None" /> <!-- Specify IFormatProvider -->
-    <Rule Id="CA1307" Action="None" /> <!-- Specify StringComparison -->
-    <Rule Id="CA1308" Action="None" /> <!-- Normalize strings to upper case -->
-    <Rule Id="CA1707" Action="None" /> <!-- Identifers should not contain underscores -->
-    <Rule Id="CA1710" Action="None" /> <!-- Identifers should have correct suffix -->
-    <Rule Id="CA1712" Action="None" /> <!-- Do not prefix enum values with type name -->
-    <Rule Id="CA1714" Action="None" /> <!-- Flags enums should have plural names -->
-    <Rule Id="CA1715" Action="None" /> <!-- Type parameters names should be prefixed with T -->
-    <Rule Id="CA1716" Action="None" /> <!-- Identifiers should not match keywords -->
-    <Rule Id="CA1717" Action="None" /> <!-- Only FlagsAttribute enums should have plural names -->
-    <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
-    <Rule Id="CA1721" Action="None" /> <!-- Property names should not match get methods -->
-    <Rule Id="CA1724" Action="None" /> <!-- Type names should not match namespaces -->
-    <Rule Id="CA1801" Action="None" /> <!-- Review unused parameters -->
-    <Rule Id="CA1806" Action="None" /> <!-- Do not ignore method results -->
-    <Rule Id="CA1812" Action="None" /> <!-- Avoid uninstantiated internal classes -->
-    <Rule Id="CA1814" Action="None" /> <!-- Prefer jagged arrays over multidimensional -->
-    <Rule Id="CA1815" Action="None" /> <!-- Override equals and operator equals on value types -->
-    <Rule Id="CA1816" Action="None" /> <!-- Dispose methods should call SuppressFinalize -->
-    <Rule Id="CA1819" Action="None" /> <!-- Properties should not return arrays -->
-    <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings using string length -->
-    <Rule Id="CA1822" Action="None" /> <!-- Mark members as static -->
-    <Rule Id="CA2000" Action="None" /> <!-- Dispose objects before losing scope -->
-    <Rule Id="CA2002" Action="None" /> <!-- Do not lock on objects with weak identity -->
-    <Rule Id="CA2010" Action="None" /> <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
-    <Rule Id="CA2100" Action="None" /> <!-- Review SQL queries for security vulnerabilities -->
-    <Rule Id="CA2101" Action="None" /> <!-- Specify marshaling for P/Invoke string arguments -->
-    <Rule Id="CA2119" Action="None" /> <!-- Seal methods that satisfy private interfaces -->
-    <Rule Id="CA2208" Action="None" /> <!-- Instantiate exception arguments correctly -->
-    <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
-    <Rule Id="CA2213" Action="None" /> <!-- Disposable Fields should be disposed -->
-    <Rule Id="CA2214" Action="None" /> <!-- Do not call overridable methods in constructors -->
-    <Rule Id="CA2216" Action="None" /> <!-- Disposable types should declare finalizer -->
-    <Rule Id="CA2219" Action="None" /> <!-- Do not raise exceptions in finally clauses -->
-    <Rule Id="CA2225" Action="None" /> <!-- Operator overloads have named alternates -->
-    <Rule Id="CA2227" Action="None" /> <!-- Collection properties should be read only -->
-    <Rule Id="CA2231" Action="None" /> <!-- Overload operator equals when overriding ValueType.Equals -->
-    <Rule Id="CA2235" Action="None" /> <!-- Serializable type has non serializable field -->
-    <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to types that implement ISerializable -->
-    <Rule Id="CA5366" Action="None" /> <!-- Use XmlReader For DataSet Read Xml -->
-    <Rule Id="CA5369" Action="None" /> <!-- Use XmlReader For Deserialize -->
-    <Rule Id="CA5371" Action="None" /> <!-- Use XmlReader For Schema Read -->
-    <Rule Id="CA5372" Action="None" /> <!-- Use XmlReader For XPathDocument -->
-    <Rule Id="CA5397" Action="None" /> <!-- Security protocol version is deprecated -->
+      <Rule Id="CA1000" Action="None" />             <!-- Do not declare static members on generic types -->
+      <Rule Id="CA1001" Action="None" />             <!-- Types that own disposable fields should be disposable -->
+      <Rule Id="CA1003" Action="None" />             <!-- Use generic event handler instances -->
+      <Rule Id="CA1008" Action="None" />             <!-- Enums should have zero value -->
+      <Rule Id="CA1010" Action="None" />             <!-- Collections should implement generic interface -->
+      <Rule Id="CA1012" Action="None" />             <!-- Abstract types should not have constructors -->
+      <Rule Id="CA1014" Action="None" />             <!-- Mark assemblies with CLSCompliant -->
+      <Rule Id="CA1016" Action="None" />             <!-- Mark assemblies with assembly version -->
+      <Rule Id="CA1017" Action="None" />             <!-- Mark assemblies with ComVisible -->
+      <Rule Id="CA1018" Action="Warning" />          <!-- Mark attributes with AttributeUsageAttribute -->
+      <Rule Id="CA1019" Action="None" />             <!-- Define accessors for attribute arguments -->
+      <Rule Id="CA1021" Action="None" />             <!-- Avoid out parameters -->
+      <Rule Id="CA1024" Action="None" />             <!-- Use properties where appropriate -->
+      <Rule Id="CA1027" Action="None" />             <!-- Mark enums with FlagsAttribute -->
+      <Rule Id="CA1028" Action="None" />             <!-- Enum Storage should be Int32 -->
+      <Rule Id="CA1030" Action="None" />             <!-- Use events where appropriate -->
+      <Rule Id="CA1031" Action="None" />             <!-- Do not catch general exception types -->
+      <Rule Id="CA1032" Action="None" />             <!-- Implement standard exception constructors -->
+      <Rule Id="CA1033" Action="None" />             <!-- Interface methods should be callable by child types -->
+      <Rule Id="CA1034" Action="None" />             <!-- Nested types should not be visible -->
+      <Rule Id="CA1036" Action="None" />             <!-- Override methods on comparable types -->
+      <Rule Id="CA1040" Action="None" />             <!-- Avoid empty interfaces -->
+      <Rule Id="CA1041" Action="None" />             <!-- Provide ObsoleteAttribute message -->
+      <Rule Id="CA1043" Action="None" />             <!-- Use Integral Or String Argument For Indexers -->
+      <Rule Id="CA1044" Action="None" />             <!-- Properties should not be write only -->
+      <Rule Id="CA1050" Action="Warning" />          <!-- Declare types in namespaces -->
+      <Rule Id="CA1051" Action="None" />             <!-- Do not declare visible instance fields -->
+      <Rule Id="CA1052" Action="None" />             <!-- Static holder types should be Static or NotInheritable -->
+      <Rule Id="CA1054" Action="None" />             <!-- Uri parameters should not be strings -->
+      <Rule Id="CA1055" Action="None" />             <!-- Uri return values should not be strings -->
+      <Rule Id="CA1056" Action="None" />             <!-- Uri properties should not be strings -->
+      <Rule Id="CA1058" Action="None" />             <!-- Types should not extend certain base types -->
+      <Rule Id="CA1060" Action="None" />             <!-- Move pinvokes to native methods class -->
+      <Rule Id="CA1061" Action="None" />             <!-- Do not hide base class methods -->
+      <Rule Id="CA1062" Action="None" />             <!-- Validate arguments of public methods -->
+      <Rule Id="CA1063" Action="None" />             <!-- Implement IDisposable Correctly -->
+      <Rule Id="CA1064" Action="None" />             <!-- Exceptions should be public -->
+      <Rule Id="CA1065" Action="None" />             <!-- Do not raise exceptions in unexpected locations -->
+      <Rule Id="CA1066" Action="None" />             <!-- Type {0} should implement IEquatable<T> because it overrides Equals -->
+      <Rule Id="CA1067" Action="None" />             <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
+      <Rule Id="CA1068" Action="None" />             <!-- CancellationToken parameters must come last -->
+      <Rule Id="CA1069" Action="Warning" />          <!-- Enums values should not be duplicated -->
+      <Rule Id="CA1200" Action="Warning" />          <!-- Avoid using cref tags with a prefix -->
+      <Rule Id="CA1303" Action="None" />             <!-- Do not pass literals as localized parameters -->
+      <Rule Id="CA1304" Action="None" />             <!-- Specify CultureInfo -->
+      <Rule Id="CA1305" Action="None" />             <!-- Specify IFormatProvider -->
+      <Rule Id="CA1307" Action="None" />             <!-- Specify StringComparison -->
+      <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
+      <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
+      <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->
+      <Rule Id="CA1505" Action="None" />             <!-- Avoid unmaintainable code -->
+      <Rule Id="CA1506" Action="None" />             <!-- Avoid excessive class coupling -->
+      <Rule Id="CA1507" Action="Warning" />          <!-- Use nameof to express symbol names -->
+      <Rule Id="CA1508" Action="None" />             <!-- Avoid dead conditional code -->
+      <Rule Id="CA1509" Action="None" />             <!-- Invalid entry in code metrics rule specification file -->
+      <Rule Id="CA1707" Action="None" />             <!-- Identifiers should not contain underscores -->
+      <Rule Id="CA1708" Action="None" />             <!-- Identifiers should differ by more than case -->
+      <Rule Id="CA1710" Action="None" />             <!-- Identifiers should have correct suffix -->
+      <Rule Id="CA1711" Action="None" />             <!-- Identifiers should not have incorrect suffix -->
+      <Rule Id="CA1712" Action="None" />             <!-- Do not prefix enum values with type name -->
+      <Rule Id="CA1714" Action="None" />             <!-- Flags enums should have plural names -->
+      <Rule Id="CA1715" Action="None" />             <!-- Identifiers should have correct prefix -->
+      <Rule Id="CA1716" Action="None" />             <!-- Identifiers should not match keywords -->
+      <Rule Id="CA1717" Action="None" />             <!-- Only FlagsAttribute enums should have plural names -->
+      <Rule Id="CA1720" Action="None" />             <!-- Identifier contains type name -->
+      <Rule Id="CA1721" Action="None" />             <!-- Property names should not match get methods -->
+      <Rule Id="CA1724" Action="None" />             <!-- Type names should not match namespaces -->
+      <Rule Id="CA1725" Action="Info" />             <!-- Parameter names should match base declaration -->
+      <Rule Id="CA1801" Action="None" />             <!-- Review unused parameters -->
+      <Rule Id="CA1802" Action="Warning" />          <!-- Use literals where appropriate -->
+      <Rule Id="CA1806" Action="None" />             <!-- Do not ignore method results -->
+      <Rule Id="CA1810" Action="Warning" />          <!-- Initialize reference type static fields inline -->
+      <Rule Id="CA1812" Action="None" />             <!-- Avoid uninstantiated internal classes -->
+      <Rule Id="CA1813" Action="None" />             <!-- Avoid unsealed attributes -->
+      <Rule Id="CA1814" Action="None" />             <!-- Prefer jagged arrays over multidimensional -->
+      <Rule Id="CA1815" Action="None" />             <!-- Override equals and operator equals on value types -->
+      <Rule Id="CA1816" Action="None" />             <!-- Dispose methods should call SuppressFinalize -->
+      <Rule Id="CA1819" Action="None" />             <!-- Properties should not return arrays -->
+      <Rule Id="CA1820" Action="None" />             <!-- Test for empty strings using string length -->
+      <Rule Id="CA1821" Action="Warning" />          <!-- Remove empty Finalizers -->
+      <Rule Id="CA1822" Action="None" />             <!-- Mark members as static -->
+      <Rule Id="CA1823" Action="Warning" />          <!-- Avoid unused private fields -->
+      <Rule Id="CA1824" Action="Warning" />          <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+      <Rule Id="CA1825" Action="Warning" />          <!-- Avoid zero-length array allocations. -->
+      <Rule Id="CA1826" Action="Warning" />          <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+      <Rule Id="CA1827" Action="Warning" />          <!-- Do not use Count() or LongCount() when Any() can be used -->
+      <Rule Id="CA1828" Action="Warning" />          <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
+      <Rule Id="CA1829" Action="Warning" />          <!-- Use Length/Count property instead of Count() when available -->
+      <Rule Id="CA2000" Action="None" />             <!-- Dispose objects before losing scope -->
+      <Rule Id="CA2002" Action="None" />             <!-- Do not lock on objects with weak identity -->
+      <Rule Id="CA2007" Action="Warning" />          <!-- Consider calling ConfigureAwait on the awaited task -->
+      <Rule Id="CA2008" Action="Warning" />          <!-- Do not create tasks without passing a TaskScheduler -->
+      <Rule Id="CA2009" Action="Warning" />          <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
+      <Rule Id="CA2010" Action="Warning" />          <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
+      <Rule Id="CA2011" Action="Warning" />          <!-- Avoid infinite recursion -->
+      <Rule Id="CA2012" Action="Warning" />          <!-- Use ValueTasks correctly -->
+      <Rule Id="CA2100" Action="None" />             <!-- Review SQL queries for security vulnerabilities -->
+      <Rule Id="CA2101" Action="None" />             <!-- Specify marshaling for P/Invoke string arguments -->
+      <Rule Id="CA2119" Action="None" />             <!-- Seal methods that satisfy private interfaces -->
+      <Rule Id="CA2153" Action="None" />             <!-- Do Not Catch Corrupted State Exceptions -->
+      <Rule Id="CA2200" Action="Warning" />          <!-- Rethrow to preserve stack details. -->
+      <Rule Id="CA2201" Action="None" />             <!-- Do not raise reserved exception types -->
+      <Rule Id="CA2207" Action="Warning" />          <!-- Initialize value type static fields inline -->
+      <Rule Id="CA2208" Action="None" />             <!-- Instantiate argument exceptions correctly -->
+      <Rule Id="CA2211" Action="None" />             <!-- Non-constant fields should not be visible -->
+      <Rule Id="CA2213" Action="None" />             <!-- Disposable fields should be disposed -->
+      <Rule Id="CA2214" Action="None" />             <!-- Do not call overridable methods in constructors -->
+      <Rule Id="CA2215" Action="None" />             <!-- Dispose methods should call base class dispose -->
+      <Rule Id="CA2216" Action="None" />             <!-- Disposable types should declare finalizer -->
+      <Rule Id="CA2217" Action="None" />             <!-- Do not mark enums with FlagsAttribute -->
+      <Rule Id="CA2218" Action="None" />             <!-- Override GetHashCode on overriding Equals -->
+      <Rule Id="CA2219" Action="None" />             <!-- Do not raise exceptions in finally clauses -->
+      <Rule Id="CA2224" Action="None" />             <!-- Override Equals on overloading operator equals -->
+      <Rule Id="CA2225" Action="None" />             <!-- Operator overloads have named alternates -->
+      <Rule Id="CA2226" Action="None" />             <!-- Operators should have symmetrical overloads -->
+      <Rule Id="CA2227" Action="None" />             <!-- Collection properties should be read only -->
+      <Rule Id="CA2229" Action="Warning" />          <!-- Implement serialization constructors -->
+      <Rule Id="CA2231" Action="None" />             <!-- Overload operator equals on overriding value type Equals -->
+      <Rule Id="CA2234" Action="None" />             <!-- Pass system uri objects instead of strings -->
+      <Rule Id="CA2235" Action="None" />             <!-- Mark all non-serializable fields -->
+      <Rule Id="CA2237" Action="None" />             <!-- Mark ISerializable types with serializable -->
+      <Rule Id="CA2241" Action="Warning" />          <!-- Provide correct arguments to formatting methods -->
+      <Rule Id="CA2242" Action="Warning" />          <!-- Test for NaN correctly -->
+      <Rule Id="CA2243" Action="Warning" />          <!-- Attribute string literals should parse correctly -->
+      <Rule Id="CA2244" Action="None" />             <!-- Do not duplicate indexed element initializations -->
+      <Rule Id="CA2245" Action="Warning" />          <!-- Do not assign a property to itself. -->
+      <Rule Id="CA2246" Action="None" />             <!-- Assigning symbol and its member in the same statement. -->
+      <Rule Id="CA2300" Action="None" />             <!-- Do not use insecure deserializer BinaryFormatter -->
+      <Rule Id="CA2301" Action="None" />             <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
+      <Rule Id="CA2302" Action="None" />             <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
+      <Rule Id="CA2305" Action="None" />             <!-- Do not use insecure deserializer LosFormatter -->
+      <Rule Id="CA2310" Action="None" />             <!-- Do not use insecure deserializer NetDataContractSerializer -->
+      <Rule Id="CA2311" Action="None" />             <!-- Do not deserialize without first setting NetDataContractSerializer.Binder -->
+      <Rule Id="CA2312" Action="None" />             <!-- Ensure NetDataContractSerializer.Binder is set before deserializing -->
+      <Rule Id="CA2315" Action="None" />             <!-- Do not use insecure deserializer ObjectStateFormatter -->
+      <Rule Id="CA2321" Action="None" />             <!-- Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver -->
+      <Rule Id="CA2322" Action="None" />             <!-- Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing -->
+      <Rule Id="CA2326" Action="None" />             <!-- Do not use TypeNameHandling values other than None -->
+      <Rule Id="CA2327" Action="None" />             <!-- Do not use insecure JsonSerializerSettings -->
+      <Rule Id="CA2328" Action="None" />             <!-- Ensure that JsonSerializerSettings are secure -->
+      <Rule Id="CA2329" Action="None" />             <!-- Do not deserialize with JsonSerializer using an insecure configuration -->
+      <Rule Id="CA2330" Action="None" />             <!-- Ensure that JsonSerializer has a secure configuration when deserializing -->
+      <Rule Id="CA3001" Action="None" />             <!-- Review code for SQL injection vulnerabilities -->
+      <Rule Id="CA3002" Action="None" />             <!-- Review code for XSS vulnerabilities -->
+      <Rule Id="CA3003" Action="None" />             <!-- Review code for file path injection vulnerabilities -->
+      <Rule Id="CA3004" Action="None" />             <!-- Review code for information disclosure vulnerabilities -->
+      <Rule Id="CA3005" Action="None" />             <!-- Review code for LDAP injection vulnerabilities -->
+      <Rule Id="CA3006" Action="None" />             <!-- Review code for process command injection vulnerabilities -->
+      <Rule Id="CA3007" Action="None" />             <!-- Review code for open redirect vulnerabilities -->
+      <Rule Id="CA3008" Action="None" />             <!-- Review code for XPath injection vulnerabilities -->
+      <Rule Id="CA3009" Action="None" />             <!-- Review code for XML injection vulnerabilities -->
+      <Rule Id="CA3010" Action="None" />             <!-- Review code for XAML injection vulnerabilities -->
+      <Rule Id="CA3011" Action="None" />             <!-- Review code for DLL injection vulnerabilities -->
+      <Rule Id="CA3012" Action="None" />             <!-- Review code for regex injection vulnerabilities -->
+      <Rule Id="CA3061" Action="Warning" />          <!-- Do Not Add Schema By URL -->
+      <Rule Id="CA3075" Action="Warning" />          <!-- Insecure DTD processing in XML -->
+      <Rule Id="CA3076" Action="Warning" />          <!-- Insecure XSLT script processing. -->
+      <Rule Id="CA3077" Action="Warning" />          <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
+      <Rule Id="CA3147" Action="Warning" />          <!-- Mark Verb Handlers With Validate Antiforgery Token -->
+      <Rule Id="CA5350" Action="Warning" />          <!-- Do Not Use Weak Cryptographic Algorithms -->
+      <Rule Id="CA5351" Action="Warning" />          <!-- Do Not Use Broken Cryptographic Algorithms -->
+      <Rule Id="CA5358" Action="None" />             <!-- Do Not Use Unsafe Cipher Modes -->
+      <Rule Id="CA5359" Action="Warning" />          <!-- Do Not Disable Certificate Validation -->
+      <Rule Id="CA5360" Action="Warning" />          <!-- Do Not Call Dangerous Methods In Deserialization -->
+      <Rule Id="CA5361" Action="Warning" />          <!-- Do Not Disable SChannel Use of Strong Crypto -->
+      <Rule Id="CA5362" Action="None" />             <!-- Do Not Refer Self In Serializable Class -->
+      <Rule Id="CA5363" Action="Warning" />          <!-- Do Not Disable Request Validation -->
+      <Rule Id="CA5364" Action="Warning" />          <!-- Do Not Use Deprecated Security Protocols -->
+      <Rule Id="CA5365" Action="Warning" />          <!-- Do Not Disable HTTP Header Checking -->
+      <Rule Id="CA5366" Action="None" />             <!-- Use XmlReader For DataSet Read Xml -->
+      <Rule Id="CA5367" Action="None" />             <!-- Do Not Serialize Types With Pointer Fields -->
+      <Rule Id="CA5368" Action="Warning" />          <!-- Set ViewStateUserKey For Classes Derived From Page -->
+      <Rule Id="CA5369" Action="None" />             <!-- Use XmlReader For Deserialize -->
+      <Rule Id="CA5370" Action="Warning" />          <!-- Use XmlReader For Validating Reader -->
+      <Rule Id="CA5371" Action="None" />             <!-- Use XmlReader For Schema Read -->
+      <Rule Id="CA5372" Action="None" />             <!-- Use XmlReader For XPathDocument -->
+      <Rule Id="CA5373" Action="Warning" />          <!-- Do not use obsolete key derivation function -->
+      <Rule Id="CA5374" Action="Warning" />          <!-- Do Not Use XslTransform -->
+      <Rule Id="CA5375" Action="None" />             <!-- Do Not Use Account Shared Access Signature -->
+      <Rule Id="CA5376" Action="Warning" />          <!-- Use SharedAccessProtocol HttpsOnly -->
+      <Rule Id="CA5377" Action="Warning" />          <!-- Use Container Level Access Policy -->
+      <Rule Id="CA5378" Action="Warning" />          <!-- Do not disable ServicePointManagerSecurityProtocols -->
+      <Rule Id="CA5379" Action="Warning" />          <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+      <Rule Id="CA5380" Action="Warning" />          <!-- Do Not Add Certificates To Root Store -->
+      <Rule Id="CA5381" Action="Warning" />          <!-- Ensure Certificates Are Not Added To Root Store -->
+      <Rule Id="CA5382" Action="None" />             <!-- Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5383" Action="None" />             <!-- Ensure Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5384" Action="Warning" />          <!-- Do Not Use Digital Signature Algorithm (DSA) -->
+      <Rule Id="CA5385" Action="Warning" />          <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
+      <Rule Id="CA5386" Action="None" />             <!-- Avoid hardcoding SecurityProtocolType value -->
+      <Rule Id="CA5387" Action="None" />             <!-- Do Not Use Weak Key Derivation Function With Insufficient Iteration Count -->
+      <Rule Id="CA5388" Action="None" />             <!-- Ensure Sufficient Iteration Count When Using Weak Key Derivation Function -->
+      <Rule Id="CA5389" Action="None" />             <!-- Do Not Add Archive Item's Path To The Target File System Path -->
+      <Rule Id="CA5390" Action="None" />             <!-- Do not hard-code encryption key -->
+      <Rule Id="CA5391" Action="None" />             <!-- Use antiforgery tokens in ASP.NET Core MVC controllers -->
+      <Rule Id="CA5392" Action="None" />             <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
+      <Rule Id="CA5393" Action="None" />             <!-- Do not use unsafe DllImportSearchPath value -->
+      <Rule Id="CA5394" Action="None" />             <!-- Do not use insecure randomness -->
+      <Rule Id="CA5395" Action="None" />             <!-- Miss HttpVerb attribute for action methods -->
+      <Rule Id="CA5396" Action="None" />             <!-- Set HttpOnly to true for HttpCookie -->
+      <Rule Id="CA5397" Action="None" />             <!-- Do not use deprecated SslProtocols values -->
+      <Rule Id="CA5398" Action="None" />             <!-- Avoid hardcoded SslProtocols values -->
+      <Rule Id="CA5399" Action="None" />             <!-- HttpClients should enable certificate revocation list checks -->
+      <Rule Id="CA5400" Action="None" />             <!-- Ensure HttpClient certificate revocation list check is not disabled -->
+      <Rule Id="CA5401" Action="None" />             <!-- Do not use CreateEncryptor with non-default IV -->
+      <Rule Id="CA5402" Action="None" />             <!-- Use CreateEncryptor with the default IV  -->
+      <Rule Id="CA5403" Action="None" />             <!-- Do not hard-code certificate -->
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" /> <!-- Analyzer threw an exception -->


### PR DESCRIPTION
This is based on the AllRulesDefault.ruleset that's in the analyzers' nuget package.  I then tweaked places where it was different from our current selections.
cc: @ViktorHofer, @safern