### PR TITLE
Fix RegexBoyerMoore.IsMatch case-insensitive (regression from 2.1 to 3.0)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -12,11 +12,30 @@ namespace System.Text.RegularExpressions.Tests
     public class RegexCultureTests
     {
         [Theory]
+        [InlineData("^aa$", "aA", "da-DK", RegexOptions.None, false)]
+        [InlineData("^aA$", "aA", "da-DK", RegexOptions.None, true)]
+        [InlineData("^aa$", "aA", "da-DK", RegexOptions.IgnoreCase, true)]
+        [InlineData("^aA$", "aA", "da-DK", RegexOptions.IgnoreCase, true)]
+        public void CharactersComparedOneByOne_AnchoredPattern(string pattern, string input, string culture, RegexOptions options, bool expected)
+        {
+            // Regex compares characters one by one.  If that changes, it could impact the behavior of
+            // a case like this, where these characters are not the same, but the strings compare
+            // as equal with the invariant culture (and some other cultures as well).
+            using (new ThreadCultureChange(culture))
+            {
+                foreach (RegexOptions compiled in new[] { RegexOptions.None, RegexOptions.Compiled })
+                {
+                    Assert.Equal(expected, new Regex(pattern, options | compiled).IsMatch(input));
+                }
+            }
+        }
+
+        [Theory]
         [InlineData(RegexOptions.None)]
         [InlineData(RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-        public void CharactersComparedOneByOne(RegexOptions options)
+        public void CharactersComparedOneByOne_Invariant(RegexOptions options)
         {
             // Regex compares characters one by one.  If that changes, it could impact the behavior of
             // a case like this, where these characters are not the same, but the strings compare


### PR DESCRIPTION
As part of a larger change, a change was made for .NET Core 3.0 that switched a character-by-character comparison loop to instead use string.Compare.  This represents a regression, however, when a culture-aware character-by-character comparison yields different results from a multiple-character comparison.

Fixes https://github.com/dotnet/runtime/issues/32534
cc: @ViktorHofer, @tarekgh, @eerhardt, @pgovind 