### PR TITLE
[wasm][debugger] Always pass failed breakpoint requests to target

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -655,18 +655,20 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 		case MONO_TYPE_SZARRAY:
 		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_CLASS: {
 			MonoObject *obj = *(MonoObject**)addr;
 			MonoClass *klass = type->data.klass;
 
 			char *class_name = mono_type_full_name (type);
+			int obj_id = type->type == MONO_TYPE_VALUETYPE ? 0 : get_object_id (obj);
 
 			if (type->type == MONO_TYPE_SZARRAY || type->type == MONO_TYPE_ARRAY) {
-				mono_wasm_add_array_var (class_name, get_object_id (obj));
+				mono_wasm_add_array_var (class_name, obj_id);
 			} else if (m_class_is_delegate (klass)) {
-				mono_wasm_add_func_var (class_name, get_object_id (obj));
+				mono_wasm_add_func_var (class_name, obj_id);
 			} else {
-				mono_wasm_add_obj_var (class_name, get_object_id (obj));
+				mono_wasm_add_obj_var (class_name, obj_id);
 			}
 			g_free (class_name);
 			break;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19053,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Originally we had a simple way to detect that breakpoints were
meant for the runtime but that is no longer true.  Now if we
can't locate a breakpoint we need to pass the request on to the
target so it can make an attempt.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
