### PR TITLE
Updating labels to reflect the -coreclr post-fix

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -2,36 +2,37 @@ Below table shows the combined area owners on this repository:
 
 | Area        | Owners / experts | Description |
 |-------------|------------------|------------------|
-| area-AssemblyLoader | @jeffschwMSFT @vitek-karas | |
-| area-CodeGen | @BruceForstall @dotnet/jit-contrib | |
-| area-CrossGen/NGEN | @fadimounir | |
-| area-crossgen2 | @nattress @MichalStrehovsky @trylek @fadimounir | |
+| area-AssemblyLoader-coreclr | @jeffschwMSFT @vitek-karas | |
+| area-CodeGen-coreclr | @BruceForstall @dotnet/jit-contrib | |
+| area-CrossGen/NGEN-coreclr | @fadimounir | |
+| area-crossgen2-coreclr | @nattress @MichalStrehovsky @trylek @fadimounir | |
 | area-DependencyModel | @eerhardt | Microsoft.Extensions.DependencyModel |
-| area-Diagnostics | @tommcdon | |
-| area-ExceptionHandling | @janvorli | |
-| area-GC | @Maoni0 | |
+| area-Diagnostics-coreclr | @tommcdon | |
+| area-ExceptionHandling-coreclr | @janvorli | |
+| area-GC-coreclr | @Maoni0 | |
 | area-Host | @jeffschwMSFT @vitek-karas @swaroop-sridhar | Issues with dotnet.exe including bootstrapping, framework detection, hostfxr.dll and hostpolicy.dll |
 | area-HostModel | @vitek-karas @swaroop-sridhar | |
-| area-ILTools | @BruceForstall @dotnet/jit-contrib | |
+| area-ILTools-coreclr | @BruceForstall @dotnet/jit-contrib | |
 | area-Infrastructure-coreclr | @jeffschwMSFT @jashook @trylek | |
 | area-Infrastructure-installer | @dleeapho @dagood | |
 | area-Infrastructure-libraries | @ViktorHofer @ericstj @safern @Anipik | Covers:<ul><li>Packaging</li><li>Build and test infra for libraries in dotnet/runtime repo</li><li>VS integration</li></ul><br/> |
 | area-Infrastructure | @ViktorHofer @jeffschwMSFT @dleeapho | |
-| area-Interop | @jeffschwMSFT @AaronRobinsonMSFT | |
+| area-Interop-coreclr | @jeffschwMSFT @AaronRobinsonMSFT | |
 | area-Meta | @joperezr | Issues without clear association to any specific API/contract, e.g. <ul><li>new contract proposals</li><li>cross-cutting code/test pattern changes (e.g. FxCop failures)</li><li>project-wide docs</li></ul><br/> |
-| area-PAL | @janvorli | |
-| area-R2RDump | @nattress | |
-| area-ReadyToRun | @fadimounir | |
+| area-PAL-coreclr | @janvorli | |
+| area-R2RDump-coreclr | @nattress | |
+| area-ReadyToRun-coreclr | @nattress | |
 | area-Setup | @dagood @dleeapho | Distro-specific (Linux, Mac and Windows) setup packages and msi files  |
+| area-Single-File | @swaroop-sridhar | |
 | area-SDK | @janvorli | General development issues and overlap with the SDK and CLI |
 | area-Serialization | @StephenMolloy @HongGit | Packages:<ul><li>System.Runtime.Serialization.Xml</li><li>System.Runtime.Serialization.Json</li><li>System.Private.DataContractSerialization</li><li>System.Xml.XmlSerializer</li></ul> Excluded:<ul><li>System.Runtime.Serialization.Formatters</li></ul> |
 | area-Snap | @dleeapho @leecow @MichaelSimons | |
-| area-TieredCompilation | @kouvel | |
+| area-TieredCompilation-coreclr | @kouvel | |
 | area-Tizen | @alpencolt @gbalykov | |
-| area-Tracing | @sywhang @josalem | |
-| area-TypeSystem | @davidwrighton @MichalStrehovsky @fadimounir | |
+| area-Tracing-coreclr | @sywhang @josalem | |
+| area-TypeSystem-coreclr | @davidwrighton @MichalStrehovsky @fadimounir | |
 | area-UWP | @nattress | UWP-specific issues including Microsoft.NETCore.UniversalWindowsPlatform and Microsoft.Net.UWPCoreRuntimeSdk |
-| area-VM | @sergiy-k | |
+| area-VM-coreclr | @jeffschw | |
 | area-AssemblyLoader-mono | @CoffeeFlux | |
 | area-Codegen-meta-mono | @vargaz | |
 | area-Codegen-JIT-mono | @SamMonoRT | |


### PR DESCRIPTION
Updating the coreclr `area-*` labels after we added the coreclr post-fix to differentiate between mono and coreclr runtimes.

cc @jkotas @AaronRobinsonMSFT 