### PR TITLE
Re-re-enable Regex tests on .NET Framework

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <NoWarn>$(NoWarn);xUnit2008</NoWarn>
-    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>


### PR DESCRIPTION
I'd previously done this in the Configuration.props, but then those were deleted and my change was apparently lost in the transition.

Thanks @ViktorHofer for helping me figure out what happened.

cc: @eerhardt, @Anipik