### PR TITLE
Rename a parameter

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.Loader
         private const string LibraryNameSuffix = ".so";
 #endif
 
-        internal static IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath, bool forSystemApi = false)
+        internal static IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath, bool forOSLoader = false)
         {
             // This is a copy of the logic in DetermineLibNameVariations in dllimport.cpp in CoreCLR
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Windows.cs
@@ -10,15 +10,15 @@ namespace System.Runtime.Loader
     {
         private const string LibraryNameSuffix = ".dll";
 
-        internal static IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath, bool forSystemApi = false)
+        internal static IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath, bool forOSLoader = false)
         {
             // This is a copy of the logic in DetermineLibNameVariations in dllimport.cpp in CoreCLR
 
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 
-            // Follow LoadLibrary rules if forSystemApi is true
+            // Follow LoadLibrary rules if forOSLoader is true
             if (isRelativePath &&
-                (!forSystemApi || libName.Contains('.') && !libName.EndsWith('.')) &&
+                (!forOSLoader || libName.Contains('.') && !libName.EndsWith('.')) &&
                 !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
                 !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
Continued from #32707 

- `Api` -> `Loader`: `File.Exists` uses Windows API as well.
- `System` -> `OS`: IIUC the term `System` usually refers to the platform itself, e.g. `SystemException`.