### PR TITLE
Set GenFacadesForceZeroVersionSeeds for all shims

### DIFF
--- a/src/libraries/shims/Directory.Build.props
+++ b/src/libraries/shims/Directory.Build.props
@@ -11,6 +11,11 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <GenFacadesIgnoreMissingTypes>true</GenFacadesIgnoreMissingTypes>
+    <!-- ensure the desktop compat shims reference the lowest possible version of dependencies
+         since those do not all ship as part of the framework and we don't want to force apps
+         to reference the latest packages.
+         netstandard.dll doesn't need to do this since it has no dangling dependencies -->
+    <GenFacadesForceZeroVersionSeeds Condition="'$(MSBuildProjectName)' != 'netstandard'">true</GenFacadesForceZeroVersionSeeds>
     <IncludeDefaultReferences>false</IncludeDefaultReferences>
     <HasMatchingContract>true</HasMatchingContract>
     <!-- Shims have no code in them. No point in running IL linker over them -->


### PR DESCRIPTION
Opts into GenFacadesForceZeroVersionSeeds for all shims.  This is consistent with what we did in 2.x.

I've manually updated GenFacades rather than wait for https://github.com/dotnet/runtime/pull/32858

