### PR TITLE
Additional code coverage in System.Text.Json

### DIFF
--- a/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Tests
             var random = new Random(42);
             var charArray = new char[502];
             charArray[0] = '"';
-            for (int i = 1; i < charArray.Length; i++)
+            for (int i = 1; i < charArray.Length - 1; i++)
             {
                 charArray[i] = (char)random.Next('A', 'Z'); // ASCII values (between 65 and 90) that constitute valid base 64 string.
             }
@@ -46,7 +46,7 @@ namespace System.Text.Json.Tests
             var random = new Random(42);
             var charArray = new char[500];
             charArray[0] = '"';
-            for (int i = 1; i < charArray.Length; i++)
+            for (int i = 1; i < charArray.Length - 1; i++)
             {
                 charArray[i] = (char)random.Next('?', '\\'); // ASCII values (between 63 and 91) that don't need to be escaped.
             }

--- a/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace System.Text.Json.Tests
 {

--- a/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
@@ -19,8 +19,8 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"ABC===\"" };
             yield return new object[] { "\"ABC\"" };
             yield return new object[] { "\"ABC!\"" };
-            yield return new object[] { GenerateRandomInvalidLargeString(true) };
-            yield return new object[] { GenerateRandomInvalidLargeString(false) };
+            yield return new object[] { GenerateRandomInvalidLargeString(includeEscapedCharacter: true) };
+            yield return new object[] { GenerateRandomInvalidLargeString(includeEscapedCharacter: false) };
         }
 
         private static string GenerateRandomValidLargeString()

--- a/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+
+namespace System.Text.Json.Tests
+{
+    internal class JsonBase64TestData
+    {
+        public static IEnumerable<object[]> ValidBase64Tests()
+        {
+            yield return new object[] { "\"ABC=\"" };
+            yield return new object[] { "\"AB+D\"" };
+            yield return new object[] { "\"ABCD\"" };
+            yield return new object[] { "\"ABC/\"" };
+            yield return new object[] { "\"++++\"" };
+            yield return new object[] { GenerateRandomValidLargeString() };
+        }
+
+        public static IEnumerable<object[]> InvalidBase64Tests()
+        {
+            yield return new object[] { "\"ABC===\"" };
+            yield return new object[] { "\"ABC\"" };
+            yield return new object[] { "\"ABC!\"" };
+            yield return new object[] { GenerateRandomInvalidLargeString(true) };
+            yield return new object[] { GenerateRandomInvalidLargeString(false) };
+        }
+
+        private static string GenerateRandomValidLargeString()
+        {
+            var random = new Random(42);
+            var charArray = new char[502];
+            charArray[0] = '"';
+            for (int i = 1; i < charArray.Length; i++)
+            {
+                charArray[i] = (char)random.Next('A', 'Z'); // ASCII values (between 65 and 90) that constitute valid base 64 string.
+            }
+            charArray[charArray.Length - 1] = '"';
+            var jsonString = new string(charArray);
+            return jsonString;
+        }
+
+        private static string GenerateRandomInvalidLargeString(bool includeEscapedCharacter)
+        {
+            var random = new Random(42);
+            var charArray = new char[500];
+            charArray[0] = '"';
+            for (int i = 1; i < charArray.Length; i++)
+            {
+                charArray[i] = (char)random.Next('?', '\\'); // ASCII values (between 63 and 91) that don't need to be escaped.
+            }
+
+            if (includeEscapedCharacter)
+            {
+                charArray[256] = '\\';
+                charArray[257] = '"';
+            }
+
+            charArray[charArray.Length - 1] = '"';
+            var jsonString = new string(charArray);
+            return jsonString;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonBase64TestData.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Tests
         private static string GenerateRandomValidLargeString()
         {
             var random = new Random(42);
-            var charArray = new char[502];
+            var charArray = new char[502]; // valid Base64 strings must have length divisible by 4 (not including surrounding quotes)
             charArray[0] = '"';
             for (int i = 1; i < charArray.Length - 1; i++)
             {

--- a/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1911,27 +1911,9 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("\"ABC=\"")]
-        [InlineData("\"AB+D\"")]
-        [InlineData("\"ABCD\"")]
-        [InlineData("\"ABC/\"")]
-        [InlineData("\"++++\"")]
-        [InlineData(null)]  // Large randomly generated string
+        [MemberData(nameof(JsonBase64TestData.ValidBase64Tests), MemberType = typeof(JsonBase64TestData))]
         public static void ReadBase64String(string jsonString)
         {
-            if (jsonString == null)
-            {
-                var random = new Random(42);
-                var charArray = new char[502];
-                charArray[0] = '"';
-                for (int i = 1; i < charArray.Length; i++)
-                {
-                    charArray[i] = (char)random.Next('A', 'Z'); // ASCII values (between 65 and 90) that constitute valid base 64 string.
-                }
-                charArray[charArray.Length - 1] = '"';
-                jsonString = new string(charArray);
-            }
-
             byte[] expected = Convert.FromBase64String(jsonString.AsSpan(1, jsonString.Length - 2).ToString());
 
             using (JsonDocument doc = JsonDocument.Parse(jsonString))
@@ -1944,28 +1926,9 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("\"ABC===\"")]
-        [InlineData("\"ABC\"")]
-        [InlineData("\"ABC!\"")]
-        [InlineData(null)]  // Large randomly generated string
+        [MemberData(nameof(JsonBase64TestData.InvalidBase64Tests), MemberType = typeof(JsonBase64TestData))]
         public static void InvalidBase64(string jsonString)
         {
-            if (jsonString == null)
-            {
-                var random = new Random(42);
-                var charArray = new char[500];
-                charArray[0] = '"';
-                for (int i = 1; i < charArray.Length; i++)
-                {
-                    charArray[i] = (char)random.Next('?', '\\'); // ASCII values (between 63 and 91) that don't need to be escaped.
-                }
-
-                charArray[256] = '\\';
-                charArray[257] = '"';
-                charArray[charArray.Length - 1] = '"';
-                jsonString = new string(charArray);
-            }
-
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             using (JsonDocument doc = JsonDocument.Parse(dataUtf8))

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
@@ -70,6 +70,22 @@ namespace System.Text.Json.Serialization.Tests
             public int MyInt { get; set; }
         }
 
+        private class NullConverterAttribute : JsonConverterAttribute
+        {
+            public NullConverterAttribute() : base(null) { }
+
+            public override JsonConverter CreateConverter(Type typeToConvert)
+            {
+                return null;
+            }
+        }
+
+        private class PocoWithNullConverter
+        {
+            [NullConverter]
+            public int MyInt { get; set; }
+        }
+
         [Fact]
         public static void AttributeCreateConverterFail()
         {
@@ -81,6 +97,15 @@ namespace System.Text.Json.Serialization.Tests
 
             ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithInvalidConverter>("{}"));
             Assert.Contains("'System.Text.Json.Serialization.Tests.CustomConverterTests+PocoWithInvalidConverter.MyInt'", ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new PocoWithNullConverter()));
+            // Message should be in the form "The converter specified on 'System.Text.Json.Serialization.Tests.CustomConverterTests+PocoWithNullConverter.MyInt'  is not compatible with the type 'System.Int32'."
+            Assert.Contains("'System.Text.Json.Serialization.Tests.CustomConverterTests+PocoWithNullConverter.MyInt'", ex.Message);
+            Assert.Contains("'System.Int32'", ex.Message);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithNullConverter>("{}"));
+            Assert.Contains("'System.Text.Json.Serialization.Tests.CustomConverterTests+PocoWithNullConverter.MyInt'", ex.Message);
+            Assert.Contains("'System.Int32'", ex.Message);
         }
 
         private class InvalidTypeConverterClass

--- a/src/libraries/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -21,35 +21,43 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(10)]
-        [InlineData(70)]
-        public static void WriteCyclicFail(int depth)
+        [InlineData(1, 2)]
+        [InlineData(2, 3)]
+        [InlineData(10, 11)]
+        [InlineData(70, 71)]
+        [InlineData(10, 0)]
+        public static void WriteCyclic(int objectHierarchyDepth, int maxDepth)
         {
             var rootObj = new TestClassWithCycle("root");
-            CreateObjectHierarchy(1, depth, rootObj);
+            CreateObjectHierarchy(1, objectHierarchyDepth, rootObj);
 
-            {
-                var options = new JsonSerializerOptions();
-                options.MaxDepth = depth + 1;
+            var options = new JsonSerializerOptions();
+            options.MaxDepth = maxDepth;
 
-                // No exception since depth was not greater than MaxDepth.
-                string json = JsonSerializer.Serialize(rootObj, options);
-                Assert.False(string.IsNullOrEmpty(json));
-            }
+            string json = JsonSerializer.Serialize(rootObj, options);
+            Assert.False(string.IsNullOrEmpty(json));
+        }
 
-            {
-                var options = new JsonSerializerOptions();
-                options.MaxDepth = depth;
-                JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+        [Theory]
+        [InlineData(1, 1, 0)]
+        [InlineData(2, 2, 1)]
+        [InlineData(10, 10, 9)]
+        [InlineData(70, 70, 69)]
+        [InlineData(70, 0, 63)]
+        public static void WriteCyclicFail(int objectHierarchyDepth, int maxDepth, int expectedPathDepth)
+        {
+            var rootObj = new TestClassWithCycle("root");
+            CreateObjectHierarchy(1, objectHierarchyDepth, rootObj);
 
-                // Exception should contain the path and MaxDepth.
-                // Since the last Parent property is null, the serializer moves onto the Children property.
-                string expectedPath = "$" + string.Concat(Enumerable.Repeat(".Parent", depth - 1));
-                Assert.Contains(expectedPath, ex.Path);
-                Assert.Contains(depth.ToString(), ex.ToString());
-            }
+            var options = new JsonSerializerOptions();
+            options.MaxDepth = maxDepth;
+            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+
+            // Exception should contain the path and MaxDepth.
+            // Since the last Parent property is null, the serializer moves onto the Children property.
+            string expectedPath = "$" + string.Concat(Enumerable.Repeat(".Parent", expectedPathDepth));
+            Assert.Contains(expectedPath, ex.Path);
+            Assert.Contains(maxDepth.ToString(), ex.ToString());
         }
 
         private static TestClassWithCycle CreateObjectHierarchy(int i, int max, TestClassWithCycle previous)

--- a/src/libraries/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(2, 3)]
         [InlineData(10, 11)]
         [InlineData(70, 71)]
-        [InlineData(10, 0)]
+        [InlineData(10, 0)] // 0 (or default) max depth is treated as 64
         public static void WriteCyclic(int objectHierarchyDepth, int maxDepth)
         {
             var rootObj = new TestClassWithCycle("root");
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(2, 2, 1)]
         [InlineData(10, 10, 9)]
         [InlineData(70, 70, 69)]
-        [InlineData(70, 0, 63)]
+        [InlineData(70, 0, 63)] // 0 (or default) max depth is treated as 64
         public static void WriteCyclicFail(int objectHierarchyDepth, int maxDepth, int expectedPathDepth)
         {
             var rootObj = new TestClassWithCycle("root");

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlingTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlingTests.Deserialize.cs
@@ -912,12 +912,13 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(@"{""$iz"": ""1""}")]
-        [InlineData(@"{""$rez"": ""1""}")]
-        [InlineData(@"{""$valuez"": []}")]
-        public static void InvalidMetadataPropertyNameWithSameLengthIsNotRecognized(string json)
+        [InlineData(@"{""$iz"": ""1""}", "$.$iz")]
+        [InlineData(@"{""$rez"": ""1""}", "$.$rez")]
+        [InlineData(@"{""$valuez"": []}", "$.$valuez")]
+        public static void InvalidMetadataPropertyNameWithSameLengthIsNotRecognized(string json, string expectedPath)
         {
             JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, s_deserializerOptionsPreserve));
+            Assert.Equal(expectedPath, ex.Path);
         }
 
         #endregion

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlingTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlingTests.Deserialize.cs
@@ -910,6 +910,16 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("$[1].$ref", ex.Path);
             Assert.Contains($"'{typeof(EmployeeStruct)}'", ex.Message);
         }
+
+        [Theory]
+        [InlineData(@"{""$iz"": ""1""}")]
+        [InlineData(@"{""$rez"": ""1""}")]
+        [InlineData(@"{""$valuez"": []}")]
+        public static void InvalidMetadataPropertyNameWithSameLengthIsNotRecognized(string json)
+        {
+            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, s_deserializerOptionsPreserve));
+        }
+
         #endregion
 
         #region Throw on immutables

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="DebuggerTests.cs" />
     <Compile Include="FixedSizedBufferWriter.cs" />
     <Compile Include="InvalidBufferWriter.cs" />
+    <Compile Include="JsonBase64TestData.cs" />
     <Compile Include="JsonDateTimeTestData.cs" />
     <Compile Include="JsonDocumentTests.cs" />
     <Compile Include="JsonElementCloneTests.cs" />

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -1157,27 +1157,9 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("\"ABC=\"")]
-        [InlineData("\"AB+D\"")]
-        [InlineData("\"ABCD\"")]
-        [InlineData("\"ABC/\"")]
-        [InlineData("\"++++\"")]
-        [InlineData(null)]  // Large randomly generated string
+        [MemberData(nameof(JsonBase64TestData.ValidBase64Tests), MemberType = typeof(JsonBase64TestData))]
         public static void ValidBase64(string jsonString)
         {
-            if (jsonString == null)
-            {
-                var random = new Random(42);
-                var charArray = new char[502];
-                charArray[0] = '"';
-                for (int i = 1; i < charArray.Length; i++)
-                {
-                    charArray[i] = (char)random.Next('A', 'Z'); // ASCII values (between 65 and 90) that constitute valid base 64 string.
-                }
-                charArray[charArray.Length - 1] = '"';
-                jsonString = new string(charArray);
-            }
-
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state: default);
@@ -1192,28 +1174,9 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("\"ABC===\"")]
-        [InlineData("\"ABC\"")]
-        [InlineData("\"ABC!\"")]
-        [InlineData(null)]  // Large randomly generated string
+        [MemberData(nameof(JsonBase64TestData.InvalidBase64Tests), MemberType = typeof(JsonBase64TestData))]
         public static void InvalidBase64(string jsonString)
         {
-            if (jsonString == null)
-            {
-                var random = new Random(42);
-                var charArray = new char[500];
-                charArray[0] = '"';
-                for (int i = 1; i < charArray.Length; i++)
-                {
-                    charArray[i] = (char)random.Next('?', '\\'); // ASCII values (between 63 and 91) that don't need to be escaped.
-                }
-
-                charArray[256] = '\\';
-                charArray[257] = '"';
-                charArray[charArray.Length - 1] = '"';
-                jsonString = new string(charArray);
-            }
-
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state: default);


### PR DESCRIPTION
Part of #32341

**Note 1**

In order to get coverage on the following lines, I added a missing test case using `JsonDocument.Parse` with a large, invalid base64 string _without_ an escaped character.  The test data previously used `[InlineData(...)]` attributes where the large strings were generated from the `[InlineData(null)]` case, using `null` as a sentinel value.  I weighed a few different options for how to add this new case, and eventually settled on moving the test data to its own class and using `[MemberData(...)]` instead to simplify the tests themselves.  Certainly open to suggestions! 

https://github.com/dotnet/runtime/blob/11b37df0e50e45465b2071b191c365d84e8932ac/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs#L162-L166

**Note 2**
There was a missing case in cyclic tests that validates that `EffectiveMaxDepth` is set to 64 when `MaxDepth` is set to 0 (lines).  I ended up splitting `WriteCyclicFail`, which had two logical subgroups into `WriteCyclic` and `WriteCyclicFail`.

https://github.com/dotnet/runtime/blob/527adf211a45046876d680480e45131b5334fcf6/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs#L203