### PR TITLE
Mark HostModel package as non-shipping

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Abstractions for modifying .net core host-binaries</Description>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The Microsoft.NET.HostModel nuget package is for internal consumption by the SDK.
Therefore mark it as non-shipping, so that it is not published to nuget.org

Fixes https://github.com/dotnet/runtime/issues/32825