### PR TITLE
Default culture name to be neutral when read from MetadataReader

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata
         internal AssemblyName GetAssemblyName(StringHandle nameHandle, Version version, StringHandle cultureHandle, BlobHandle publicKeyOrTokenHandle, AssemblyHashAlgorithm assemblyHashAlgorithm, AssemblyFlags flags)
         {
             string name = GetString(nameHandle);
-            string? cultureName = (!cultureHandle.IsNil) ? GetString(cultureHandle) : null;
+            string? cultureName = (!cultureHandle.IsNil) ? GetString(cultureHandle) : string.Empty;
             var hashAlgorithm = (Configuration.Assemblies.AssemblyHashAlgorithm)assemblyHashAlgorithm;
             byte[]? publicKeyOrToken = !publicKeyOrTokenHandle.IsNil ? GetBlobBytes(publicKeyOrTokenHandle) : null;
 

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyDefinitionTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyDefinitionTests.cs
@@ -56,7 +56,7 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal(assembly.Version, assemblyName.Version);
                 Assert.Equal(assembly.Name, assemblyName.Name);
                 Assert.Equal(assembly.ContentType, assemblyName.ContentType);
-                Assert.Null(assemblyName.CultureName);
+                Assert.Empty(assemblyName.CultureName);
                 Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.SHA1, assemblyName.HashAlgorithm);
                 Assert.Equal(assembly.Flags, assemblyName.Flags);
                 Assert.NotNull(assemblyName.GetPublicKeyToken());
@@ -95,7 +95,7 @@ namespace System.Reflection.Metadata.Tests
                     Assert.Equal(item.Version, assemblyName.Version);
                     Assert.Equal(item.Name, assemblyName.Name);
                     Assert.Equal(item.ContentType, assemblyName.ContentType);
-                    Assert.Null(assemblyName.CultureName);
+                    Assert.Empty(assemblyName.CultureName);
                     Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.SHA1, assemblyName.HashAlgorithm);
                     Assert.Null(assemblyName.GetPublicKey());
                     Assert.Null(assemblyName.GetPublicKeyToken());

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyReferenceTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/TypeSystem/AssemblyReferenceTests.cs
@@ -22,7 +22,7 @@ namespace System.Reflection.Metadata.Tests
             Assert.Equal("System.Runtime", assemblyName.Name);
             Assert.Equal(new Version(4, 0, 0, 0), assemblyName.Version);
             Assert.Equal(new byte[] { 0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A }, assemblyName.GetPublicKeyToken());
-            Assert.Null(assemblyName.CultureName);
+            Assert.Empty(assemblyName.CultureName);
             Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.None, assemblyName.HashAlgorithm);
             Assert.Null(assemblyName.GetPublicKey());
             Assert.Equal(AssemblyNameFlags.None, assemblyName.Flags);
@@ -71,7 +71,7 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal(expRefs[i], assemblyName.Name);
                 Assert.Equal(expVers[i], assemblyName.Version);
                 Assert.Equal(expKeys[i], assemblyName.GetPublicKeyToken());
-                Assert.Null(assemblyName.CultureName);
+                Assert.Empty(assemblyName.CultureName);
                 Assert.Equal(Configuration.Assemblies.AssemblyHashAlgorithm.None, assemblyName.HashAlgorithm);
                 Assert.Null(assemblyName.GetPublicKey());
                 Assert.Equal(AssemblyNameFlags.None, assemblyName.Flags);


### PR DESCRIPTION
When read from the MetatableReader, ensure that the default value
returned for the culture is neutral, which is mapped to string.empty
in both the compiler and the AssemblyNameFormatter.

Fix #28153