### PR TITLE
[debugger] Implementing step through multithreaded code.

### DIFF
--- a/src/mono/mono/mini/debugger-engine.c
+++ b/src/mono/mono/mini/debugger-engine.c
@@ -591,8 +591,26 @@ mono_de_clear_breakpoints_for_domain (MonoDomain *domain)
 /* Number of single stepping operations in progress */
 static int ss_count;
 
-/* The single step request instance */
-static SingleStepReq *the_ss_req;
+/* The single step request instances */
+static GPtrArray *the_ss_reqs;
+
+static void
+ss_req_init (void)
+{
+	the_ss_reqs = g_ptr_array_new ();
+}
+
+static void
+ss_req_cleanup (void)
+{
+	dbg_lock ();
+
+	g_ptr_array_free (the_ss_reqs, TRUE);
+
+	the_ss_reqs = NULL;
+
+	dbg_unlock ();
+}
 
 /*
  * mono_de_start_single_stepping:
@@ -716,17 +734,27 @@ ss_destroy (SingleStepReq *req)
 	g_free (req);
 }
 
-static SingleStepReq*
-ss_req_acquire (void)
+SingleStepReq*
+ss_req_acquire (MonoInternalThread *thread)
 {
-	SingleStepReq *req;
-
+	SingleStepReq *req = NULL;
 	dbg_lock ();
-	req = the_ss_req;
-	if (req)
-		req->refcount ++;
+	int i;
+	for (i = 0; i < the_ss_reqs->len; ++i) {
+		SingleStepReq *current_req = (SingleStepReq *)g_ptr_array_index (the_ss_reqs, i);
+		if (current_req->thread == thread) {
+			current_req->refcount ++;	
+			req = current_req;
+		}
+	}
 	dbg_unlock ();
 	return req;
+}
+
+int 
+ss_req_count ()
+{
+	return the_ss_reqs->len;
 }
 
 static void
@@ -739,23 +767,30 @@ mono_de_ss_req_release (SingleStepReq *req)
 	req->refcount --;
 	if (req->refcount == 0)
 		free = TRUE;
-	dbg_unlock ();
 	if (free) {
-		if (req == the_ss_req)
-			the_ss_req = NULL;
+		g_ptr_array_remove (the_ss_reqs, req);
 		ss_destroy (req);
+	}
+	dbg_unlock ();
+}
+
+void
+mono_de_cancel_ss (SingleStepReq *req)
+{
+	if (the_ss_reqs) {
+		mono_de_ss_req_release (req);
 	}
 }
 
 void
-mono_de_cancel_ss (void)
+mono_de_cancel_all_ss ()
 {
-	if (the_ss_req) {
-		mono_de_ss_req_release (the_ss_req);
-		the_ss_req = NULL;
+	int i;
+	for (i = 0; i < the_ss_reqs->len; ++i) {
+		SingleStepReq *current_req = (SingleStepReq *)g_ptr_array_index (the_ss_reqs, i);
+		mono_de_ss_req_release (current_req);
 	}
 }
-
 
 void
 mono_de_process_single_step (void *tls, gboolean from_signal)
@@ -774,21 +809,17 @@ mono_de_process_single_step (void *tls, gboolean from_signal)
 	/* Skip the instruction causing the single step */
 	rt_callbacks.begin_single_step_processing (ctx, from_signal);
 
-	if (rt_callbacks.try_process_suspend (tls, ctx))
+	if (rt_callbacks.try_process_suspend (tls, ctx, FALSE))
 		return;
 
 	/*
 	 * This can run concurrently with a clear_event_request () call, so needs locking/reference counts.
 	 */
-	ss_req = ss_req_acquire ();
+	ss_req = ss_req_acquire (mono_thread_internal_current ());
 
 	if (!ss_req)
 		// FIXME: A suspend race
 		return;
-
-	if (mono_thread_internal_current () != ss_req->thread)
-		goto exit;
-
 	ip = (guint8 *)MONO_CONTEXT_GET_IP (ctx);
 
 	ji = get_top_method_ji (ip, &domain, (gpointer*)&ip);
@@ -1022,7 +1053,7 @@ mono_de_process_breakpoint (void *void_tls, gboolean from_signal)
 	SeqPoint sp;
 	gboolean found_sp;
 
-	if (rt_callbacks.try_process_suspend (tls, ctx))
+	if (rt_callbacks.try_process_suspend (tls, ctx, TRUE))
 		return;
 
 	ip = (guint8 *)MONO_CONTEXT_GET_IP (ctx);
@@ -1488,7 +1519,7 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 		return err;
 
 	// FIXME: Multiple requests
-	if (the_ss_req) {
+	if (ss_req_count () > 1) {
 		err = rt_callbacks.handle_multiple_ss_requests ();
 
 		if (err == DE_ERR_NOT_IMPLEMENTED) {
@@ -1519,8 +1550,7 @@ mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, S
 	err = rt_callbacks.ss_create_init_args (ss_req, &args);
 	if (err)
 		return err;
-
-	the_ss_req = ss_req;
+	g_ptr_array_add (the_ss_reqs, ss_req);
 
 	mono_de_ss_start (ss_req, &args);
 
@@ -1552,7 +1582,7 @@ mono_de_init (DebuggerEngineCallbacks *cbs)
 
 	domains_init ();
 	breakpoints_init ();
-
+	ss_req_init ();
 	mono_debugger_log_init ();
 }
 
@@ -1561,6 +1591,7 @@ mono_de_cleanup (void)
 {
 	breakpoints_cleanup ();
 	domains_cleanup ();
+	ss_req_cleanup ();
 }
 
 void

--- a/src/mono/mono/mini/debugger-engine.h
+++ b/src/mono/mono/mini/debugger-engine.h
@@ -232,7 +232,7 @@ mono_debugger_get_thread_state (DebuggerTlsData *ref);
 
 typedef struct {
 	MonoContext *(*tls_get_restore_state) (void *tls);
-	gboolean (*try_process_suspend) (void *tls, MonoContext *ctx);
+	gboolean (*try_process_suspend) (void *tls, MonoContext *ctx, gboolean from_breakpoint);
 	gboolean (*begin_breakpoint_processing) (void *tls, MonoContext *ctx, MonoJitInfo *ji, gboolean from_signal);
 	void (*begin_single_step_processing) (MonoContext *ctx, gboolean from_signal);
 
@@ -284,6 +284,9 @@ void mono_de_stop_single_stepping (void);
 void mono_de_process_breakpoint (void *tls, gboolean from_signal);
 void mono_de_process_single_step (void *tls, gboolean from_signal);
 DbgEngineErrorCode mono_de_ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, StepFilter filter, EventRequest *req);
-void mono_de_cancel_ss (void);
+void mono_de_cancel_ss (SingleStepReq *req);
+void mono_de_cancel_all_ss (void);
 
+SingleStepReq* ss_req_acquire (MonoInternalThread *thread);
+int ss_req_count (void);
 #endif

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2377,6 +2377,7 @@ lookup_start:
 			g_assert (vtable);
 			if (!mono_runtime_class_init_full (vtable, error))
 				return NULL;
+			MONO_PROFILER_RAISE (jit_done, (method, info));
 			return mono_create_ftnptr (target_domain, info->code_start);
 		}
 	}

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -155,7 +155,7 @@ tls_get_restore_state (void *tls)
 }
 
 static gboolean
-try_process_suspend (void *tls, MonoContext *ctx)
+try_process_suspend (void *tls, MonoContext *ctx, gboolean from_breakpoint)
 {
 	return FALSE;
 }
@@ -241,7 +241,7 @@ process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, in
 	BpEvents *evts = (BpEvents*)_evts;
 	if (evts) {
 		if (evts->is_ss)
-			mono_de_cancel_ss ();
+			mono_de_cancel_all_ss ();
 		mono_wasm_fire_bp ();
 		g_free (evts);
 	}
@@ -295,7 +295,7 @@ ss_args_destroy (SingleStepArgs *ss_args)
 
 static int
 handle_multiple_ss_requests (void) {
-	mono_de_cancel_ss ();
+	mono_de_cancel_all_ss ();
 	return 1;
 }
 
@@ -399,7 +399,7 @@ mono_wasm_setup_single_step (int kind)
 		}
 	}
 	if (!isBPOnNativeCode) {
-		mono_de_cancel_ss ();
+		mono_de_cancel_all_ss ();
 	}
 	return isBPOnNativeCode;
 }


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19103,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>I've changed the variable the_ss_req to an array, in this array I saved all the single steps requisitions received and whenever the debugger stops in a possible singles step I get the right requisition in the array and answer it.
It is necessary to change debugger-libs together, because we can send a single step for thread A and receive an answer of thread B, so we shouldn't cancel the single step requisition for thread A, because it wasn't answered yet.
If the change in debugger-libs is not synchronised together if mono we will not have any side effect, the multithreaded step just don't work as nowadays.

Fixes mono/mono#14456

