### PR TITLE
JIT: convert codegen over to new style phases

### DIFF
--- a/src/coreclr/src/jit/codegeninterface.h
+++ b/src/coreclr/src/jit/codegeninterface.h
@@ -66,6 +66,11 @@ public:
     CodeGenInterface(Compiler* theCompiler);
     virtual void genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode) = 0;
 
+    Compiler* GetCompiler() const
+    {
+        return compiler;
+    }
+
     // genSpillVar is called by compUpdateLifeVar.
     // TODO-Cleanup: We should handle the spill directly in CodeGen, rather than
     // calling it from compUpdateLifeVar.  Then this can be non-virtual.

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4910,6 +4910,10 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     // Generate code
     codeGen->genGenerateCode(methodCodePtr, methodCodeSize);
 
+    // We're done -- set the active phase to the last phase
+    // (which isn't really a phase)
+    mostRecentlyActivePhase = PHASE_POST_EMIT;
+
 #ifdef FEATURE_JIT_METHOD_PERF
     if (pCompJitTimer)
     {

--- a/src/coreclr/src/jit/compphases.h
+++ b/src/coreclr/src/jit/compphases.h
@@ -103,6 +103,7 @@ CompPhaseNameMacro(PHASE_LINEAR_SCAN_RESOLVE,    "LSRA resolve",                
 CompPhaseNameMacro(PHASE_GENERATE_CODE,          "Generate code",                  "CODEGEN",  false, -1, false)
 CompPhaseNameMacro(PHASE_EMIT_CODE,              "Emit code",                      "EMIT",     false, -1, false)
 CompPhaseNameMacro(PHASE_EMIT_GCEH,              "Emit GC+EH tables",              "EMT-GCEH", false, -1, false)
+CompPhaseNameMacro(PHASE_POST_EMIT,              "Post-Emit",                      "POST-EMIT", false, -1, false)
 
 #if MEASURE_CLRAPI_CALLS
 // The following is a "pseudo-phase" - it aggregates timing info

--- a/src/coreclr/src/jit/phase.h
+++ b/src/coreclr/src/jit/phase.h
@@ -48,7 +48,7 @@ private:
     A action;
 };
 
-// Wrapper for using ActionPhase
+// Wrappers for using ActionPhase
 //
 template <typename A>
 void DoPhase(Compiler* _compiler, Phases _phase, A _action)


### PR DESCRIPTION
Convert codegen over to new style phases. To facilitate this, some
of the state that was passed around in locals in `genGenerateCode`
are now fields on the codegen object.

Also add a final "pseudo phase" in case we see very late asserts.

Fixes #32497.