### PR TITLE
Disable force_install warning produced by CMake for libraries native build.

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -22,14 +22,7 @@ jobs:
     workspace:
       clean: all
 
-    variables:
-    - ${{ each variable in parameters.variables }}:
-      - ${{insert}}: ${{ variable }}
-    - name: noWarnAsErrorArg
-      value: ''
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - name: noWarnAsErrorArg
-        value: -warnAsError:0
+    variables: ${{ parameters.variables }}
 
     steps:
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
@@ -45,7 +38,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(noWarnAsErrorArg) ${{ parameters.buildArgs }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} ${{ parameters.buildArgs }}
       displayName: Build product
 
     - task: PublishBuildArtifacts@1

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -89,23 +89,13 @@ jobs:
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
-          ${{ if eq(parameters.jobParameters.useVsPreviewPool, true) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
-
-          ${{ if ne(parameters.jobParameters.useVsPreviewPool, true) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019
 
         # Public Windows Build Pool
         ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
-          ${{ if eq(parameters.jobParameters.useVsPreviewPool, true) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-
-          ${{ if ne(parameters.jobParameters.useVsPreviewPool, true) }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Open
+          name: NetCorePublic-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.Open
 
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -1,4 +1,3 @@
-
 trigger:
   batch: true
   branches:

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -1,3 +1,4 @@
+
 trigger:
   batch: true
   branches:
@@ -52,7 +53,7 @@ jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
     buildConfig: release
     platforms:
     - Linux_x64
@@ -60,20 +61,6 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       testGroup: perf
-      useVsPreviewPool: false
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    - Windows_NT_x64
-    - Windows_NT_x86
-    jobParameters:
-      useVsPreviewPool: true
-      liveRuntimeBuildConfig: release
-
     
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -58,7 +58,6 @@ stages:
       - Windows_NT_arm
       - Windows_NT_arm64
       jobParameters:
-        useVsPreviewPool: false
         isOfficialBuild: ${{ variables.isOfficialBuild }}
 
   #
@@ -80,7 +79,6 @@ stages:
       - Windows_NT_arm
       - Windows_NT_arm64
       jobParameters:
-        useVsPreviewPool: true
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         liveRuntimeBuildConfig: release
 
@@ -94,7 +92,6 @@ stages:
       platforms:
       - Windows_NT_x64
       jobParameters:
-        useVsPreviewPool: true
         framework: allConfigurations
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         isOfficialAllConfigurations: true
@@ -106,7 +103,6 @@ stages:
   - template: /eng/pipelines/installer/installer-matrix.yml
     parameters:
       jobParameters:
-        useVsPreviewPool: false
         liveRuntimeBuildConfig: release
         liveLibrariesBuildConfig: Release
         isOfficialBuild: ${{ variables.isOfficialBuild }}

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -58,6 +58,7 @@ stages:
       - Windows_NT_arm
       - Windows_NT_arm64
       jobParameters:
+        useVsPreviewPool: false
         isOfficialBuild: ${{ variables.isOfficialBuild }}
 
   #
@@ -79,6 +80,7 @@ stages:
       - Windows_NT_arm
       - Windows_NT_arm64
       jobParameters:
+        useVsPreviewPool: true
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         liveRuntimeBuildConfig: release
 
@@ -92,6 +94,7 @@ stages:
       platforms:
       - Windows_NT_x64
       jobParameters:
+        useVsPreviewPool: true
         framework: allConfigurations
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         isOfficialAllConfigurations: true
@@ -103,6 +106,7 @@ stages:
   - template: /eng/pipelines/installer/installer-matrix.yml
     parameters:
       jobParameters:
+        useVsPreviewPool: false
         liveRuntimeBuildConfig: release
         liveLibrariesBuildConfig: Release
         isOfficialBuild: ${{ variables.isOfficialBuild }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -137,7 +137,6 @@ jobs:
     - Windows_NT_arm64
     jobParameters:
       testGroup: innerloop
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -155,7 +154,6 @@ jobs:
     - OSX_x64
     jobParameters:
       testGroup: innerloop
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -182,7 +180,6 @@ jobs:
     - Windows_NT_arm
     - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       testGroup: innerloop
 
 #
@@ -196,7 +193,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     jobParameters:
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -223,7 +219,6 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -251,7 +246,6 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -280,7 +274,6 @@ jobs:
     # - Windows_NT_arm64
     jobParameters:
       llvm: true
-      useVsPreviewPool: false
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -308,7 +301,6 @@ jobs:
     # - Windows_NT_arm
     # - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       llvm: true
       condition: >-
         or(
@@ -334,7 +326,6 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       liveRuntimeBuildConfig: release
-      useVsPreviewPool: true
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -348,7 +339,6 @@ jobs:
     - Windows_NT_x64
     jobParameters:
       liveRuntimeBuildConfig: release
-      useVsPreviewPool: true
 #
 # Libraries Build that only run when libraries is changed
 #
@@ -362,7 +352,6 @@ jobs:
       - Windows_NT_x86
     jobParameters:
       liveRuntimeBuildConfig: release
-      useVsPreviewPool: true
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
@@ -378,7 +367,6 @@ jobs:
       - Windows_NT_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: true
       isFullMatrix: ${{ variables.isFullMatrix }}
       framework: net472
       runTests: true
@@ -396,7 +384,6 @@ jobs:
     - Windows_NT_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: true
       isFullMatrix: ${{ variables.isFullMatrix }}
       framework: allConfigurations
       runTests: true
@@ -421,7 +408,6 @@ jobs:
       - Windows_NT_arm
       - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: Release
 
@@ -435,7 +421,6 @@ jobs:
       - Linux_musl_x64
       - Windows_NT_x64
     jobParameters:
-      useVsPreviewPool: false
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
@@ -452,7 +437,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     jobParameters:
-      useVsPreviewPool: false
       isOfficialBuild: false
       liveRuntimeBuildConfig: release
       testScope: innerloop
@@ -476,7 +460,6 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       liveLibrariesBuildConfig: Release
       condition: >-
         or(
@@ -497,7 +480,6 @@ jobs:
     - Windows_NT_arm
     - Windows_NT_arm64
     jobParameters:
-      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
       condition: >-
@@ -519,7 +501,6 @@ jobs:
     - Linux_arm64
     - Windows_NT_x64
     jobParameters:
-      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       condition: >-
@@ -543,7 +524,6 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
       condition: >-
@@ -563,7 +543,6 @@ jobs:
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       condition: >-
@@ -587,7 +566,6 @@ jobs:
     - Linux_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -612,7 +590,6 @@ jobs:
     - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -645,7 +622,6 @@ jobs:
       - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
-      useVsPreviewPool: false
       isOfficialBuild: false
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
@@ -671,7 +647,6 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
-      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
@@ -692,7 +667,6 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
-      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
@@ -715,7 +689,6 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:
-      useVsPreviewPool: false
       testScope: innerloop
       liveRuntimeBuildConfig: checked
       dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}

--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -145,7 +145,7 @@ goto :Failure
 
 :BuildNativeProj
 :: Build the project created by Cmake
-set __msbuildArgs=/p:Platform=%__BuildArch% /p:PlatformToolset="%__PlatformToolset%"
+set __msbuildArgs=/p:Platform=%__BuildArch% /p:PlatformToolset="%__PlatformToolset%" -noWarn:MSB8065
 
 call msbuild "%__IntermediatesDir%\install.vcxproj" /t:%__BuildTarget% /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
 IF ERRORLEVEL 1 (


### PR DESCRIPTION
This lets us enable warn as error in libraries build.

Fixes: https://github.com/dotnet/runtime/issues/32876

cc: @dotnet/runtime-infrastructure 