### PR TITLE
Build CoreCLR tests as platform independent (AnyCPU)

### DIFF
--- a/src/coreclr/tests/dir.common.props
+++ b/src/coreclr/tests/dir.common.props
@@ -10,7 +10,7 @@
        tests/dir.props directly - these should eventually go away. -->
 
   <PropertyGroup>
-    <OSPlatformConfig>$(BuildOS).$(Platform).$(Configuration)</OSPlatformConfig>
+    <OSPlatformConfig>$(BuildOS).$(BuildArch).$(Configuration)</OSPlatformConfig>
 
     <TestSrcDir>$(MSBuildThisFileDirectory)src</TestSrcDir>
     <BuildProjectRelativeDir>$([MSBuild]::MakeRelative($(TestSrcDir), $(MSBuildProjectDirectory)))\$(MSBuildProjectName)\</BuildProjectRelativeDir>

--- a/src/coreclr/tests/dir.sdkbuild.props
+++ b/src/coreclr/tests/dir.sdkbuild.props
@@ -9,7 +9,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <Platform>$(BuildArch)</Platform>
+    <Platform>AnyCPU</Platform>
 
     <!-- [ARCADE REMOVE] This line should be removed we use the Arcade Sdk. -->
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/src/coreclr/tests/src/Directory.Build.props
+++ b/src/coreclr/tests/src/Directory.Build.props
@@ -30,7 +30,7 @@
     <BinDir>$(BaseOutputPathWithConfig)</BinDir>
     <BaseIntermediateOutputPath>$(RootRepoDir)\artifacts\tests\coreclr\obj\$(OSPlatformConfig)\Managed\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
-    <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\..\coreclr\obj\$(BuildOS).$(Platform).$(Configuration)\Native\))</__NativeTestIntermediatesDir>
+    <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\..\coreclr\obj\$(BuildOS).$(BuildArch).$(Configuration)\Native\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(TestSourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(TestSourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\</IntermediateOutputPath>

--- a/src/coreclr/tests/src/GC/API/GC/GetAllocatedBytesForCurrentThread.csproj
+++ b/src/coreclr/tests/src/GC/API/GC/GetAllocatedBytesForCurrentThread.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'arm'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'arm'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/coreclr/tests/src/GC/API/GC/GetTotalAllocatedBytes.csproj
+++ b/src/coreclr/tests/src/GC/API/GC/GetTotalAllocatedBytes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'arm'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'arm'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/coreclr/tests/src/GC/Regressions/v2.0-rtm/494226/494226.csproj
+++ b/src/coreclr/tests/src/GC/Regressions/v2.0-rtm/494226/494226.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'x86' or '$(BuildArch)' == 'arm' or '$(BuildArch)' == 'arm64'">true</HeapVerifyIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/GC/Scenarios/ServerModel/servermodel.csproj
+++ b/src/coreclr/tests/src/GC/Scenarios/ServerModel/servermodel.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestExecutionArguments>/numrequests:100</CLRTestExecutionArguments>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'x86' or '$(BuildArch)' == 'arm' or '$(BuildArch)' == 'arm64'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cache.cs" />

--- a/src/coreclr/tests/src/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
@@ -7,7 +7,7 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
@@ -7,7 +7,7 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/IJW/LoadIjwFromModuleHandle/LoadIjwFromModuleHandle.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/LoadIjwFromModuleHandle/LoadIjwFromModuleHandle.csproj
@@ -9,7 +9,7 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -7,7 +7,7 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -7,7 +7,7 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
+++ b/src/coreclr/tests/src/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
@@ -7,9 +7,9 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <!-- IJW is not supported on ARM64 -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- Native varargs not supported on ARM -->
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm'">true</DisableProjectBuild>
     <!-- Loading IJW assemblies into an unloadable context is not allowed -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/Interop.settings.targets
+++ b/src/coreclr/tests/src/Interop/Interop.settings.targets
@@ -22,8 +22,8 @@
   <ItemGroup
     Condition="'$(TargetsWindows)' == 'true' And ('$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Checked') And '$(CopyDebugCRTDllsToOutputDirectory)' == 'true'" >
 
-    <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
-    <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/msvcp*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always" />
+    <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(BuildArch)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
+    <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(BuildArch)/Microsoft.VC*.DebugCRT/msvcp*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
+    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(BuildArch)/ucrtbased.dll" CopyToOutputDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
+++ b/src/coreclr/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
@@ -4,7 +4,7 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm' or '$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
     <!-- WinRT interop is not compatible with unloadability -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/coreclr/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
@@ -6,7 +6,7 @@
     <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <JitOptimizationSensitive Condition="'$(Platform)' == 'arm64'">true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(BuildArch)' == 'arm64'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VectorMgdMgd.cs" />

--- a/src/coreclr/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
+++ b/src/coreclr/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <DisableProjectBuild Condition="'$(Platform)' == 'x64'">true</DisableProjectBuild>
-    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'x64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' == 'arm64'">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/coreclr/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
+++ b/src/coreclr/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
+++ b/src/coreclr/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -8,11 +8,11 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
   <PropertyGroup>
-    <PointerSize Condition="'$(Platform)'=='x64'">64</PointerSize>
-    <PointerSize Condition="'$(Platform)'=='arm64'">64</PointerSize>
-    <PointerSize Condition="'$(Platform)'=='x86'">32</PointerSize>
-    <PointerSize Condition="'$(Platform)'=='arm'">32</PointerSize>
-    <PointerSize Condition="'$(Platform)'=='armel'">32</PointerSize>
+    <PointerSize Condition="'$(BuildArch)'=='x64'">64</PointerSize>
+    <PointerSize Condition="'$(BuildArch)'=='arm64'">64</PointerSize>
+    <PointerSize Condition="'$(BuildArch)'=='x86'">32</PointerSize>
+    <PointerSize Condition="'$(BuildArch)'=='arm'">32</PointerSize>
+    <PointerSize Condition="'$(BuildArch)'=='armel'">32</PointerSize>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PointerSize)' == '64' ">
     <Compile Include="DevDiv_278523_64.il" />

--- a/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/coreclr/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_d.csproj
+++ b/src/coreclr/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_d.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/coreclr/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_r.csproj
+++ b/src/coreclr/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_r.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
+    <GCStressIncompatible Condition="'$(BuildArch)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(BuildArch)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/coreclr/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/src/coreclr/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -9,7 +9,7 @@
     <Optimize>True</Optimize>
     <!-- This test is very resource heavy and doesn't play well with some JitStress modes, especially when memory is limited  (x86),
          on arm the test fails to crossgen with stress mode because of an relocation offset size limit, see #16587 -->
-    <JitOptimizationSensitive Condition="'$(Platform)' == 'x86' Or '$(Platform)' == 'arm'">true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(BuildArch)' == 'x86' Or '$(BuildArch)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hugeexpr1.cs" />

--- a/src/coreclr/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/src/coreclr/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -5,7 +5,7 @@
     <!-- This test takes a long time to complete -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- https://github.com/dotnet/coreclr/issues/24633 -->
-    <JitOptimizationSensitive Condition="'$(Platform)' == 'arm'">true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(BuildArch)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -4,7 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Crossgen2 currently targets only x64 -->
-    <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' != 'x64'">true</DisableProjectBuild>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/coreclr/issues/26633 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->

--- a/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -6,7 +6,7 @@
     <CLRTestPriority>0</CLRTestPriority>
 
     <!-- Crossgen2 currently targets only x64 -->
-    <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' != 'x64'">true</DisableProjectBuild>
 
     <!-- Generate ILDLL so that the DLL can be the crossgenned assembly -->
     <TargetExt>.ildll</TargetExt>

--- a/src/coreclr/tests/src/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/coreclr/tests/src/readytorun/determinism/crossgen2determinism.csproj
@@ -4,7 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Crossgen2 currently targets only x64 -->
-    <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(BuildArch)' != 'x64'">true</DisableProjectBuild>
     <!-- Known not to work with GCStress for now: https://github.com/dotnet/coreclr/issues/26633 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->

--- a/src/coreclr/tests/src/readytorun/r2rdump/R2RDumpTest.csproj
+++ b/src/coreclr/tests/src/readytorun/r2rdump/R2RDumpTest.csproj
@@ -12,7 +12,7 @@
     <!-- Test unsupported outside of windows -->
     <!-- Test unsupported on arm targets -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
-    <DisableProjectBuild Condition=" '$(Platform)' == 'arm64' or '$(Platform)' == 'arm' or '$(TargetsUnix)' == 'true' ">true</DisableProjectBuild>
+    <DisableProjectBuild Condition=" '$(BuildArch)' == 'arm64' or '$(BuildArch)' == 'arm' or '$(TargetsUnix)' == 'true' ">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Fails with JIT stress modes, issue #19415 -->


### PR DESCRIPTION
After this change same test dll can be launched on different architectures.

Related issue: #31793 

cc @alpencolt @jkotas 