### PR TITLE
Update Helix SDK to address Azure DevOps reporting problem

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,9 +10,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>03bd0e0cefb81d33d08c4853fa5d6a8057c34d94</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20124.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20126.7">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>03bd0e0cefb81d33d08c4853fa5d6a8057c34d94</Sha>
+      <Sha>cd4164e1f3f7daf2a6f8dbd012210c93521bd82f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20124.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20124.3",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20124.3",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20124.3",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20124.3",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20126.7",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-alpha.1.20076.2",
     "Microsoft.Build.NoTargets": "1.0.53",


### PR DESCRIPTION
As described in https://github.com/dotnet/core-eng/issues/9132.  

Some details:
- Fix has already been ported to arcade's release/3.x branch
- Logs, core dumps, and pass-fail information are unaffected, simply the ability to import test facts into Azure devops builds.  If your Helix job passes, all work items ran as usual and passed.
- Note that AzDO reporting may still not work immediately after this change;  We'll need to update all actively used AzDO reporters to fix this.  