### PR TITLE
Invert Environment.UserInteractive (fix)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -134,7 +134,7 @@ namespace System
                     uint dummy = 0;
                     if (Interop.User32.GetUserObjectInformationW(handle, Interop.User32.UOI_FLAGS, &flags, (uint)sizeof(Interop.User32.USEROBJECTFLAGS), ref dummy))
                     {
-                        return ((flags.dwFlags & Interop.User32.WSF_VISIBLE) == 0);
+                        return ((flags.dwFlags & Interop.User32.WSF_VISIBLE) != 0);
                     }
                 }
 

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -136,7 +136,6 @@ namespace System.ServiceProcess.Tests
             controller.WaitForStatus(ServiceControllerStatus.Stopped);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1724")]
         [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnExecuteCustomCommand()
         {


### PR DESCRIPTION
Fixes #1724 

When porting this the condition was inverted.  Fix by correcting the condition and re-enabling the test.