### PR TITLE
Guard against NRE when deserializing extension data into dictionary without parameterless ctor

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -229,7 +229,7 @@ namespace System.Text.Json
                     typeof(IDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType))
                 {
                     JsonConverter? converter = Options.GetConverter(declaredPropertyType);
-                    if (converter == null)
+                    if (converter == null || jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)
                     {
                         ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(declaredPropertyType);
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -229,7 +229,7 @@ namespace System.Text.Json
                     typeof(IDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType))
                 {
                     JsonConverter? converter = Options.GetConverter(declaredPropertyType);
-                    if (converter == null || jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)
+                    if (converter == null)
                     {
                         ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(declaredPropertyType);
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -117,7 +117,11 @@ namespace System.Text.Json
                     jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(object) ||
                     jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(JsonElement));
 
-                Debug.Assert(jsonPropertyInfo.RuntimeClassInfo.CreateObject != null);
+                if (jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)
+                {
+                    ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(jsonPropertyInfo.DeclaredPropertyType);
+                }
+
                 extensionData = (IDictionary?)jsonPropertyInfo.RuntimeClassInfo.CreateObject();
                 jsonPropertyInfo.SetValueAsObject(obj, extensionData);
             }

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Xunit;
@@ -220,6 +221,12 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, object> MyOverflow2 { get; set; }
         }
 
+        private class ClassWithNotSupportedExtensionPropertyImmutableDictionary
+        {
+            [JsonExtensionData]
+            public ImmutableDictionary<string, object> MyOverflow { get; set; }
+        }
+
         [Fact]
         public static void InvalidExtensionPropertyFail()
         {
@@ -229,6 +236,7 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithInvalidExtensionProperty>(@"{}"));
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionProperties>(@"{}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithNotSupportedExtensionPropertyImmutableDictionary>(@"{}"));
         }
 
         private class ClassWithIgnoredData

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -221,12 +221,6 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, object> MyOverflow2 { get; set; }
         }
 
-        private class ClassWithNotSupportedExtensionPropertyImmutableDictionary
-        {
-            [JsonExtensionData]
-            public ImmutableDictionary<string, object> MyOverflow { get; set; }
-        }
-
         [Fact]
         public static void InvalidExtensionPropertyFail()
         {
@@ -236,7 +230,6 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithInvalidExtensionProperty>(@"{}"));
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionProperties>(@"{}"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithNotSupportedExtensionPropertyImmutableDictionary>(@"{}"));
         }
 
         private class ClassWithIgnoredData
@@ -697,6 +690,45 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, object> MyOverflow { get; set; }
 
             public Dictionary<string, object> ActualDictionary { get; set; }
+        }
+
+        [Fact]
+        public static void DeserializeIntoImmutableDictionaryProperty()
+        {
+            // baseline
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyAsImmutable>(@"{}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyAsImmutableJsonElement>(@"{}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructor>(@"{}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructorJsonElement>(@"{}");
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyAsImmutable>("{\"hello\":\"world\"}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyAsImmutableJsonElement>("{\"hello\":\"world\"}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructor>("{\"hello\":\"world\"}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructorJsonElement>("{\"hello\":\"world\"}"));
+        }
+
+        private class ClassWithExtensionPropertyAsImmutable
+        {
+            [JsonExtensionData]
+            public ImmutableDictionary<string, object> MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyAsImmutableJsonElement
+        {
+            [JsonExtensionData]
+            public ImmutableDictionary<string, JsonElement> MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyPrivateConstructor
+        {
+            [JsonExtensionData]
+            public StringToGenericIDictionaryWrapperPrivateConstructor<object> MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyPrivateConstructorJsonElement
+        {
+            [JsonExtensionData]
+            public StringToGenericIDictionaryWrapperPrivateConstructor<JsonElement> MyOverflow { get; set; }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -705,6 +705,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyAsImmutableJsonElement>("{\"hello\":\"world\"}"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructor>("{\"hello\":\"world\"}"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructorJsonElement>("{\"hello\":\"world\"}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutable>("{\"hello\":\"world\"}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutableJsonElement>("{\"hello\":\"world\"}"));
         }
 
         [Fact]
@@ -755,6 +757,19 @@ namespace System.Text.Json.Serialization.Tests
             [JsonExtensionData]
             public GenericIDictionaryWrapperPrivateConstructor<string, JsonElement> MyOverflow { get; set; }
         }
+
+        private class ClassWithExtensionPropertyCustomIImmutable
+        {
+            [JsonExtensionData]
+            public GenericIImmutableDictionaryWrapper<string, object> MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyCustomIImmutableJsonElement
+        {
+            [JsonExtensionData]
+            public GenericIImmutableDictionaryWrapper<string, JsonElement> MyOverflow { get; set; }
+        }
+
 
         [Fact]
         public static void CustomObjectConverterInExtensionProperty()

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -722,13 +722,13 @@ namespace System.Text.Json.Serialization.Tests
         private class ClassWithExtensionPropertyPrivateConstructor
         {
             [JsonExtensionData]
-            public StringToGenericIDictionaryWrapperPrivateConstructor<object> MyOverflow { get; set; }
+            public GenericIDictionaryWrapperPrivateConstructor<string, object> MyOverflow { get; set; }
         }
 
         private class ClassWithExtensionPropertyPrivateConstructorJsonElement
         {
             [JsonExtensionData]
-            public StringToGenericIDictionaryWrapperPrivateConstructor<JsonElement> MyOverflow { get; set; }
+            public GenericIDictionaryWrapperPrivateConstructor<string, JsonElement> MyOverflow { get; set; }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -707,6 +707,31 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructorJsonElement>("{\"hello\":\"world\"}"));
         }
 
+        [Fact]
+        public static void SerializeIntoImmutableDictionaryProperty()
+        {
+            // attempt to serialize a null immutable dictionary
+            string expectedJson = "{}";
+            var obj = new ClassWithExtensionPropertyAsImmutable();
+            var json = JsonSerializer.Serialize(obj);
+            Assert.Equal(expectedJson, json);
+
+            // attempt to serialize an empty immutable dictionary
+            expectedJson = "{}";
+            obj = new ClassWithExtensionPropertyAsImmutable();
+            obj.MyOverflow = ImmutableDictionary<string, object>.Empty;
+            json = JsonSerializer.Serialize(obj);
+            Assert.Equal(expectedJson, json);
+
+            // attempt to serialize a populated immutable dictionary
+            expectedJson = "{\"hello\":\"world\"}";
+            obj = new ClassWithExtensionPropertyAsImmutable();
+            var dictionaryStringObject = new Dictionary<string, object> { { "hello", "world" } };
+            obj.MyOverflow = ImmutableDictionary.CreateRange(dictionaryStringObject);
+            json = JsonSerializer.Serialize(obj);
+            Assert.Equal(expectedJson, json);
+        }
+
         private class ClassWithExtensionPropertyAsImmutable
         {
             [JsonExtensionData]

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -864,11 +864,6 @@ namespace System.Text.Json.Serialization.Tests
     public class GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> : GenericIDictionaryWrapper<TKey, TValue>
     {
         private GenericIDictionaryWrapperPrivateConstructor() { }
-
-        public static GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> Create()
-        {
-            return new GenericIDictionaryWrapperPrivateConstructor<TKey, TValue>();
-        }
     }
 
     public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -861,6 +861,83 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private Dictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>();
+
+        private GenericIDictionaryWrapperPrivateConstructor() { }
+
+        public static GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> Create()
+        {
+            return new GenericIDictionaryWrapperPrivateConstructor<TKey, TValue>();
+        }
+
+        public TValue this[TKey key] { get => ((IDictionary<TKey, TValue>)_dict)[key]; set => ((IDictionary<TKey, TValue>)_dict)[key] = value; }
+
+        public ICollection<TKey> Keys => ((IDictionary<TKey, TValue>)_dict).Keys;
+
+        public ICollection<TValue> Values => ((IDictionary<TKey, TValue>)_dict).Values;
+
+        public int Count => ((IDictionary<TKey, TValue>)_dict).Count;
+
+        public bool IsReadOnly => ((IDictionary<TKey, TValue>)_dict).IsReadOnly;
+
+        public void Add(TKey key, TValue value)
+        {
+            ((IDictionary<TKey, TValue>)_dict).Add(key, value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((IDictionary<TKey, TValue>)_dict).Add(item);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary<TKey, TValue>)_dict).Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Contains(item);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((IDictionary<TKey, TValue>)_dict).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
+        }
+
+        public bool Remove(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Remove(item);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
+        }
+    }
+
     public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper
     {
         public override bool IsReadOnly => true;
@@ -946,83 +1023,6 @@ namespace System.Text.Json.Serialization.Tests
     public class StringToGenericIDictionaryWrapper<TValue> : IDictionary<string, TValue>
     {
         private Dictionary<string, TValue> _dictionary = new Dictionary<string, TValue>();
-
-        public TValue this[string key] { get => ((IDictionary<string, TValue>)_dictionary)[key]; set => ((IDictionary<string, TValue>)_dictionary)[key] = value; }
-
-        public ICollection<string> Keys => ((IDictionary<string, TValue>)_dictionary).Keys;
-
-        public ICollection<TValue> Values => ((IDictionary<string, TValue>)_dictionary).Values;
-
-        public int Count => ((IDictionary<string, TValue>)_dictionary).Count;
-
-        public bool IsReadOnly => ((IDictionary<string, TValue>)_dictionary).IsReadOnly;
-
-        public void Add(string key, TValue value)
-        {
-            ((IDictionary<string, TValue>)_dictionary).Add(key, value);
-        }
-
-        public void Add(KeyValuePair<string, TValue> item)
-        {
-            ((IDictionary<string, TValue>)_dictionary).Add(item);
-        }
-
-        public void Clear()
-        {
-            ((IDictionary<string, TValue>)_dictionary).Clear();
-        }
-
-        public bool Contains(KeyValuePair<string, TValue> item)
-        {
-            return ((IDictionary<string, TValue>)_dictionary).Contains(item);
-        }
-
-        public bool ContainsKey(string key)
-        {
-            return ((IDictionary<string, TValue>)_dictionary).ContainsKey(key);
-        }
-
-        public void CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex)
-        {
-            ((IDictionary<string, TValue>)_dictionary).CopyTo(array, arrayIndex);
-        }
-
-        public IEnumerator<KeyValuePair<string, TValue>> GetEnumerator()
-        {
-            return ((IDictionary<string, TValue>)_dictionary).GetEnumerator();
-        }
-
-        public bool Remove(string key)
-        {
-            return ((IDictionary<string, TValue>)_dictionary).Remove(key);
-        }
-
-        public bool Remove(KeyValuePair<string, TValue> item)
-        {
-            return ((IDictionary<string, TValue>)_dictionary).Remove(item);
-        }
-
-        public bool TryGetValue(string key, out TValue value)
-        {
-            return ((IDictionary<string, TValue>)_dictionary).TryGetValue(key, out value);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IDictionary<string, TValue>)_dictionary).GetEnumerator();
-        }
-    }
-
-    public class StringToGenericIDictionaryWrapperPrivateConstructor<TValue> : IDictionary<string, TValue>
-    {
-        private Dictionary<string, TValue> _dictionary = new Dictionary<string, TValue>();
-
-        private StringToGenericIDictionaryWrapperPrivateConstructor() { }
-
-        public static StringToGenericIDictionaryWrapperPrivateConstructor<TValue> Create()
-        {
-            return new StringToGenericIDictionaryWrapperPrivateConstructor<TValue>();
-        }
 
         public TValue this[string key] { get => ((IDictionary<string, TValue>)_dictionary)[key]; set => ((IDictionary<string, TValue>)_dictionary)[key] = value; }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -861,80 +861,13 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> : IDictionary<TKey, TValue>
+    public class GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> : GenericIDictionaryWrapper<TKey, TValue>
     {
-        private Dictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>();
-
         private GenericIDictionaryWrapperPrivateConstructor() { }
 
         public static GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> Create()
         {
             return new GenericIDictionaryWrapperPrivateConstructor<TKey, TValue>();
-        }
-
-        public TValue this[TKey key] { get => ((IDictionary<TKey, TValue>)_dict)[key]; set => ((IDictionary<TKey, TValue>)_dict)[key] = value; }
-
-        public ICollection<TKey> Keys => ((IDictionary<TKey, TValue>)_dict).Keys;
-
-        public ICollection<TValue> Values => ((IDictionary<TKey, TValue>)_dict).Values;
-
-        public int Count => ((IDictionary<TKey, TValue>)_dict).Count;
-
-        public bool IsReadOnly => ((IDictionary<TKey, TValue>)_dict).IsReadOnly;
-
-        public void Add(TKey key, TValue value)
-        {
-            ((IDictionary<TKey, TValue>)_dict).Add(key, value);
-        }
-
-        public void Add(KeyValuePair<TKey, TValue> item)
-        {
-            ((IDictionary<TKey, TValue>)_dict).Add(item);
-        }
-
-        public void Clear()
-        {
-            ((IDictionary<TKey, TValue>)_dict).Clear();
-        }
-
-        public bool Contains(KeyValuePair<TKey, TValue> item)
-        {
-            return ((IDictionary<TKey, TValue>)_dict).Contains(item);
-        }
-
-        public bool ContainsKey(TKey key)
-        {
-            return ((IDictionary<TKey, TValue>)_dict).ContainsKey(key);
-        }
-
-        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-        {
-            ((IDictionary<TKey, TValue>)_dict).CopyTo(array, arrayIndex);
-        }
-
-        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
-        {
-            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
-        }
-
-        public bool Remove(TKey key)
-        {
-            return ((IDictionary<TKey, TValue>)_dict).Remove(key);
-        }
-
-        public bool Remove(KeyValuePair<TKey, TValue> item)
-        {
-            return ((IDictionary<TKey, TValue>)_dict).Remove(item);
-        }
-
-        public bool TryGetValue(TKey key, out TValue value)
-        {
-            return ((IDictionary<TKey, TValue>)_dict).TryGetValue(key, out value);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -1013,6 +1013,83 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class StringToGenericIDictionaryWrapperPrivateConstructor<TValue> : IDictionary<string, TValue>
+    {
+        private Dictionary<string, TValue> _dictionary = new Dictionary<string, TValue>();
+
+        private StringToGenericIDictionaryWrapperPrivateConstructor() { }
+
+        public static StringToGenericIDictionaryWrapperPrivateConstructor<TValue> Create()
+        {
+            return new StringToGenericIDictionaryWrapperPrivateConstructor<TValue>();
+        }
+
+        public TValue this[string key] { get => ((IDictionary<string, TValue>)_dictionary)[key]; set => ((IDictionary<string, TValue>)_dictionary)[key] = value; }
+
+        public ICollection<string> Keys => ((IDictionary<string, TValue>)_dictionary).Keys;
+
+        public ICollection<TValue> Values => ((IDictionary<string, TValue>)_dictionary).Values;
+
+        public int Count => ((IDictionary<string, TValue>)_dictionary).Count;
+
+        public bool IsReadOnly => ((IDictionary<string, TValue>)_dictionary).IsReadOnly;
+
+        public void Add(string key, TValue value)
+        {
+            ((IDictionary<string, TValue>)_dictionary).Add(key, value);
+        }
+
+        public void Add(KeyValuePair<string, TValue> item)
+        {
+            ((IDictionary<string, TValue>)_dictionary).Add(item);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary<string, TValue>)_dictionary).Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, TValue> item)
+        {
+            return ((IDictionary<string, TValue>)_dictionary).Contains(item);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return ((IDictionary<string, TValue>)_dictionary).ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex)
+        {
+            ((IDictionary<string, TValue>)_dictionary).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<string, TValue>> GetEnumerator()
+        {
+            return ((IDictionary<string, TValue>)_dictionary).GetEnumerator();
+        }
+
+        public bool Remove(string key)
+        {
+            return ((IDictionary<string, TValue>)_dictionary).Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<string, TValue> item)
+        {
+            return ((IDictionary<string, TValue>)_dictionary).Remove(item);
+        }
+
+        public bool TryGetValue(string key, out TValue value)
+        {
+            return ((IDictionary<string, TValue>)_dictionary).TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<string, TValue>)_dictionary).GetEnumerator();
+        }
+    }
+
     public class StringToStringIReadOnlyDictionaryWrapper : IReadOnlyDictionary<string, string>
     {
         private Dictionary<string, string> _dictionary = new Dictionary<string, string>();

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ImmutableCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ImmutableCollections.cs
@@ -219,6 +219,91 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericIImmutableDictionaryWrapper<TKey, TValue> : IImmutableDictionary<TKey, TValue>
+    {
+        private ImmutableDictionary<TKey, TValue> _dictionary;
+
+        public GenericIImmutableDictionaryWrapper() { }
+
+        public GenericIImmutableDictionaryWrapper(Dictionary<TKey, TValue> items)
+        {
+            _dictionary = ImmutableDictionary.CreateRange(items);
+        }
+
+        public TValue this[TKey key] => _dictionary[key];
+
+        public IEnumerable<TKey> Keys => _dictionary.Keys;
+
+        public IEnumerable<TValue> Values => _dictionary.Values;
+
+        public int Count => _dictionary.Count;
+
+        public IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).Add(key, value);
+        }
+
+        public IImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).AddRange(pairs);
+        }
+
+        public IImmutableDictionary<TKey, TValue> Clear()
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> pair)
+        {
+            return _dictionary.Contains(pair);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return _dictionary.ContainsKey(key);
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).GetEnumerator();
+        }
+
+        public IImmutableDictionary<TKey, TValue> Remove(TKey key)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).Remove(key);
+        }
+
+        public IImmutableDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).RemoveRange(keys);
+        }
+
+        public IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).SetItem(key, value);
+        }
+
+        public IImmutableDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).SetItems(items);
+        }
+
+        public bool TryGetKey(TKey equalKey, out TKey actualKey)
+        {
+            return _dictionary.TryGetKey(equalKey, out actualKey);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return _dictionary.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IImmutableDictionary<TKey, TValue>)_dictionary).GetEnumerator();
+        }
+    }
+
     public class StringIImmutableListWrapper : IImmutableList<string>
     {
         private ImmutableList<string> _list = ImmutableList.Create<string>();


### PR DESCRIPTION
fixes #32408

**Notes**

This change means that attempting to use an `ImmutableDictionary<>` with `[JsonExtensionData]` with throw a `NotSupportedException` where previously a `NullReferenceException` was thrown from the following line:

https://github.com/dotnet/runtime/blob/53c67cb43269269fd656e25b7199a065d04aeca1/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs#L121