### PR TITLE
Remove macOS restriction from Timer test

### DIFF
--- a/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -285,7 +285,6 @@ namespace System.Threading.Tests
                                }));
         }
 
-        [PlatformSpecific(~TestPlatforms.OSX)] // macOS in CI appears to have a lot more variation
         [OuterLoop("Takes several seconds")]
         [Theory] // selection based on 333ms threshold used by implementation
         [InlineData(new int[] { 15 })]


### PR DESCRIPTION
It was suspected that https://github.com/dotnet/runtime/issues/11226 is the same as https://github.com/dotnet/runtime/issues/7639, which was closed as being non-reproduceable after moving to a more recent macOS version.  Trying to enable this as well.

Closes https://github.com/dotnet/runtime/issues/11226
cc: @kouvel, @janvorli 