### PR TITLE
 Use nuget package for desktop ref assms

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,6 +35,8 @@
       release, increase this number by one.
     -->
     <NETStandardPatchVersion>0</NETStandardPatchVersion>
+    <!-- Restore the .NETFramework reference assemblies from NuGet packages -->
+    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
   </PropertyGroup>
   <!--
     Servicing build settings for Setup/Installer packages. Instructions:


### PR DESCRIPTION
This enables build from windows without installing older
.NETFramework targeting packs.

Without this, I was failing to build installer tasks on a new machine without the .NETFramework 4.6 targeting pack.