### PR TITLE
[threads] If shutting_down, don't create new thread, kill current thread

### DIFF
--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1356,8 +1356,12 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	mono_threads_lock ();
 	if (shutting_down && !(flags & MONO_THREAD_CREATE_FLAGS_FORCE_CREATE)) {
 		mono_threads_unlock ();
-		mono_error_set_execution_engine (error, "Couldn't create thread. Runtime is shutting down.");
-		return FALSE;
+		/* We're already shutting down, don't create the new
+		 * thread. Instead detach and exit from the current thread.
+		 * Don't expect mono_threads_set_shutting_down to return.
+		 */
+		mono_threads_set_shutting_down ();
+		g_assert_not_reached ();
 	}
 	if (threads_starting_up == NULL) {
 		threads_starting_up = mono_g_hash_table_new_type_internal (NULL, NULL, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Starting Table");


### PR DESCRIPTION
If the runtime is shutting down, instead of creating a new thread, or throwing
an exception on the current thread, just shut down the current thread.

This takes advantage of `mono_threads_set_shutting_down`'s behavior that if you
call it after shutdown is already started, it will suspend, detach and exit
from the current thread.

Fixes https://github.com/dotnet/runtime/issues/31842