### PR TITLE
Removed unused local variables in System.IO.Ports

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -1012,7 +1012,6 @@ namespace System.IO.Ports
             if (value.Length == 0)
                 throw new ArgumentException(SR.Format(SR.InvalidNullEmptyArgument, nameof(value)), nameof(value));
 
-            int startTicks = Environment.TickCount;
             int numCharsRead;
             int timeUsed = 0;
             int timeNow;
@@ -1025,7 +1024,6 @@ namespace System.IO.Ports
             MaybeResizeBuffer(bytesInStream);
 
             _readLen += _internalSerialStream.Read(_inBuffer, _readLen, bytesInStream);
-            int beginReadPos = _readPos;
 
             if (_singleCharBuffer == null)
             {


### PR DESCRIPTION
Part of #30457.

Both locals in this library appear unused and without side effects (unless there's something about `System.Environment` I'm not thinking about).