### PR TITLE
Fix JIT traces for the case where a tier 1 compilation switches to MinOpts

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -3795,6 +3795,7 @@ _SetMinOpts:
         !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT) && !opts.compDbgCode)
     {
         info.compCompHnd->setMethodAttribs(info.compMethodHnd, CORINFO_FLG_SWITCHED_TO_MIN_OPT);
+        opts.jitFlags->Clear(JitFlags::JIT_FLAG_TIER1);
         compSwitchedToMinOpts = true;
     }
 


### PR DESCRIPTION
Updated to clear the tier 1 flag when switching to MinOpts. Clearing the flag avoids printing "tier 1" in traces and to print more accurate information around here:
https://github.com/dotnet/runtime/blob/c727a412bf2c415bb2b94eeef0939aa07b87591c/src/coreclr/src/jit/compiler.cpp#L4035-L4044