### PR TITLE
Enable Mono netcore LLVM build on Windows.

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -75,7 +75,7 @@
   <Target Name="BuildMonoRuntimeWindows" Condition="'$(OS)' == 'Windows_NT'">
     <PropertyGroup>
         <_MonoBuildParams>/p:MONO_BUILD_DIR_PREFIX=&quot;&quot;$(MonoObjDir)&quot;&quot; /p:MONO_ENABLE_NETCORE=true /p:CL_MPCount=8 /v:minimal</_MonoBuildParams>
-        <_MonoBuildParams Condition="$(MonoEnableLLVM) == true">/p:MONO_ENABLE_LLVM=true $(_MonoBuildParams)</_MonoBuildParams>
+        <_MonoBuildParams Condition="$(MonoEnableLLVM) == true">/p:MONO_ENABLE_LLVM=true /p:MONO_EXTERNAL_LLVM_CONFIG=&quot;&quot;$(MonoLLVMDir)\bin\llvm-config.exe&quot;&quot; $(_MonoBuildParams)</_MonoBuildParams>
         <_MonoBuildPlatform Condition="'$(Platform)' == 'x64'">x64</_MonoBuildPlatform>
         <_MonoBuildPlatform Condition="'$(Platform)' == 'x86'">win32</_MonoBuildPlatform>
     </PropertyGroup>


### PR DESCRIPTION
Current Mono netcore LLVM build on Windows uses a prebuild LLVM and doesn't support local build LLVM. Current mono.proj only use configure and --with-llvm argument on none Windows build. On Windows, trying to build Mono netcore using LLVM will fail.

Fix sets msbuild property, MONO_EXTERNAL_LLVM_CONFIG to full path of downloaded llvm-config.exe, this is what's set when doing LLVM build using configure --with-llvm on Mono Windows build in Mono repro, but since Mono netcore Windows build won't use configure, the property should be specified directly when calling msbuild.