### PR TITLE
Package libcoreclrtraceptprovider.so with sharedFramework

### DIFF
--- a/src/coreclr/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/eventprovider/lttngprovider/CMakeLists.txt
@@ -72,3 +72,4 @@ set_target_properties(coreclrtraceptprovider PROPERTIES LINKER_LANGUAGE CXX)
 _install(TARGETS eventprovider DESTINATION lib)
 # Install the static coreclrtraceptprovider library
 install_clr(TARGETS coreclrtraceptprovider)
+install_clr(TARGETS coreclrtraceptprovider DESTINATION sharedFramework SKIP_STRIP)


### PR DESCRIPTION
`libcoreclrtraceptprovider.so` was being dropped from the latest SDK drops because it wasn't being put into sharedFramework directory. 