### PR TITLE
Update System.Drawing to reflect GDI+ changes

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -2105,6 +2105,9 @@ namespace System.Drawing.Imaging
         public static readonly System.Drawing.Imaging.Encoder ScanMethod;
         public static readonly System.Drawing.Imaging.Encoder Transformation;
         public static readonly System.Drawing.Imaging.Encoder Version;
+        public static readonly System.Drawing.Imaging.Encoder ColorSpace;
+        public static readonly System.Drawing.Imaging.Encoder ImageItems;
+        public static readonly System.Drawing.Imaging.Encoder SaveAsCmyk;
         public Encoder(System.Guid guid) { }
         public System.Guid Guid { get { throw null; } }
     }
@@ -2152,6 +2155,7 @@ namespace System.Drawing.Imaging
         ValueTypeLongRange = 6,
         ValueTypeUndefined = 7,
         ValueTypeRationalRange = 8,
+        ValueTypePointer = 9,
     }
     public enum EncoderValue
     {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
@@ -16,6 +16,9 @@ namespace System.Drawing.Imaging
         public static readonly Encoder LuminanceTable = new Encoder(new Guid(unchecked((int)0xedb33bce), unchecked((short)0x0266), unchecked((short)0x4a77), new byte[] { 0xb9, 0x04, 0x27, 0x21, 0x60, 0x99, 0xe7, 0x17 }));
         public static readonly Encoder ChrominanceTable = new Encoder(new Guid(unchecked((int)0xf2e455dc), unchecked((short)0x09b3), unchecked((short)0x4316), new byte[] { 0x82, 0x60, 0x67, 0x6a, 0xda, 0x32, 0x48, 0x1c }));
         public static readonly Encoder SaveFlag = new Encoder(new Guid(unchecked((int)0x292266fc), unchecked((short)0xac40), unchecked((short)0x47bf), new byte[] { 0x8c, 0xfc, 0xa8, 0x5b, 0x89, 0xa6, 0x55, 0xde }));
+        public static readonly Encoder ColorSpace = new Encoder(new Guid(unchecked((int)0xae7a62a0), unchecked((short)0xee2c), unchecked((short)0x49d8), new byte[] { 0x9d, 0x07, 0x1b, 0xa8, 0xa9, 0x27, 0x59, 0x6e }));
+        public static readonly Encoder ImageItems = new Encoder(new Guid(unchecked((int)0x63875e13), unchecked((short)0x1f1d), unchecked((short)0x45ab), new byte[] { 0x91, 0x95, 0xa2, 0x9b, 0x60, 0x66, 0xa6, 0x50 }));
+        public static readonly Encoder SaveAsCmyk = new Encoder(new Guid(unchecked((int)0xa219bbc9), unchecked((short)0x0a9d), unchecked((short)0x4005), new byte[] { 0xa3, 0xee, 0x3a, 0x42, 0x1b, 0x8b, 0xb0, 0x6c }));
 
         private Guid _guid;
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Encoder.cs
@@ -16,8 +16,20 @@ namespace System.Drawing.Imaging
         public static readonly Encoder LuminanceTable = new Encoder(new Guid(unchecked((int)0xedb33bce), unchecked((short)0x0266), unchecked((short)0x4a77), new byte[] { 0xb9, 0x04, 0x27, 0x21, 0x60, 0x99, 0xe7, 0x17 }));
         public static readonly Encoder ChrominanceTable = new Encoder(new Guid(unchecked((int)0xf2e455dc), unchecked((short)0x09b3), unchecked((short)0x4316), new byte[] { 0x82, 0x60, 0x67, 0x6a, 0xda, 0x32, 0x48, 0x1c }));
         public static readonly Encoder SaveFlag = new Encoder(new Guid(unchecked((int)0x292266fc), unchecked((short)0xac40), unchecked((short)0x47bf), new byte[] { 0x8c, 0xfc, 0xa8, 0x5b, 0x89, 0xa6, 0x55, 0xde }));
+
+        /// <summary>
+        /// An <see cref="Encoder" /> object that is initialized with the globally unique identifier for the color space category.
+        /// </summary>
         public static readonly Encoder ColorSpace = new Encoder(new Guid(unchecked((int)0xae7a62a0), unchecked((short)0xee2c), unchecked((short)0x49d8), new byte[] { 0x9d, 0x07, 0x1b, 0xa8, 0xa9, 0x27, 0x59, 0x6e }));
+
+        /// <summary>
+        /// An <see cref="Encoder" /> object that is initialized with the globally unique identifier for the image items category.
+        /// </summary>
         public static readonly Encoder ImageItems = new Encoder(new Guid(unchecked((int)0x63875e13), unchecked((short)0x1f1d), unchecked((short)0x45ab), new byte[] { 0x91, 0x95, 0xa2, 0x9b, 0x60, 0x66, 0xa6, 0x50 }));
+
+        /// <summary>
+        /// An <see cref="Encoder" /> object that is initialized with the globally unique identifier for the save as CMYK category.
+        /// </summary>
         public static readonly Encoder SaveAsCmyk = new Encoder(new Guid(unchecked((int)0xa219bbc9), unchecked((short)0x0a9d), unchecked((short)0x4005), new byte[] { 0xa3, 0xee, 0x3a, 0x42, 0x1b, 0x8b, 0xb0, 0x6c }));
 
         private Guid _guid;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -381,6 +381,9 @@ namespace System.Drawing.Imaging
                 case EncoderParameterValueType.ValueTypeRationalRange:
                     size = 2 * 2 * 4;
                     break;
+                case EncoderParameterValueType.ValueTypePointer:
+                    size = IntPtr.Size;
+                    break;
                 default:
                     throw Gdip.StatusException(Gdip.WrongState);
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterValueType.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterValueType.cs
@@ -44,6 +44,10 @@ namespace System.Drawing.Imaging
         /// Two Rationals. The first Rational specifies the lower end and the second specifies the higher end.
         /// All values are inclusive at both ends
         /// </summary>
-        ValueTypeRationalRange = 8
+        ValueTypeRationalRange = 8,
+        /// <summary>
+        /// The parameter is a pointer to a block of custom metadata.
+        /// </summary>
+        ValueTypePointer = 9,
     }
 }

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -158,6 +158,9 @@ namespace System.Drawing.Tests
                 }
             };
 
+#if !NETFRAMEWORK
+            // NetFX doesn't support pointer-type encoder parameters, and doesn't define Encoder.ImageItems. Skip this test
+            // on NetFX.
             yield return new object[]
             {
                 ImageFormat.Jpeg,
@@ -170,6 +173,7 @@ namespace System.Drawing.Tests
                     Encoder.ImageItems.Guid
                 }
             };
+#endif
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -157,6 +157,19 @@ namespace System.Drawing.Tests
                     new Guid(unchecked((int)0xa219bbc9), unchecked((short)0x0a9d), unchecked((short)0x4005), new byte[] { 0xa3, 0xee, 0x3a, 0x42, 0x1b, 0x8b, 0xb0, 0x6c }) /* Encoder.SaveAsCmyk.Guid */
                 }
             };
+
+            yield return new object[]
+            {
+                ImageFormat.Jpeg,
+                new Guid[]
+                {
+                    Encoder.Transformation.Guid,
+                    Encoder.Quality.Guid,
+                    Encoder.LuminanceTable.Guid,
+                    Encoder.ChrominanceTable.Guid,
+                    Encoder.ImageItems.Guid
+                }
+            };
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]


### PR DESCRIPTION
This is the last part of the work done in dotnet/corefx#40181 which was pending API approval (#30543).

1. Add support `ValueTypePointer` encoder parameters ([doc](https://docs.microsoft.com/en-us/windows/win32/api/gdiplusenums/ne-gdiplusenums-encoderparametervaluetype))
2. Support `ColorSpace`, `ImageItems` and `SaveAsCmyk` encoders ([doc](https://docs.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-constant-image-encoder-constants))
3. By virtue of 1., fixes a bug where `GetEncoderParameterList` was broken for the JPEG encoder, which now returns (an empty list of) parameters of type `EncoderParameterValueTypePointer`. This was broken in .NET Framework, too (see [e.g. this StackOverflow report](https://stackoverflow.com/questions/3152506/unexpected-bitmap-region-is-already-locked-exception-with-getencoderparameterl))

Fixes #30543