### PR TITLE
Add support for non-string Tkey on Dictionary

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
@@ -59,7 +59,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentQueueOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentStackOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\DictionaryDefaultConverter.cs" />
-    <Compile Include="System\Text\Json\Serialization\Converters\Collection\DictionaryOfStringTValueConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\DictionaryOfTKeyTValue.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ICollectionOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IDictionaryConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IDictionaryOfStringTValueConverter.cs" />
@@ -78,6 +78,12 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ListOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\QueueOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\StackOfTConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\EnumKeyConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\GuidKeyConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\Int32KeyConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\KeyConverterOfTKey.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\ObjectKeyConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\KeyConverters\StringKeyConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Object\ObjectConverterFactory.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Object\ObjectDefaultConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\BooleanConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -583,6 +583,11 @@ namespace System.Text.Json
                 throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
             }
 
+            return TryGetInt32AfterValidation(out value);
+        }
+
+        internal bool TryGetInt32AfterValidation(out int value)
+        {
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
             if (Utf8Parser.TryParse(span, out int tmp, out int bytesConsumed)
                 && span.Length == bytesConsumed)
@@ -945,6 +950,11 @@ namespace System.Text.Json
                 throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
             }
 
+            return TryGetGuidAfterValidation(out value);
+        }
+
+        internal bool TryGetGuidAfterValidation(out Guid value)
+        {
             ReadOnlySpan<byte> span = stackalloc byte[0];
 
             if (HasValueSequence)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValue.cs
@@ -3,23 +3,20 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
     /// <summary>
-    /// Converter for Dictionary{string, TValue} that (de)serializes as a JSON object with properties
+    /// Converter for Dictionary{TKey, TValue} that (de)serializes as a JSON object with properties
     /// representing the dictionary element key and value.
     /// </summary>
-    internal sealed class DictionaryOfStringTValueConverter<TCollection, TValue>
-        : DictionaryDefaultConverter<TCollection, TValue>
-        where TCollection : Dictionary<string, TValue>
+    internal sealed class DictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>
+        : DictionaryDefaultConverter<TCollection, TKey, TValue>
+        where TCollection : Dictionary<TKey, TValue>
+        where TKey : notnull
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(TKey key, TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
-            Debug.Assert(state.Current.ReturnValue is TCollection);
-
-            string key = state.Current.JsonPropertyNameAsString!;
             ((TCollection)state.Current.ReturnValue!)[key] = value;
         }
 
@@ -39,7 +36,12 @@ namespace System.Text.Json.Serialization.Converters
             JsonSerializerOptions options,
             ref WriteStack state)
         {
-            Dictionary<string, TValue>.Enumerator enumerator;
+            // Get the key converter at the very beginning; will throw NSE if there is no converter for TKey.
+            // This is performed at the very beginning to avoid processing unsupported types.
+            KeyConverter<TKey> keyConverter = GetKeyConverter(state.Current.JsonClassInfo);
+
+            Dictionary<TKey, TValue>.Enumerator enumerator;
+
             if (state.Current.CollectionEnumerator == null)
             {
                 enumerator = value.GetEnumerator();
@@ -50,20 +52,19 @@ namespace System.Text.Json.Serialization.Converters
             }
             else
             {
-                Debug.Assert(state.Current.CollectionEnumerator is Dictionary<string, TValue>.Enumerator);
-                enumerator = (Dictionary<string, TValue>.Enumerator)state.Current.CollectionEnumerator;
+                enumerator = (Dictionary<TKey, TValue>.Enumerator)state.Current.CollectionEnumerator;
             }
 
-            JsonConverter<TValue> converter = GetValueConverter(ref state);
-            if (!state.SupportContinuation && converter.CanUseDirectReadOrWrite)
+            JsonConverter<TValue> valueConverter = GetValueConverter(ref state);
+
+            if (!state.SupportContinuation && valueConverter.CanUseDirectReadOrWrite)
             {
                 // Fast path that avoids validation and extra indirection.
                 do
                 {
-                    string key = GetKeyName(enumerator.Current.Key, ref state, options);
-                    writer.WritePropertyName(key);
+                    keyConverter.OnTryWrite(writer, enumerator.Current.Key, options, ref state);
                     // TODO: https://github.com/dotnet/runtime/issues/32523
-                    converter.Write(writer, enumerator.Current.Value!, options);
+                    valueConverter.Write(writer, enumerator.Current.Value!, options);
                 } while (enumerator.MoveNext());
             }
             else
@@ -77,14 +78,14 @@ namespace System.Text.Json.Serialization.Converters
                     }
 
                     TValue element = enumerator.Current.Value;
+
                     if (state.Current.PropertyState < StackFramePropertyState.Name)
                     {
                         state.Current.PropertyState = StackFramePropertyState.Name;
-                        string key = GetKeyName(enumerator.Current.Key, ref state, options);
-                        writer.WritePropertyName(key);
+                        keyConverter.OnTryWrite(writer, enumerator.Current.Key, options, ref state);
                     }
 
-                    if (!converter.TryWrite(writer, element, options, ref state))
+                    if (!valueConverter.TryWrite(writer, element, options, ref state))
                     {
                         state.Current.CollectionEnumerator = enumerator;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -13,10 +13,10 @@ namespace System.Text.Json.Serialization.Converters
     /// representing the dictionary element key and value.
     /// </summary>
     internal sealed class IDictionaryConverter<TCollection>
-        : DictionaryDefaultConverter<TCollection, object?>
+        : DictionaryDefaultConverter<TCollection, string, object?>
         where TCollection : IDictionary
     {
-        protected override void Add(object? value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(string _, object? value, JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(state.Current.ReturnValue is IDictionary);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfStringTValueConverter.cs
@@ -12,10 +12,10 @@ namespace System.Text.Json.Serialization.Converters
     /// (de)serializes as a JSON object with properties representing the dictionary element key and value.
     /// </summary>
     internal sealed class IDictionaryOfStringTValueConverter<TCollection, TValue>
-        : DictionaryDefaultConverter<TCollection, TValue>
+        : DictionaryDefaultConverter<TCollection, string, TValue>
         where TCollection : IDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(string _, TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(state.Current.ReturnValue is TCollection);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfStringTValueConverter.cs
@@ -8,10 +8,10 @@ using System.Diagnostics;
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class IReadOnlyDictionaryOfStringTValueConverter<TCollection, TValue>
-        : DictionaryDefaultConverter<TCollection, TValue>
+        : DictionaryDefaultConverter<TCollection, string,  TValue>
         where TCollection : IReadOnlyDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(string _, TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(state.Current.ReturnValue is Dictionary<string, TValue>);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
@@ -8,10 +8,10 @@ using System.Diagnostics;
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ImmutableDictionaryOfStringTValueConverter<TCollection, TValue>
-        : DictionaryDefaultConverter<TCollection, TValue>
+        : DictionaryDefaultConverter<TCollection, string, TValue>
         where TCollection : IReadOnlyDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(string _, TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(state.Current.ReturnValue is Dictionary<string, TValue>);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/EnumKeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/EnumKeyConverter.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text.Unicode;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class EnumKeyConverter<TEnum> : KeyConverter<TEnum> where TEnum : struct, Enum
+    {
+        public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string? enumValue = reader.GetString();
+            if (!Enum.TryParse(enumValue, out TEnum value)
+                    && !Enum.TryParse(enumValue, ignoreCase: true, out value))
+            {
+                ThrowHelper.ThrowJsonException();
+            }
+
+            return value;
+        }
+
+        public override TEnum ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
+        {
+            int idx = bytes.IndexOf(JsonConstants.BackSlash);
+            // if no escaping, just parse the bytes to string using TranscodeHelper.
+            string unescapedKeyName = idx > -1 ? JsonReaderHelper.GetUnescapedString(bytes, idx) : JsonReaderHelper.TranscodeHelper(bytes);
+
+            if (!Enum.TryParse(unescapedKeyName, out TEnum value)
+                    && !Enum.TryParse(unescapedKeyName, ignoreCase: true, out value))
+            {
+                ThrowHelper.ThrowJsonException();
+            }
+
+            return value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+        {
+            string keyName = value.ToString();
+            // Unlike EnumConverter we don't do any validation here since PropertyName can only be string.
+            writer.WritePropertyName(keyName);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/GuidKeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/GuidKeyConverter.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class GuidKeyConverter : KeyConverter<Guid>
+    {
+        public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (!reader.TryGetGuidAfterValidation(out Guid keyValue))
+            {
+                throw ThrowHelper.GetFormatException(DataType.Guid);
+            }
+
+            return keyValue;
+        }
+
+        public override Guid ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
+        {
+            int idx = bytes.IndexOf(JsonConstants.BackSlash);
+            ReadOnlySpan<byte> unescapedBytes = idx > -1 ? JsonReaderHelper.GetUnescapedSpan(bytes, idx) : bytes;
+
+            if (Utf8Parser.TryParse(unescapedBytes, out Guid keyValue, out int bytesConsumed) && bytesConsumed == unescapedBytes.Length)
+            {
+                return keyValue;
+            }
+
+            throw ThrowHelper.GetFormatException(DataType.Guid);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Guid key, JsonSerializerOptions options)
+            => writer.WritePropertyName(key);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/Int32KeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/Int32KeyConverter.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class Int32KeyConverter : KeyConverter<int>
+    {
+        public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (!reader.TryGetInt32AfterValidation(out int keyValue))
+            {
+                throw ThrowHelper.GetFormatException(NumericType.Int32);
+            }
+
+            return keyValue;
+        }
+
+        public override int ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
+        {
+            int idx = bytes.IndexOf(JsonConstants.BackSlash);
+            ReadOnlySpan<byte> unescapedBytes = idx > -1 ? JsonReaderHelper.GetUnescapedSpan(bytes, idx) : bytes;
+
+            if (Utf8Parser.TryParse(unescapedBytes, out int keyValue, out int bytesConsumed) && bytesConsumed == unescapedBytes.Length)
+            {
+               return keyValue;
+            }
+
+            throw ThrowHelper.GetFormatException(NumericType.Int32);
+        }
+
+        public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            => writer.WritePropertyName(value);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/KeyConverterOfTKey.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/KeyConverterOfTKey.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal abstract class KeyConverter<TKey> : JsonConverter<TKey> where TKey : notnull
+    {
+        // This is less API friendly than just call Read and keep the resulting dictionary key boxed in state.Current.
+        // Maybe we can call this only for internal converters.
+        public abstract TKey ReadKeyFromBytes(ReadOnlySpan<byte> bytes);
+
+        internal override bool OnTryWrite(Utf8JsonWriter writer, TKey value, JsonSerializerOptions options, ref WriteStack state)
+        {
+            if (CanBePolymorphic)
+            {
+                JsonConverter runtimeConverter = GetPolymorphicConverter(value, options, ref state);
+                // Redirect to the runtime-type key converter.
+                runtimeConverter.WriteKeyAsObject(writer, value, options, ref state);
+            }
+            // If we need to apply the policy, we are forced to get a string since that is the only type that ConvertName can take as argument.
+            else if (options.DictionaryKeyPolicy != null && !state.Current.IgnoreDictionaryKeyPolicy)
+            {
+                string keyAsString = value.ToString()!;
+                keyAsString = options.DictionaryKeyPolicy.ConvertName(keyAsString);
+
+                if (keyAsString == null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_SerializerDictionaryKeyNull(options.DictionaryKeyPolicy.GetType());
+                }
+
+                writer.WritePropertyName(keyAsString);
+            }
+            else
+            {
+                Write(writer, value, options);
+            }
+
+            return true;
+        }
+
+        private JsonConverter GetPolymorphicConverter(object value, JsonSerializerOptions options, ref WriteStack state)
+        {
+            Type runtimeType = value.GetType();
+            JsonConverter runtimeConverter = options.GetOrAddKeyConverter(runtimeType, state.Current.JsonClassInfo.Type);
+
+            // We don't support object itself as TKey, only the other supported types when they are boxed.
+            if (runtimeConverter is JsonConverter<object>)
+            {
+                ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonClassInfo.Type);
+            }
+
+            return runtimeConverter;
+        }
+
+        internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out TKey value)
+        {
+            // We already called reader.GetString(), there is no need to do it again for string keys.
+            if (typeof(TKey) == typeof(string))
+            {
+                value = (TKey)(object)state.Current.JsonPropertyNameAsString!;
+            }
+            else
+            {
+                // Fast path that does not support continuation.
+                if (!state.SupportContinuation && !options.ReferenceHandling.ShouldReadPreservedReferences())
+                {
+                    value = Read(ref reader, typeToConvert, options);
+                }
+                // Slow path where the reader is no longer in TokenType.PropertyName, is in the element; i.e. in TValue.
+                // We remember the PropertyName bytes in the state and parse the key from there.
+                else
+                {
+                    value = ReadKeyFromBytes(state.Current.DictionaryKeyName);
+                }
+            }
+
+            return true;
+        }
+
+        internal override void WriteKeyAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
+            => OnTryWrite(writer, (TKey)value, options, ref state);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/ObjectKeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/ObjectKeyConverter.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class ObjectKeyConverter : KeyConverter<object>
+    {
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Can't use ParseValue as ObjectConverter does since it does not parse the property name but the value token next to it.
+            return ReadKeyFromBytes(reader.GetSpan());
+        }
+
+        public override object ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
+        {
+            int idx = bytes.IndexOf(JsonConstants.BackSlash);
+            ReadOnlySpan<byte> unescapedBytes = idx > -1 ? JsonReaderHelper.GetUnescapedSpan(bytes, idx) : bytes;
+
+            // Always wrap property name in quotes since reader.GetSpan() removes it from property names.
+            // The side effect of this is that any boxed number will be a JsonElement of JsonValueKind.String.
+            byte[] propertyNameArray = new byte[unescapedBytes.Length + 2];
+            Span<byte> span = propertyNameArray;
+            span[0] = (byte)'"';
+            unescapedBytes.CopyTo(span.Slice(1));
+            span[span.Length - 1] = (byte)'"';
+
+            using (JsonDocument document = JsonDocument.Parse(propertyNameArray))
+            {
+                return document.RootElement.Clone();
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/StringKeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/StringKeyConverter.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class StringKeyConverter : KeyConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string key, JsonSerializerOptions options)
+            => writer.WritePropertyName(key);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/StringKeyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/KeyConverters/StringKeyConverter.cs
@@ -8,12 +8,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         public override string ReadKeyFromBytes(ReadOnlySpan<byte> bytes)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         public override void Write(Utf8JsonWriter writer, string key, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -46,6 +46,7 @@ namespace System.Text.Json.Serialization
         internal abstract JsonPropertyInfo CreateJsonPropertyInfo();
 
         internal abstract Type? ElementType { get; }
+        internal virtual Type? KeyType { get; }
 
         // For polymorphic cases, the concrete type to create.
         internal virtual Type RuntimeType => TypeToConvert;
@@ -61,5 +62,6 @@ namespace System.Text.Json.Serialization
 
         internal abstract bool TryReadAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out object? value);
         internal abstract bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);
+        internal virtual void WriteKeyAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state) { }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -319,6 +319,7 @@ namespace System.Text.Json.Serialization
 
                 // Ignore the naming policy for extension data.
                 state.Current.IgnoreDictionaryKeyPolicy = true;
+                state.Current.DeclaredJsonPropertyInfo = state.Current.JsonClassInfo.ElementClassInfo!.PolicyProperty!;
 
                 success = dictionaryConverter.OnWriteResume(writer, value, options, ref state);
                 if (success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfTTypeToConvert.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfTTypeToConvert.cs
@@ -124,7 +124,6 @@ namespace System.Text.Json
             }
             else
             {
-                state.Current.PolymorphicJsonPropertyInfo = state.Current.DeclaredJsonPropertyInfo!.RuntimeClassInfo.ElementClassInfo!.PolicyProperty;
                 success = Converter.TryWriteDataExtensionProperty(writer, value, Options, ref state);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json
         // Support JSON Path on exceptions.
         public byte[]? JsonPropertyName; // This is Utf8 since we don't want to convert to string until an exception is thown.
         public string? JsonPropertyNameAsString; // This is used for dictionary keys and re-entry cases that specify a property name.
+        internal byte[]? DictionaryKeyName; // This will contain the Utf8 Json property name that represents a dictionary key; used to defer parsing on async/re-entry.
 
         // Validation state.
         public int OriginalDepth;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -378,5 +378,15 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
         }
+
+        internal void WritePropertyName(Guid value)
+        {
+            Span<byte> utf8PropertyName = stackalloc byte[JsonConstants.MaximumFormatGuidLength];
+
+            bool result = Utf8Formatter.TryFormat(value, utf8PropertyName, out int bytesWritten);
+            Debug.Assert(result);
+
+            WritePropertyName(utf8PropertyName);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -432,5 +432,15 @@ namespace System.Text.Json
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
+
+        internal void WritePropertyName(int value)
+        {
+            Span<byte> utf8PropertyName = stackalloc byte[JsonConstants.MaximumFormatInt64Length];
+
+            bool result = Utf8Formatter.TryFormat(value, utf8PropertyName, out int bytesWritten);
+            Debug.Assert(result);
+
+            WritePropertyName(utf8PropertyName.Slice(0, bytesWritten));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Text.Json

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 DictionaryWrapper = new UnsupportedDictionaryWrapper()
             };
-            wrapper.DictionaryWrapper[1] = 1;
+            wrapper.DictionaryWrapper[new Uri("https://github.com/dotnet/runtime/pull/32676")] = 1;
 
             // Without converter, we throw.
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<UnsupportedDerivedTypesWrapper_Dictionary>(json));
@@ -128,7 +128,7 @@ namespace System.Text.Json.Serialization.Tests
 
     public class DictionaryWrapper : Dictionary<string, int> { }
 
-    public class UnsupportedDictionaryWrapper : Dictionary<int, int> { }
+    public class UnsupportedDictionaryWrapper : Dictionary<Uri, int> { }
 
     public class DerivedTypesWrapper
     {

--- a/src/libraries/System.Text.Json/tests/Serialization/DictionaryTests.KeyConverter.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/DictionaryTests.KeyConverter.cs
@@ -1,0 +1,431 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public abstract class DictionaryKeyConverterTests<TKey, TValue>
+    {
+        protected abstract TKey Key { get; }
+        protected abstract TValue Value { get; }
+        protected virtual string _expectedJson => $"{{\"{Key}\":{Value}}}";
+        protected virtual string _expectedJsonHashedProperties => $"{{\"{HashingNamingPolicy.HashName(Key.ToString())}\":{Value}}}";
+
+        private static JsonSerializerOptions _policyOptions = new JsonSerializerOptions { DictionaryKeyPolicy = new HashingNamingPolicy() };
+
+        protected virtual void Validate(Dictionary<TKey, TValue> dictionary)
+        {
+            bool success = dictionary.TryGetValue(Key, out TValue value);
+            Assert.True(success);
+            Assert.Equal(Value, value);
+        }
+
+        protected virtual void ValidateHashed(Dictionary<int, TValue> dictionary)
+        {
+            bool success = dictionary.TryGetValue(Key.ToString().GetHashCode(), out TValue value);
+            Assert.True(success);
+            Assert.Equal(Value, value);
+        }
+
+        protected virtual Dictionary<TKey, TValue> BuildDictionary()
+        {
+            var dictionary = new Dictionary<TKey, TValue>();
+            dictionary.Add(Key, Value);
+
+            return dictionary;
+        }
+
+        [Fact]
+        public void TestNonStringKeyDictinary()
+        {
+            Dictionary<TKey, TValue> dictionary = BuildDictionary();
+
+            string json = JsonSerializer.Serialize(dictionary);
+            Assert.Equal(_expectedJson, json);
+
+            Dictionary<TKey, TValue> dictionaryCopy = JsonSerializer.Deserialize<Dictionary<TKey, TValue>>(json);
+            Validate(dictionaryCopy);
+        }
+
+        [Fact]
+        public async Task TestNonStringKeyDictionaryAsync()
+        {
+            Dictionary<TKey, TValue> dictionary = BuildDictionary();
+
+            MemoryStream serializeStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(serializeStream, dictionary);
+            string json = Encoding.UTF8.GetString(serializeStream.ToArray());
+            Assert.Equal(_expectedJson, json);
+
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(json);
+            Stream deserializeStream = new MemoryStream(jsonBytes);
+            Dictionary<TKey, TValue> dictionaryCopy = await JsonSerializer.DeserializeAsync<Dictionary<TKey, TValue>>(deserializeStream);
+            Validate(dictionaryCopy);
+        }
+
+        [Fact]
+        public void TestNonStringKeyDictinaryUsingPolicy()
+        {
+            Dictionary<TKey, TValue> dictionary = BuildDictionary();
+
+            string json = JsonSerializer.Serialize(dictionary, _policyOptions);
+            Assert.Equal(_expectedJsonHashedProperties, json);
+
+            Dictionary<int, TValue> dictionaryCopy = JsonSerializer.Deserialize<Dictionary<int, TValue>>(json);
+            ValidateHashed(dictionaryCopy);
+        }
+
+        [Fact]
+        public async Task TestNonStringKeyDictionaryAsyncUsingPolicy()
+        {
+            Dictionary<TKey, TValue> dictionary = BuildDictionary();
+
+            MemoryStream serializeStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(serializeStream, dictionary, _policyOptions);
+            string json = Encoding.UTF8.GetString(serializeStream.ToArray());
+            Assert.Equal(_expectedJsonHashedProperties, json);
+
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(json);
+            Stream deserializeStream = new MemoryStream(jsonBytes);
+            Dictionary<int, TValue> dictionaryCopy = await JsonSerializer.DeserializeAsync<Dictionary<int, TValue>>(deserializeStream);
+            ValidateHashed(dictionaryCopy);
+        }
+    }
+
+    public class DictionaryIntKey : DictionaryKeyConverterTests<int, int>
+    {
+        protected override int Key => 1;
+        protected override int Value => 1;
+    }
+
+    public class DictionaryGuidKey : DictionaryKeyConverterTests<Guid, int>
+    {
+        // Use singleton pattern here so the Guid key does not change everytime this is called.
+        protected override Guid Key { get; } = Guid.NewGuid();
+        protected override int Value => 1;
+    }
+
+    public enum MyEnum
+    {
+        Foo,
+        Bar
+    }
+
+    public class DictionaryEnumKey : DictionaryKeyConverterTests<MyEnum, int>
+    {
+        protected override MyEnum Key => MyEnum.Foo;
+        protected override int Value => 1;
+    }
+
+    [Flags]
+    public enum MyEnumFlags
+    {
+        Foo,
+        Bar,
+        Baz
+    }
+
+    public class DictionaryEnumFlagsKey : DictionaryKeyConverterTests<MyEnumFlags, int>
+    {
+        protected override MyEnumFlags Key => MyEnumFlags.Foo | MyEnumFlags.Bar;
+        protected override int Value => 1;
+    }
+
+    public class DictionaryStringKey : DictionaryKeyConverterTests<string, int>
+    {
+        protected override string Key => "KeyString";
+        protected override int Value => 1;
+    }
+
+    public class DictionaryObjectKey : DictionaryKeyConverterTests<object, int>
+    {
+        protected override object Key => 1;
+        protected override int Value => 1;
+        protected override string _expectedJson => BuildExpectedJson();
+        protected override string _expectedJsonHashedProperties => BuildExpectedJsonHashedProperties();
+        private Dictionary<object, int> _dictionary;
+        private Dictionary<string, int> _dictionaryOfStringKeys;
+        private Dictionary<int, int> _dictionaryOfHashedKeys;
+
+        protected override Dictionary<object, int> BuildDictionary()
+        {
+            var dictionary = new Dictionary<object, int>();
+            // Add a bunch of different types.
+            dictionary.Add(1, 1);
+            dictionary.Add(Guid.NewGuid(), 2);
+            dictionary.Add("Key1", 3);
+            dictionary.Add(MyEnum.Foo, 4);
+            dictionary.Add(MyEnumFlags.Foo | MyEnumFlags.Bar, 5);
+
+            _dictionary = dictionary;
+            _dictionaryOfStringKeys = dictionary.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value);
+            _dictionaryOfHashedKeys = dictionary.ToDictionary(kvp => kvp.Key.ToString().GetHashCode(), kvp => kvp.Value);
+
+            return dictionary;
+        }
+
+        private string BuildExpectedJson()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<object, int> kvp in _dictionary)
+                    {
+                        writer.WriteNumber(kvp.Key.ToString(), kvp.Value);
+                    }
+                    writer.WriteEndObject();
+                }
+
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+
+        private string BuildExpectedJsonHashedProperties()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<object, int> kvp in _dictionary)
+                    {
+                        string hashedKey = HashingNamingPolicy.HashName(kvp.Key.ToString());
+                        writer.WriteNumber(hashedKey, kvp.Value);
+                    }
+                    writer.WriteEndObject();
+                }
+
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+
+        protected override void Validate(Dictionary<object, int> dictionary)
+        {
+            foreach (KeyValuePair<object, int> kvp in dictionary)
+            {
+                if (kvp.Key is JsonElement keyJsonElement)
+                {
+                    Assert.Equal(JsonValueKind.String, keyJsonElement.ValueKind);
+
+                    string keyString = keyJsonElement.GetString();
+                    Assert.Equal(_dictionaryOfStringKeys[keyString], kvp.Value);
+                }
+                else
+                {
+                    Assert.True(false, "Polymorphic key is not JsonElement");
+                }
+            }
+        }
+
+        protected override void ValidateHashed(Dictionary<int, int> dictionary)
+        {
+            foreach (KeyValuePair<int, int> kvp in dictionary)
+            {
+                bool success = _dictionaryOfHashedKeys.TryGetValue(kvp.Key, out int value);
+                Assert.True(success);
+                Assert.Equal(value, kvp.Value);
+            }
+        }
+    }
+
+    public class HashingNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+        {
+            return HashName(name);
+        }
+
+        public static string HashName(string name)
+        {
+            return name.GetHashCode().ToString();
+        }
+    }
+
+    public abstract class DictionaryUnsupportedKeyTests<TKey, TValue>
+    {
+        private Dictionary<TKey, TValue> _dictionary => BuildDictionary();
+        private static JsonSerializerOptions _policyOptions = new JsonSerializerOptions { DictionaryKeyPolicy = new HashingNamingPolicy() };
+
+        private Dictionary<TKey, TValue> BuildDictionary()
+        {
+            return new Dictionary<TKey, TValue>();
+        }
+
+        [Fact]
+        public void ThrowUnsupportedSerialize() => Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(_dictionary));
+        [Fact]
+        public void ThrowUnsupportedSerializeUsingPolicy() => Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(_dictionary, _policyOptions));
+        [Fact]
+        public async Task ThrowUnsupportedSerializeAsync() => await Assert.ThrowsAsync<NotSupportedException>(() => JsonSerializer.SerializeAsync(new MemoryStream(), _dictionary));
+        [Fact]
+        public async Task ThrowUnsupportedSerializeAsyncUsingPolicyAsync() => await Assert.ThrowsAsync<NotSupportedException>(() => JsonSerializer.SerializeAsync(new MemoryStream(), _dictionary, _policyOptions));
+        [Fact]
+        public void ThrowUnsupportedDeserialize() => Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<TKey, TValue>>("{}"));
+        [Fact]
+        public async Task ThrowUnsupportedDeserializeAsync() => await Assert.ThrowsAsync<NotSupportedException>(async () => await JsonSerializer.DeserializeAsync<Dictionary<TKey, TValue>>(new MemoryStream(Encoding.UTF8.GetBytes("{}"))));
+    }
+
+    public class DictionaryUriKeyUnsupported : DictionaryUnsupportedKeyTests<Uri, int>{ }
+    public class MyClass { }
+    public class DictionaryMyClassKeyUnsupported : DictionaryUnsupportedKeyTests<MyClass, int>{ }
+    public struct MyStruct { }
+    public class DictionaryMyStructKeyUnsupported : DictionaryUnsupportedKeyTests<MyStruct, int> { }
+
+    public class DictionaryNonStringKeyTests
+    {
+        private static JsonSerializerOptions _policyOptions = new JsonSerializerOptions { DictionaryKeyPolicy = new HashingNamingPolicy() };
+
+        [Fact]
+        public void ThrowOnUnsupportedRuntimeType()
+        {
+            Dictionary<object, int> dictionary = new Dictionary<object, int>();
+            dictionary.Add(new Uri("http://github.com/Jozkee"), 1);
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(dictionary));
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(dictionary, _policyOptions));
+        }
+
+        [Fact]
+        public async Task ThrowOnUnsupportedRuntimeTypeAsync()
+        {
+            Dictionary<object, int> dictionary = new Dictionary<object, int>();
+            dictionary.Add(new Uri("http://github.com/Jozkee"), 1);
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => JsonSerializer.SerializeAsync(new MemoryStream(), dictionary));
+
+            await Assert.ThrowsAsync<NotSupportedException>(() => JsonSerializer.SerializeAsync(new MemoryStream(), dictionary, _policyOptions));
+        }
+
+        [Theory] // Extend this test when support for more types is added.
+        [InlineData(@"{""1.1"":1}", typeof(Dictionary<int, int>))]
+        [InlineData(@"{""{00000000-0000-0000-0000-000000000000}"":1}", typeof(Dictionary<Guid, int>))]
+        public void ThrowOnInvalidFormat(string json, Type typeToConvert)
+        {
+            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, typeToConvert));
+            Assert.Contains(typeToConvert.ToString(), ex.Message);
+        }
+         
+        [Theory] // Extend this test when support for more types is added.
+        [InlineData(@"{""1.1"":1}", typeof(Dictionary<int, int>))]
+        [InlineData(@"{""{00000000-0000-0000-0000-000000000000}"":1}", typeof(Dictionary<Guid, int>))]
+        public async Task ThrowOnInvalidFormatAsync(string json, Type typeToConvert)
+        {
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(json);
+            Stream stream = new MemoryStream(jsonBytes);
+
+            JsonException ex = await Assert.ThrowsAsync<JsonException>(async () => await JsonSerializer.DeserializeAsync(stream, typeToConvert));
+            Assert.Contains(typeToConvert.ToString(), ex.Message);
+        }
+
+        [Theory]
+        [InlineData(@"{""\u0039"":1}", typeof(Dictionary<int, int>), 9)]
+        [InlineData(@"{""\u0041"":1}", typeof(Dictionary<string, int>), "A")]
+        [InlineData(@"{""\u0066\u006f\u006f"":1}", typeof(Dictionary<MyEnum, int>), MyEnum.Foo)]
+        public static async Task TestUnescapedKeysAsync(string json, Type typeToConvert, object keyAsType)
+        {
+            byte[] utf8Json = Encoding.UTF8.GetBytes(json);
+            MemoryStream stream = new MemoryStream(utf8Json);
+
+            object result = await JsonSerializer.DeserializeAsync(stream, typeToConvert);
+
+            IDictionary dictionary = (IDictionary)result;
+            Assert.True(dictionary.Contains(keyAsType));
+        }
+
+        [Fact]
+        public static async Task TestUnescapedKeysAsync()
+        {
+            // Test Guid which cannot be passed as parameter on above method.
+            byte[] utf8Json = Encoding.UTF8.GetBytes(@"{""\u0036bb67e4e-9780-4895-851b-75f72ac34c5a"":1}");
+            MemoryStream stream = new MemoryStream(utf8Json);
+
+            Dictionary<Guid, int> result = await JsonSerializer.DeserializeAsync<Dictionary<Guid, int>>(stream);
+
+            Guid myGuid = new Guid("6bb67e4e-9780-4895-851b-75f72ac34c5a");
+            Assert.Equal(1, result[myGuid]);
+
+            // Test object.
+            utf8Json = Encoding.UTF8.GetBytes(@"{""\u0038"":1}");
+            stream = new MemoryStream(utf8Json);
+
+            Dictionary<object, int> result2 = await JsonSerializer.DeserializeAsync<Dictionary<object, int>>(stream);
+
+            Dictionary<object, int>.Enumerator enumerator = result2.GetEnumerator();
+            enumerator.MoveNext();
+
+            Assert.Equal(1, enumerator.Current.Value);
+
+            JsonElement dictionaryKey = (JsonElement)enumerator.Current.Key;
+            JsonElement myElement = JsonDocument.Parse("\"8\"").RootElement;
+
+            Assert.Equal(dictionaryKey.ValueKind, myElement.ValueKind);
+            Assert.Equal(dictionaryKey.GetString(), myElement.GetString());
+        }
+
+        private class UnsupportedDictionaryWrapper
+        {
+            public Dictionary<int[], int> Dictionary { get; set; }
+        }
+
+        private class UnsupportedDictionaryWrapper_Wrapper
+        {
+            public UnsupportedDictionaryWrapper Wrapper { get; set; }
+        }
+
+        [Fact]
+        public static void TestNotSuportedExceptionIsThrown()
+        {
+            // Dictionary<int[], int>>
+            // Does not throw NSE.
+            Assert.Null(JsonSerializer.Deserialize<Dictionary<int[], int>>("null"));
+
+            // Throws NSE.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<int[], int>>("\"\""));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<int[], int>>("{}"));
+
+            // UnsupportedDictionaryWrapper
+            // Does not throw NSE.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<UnsupportedDictionaryWrapper>("\"\""));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper>("{}"));
+            Assert.Null(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper>("null"));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper>(@"{""Dictionary"":null}"));
+
+            // Throws NSE.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<UnsupportedDictionaryWrapper>(@"{""Dictionary"":{}}"));
+
+            // UnsupportedDictionaryWrapper_Wrapper
+            // Does not throw NSE.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>("\"\""));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>("{}"));
+            Assert.Null(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>("null"));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>(@"{""Wrapper"":{}}"));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>(@"{""Wrapper"":null}"));
+            Assert.NotNull(JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>(@"{""Wrapper"":{""Dictionary"":null}}"));
+
+            // Throws NSE.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<UnsupportedDictionaryWrapper_Wrapper>(@"{""Wrapper"":{""Dictionary"":{}}"));
+
+
+            // List<Dictionary<int[], int>>
+            // Does not throw NSE.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("\"\""));
+            Assert.Null(JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("null"));
+            Assert.NotNull(JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("[]"));
+            Assert.NotNull(JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("[null]"));
+
+            // Throws NSE.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("[\"\"]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<List<Dictionary<int[], int>>>("[{}]"));
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -644,7 +644,6 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void FirstGenericArgNotStringFail()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<int, int>>(@"{1:1}"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ImmutableDictionary<int, int>>(@"{1:1}"));
         }
 
@@ -1623,9 +1622,10 @@ namespace System.Text.Json.Serialization.Tests
             }
             catch (NotSupportedException e)
             {
+                // TODO: Borrow logic from https://github.com/dotnet/runtime/pull/32669 to keep appending the parent type to the NSE message.
                 // The exception should contain className.propertyName and the invalid type.
-                Assert.Contains("ClassWithNotSupportedDictionary.MyDictionary", e.Message);
-                Assert.Contains("Dictionary`2[System.Int32,System.Int32]", e.Message);
+                //Assert.Contains("ClassWithNotSupportedDictionary.MyDictionary", e.Message);
+                Assert.Contains("Dictionary`2[System.Uri,System.Int32]", e.Message);
             }
         }
 
@@ -1846,7 +1846,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public class ClassWithNotSupportedDictionary
         {
-            public Dictionary<int, int> MyDictionary { get; set; }
+            public Dictionary<Uri, int> MyDictionary { get; set; }
         }
 
         public class ClassWithNotSupportedDictionaryButIgnored

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -655,9 +655,8 @@ namespace System.Text.Json.Serialization.Tests
             ClassWithInvalidExtensionPropertyStringString obj1 = new ClassWithInvalidExtensionPropertyStringString();
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(obj1));
 
-            // This fails with NotSupportedException since all Dictionaries currently need to have a string TKey.
             ClassWithInvalidExtensionPropertyObjectString obj2 = new ClassWithInvalidExtensionPropertyObjectString();
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj2));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(obj2));
         }
 
         private class ClassWithExtensionPropertyAlreadyInstantiated

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <DefineConstants Condition="'$(TargetsNetFx)' != 'true'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
@@ -58,6 +58,7 @@
     <Compile Include="Serialization\CustomConverterTests.Callback.cs" />
     <Compile Include="Serialization\CyclicTests.cs" />
     <Compile Include="Serialization\DictionaryTests.cs" />
+    <Compile Include="Serialization\DictionaryTests.KeyConverter.cs" />
     <Compile Include="Serialization\DictionaryTests.KeyPolicy.cs" />
     <Compile Include="Serialization\EnumConverterTests.cs" />
     <Compile Include="Serialization\EnumTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/30524

Introduces the mechanism that is going to be used for extending the supported types on `TKey` in a `Dictionary<TKey, TValue>`. The purpose of this PR is to give a taste of the way that we are going to tackle the problem.

Adds support for `int`, `enum`, `Guid` and `object` (When `object` is one of the supported types during runtime).

In subsequent PRs we should be able to extend this support to the rest of dictionaries supported by the `JsonSerializer` i.e. IDIctionary<TKey, TValue>, ImmutableDictionary<TKey, TValue>, etc.

I hold off of adding support for dictionaries  annotated with the `JsonExtensionData` attribute but those can also be included in the previous paragraph.