### PR TITLE
Plural TargetFrameworks replaced with singluar TargetFramework

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/SslStress.csproj
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/SslStress.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Stress test build fails because we have a plural tag ```<TargetFrameworks>```, but only one nested element. PR converts it to a singular ```<TargetFramework>```.

Fixes #32813