### PR TITLE
[cxx] Remove static initializers.

### DIFF
--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -478,9 +478,9 @@ typedef struct  {
 
 /* MonoRuntimeInfo: Contains information about versions supported by this runtime */
 typedef struct  {
-	const char runtime_version [12];
-	const char framework_version [4];
-	const AssemblyVersionSet version_sets [5];
+	char runtime_version [12];
+	char framework_version [4];
+	AssemblyVersionSet version_sets [5];
 } MonoRuntimeInfo;
 
 #define mono_domain_assemblies_lock(domain) mono_locks_os_acquire(&(domain)->assemblies_lock, DomainAssembliesLock)

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -1153,7 +1153,7 @@ typedef enum {
 typedef struct {
 	int hash;
 	int assembly_name;
-	const char guid [40];
+	char guid [40];
 } IgnoredAssembly;
 
 typedef struct {

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -242,8 +242,8 @@ parse_debug_options (const char* p)
 }
 
 typedef struct {
-	const char name [6];
-	const char desc [18];
+	char name [6];
+	char desc [18];
 	MonoGraphOptions value;
 } GraphName;
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19089,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In a current shipping Visual C++, 19.21.27702.2,
there is a bug involving const member data in structs, where for example:

static const struct a { // const on this line in either case
  const int b; // const on this line
} c = {1};

will have a static initializer, run usually reliably before main, but:

static const struct a { // const on this line in either case
  int b; // no const on this line
} c = {1};

will not.
The semantic difference is minuscule, so much so, that the first form
is relatively rare, and the bug shipped.

Just always use the second form.

The difference is that if you have a non-const a, b is still const, I guess.
If you have a const a, then no difference.

You can find these easily:

cd ...
for %a in (*.exe *.dll) do link /dump /disasm %a > %a.txt
findstr /c:"dynamic initializer" *.txt

Which could be automated and tested in CI.

This probably not an actual problem, but it is needlessly inefficient,
and potentially a problem. The timing/ordering of the initializers
is a bit not deterministic. You get writable data where you expect
read only.

It is in fact a compiler bug, fixed in later releases.
But it has been shipping for a while, I first noticed it over two years
ago, in code of mine that it caused to not work (a delayload implementation
which runs before main).