### PR TITLE
Fix jit build break

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -11304,11 +11304,11 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveRange::dumpVariableLiveRa
 {
     codeGen->dumpSiVarLoc(&m_VarLocation);
     printf(" [ ");
-    m_StartEmitLocation.Print();
+    m_StartEmitLocation.Print(compiler->compMethodID);
     printf(", ");
     if (m_EndEmitLocation.Valid())
     {
-        m_EndEmitLocation.Print();
+        m_EndEmitLocation.Print(compiler->compMethodID);
     }
     else
     {

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -11304,11 +11304,11 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveRange::dumpVariableLiveRa
 {
     codeGen->dumpSiVarLoc(&m_VarLocation);
     printf(" [ ");
-    m_StartEmitLocation.Print(compiler->compMethodID);
+    m_StartEmitLocation.Print(codeGen->GetCompiler()->compMethodID);
     printf(", ");
     if (m_EndEmitLocation.Valid())
     {
-        m_EndEmitLocation.Print(compiler->compMethodID);
+        m_EndEmitLocation.Print(codeGen->GetCompiler()->compMethodID);
     }
     else
     {


### PR DESCRIPTION
Two changes to codegencommon.cpp were merged in short order, and
git/github did not spot the merge conflict.

Fixes #32926.