### PR TITLE
(build-test.sh) build_test_wrappers: don't set __BuildLogRootName twice

### DIFF
--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -17,7 +17,6 @@ build_test_wrappers()
         fi
 
         # Set up directories and file names
-        __BuildLogRootName="$subDirectoryName"
         __BuildLog="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.log"
         __BuildWrn="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.wrn"
         __BuildErr="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.err"


### PR DESCRIPTION
It is assigned earlier

```
  __BuildLogRootName="Tests_XunitWrapper"
```

Previously, the logs from build_test_wrappers were going to the wrong log