### PR TITLE
Fix re-declarations of builtin functions with clang 10

### DIFF
--- a/src/coreclr/src/pal/inc/pal.h
+++ b/src/coreclr/src/pal/inc/pal.h
@@ -135,7 +135,7 @@ typedef PVOID NATIVE_LIBRARY_HANDLE;
 
 /******************* Compiler-specific glue *******************************/
 #ifndef THROW_DECL
-#if defined(_MSC_VER) || defined(__llvm__) || !defined(__cplusplus)
+#if defined(_MSC_VER) || !defined(__cplusplus)
 #define THROW_DECL
 #else
 #define THROW_DECL throw()


### PR DESCRIPTION
Clang commit [39aa8954a4846b317d3da2f0addfce8224b438de](https://github.com/llvm/llvm-project/commit/39aa8954a4846b317d3da2f0addfce8224b438de) has moved exception handling mismatches under the `-fms-compatibility` flag. This breaks compilation of pal under clang 10 (and newer).

The compilation error looks like this:

```
In file included from .../pal/src/misc/tracepointprovider.cpp:19:
In file included from .../pal/src/include/pal/palinternal.h:620:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/stdlib.h:30:
/usr/include/stdlib.h:112:36: error: exception specification in declaration does not match previous declaration
__extension__ extern long long int atoll (const char *__nptr)
                                   ^
.../pal/inc/pal.h:4227:33: note: previous declaration is here
PALIMPORT long long int __cdecl atoll(const char *) THROW_DECL;
                                ^
```

The simplest fix seems to be to make clang do the same thing as gcc and define `THROW_DECL` as `throw()`.

Testing via https://godbolt.org shows that even clang 3.3 compiles this successfully without additional compiler options:

```
    extern "C" long long atoll(char const*) throw();
    #include <stdlib.h>
```

An alternative fix would be to use `-fms-compatibility`.

More details at https://bugzilla.redhat.com/show_bug.cgi?id=1807176