### PR TITLE
Fix ARM64 intrinsic namespace in crossgen and crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/coreclr/src/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
@@ -22,17 +22,17 @@ namespace ILCompiler
 
             if (owningType.IsIntrinsic && owningType is MetadataType mdType)
             {
+                mdType = (MetadataType)mdType.ContainingType ?? mdType;
                 TargetArchitecture targetArch = owningType.Context.Target.Architecture;
 
                 if (targetArch == TargetArchitecture.X64 || targetArch == TargetArchitecture.X86)
                 {
-                    mdType = (MetadataType)mdType.ContainingType ?? mdType;
                     if (mdType.Namespace == "System.Runtime.Intrinsics.X86")
                         return true;
                 }
                 else if (targetArch == TargetArchitecture.ARM64)
                 {
-                    if (mdType.Namespace == "System.Runtime.Intrinsics.Arm.Arm64")
+                    if (mdType.Namespace == "System.Runtime.Intrinsics.Arm")
                         return true;
                 }
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1496,7 +1496,7 @@ namespace Internal.JitInterface
                 }
                 else if (_TARGET_ARM64_)
                 {
-                    fIsPlatformHWIntrinsic = (namespaceName == "System.Runtime.Intrinsics.Arm.Arm64");
+                    fIsPlatformHWIntrinsic = (namespaceName == "System.Runtime.Intrinsics.Arm");
                 }
 
                 fIsHWIntrinsic = fIsPlatformHWIntrinsic || (namespaceName == "System.Runtime.Intrinsics");

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/RelocationHelper.cs
@@ -203,7 +203,7 @@ namespace ILCompiler.PEWriter
                         relocationLength = 4;
                         int sourcePageRVA = sourceRVA & ~0xfff;
                         // Page delta always fits in 21 bits as long as we use 4-byte RVAs
-                        delta = ((targetRVA - sourcePageRVA) >> 12) & 0x1ffff;
+                        delta = ((targetRVA - sourcePageRVA) >> 12) & 0x1f_ffff;
                         break;
                     }
 

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -462,7 +462,7 @@ void ZapInfo::CompileMethod()
         const char* namespaceName;
         getMethodNameFromMetadata(m_currentMethodHandle, nullptr, &namespaceName, nullptr);
         if (strcmp(namespaceName, "System.Runtime.Intrinsics.X86") == 0
-            || strcmp(namespaceName, "System.Runtime.Intrinsics.Arm.Arm64") == 0
+            || strcmp(namespaceName, "System.Runtime.Intrinsics.Arm") == 0
             || strcmp(namespaceName, "System.Runtime.Intrinsics") == 0)
         {
             if (m_zapper->m_pOpt->m_verbose)
@@ -2121,7 +2121,7 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
         fIsPlatformHWIntrinsic = strcmp(namespaceName, "System.Runtime.Intrinsics.X86") == 0;
 #elif TARGET_ARM64
-        fIsPlatformHWIntrinsic = strcmp(namespaceName, "System.Runtime.Intrinsics.Arm.Arm64") == 0;
+        fIsPlatformHWIntrinsic = strcmp(namespaceName, "System.Runtime.Intrinsics.Arm") == 0;
 #endif
 
         fIsHWIntrinsic = fIsPlatformHWIntrinsic || (strcmp(namespaceName, "System.Runtime.Intrinsics") == 0);

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1211,9 +1211,7 @@ internal class Program
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());
-        // TODO: enabling this test requires fixes to IsManagedSequential I'm going to send out
-        // in a subsequent PR together with removal of this temporary clause [trylek]
-        // RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
+        RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
         RunTest("CastClassWithCharTest", CastClassWithCharTest());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1211,7 +1211,9 @@ internal class Program
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());
-        RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
+        // TODO: enabling this test requires fixes to IsManagedSequential I'm going to send out
+        // in a subsequent PR together with removal of this temporary clause [trylek]
+        // RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
         RunTest("CastClassWithCharTest", CastClassWithCharTest());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());


### PR DESCRIPTION
We did not update the hard-coded intrinsic namespace in crossgen and crossgen2 when moved ARM64 intrinsics to a different namespace.