### PR TITLE
[Debug] IndexOutOfRangeException when extension data doesn't have two generic parameters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -109,6 +109,7 @@ namespace System.Text.Json
             IDictionary? extensionData = (IDictionary?)jsonPropertyInfo.GetValueAsObject(obj);
             if (extensionData == null)
             {
+#if DEBUG
                 // Create the appropriate dictionary type. We already verified the types.
                 Debug.Assert(jsonPropertyInfo.DeclaredPropertyType.IsGenericType);
                 Debug.Assert(jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments().Length == 2);
@@ -116,7 +117,7 @@ namespace System.Text.Json
                 Debug.Assert(
                     jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(object) ||
                     jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(JsonElement));
-
+#endif
                 if (jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)
                 {
                     ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(jsonPropertyInfo.DeclaredPropertyType);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
@@ -109,14 +110,17 @@ namespace System.Text.Json
             IDictionary? extensionData = (IDictionary?)jsonPropertyInfo.GetValueAsObject(obj);
             if (extensionData == null)
             {
-#if DEBUG
                 // Create the appropriate dictionary type. We already verified the types.
-                Debug.Assert(jsonPropertyInfo.DeclaredPropertyType.IsGenericType);
-                Debug.Assert(jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments().Length == 2);
-                Debug.Assert(jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[0].UnderlyingSystemType == typeof(string));
+#if DEBUG
+                Type underlyingIDictionaryType = jsonPropertyInfo.DeclaredPropertyType.GetCompatibleGenericInterface(typeof(IDictionary<,>))!;
+                Type[] genericArgs = underlyingIDictionaryType.GetGenericArguments();
+
+                Debug.Assert(underlyingIDictionaryType.IsGenericType);
+                Debug.Assert(genericArgs.Length == 2);
+                Debug.Assert(genericArgs[0].UnderlyingSystemType == typeof(string));
                 Debug.Assert(
-                    jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(object) ||
-                    jsonPropertyInfo.DeclaredPropertyType.GetGenericArguments()[1].UnderlyingSystemType == typeof(JsonElement));
+                    genericArgs[1].UnderlyingSystemType == typeof(object) ||
+                    genericArgs[1].UnderlyingSystemType == typeof(JsonElement));
 #endif
                 if (jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json
         {
             Debug.Assert(jsonPropertyInfo != null);
 
-            IDictionary? extensionData = (IDictionary?)jsonPropertyInfo.GetValueAsObject(obj);
+            var extensionData = jsonPropertyInfo.GetValueAsObject(obj);
             if (extensionData == null)
             {
                 // Create the appropriate dictionary type. We already verified the types.
@@ -127,7 +127,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(jsonPropertyInfo.DeclaredPropertyType);
                 }
 
-                extensionData = (IDictionary?)jsonPropertyInfo.RuntimeClassInfo.CreateObject();
+                extensionData = jsonPropertyInfo.RuntimeClassInfo.CreateObject();
                 jsonPropertyInfo.SetValueAsObject(obj, extensionData);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json
         {
             Debug.Assert(jsonPropertyInfo != null);
 
-            var extensionData = jsonPropertyInfo.GetValueAsObject(obj);
+            object? extensionData = jsonPropertyInfo.GetValueAsObject(obj);
             if (extensionData == null)
             {
                 // Create the appropriate dictionary type. We already verified the types.

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -770,6 +770,32 @@ namespace System.Text.Json.Serialization.Tests
             public GenericIImmutableDictionaryWrapper<string, JsonElement> MyOverflow { get; set; }
         }
 
+        [Fact]
+        public static void DeserializeIntoGenericDictionaryParameterCount()
+        {
+            // baseline
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyNoGenericParameters>("{\"hello\":\"world\"}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyOneGenericParameter>("{\"hello\":\"world\"}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyThreeGenericParameters>("{\"hello\":\"world\"}");
+        }
+
+        private class ClassWithExtensionPropertyNoGenericParameters
+        {
+            [JsonExtensionData]
+            public StringToObjectIDictionaryWrapper MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyOneGenericParameter
+        {
+            [JsonExtensionData]
+            public StringToGenericIDictionaryWrapper<object> MyOverflow { get; set; }
+        }
+
+        private class ClassWithExtensionPropertyThreeGenericParameters
+        {
+            [JsonExtensionData]
+            public GenericIDictonaryWrapperThreeGenericParameters<string, object, string> MyOverflow { get; set; }
+        }
 
         [Fact]
         public static void CustomObjectConverterInExtensionProperty()

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -773,7 +773,6 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void DeserializeIntoGenericDictionaryParameterCount()
         {
-            // baseline
             JsonSerializer.Deserialize<ClassWithExtensionPropertyNoGenericParameters>("{\"hello\":\"world\"}");
             JsonSerializer.Deserialize<ClassWithExtensionPropertyOneGenericParameter>("{\"hello\":\"world\"}");
             JsonSerializer.Deserialize<ClassWithExtensionPropertyThreeGenericParameters>("{\"hello\":\"world\"}");

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -866,6 +866,8 @@ namespace System.Text.Json.Serialization.Tests
         private GenericIDictionaryWrapperPrivateConstructor() { }
     }
 
+    public class GenericIDictonaryWrapperThreeGenericParameters<TKey, TValue, TUnused> : GenericIDictionaryWrapper<TKey, TValue> { }
+
     public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper
     {
         public override bool IsReadOnly => true;


### PR DESCRIPTION
WIP for #33011

@layomia, I added the proposed tests and code change, but I still see the tests failing in debug through both VS and the CLI (EX: `Process terminated. Assertion failed`).  

I'm new to contributing to the runtime, so I wasn't sure if it was better to put this discussion in an issue or PR, but chose PR to better discuss the code changes.  Also, pardon my newbie questions: 

- The proposed change was surprising to me: should I expect that `#if DEBUG` would change the behavior of tests running in Debug configuration?
- Is there a reason to keep the `Debug.Assert` statements here at all?  If conceptually `System.Text.Json` supports dictionaries that don't match the conditions tested by the `Debug.Assert` statements, what is their purpose?