### PR TITLE
Update shared HPackEncoder

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackEncoder.cs
@@ -2,26 +2,30 @@
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
+#if KESTREL
+using HeadersEnumerator = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2HeadersEnumerator;
+#else
+using HeadersEnumerator = System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>>;
+#endif
 
 namespace System.Net.Http.HPack
 {
     internal class HPackEncoder
     {
-        private IEnumerator<KeyValuePair<string, string>> _enumerator;
+        private HeadersEnumerator _enumerator;
 
-        public bool BeginEncode(IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        public bool BeginEncode(HeadersEnumerator enumerator, Span<byte> buffer, out int length)
         {
-            _enumerator = headers.GetEnumerator();
+            _enumerator = enumerator;
             _enumerator.MoveNext();
 
             return Encode(buffer, out length);
         }
 
-        public bool BeginEncode(int statusCode, IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        public bool BeginEncode(int statusCode, HeadersEnumerator enumerator, Span<byte> buffer, out int length)
         {
-            _enumerator = headers.GetEnumerator();
+            _enumerator = enumerator;
             _enumerator.MoveNext();
 
             int statusCodeLength = EncodeStatusCode(statusCode, buffer);


### PR DESCRIPTION
Sync changes from https://github.com/dotnet/aspnetcore/pull/19393. Review now, but wait until that PR is merged before merging this.

Optimizing the enumerator eliminates allocations per HTTP request.