### PR TITLE
Specify entrypoint name for LoadLibrary import

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
         internal const int LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
 
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryExW", SetLastError = true)]
         internal static extern IntPtr LoadLibraryEx(string libFilename, IntPtr reserved, int flags);
     }
 }


### PR DESCRIPTION
The Widechar probing is unnecessary.