### PR TITLE
JIT: enable tail calls and copy omission for implicit byref structs

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16201,17 +16201,17 @@ bool GenTree::IsLocalAddrExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree,
 //    compiler -- compiler instance
 //
 // Return Value:
-//    GenTreeLclVarCommon node for the local, or nullptr.
-
-GenTreeLclVarCommon* GenTree::IsImplicitByrefParameterValue(Compiler* compiler)
+//    GenTreeLclVar node for the local, or nullptr.
+//
+GenTreeLclVar* GenTree::IsImplicitByrefParameterValue(Compiler* compiler)
 {
 #if defined(TARGET_AMD64) || defined(TARGET_ARM64)
 
-    GenTreeLclVarCommon* lcl = nullptr;
+    GenTreeLclVar* lcl = nullptr;
 
     if (OperIs(GT_LCL_VAR))
     {
-        lcl = AsLclVarCommon();
+        lcl = AsLclVar();
     }
     else if (OperIs(GT_OBJ))
     {
@@ -16219,7 +16219,7 @@ GenTreeLclVarCommon* GenTree::IsImplicitByrefParameterValue(Compiler* compiler)
 
         if (addr->OperIs(GT_LCL_VAR))
         {
-            lcl = addr->AsLclVarCommon();
+            lcl = addr->AsLclVar();
         }
         else if (addr->OperIs(GT_ADDR))
         {
@@ -16227,7 +16227,7 @@ GenTreeLclVarCommon* GenTree::IsImplicitByrefParameterValue(Compiler* compiler)
 
             if (base->OperIs(GT_LCL_VAR))
             {
-                lcl = base->AsLclVarCommon();
+                lcl = base->AsLclVar();
             }
         }
     }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16194,6 +16194,55 @@ bool GenTree::IsLocalAddrExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree,
 }
 
 //------------------------------------------------------------------------
+// IsImplicitByrefParameterValue: determine if this tree is the entire
+//     value of a local implicit byref parameter
+//
+// Arguments:
+//    compiler -- compiler instance
+//
+// Return Value:
+//    GenTreeLclVarCommon node for the local, or nullptr.
+
+GenTreeLclVarCommon* GenTree::IsImplicitByrefParameterValue(Compiler* compiler)
+{
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+
+    GenTreeLclVarCommon* lcl = nullptr;
+
+    if (OperIs(GT_LCL_VAR))
+    {
+        lcl = AsLclVarCommon();
+    }
+    else if (OperIs(GT_OBJ))
+    {
+        GenTree* addr = AsIndir()->Addr();
+
+        if (addr->OperIs(GT_LCL_VAR))
+        {
+            lcl = addr->AsLclVarCommon();
+        }
+        else if (addr->OperIs(GT_ADDR))
+        {
+            GenTree* base = addr->AsOp()->gtOp1;
+
+            if (base->OperIs(GT_LCL_VAR))
+            {
+                lcl = base->AsLclVarCommon();
+            }
+        }
+    }
+
+    if ((lcl != nullptr) && compiler->lvaIsImplicitByRefLocal(lcl->GetLclNum()))
+    {
+        return lcl;
+    }
+
+#endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
 // IsLclVarUpdateTree: Determine whether this is an assignment tree of the
 //                     form Vn = Vn 'oper' 'otherTree' where Vn is a lclVar
 //

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1843,7 +1843,7 @@ public:
 
     // Determine if this tree represents the value of an entire implict byref parameter,
     // and if so return the tree for the parameter.
-    GenTreeLclVarCommon* IsImplicitByrefParameterValue(Compiler* compiler);
+    GenTreeLclVar* IsImplicitByrefParameterValue(Compiler* compiler);
 
     // Determine if this is a LclVarCommon node and return some additional info about it in the
     // two out parameters.

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1841,6 +1841,10 @@ public:
     // yields an address into a local
     GenTreeLclVarCommon* IsLocalAddrExpr();
 
+    // Determine if this tree represents the value of an entire implict byref parameter,
+    // and if so return the tree for the parameter.
+    GenTreeLclVarCommon* IsImplicitByrefParameterValue(Compiler* compiler);
+
     // Determine if this is a LclVarCommon node and return some additional info about it in the
     // two out parameters.
     bool IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, FieldSeqNode** pFldSeq);

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1104,12 +1104,12 @@ private:
         varDsc->incLvRefCnt(1, RCS_EARLY);
 
         // See if this struct is an argument to a call. This information is recorded
-        // via the weighted early ref count for the local, and feeds the undo promition
+        // via the weighted early ref count for the local, and feeds the undo promotion
         // heuristic.
         //
         // It can be approximate, so the pattern match below need not be exhaustive.
         // But the pattern should at least subset the implicit byref cases that are
-        // handed in fgCanFastTailCall and fgMakeOutgoingStructArgCopy.
+        // handled in fgCanFastTailCall and fgMakeOutgoingStructArgCopy.
         //
         // CALL(OBJ(ADDR(LCL_VAR...)))
         bool isArgToCall   = false;

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -1097,10 +1097,67 @@ private:
         {
             return;
         }
+
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
-        JITDUMP("LocalAddressVisitor incrementing ref count from %d to %d for V%02d\n", varDsc->lvRefCnt(RCS_EARLY),
-                varDsc->lvRefCnt(RCS_EARLY) + 1, lclNum);
+        JITDUMP("LocalAddressVisitor incrementing ref count from %d to %d for implict by-ref V%02d\n",
+                varDsc->lvRefCnt(RCS_EARLY), varDsc->lvRefCnt(RCS_EARLY) + 1, lclNum);
         varDsc->incLvRefCnt(1, RCS_EARLY);
+
+        // See if this struct is an argument to a call. This information is recorded
+        // via the weighted early ref count for the local, and feeds the undo promition
+        // heuristic.
+        //
+        // It can be approximate, so the pattern match below need not be exhaustive.
+        // But the pattern should at least subset the implicit byref cases that are
+        // handed in fgCanFastTailCall and fgMakeOutgoingStructArgCopy.
+        //
+        // CALL(OBJ(ADDR(LCL_VAR...)))
+        bool isArgToCall   = false;
+        bool keepSearching = true;
+        for (int i = 0; i < m_ancestors.Height() && keepSearching; i++)
+        {
+            GenTree* node = m_ancestors.Top(i);
+            switch (i)
+            {
+                case 0:
+                {
+                    keepSearching = node->OperIs(GT_LCL_VAR);
+                }
+                break;
+
+                case 1:
+                {
+                    keepSearching = node->OperIs(GT_ADDR);
+                }
+                break;
+
+                case 2:
+                {
+                    keepSearching = node->OperIs(GT_OBJ);
+                }
+                break;
+
+                case 3:
+                {
+                    keepSearching = false;
+                    isArgToCall   = node->IsCall();
+                }
+                break;
+                default:
+                {
+                    keepSearching = false;
+                }
+                break;
+            }
+        }
+
+        if (isArgToCall)
+        {
+            JITDUMP("LocalAddressVisitor incrementing weighted ref count from %d to %d"
+                    " for implict by-ref V%02d arg passed to call\n",
+                    varDsc->lvRefCntWtd(RCS_EARLY), varDsc->lvRefCntWtd(RCS_EARLY) + 1, lclNum);
+            varDsc->incLvRefCntWtd(1, RCS_EARLY);
+        }
     }
 };
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6787,12 +6787,14 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
                                     // So, we also need to scan all 'lcl's fields, if any, to see if they
                                     // are exposed.
                                     //
-                                    // TODO: we should not need to check for TYP_I_IMPL here, any
-                                    // aliasing value should be TYP_BYREF.
-                                    //
-                                    // Note we don't need to check for native pointers (abstractly)
-                                    // because aliasing native pointers require pinning, and we
-                                    // reject all tail calls in methods with pinned locals.
+                                    // When looking for aliases from other args, we check for both TYP_BYREF
+                                    // and TYP_I_IMPL typed args here. Conceptually anything that points into
+                                    // an implicit byref parameter should be TYP_BYREF, as these parameters could
+                                    // refer to boxed heap locations (say if the method is invoked by reflection)
+                                    // but there are some stack only structs (like typed references) where
+                                    // the importer/runtime code uses TYP_I_IMPL, and fgInitArgInfo will
+                                    // transiently retype all simple address-of implicit parameter args as
+                                    // TYP_I_IMPL.
                                     //
                                     if ((arg2->argType == TYP_BYREF) || (arg2->argType == TYP_I_IMPL))
                                     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -4796,45 +4796,48 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall*         call,
     //
     // We don't need a copy if this is the last use of an implicit by-ref local.
     //
-    // We can't determine that all of the time, but if there is only
-    // one use and the method has no loops, then this use must be the last.
     if (opts.OptimizationEnabled())
     {
-        GenTreeLclVarCommon* lcl = nullptr;
-
-        if (argx->OperIsLocal())
-        {
-            lcl = argx->AsLclVarCommon();
-        }
-        else if ((argx->OperGet() == GT_OBJ) && argx->AsIndir()->Addr()->OperIsLocal())
-        {
-            lcl = argx->AsObj()->Addr()->AsLclVarCommon();
-        }
+        GenTreeLclVarCommon* const lcl = argx->IsImplicitByrefParameterValue(this);
 
         if (lcl != nullptr)
         {
-            unsigned varNum = lcl->AsLclVarCommon()->GetLclNum();
-            if (lvaIsImplicitByRefLocal(varNum))
+            unsigned             varNum           = lcl->AsLclVarCommon()->GetLclNum();
+            LclVarDsc*           varDsc           = lvaGetDesc(varNum);
+            const unsigned short totalAppearances = varDsc->lvRefCnt(RCS_EARLY);
+
+            // We don't have liveness so we rely on other indications of last use.
+            //
+            // We handle these cases:
+            //
+            // * (must not copy) If the call is a tail call, the use is a last use.
+            //   We must skip the copy if we have a fast tail call.
+            //
+            // * (must copy) However the current slow tail call helper always copies
+            //   the tail call args from the current frame, so we must copy
+            //   if the tail call is a slow tail call.
+            //
+            // * (may not copy) if the call is noreturn, the use is a last use.
+            //
+            // * (may not copy) if there is exactly one use of the local in the method,
+            //   and the call is not in loop, this is a last use.
+            //
+            const bool isTailCallLastUse = call->IsTailCall();
+            const bool isCallLastUse     = (totalAppearances == 1) && !fgMightHaveLoop();
+            const bool isNoReturnLastUse = call->IsNoReturn();
+            if (!call->IsTailCallViaHelper() && (isTailCallLastUse || isCallLastUse || isNoReturnLastUse))
             {
-                LclVarDsc* varDsc = &lvaTable[varNum];
-                // JIT_TailCall helper has an implicit assumption that all tail call arguments live
-                // on the caller's frame. If an argument lives on the caller caller's frame, it may get
-                // overwritten if that frame is reused for the tail call. Therefore, we should always copy
-                // struct parameters if they are passed as arguments to a tail call.
-                if (!call->IsTailCallViaHelper() && (varDsc->lvRefCnt(RCS_EARLY) == 1) && !fgMightHaveLoop())
-                {
-                    assert(!call->IsTailCall());
+                varDsc->setLvRefCnt(0, RCS_EARLY);
+                args->SetNode(lcl);
+                assert(argEntry->GetNode() == lcl);
 
-                    varDsc->setLvRefCnt(0, RCS_EARLY);
-                    args->SetNode(lcl);
-                    assert(argEntry->GetNode() == lcl);
-
-                    JITDUMP("did not have to make outgoing copy for V%2d", varNum);
-                    return;
-                }
+                JITDUMP("did not need to make outgoing copy for last use of implicit byref V%2d\n", varNum);
+                return;
             }
         }
     }
+
+    JITDUMP("making an outgoing copy for struct arg\n");
 
     if (fgOutgoingArgTemps == nullptr)
     {
@@ -6550,7 +6553,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //
 // Windows Amd64:
 //    A fast tail call can be made whenever the number of callee arguments
-//    is larger than or equal to the number of caller arguments, or we have four
+//    is less than or equal to the number of caller arguments, or we have four
 //    or fewer callee arguments. This is because, on Windows AMD64, each
 //    argument uses exactly one register or one 8-byte stack slot. Thus, we only
 //    need to count arguments, and not be concerned with the size of each
@@ -6688,12 +6691,30 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 
         if (arg->isStruct)
         {
-            // Byref struct arguments are not allowed to fast tail call as the information
-            // of the caller's stack is lost when the callee is compiled.
             if (arg->passedByRef)
             {
-                hasByrefParameter = true;
-                break;
+                // If we're optimizing, we may be able to pass our caller's byref to our callee,
+                // and so still be able to tail call.
+                GenTreeLclVarCommon* const lcl = arg->GetNode()->IsImplicitByrefParameterValue(this);
+
+                // For this to work we must not have promoted the parameter; if we've promoted
+                // then we'll make a local struct at the call.
+                //
+                // We could handle this if there was some way to copy back to the original struct.
+                if (opts.OptimizationEnabled() && (lcl != nullptr) && !lvaGetDesc(lcl)->lvPromoted)
+                {
+                    // We can still tail call in this case, provided we
+                    // suppress the copy in fgMakeOutgoingStructArgCopy
+                    JITDUMP("Arg [%06u] is unpromoted implicit byref V%02u\n", dspTreeID(arg->GetNode()),
+                            lcl->GetLclNum());
+                }
+                else
+                {
+                    // We can't tail call in this case; note the reason why
+                    // and skip looking at the rest of the args.
+                    hasByrefParameter = true;
+                    break;
+                }
             }
         }
     }
@@ -6748,17 +6769,18 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 #endif // DEBUG
     };
 
-// Note on vararg methods:
-// If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
-// But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its
-// fixed args. Therefore, we can allow a vararg method to fast tail call other methods as long as
-// out-going area required for callee is bounded by caller's fixed argument space.
-//
-// Note that callee being a vararg method is not a problem since we can account the params being passed.
-//
-// We will currently decide to not fast tail call on Windows armarch if the caller or callee is a vararg
-// method. This is due to the ABI differences for native vararg methods for these platforms. There is
-// work required to shuffle arguments to the correct locations.
+    // Note on vararg methods:
+    // If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
+    // But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its
+    // fixed args. Therefore, we can allow a vararg method to fast tail call other methods as long as
+    // out-going area required for callee is bounded by caller's fixed argument space.
+    //
+    // Note that callee being a vararg method is not a problem since we can account the params being passed.
+    //
+    // We will currently decide to not fast tail call on Windows armarch if the caller or callee is a vararg
+    // method. This is due to the ABI differences for native vararg methods for these platforms. There is
+    // work required to shuffle arguments to the correct locations.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if (defined(TARGET_WINDOWS) && defined(TARGET_ARM)) || (defined(TARGET_WINDOWS) && defined(TARGET_ARM64))
     if (info.compIsVarArgs || callee->IsVarargs())
@@ -6836,13 +6858,18 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
     // It cannot be an inline candidate
     assert(!call->IsInlineCandidate());
 
-    auto failTailCall = [&](const char* reason) {
+    auto failTailCall = [&](const char* reason, unsigned lclNum = BAD_VAR_NUM) {
 #ifdef DEBUG
         if (verbose)
         {
             printf("\nRejecting tail call in morph for call ");
             printTreeID(call);
-            printf(": %s\n", reason);
+            printf(": %s", reason);
+            if (lclNum != BAD_VAR_NUM)
+            {
+                printf(" V%02u", lclNum);
+            }
+            printf("\n");
         }
 #endif
 
@@ -6946,9 +6973,9 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         //
         if (call->IsImplicitTailCall())
         {
-            if (varDsc->lvHasLdAddrOp)
+            if (varDsc->lvHasLdAddrOp && !lvaIsImplicitByRefLocal(varNum))
             {
-                failTailCall("Local address taken");
+                failTailCall("Local address taken", varNum);
                 return nullptr;
             }
             if (varDsc->lvAddrExposed)
@@ -6971,20 +6998,20 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
                 }
                 else
                 {
-                    failTailCall("Local address taken");
+                    failTailCall("Local address taken", varNum);
                     return nullptr;
                 }
             }
             if (varDsc->lvPromoted && varDsc->lvIsParam && !lvaIsImplicitByRefLocal(varNum))
             {
-                failTailCall("Has Struct Promoted Param");
+                failTailCall("Has Struct Promoted Param", varNum);
                 return nullptr;
             }
             if (varDsc->lvPinned)
             {
                 // A tail call removes the method from the stack, which means the pinning
                 // goes away for the callee.  We can't allow that.
-                failTailCall("Has Pinned Vars");
+                failTailCall("Has Pinned Vars", varNum);
                 return nullptr;
             }
         }
@@ -16828,8 +16855,23 @@ void Compiler::fgRetypeImplicitByRefArgs()
                 // through the pointer parameter, the same as we'd do for this
                 // parameter if it weren't promoted at all (otherwise the initialization
                 // of the new temp would just be a needless memcpy at method entry).
-                bool undoPromotion = (lvaGetPromotionType(newVarDsc) == PROMOTION_TYPE_DEPENDENT) ||
-                                     (varDsc->lvRefCnt(RCS_EARLY) <= varDsc->lvFieldCnt);
+                //
+                // Otherwise, see how many appearances there are. We keep two early ref counts: total
+                // number of references to the struct or some field, and how many of these are
+                // arguments to calls. We undo promotion unless we see enougn non-call uses.
+                //
+                const unsigned totalAppearances = varDsc->lvRefCnt(RCS_EARLY);
+                const unsigned callAppearances  = varDsc->lvRefCntWtd(RCS_EARLY);
+                assert(totalAppearances >= callAppearances);
+                const unsigned nonCallAppearances = totalAppearances - callAppearances;
+
+                bool undoPromotion = ((lvaGetPromotionType(newVarDsc) == PROMOTION_TYPE_DEPENDENT) ||
+                                      (nonCallAppearances <= varDsc->lvFieldCnt));
+
+                JITDUMP("%s promotion of implicit by-ref V%02u: %s total: %u non-call: %u fields: %u\n",
+                        undoPromotion ? "Undoing" : "Keeping", lclNum,
+                        (lvaGetPromotionType(newVarDsc) == PROMOTION_TYPE_DEPENDENT) ? "dependent;" : "",
+                        totalAppearances, nonCallAppearances, varDsc->lvFieldCnt);
 
                 if (!undoPromotion)
                 {
@@ -16863,7 +16905,7 @@ void Compiler::fgRetypeImplicitByRefArgs()
                     {
                         // Set the new parent.
                         fieldVarDsc->lvParentLcl = newLclNum;
-                        // Clear the ref count field; it is used to communicate the nubmer of references
+                        // Clear the ref count field; it is used to communicate the number of references
                         // to the implicit byref parameter when morphing calls that pass the implicit byref
                         // out as an outgoing argument value, but that doesn't pertain to this field local
                         // which is now a field of a non-arg local.

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6703,7 +6703,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
                 // and so still be able to tail call.
                 if (opts.OptimizationEnabled())
                 {
-                    // First, see if this arg is a byref param.
+                    // First, see if this arg is an implicit byref param.
                     GenTreeLclVarCommon* const lcl = arg->GetNode()->IsImplicitByrefParameterValue(this);
 
                     // If so, it must not be promoted; if we've promoted, then the arg will be
@@ -6835,7 +6835,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
                                             }
                                             else if (varDsc->lvFieldLclStart != 0)
                                             {
-                                                // This the promoted/undone struct case.
+                                                // This is the promoted/undone struct case.
                                                 //
                                                 // The field start is actually the local number of the promoted local,
                                                 // use it to enumerate the fields.

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.cs
@@ -15,6 +15,7 @@ public class ImplicitByrefTailCalls
     public static void Z() { }
     public static bool Z(bool b) => b;
 
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static int ZZ(Span<int> x)
     {
         int result = 0;
@@ -25,10 +26,9 @@ public class ImplicitByrefTailCalls
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static int ZZZ(Span<int> x, int a, int b, int c, int d, int e, int f)
     {
-        Z(); Z(); Z(); Z();
-        Z(); Z(); Z(); Z();
         int result = 0;
         for (int i = 0; i < x.Length; i++)
         {
@@ -137,7 +137,10 @@ public class ImplicitByrefTailCalls
     }
 
     // Must copy at the normal call site
-    // but can avoid at tail call site
+    // but can avoid at tail call site. However
+    // we're currently blocked because we reuse
+    // the temp used to pass the argument and
+    // it is exposed in the first call.
     public static int T(Span<int> x, ref int q)
     {
         Z(); Z();

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Tail calls with implicit byref parameters as arguments.
+//
+// Generally, we can tail call provided we don't copy the 
+// argument to the local frame.
+
+public class ImplicitByrefTailCalls
+{
+    public static void Z() {}
+    public static bool Z(bool b) => b;
+
+    public static int ZZ(Span<int> x)
+    {
+        int result = 0;
+        for (int i = 0; i < x.Length; i++)
+        {
+            result += x[i] * x[i] + i;
+        }
+        return result;
+    }
+
+    public static int ZZZ(Span<int> x, int a, int b, int c, int d, int e, int f)
+    {
+        Z(); Z();
+        Z(); Z();
+        int result = 0;
+        for (int i = 0; i < x.Length; i++)
+        {
+            result += x[i] * x[i] + i;
+        }
+        return result;
+    }
+
+    // Various methods that should fast tail call
+
+    public static int A(Span<int> x)
+    {
+        Z(); Z(); return ZZ(x);
+    } 
+
+    public static int B(Span<int> x)
+    {
+        Z(); Z(); return A(x);
+    }
+
+    public static int C(Span<int> x, bool p)
+    {
+        Z(); Z();
+        if (Z(p))
+        {
+            return A(x);
+        }
+        else
+        {
+            return B(x);
+        }
+    }
+
+    public static int D(Span<int> x, bool p)
+    {
+        Z(); Z();
+        return Z(p) ? A(x) : B(x);
+    }
+
+    public static int E(Span<int> x, Span<int> y, bool p)
+    {
+        Z(); Z(); Z(); Z();
+        if (Z(p))
+        {
+            return A(x);
+        }
+        else
+        {
+            return B(y);
+        }
+    }
+
+    public static int F(Span<int> x, Span<int> y, bool p)
+    {
+        Z(); Z(); Z(); Z();
+        return Z(p) ? ZZ(x) : ZZ(y);
+    }
+
+    // Methods with tail call sites and other uses
+
+    public static int G(Span<int> x, bool p)
+    {
+        Z(); Z();
+        if (Z(p))
+        {
+            return ZZ(x);
+        }
+        else
+        {
+            return x.Length;
+        }
+    }
+
+    // Here there are enough actual uses to
+    // justify promotion, hence we can't tail
+    // call, as "undoing" promotion at the end
+    // entails making a local copy.
+    //
+    // We could handle this by writing the updated 
+    // struct values back to the original byref
+    // before tail calling....
+    public static int H(Span<int> x, int y)
+    {
+        Z(); Z();
+        if (y < x.Length)
+        {
+            int result = 0;
+            for (int i = 0; i < y; i++)
+            {
+                result += x[i];
+            }
+            return result;
+        }
+
+        return ZZ(x);
+    }
+
+    // Here the call to ZZZ would need to be a slow tail call,
+    // so we won't tail call at all. But the only
+    // reference to x is at the call, and it's not in 
+    // a loop, so we can still can avoid making a copy.
+    public static int S(Span<int> x)
+    {
+        Z(); Z();
+        return ZZZ(x, 1, 2, 3, 4, 5, 6);
+    } 
+
+    // Must copy at the normal call site
+    // but can avoid at tail call site
+    public static int T(Span<int> x, ref int q)
+    {
+        Z(); Z();
+        q = ZZ(x);
+        return ZZ(x);
+    }
+
+    static bool p;
+
+    public static int Main()
+    {
+        int[] a = new int[100];
+        a[45] = 55;
+        a[55] = 45;
+        p = false;
+
+        Span<int> s = new Span<int>(a);
+        int q = 0;
+
+        int ra = A(s);
+        int rb = B(s);
+        int rc = C(s, p);
+        int rd = D(s, p);
+        int re = E(s, s, p);
+        int rf = F(s, s, p);
+        int rg = G(s, p);
+        int rh = H(s, 46);
+        int rs = S(s);
+        int rt = T(s, ref q);
+
+        Console.WriteLine($"{ra},{rb},{rc},{rd},{re},{rf},{rg},{rh},{rs},{rt}");
+        
+        return ra + rb + rc + rd + re + rf + rg + rh + rs + rt - 80055;
+    }
+}

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.csproj
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.csproj
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCalls.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public struct S
+{
+    public long x;
+    public long y;
+}
+
+// Tail calls with implicit byref parameters as arguments.
+//
+// We need to ensure that we don't introduce aliased
+// implicit byref parameters by optimizing away copies.
+
+public class ImplicitByrefTailCalls
+{
+    public static void Z() {}
+
+    // Will return different answers if x and y refer to the same struct.
+    public static long Alias(S x, S y)
+    {
+        Z(); Z(); Z(); Z();
+        y.x++;
+        long result = 0;
+        for (int i = 0; i < 100; i++)
+        {
+            x.x++;
+            result += x.x + x.y;
+        }
+        return result;
+    }
+
+    // Will return different answers if y refers to some part of x.
+    public static unsafe long Alias2(S x, long* y)
+    {
+        Z(); Z(); Z(); Z();
+        *y += 1;
+        long result = 0;
+        for (int i = 0; i < 100; i++)
+        {
+            x.x++;
+            result += x.x + x.y;
+        }
+        return result;
+    }
+
+    // A must copy params locally when calling Alias
+    // and so can't tail call
+    public static long A(S x)
+    {
+        Z(); Z(); Z(); Z();
+        return Alias(x, x);
+    } 
+
+    // B must copy params locally when calling Alias2
+    // and so can't tail call
+    public static unsafe long B(S x)
+    {
+        Z(); Z(); Z(); Z();
+        return Alias2(x, &x.y);
+    } 
+
+    public static int Main()
+    {
+        S s = new S();
+        s.x = 1;
+        s.y = 2;
+        long ra = A(s);
+        long rb = B(s);
+
+        Console.WriteLine($"{ra},{rb}");
+        
+        return (ra == 5350) && (rb == 5350) ? 100 : -1;
+    }
+}

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
@@ -83,7 +83,7 @@ public class ImplicitByrefTailCalls
         return result;
     }
 
-    // Will return different answers if x and r refer to the same struct.
+    // Will return different answers if x and r.s refer to the same struct.
     public static long Alias5(S x, R r)
     {
         Z(); Z(); Z(); Z();

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.cs
@@ -28,9 +28,9 @@ public class ImplicitByrefTailCalls
     public static void Z() { }
 
     // Will return different answers if x and y refer to the same struct.
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias(S x, S y)
     {
-        Z(); Z(); Z(); Z();
         y.s_x++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -42,9 +42,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if y refers to some part of x.
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias2(S x, ref long y)
     {
-        Z(); Z(); Z(); Z();
         y++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -56,9 +56,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if x and y refer to same struct
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias3(int a, int b, int c, int d, int e, int f, S x, S y)
     {
-        Z(); Z(); Z(); Z();
         y.s_x++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -70,9 +70,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if y refers to some part of x
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias4(ref long y, int b, int c, int d, int e, int f, S x)
     {
-        Z(); Z(); Z(); Z();
         y++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -84,9 +84,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if x and r.s refer to the same struct.
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias5(S x, R r)
     {
-        Z(); Z(); Z(); Z();
         r.r_s.s_x++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -98,9 +98,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if ss and x refer to the same struct
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias6(Span<S> ss, S x)
     {
-        Z(); Z(); Z(); Z();
         ss[0].s_x++;
         long result = 0;
         for (int i = 0; i < 100; i++)
@@ -112,9 +112,9 @@ public class ImplicitByrefTailCalls
     }
 
     // Will return different answers if x and y refer to the same struct.
+    [MethodImpl(MethodImplOptions.NoOptimization)]
     public static long Alias7(S x, ref S y)
     {
-        Z(); Z(); Z(); Z();
         y.s_x++;
         long result = 0;
         for (int i = 0; i < 100; i++)

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.csproj
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.csproj
+++ b/src/coreclr/tests/src/JIT/opt/Tailcall/ImplicitByrefTailCallsAliasing.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Handle cases where a caller passes an implicit byref argument struct to
a callee in tail position. There is no need to create a local copy or
to block tail calling.

This pattern comes up increasingly often as we write more layered code
operating on spans and similar structs.