### PR TITLE
Baseline Crossgen2 outer loop failing tests

### DIFF
--- a/eng/pipelines/coreclr/templates/run-test-job.yml
+++ b/eng/pipelines/coreclr/templates/run-test-job.yml
@@ -168,7 +168,7 @@ jobs:
     # the native artifacts to the final test folders is dependent on availability of the
     # managed test artifacts.
     - ${{ if ne(parameters.corefxTests, true) }}:
-      - script: $(coreClrRepoRootDir)build-test$(scriptExt) copynativeonly $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg)
+      - script: $(coreClrRepoRootDir)build-test$(scriptExt) copynativeonly $(crossgenArg) $(buildConfig) $(archType) $(priorityArg) $(librariesOverrideArg)
         displayName: Copy native test components to test output folder
 
 

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -26,7 +26,7 @@ build_test_wrappers()
         __MsbuildErr="/fileloggerparameters2:\"ErrorsOnly;LogFile=${__BuildErr}\""
         __Logging="$__MsbuildLog $__MsbuildWrn $__MsbuildErr /consoleloggerparameters:$buildVerbosity"
 
-        nextCommand="\"${__DotNetCli}\" msbuild \"${__ProjectDir}/tests/src/runtest.proj\" /nodereuse:false /p:BuildWrappers=true /p:TargetsWindows=false $__Logging /p:__BuildOS=$__BuildOS /p:__BuildType=$__BuildType /p:__BuildArch=$__BuildArch"
+        nextCommand="\"${__DotNetCli}\" msbuild \"${__ProjectDir}/tests/src/runtest.proj\" /nodereuse:false /p:BuildWrappers=true /p:TestBuildMode=$__TestBuildMode /p:TargetsWindows=false $__Logging /p:__BuildOS=$__BuildOS /p:__BuildType=$__BuildType /p:__BuildArch=$__BuildArch"
         eval $nextCommand
 
         local exitCode="$?"
@@ -135,7 +135,9 @@ generate_layout()
 
     # Precompile framework assemblies with crossgen if required
     if [[ "$__DoCrossgen" != 0 || "$__DoCrossgen2" != 0 ]]; then
-        precompile_coreroot_fx
+        if [[ "$__SkipCrossgenFramework" == 0 ]]; then
+            precompile_coreroot_fx
+        fi
     fi
 }
 
@@ -503,14 +505,17 @@ handle_arguments_local() {
             __SkipManaged=1
             __CopyNativeTestBinaries=1
             __CopyNativeProjectsAfterCombinedTestBuild=true
+            __SkipCrossgenFramework=1
             ;;
 
         crossgen|-crossgen)
             __DoCrossgen=1
+            __TestBuildMode=crossgen
             ;;
 
         crossgen2|-crossgen2)
             __DoCrossgen2=1
+            __TestBuildMode=crossgen2
             ;;
 
         generatetesthostonly|-generatetesthostonly)
@@ -587,6 +592,7 @@ __SkipManaged=0
 __SkipNative=0
 __SkipRestore=""
 __SkipRestorePackages=0
+__SkipCrossgenFramework=0
 __SourceDir="$__ProjectDir/src"
 __UnprocessedBuildArgs=
 __LocalCoreFXConfig=${__BuildType}

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -954,6 +954,31 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- Crossgen2 specific -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'crossgen2'">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_r/*">
+            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_ro/*">
+            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.1/DDB/B168384/LdfldaHack/*">
+            <Issue>https://github.com/dotnet/runtime/issues/615</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/**/*">
+            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/tracelogging/tracelogging/*">
+            <Issue>https://github.com/dotnet/runtime/issues/32728</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/*">
+            <Issue>Not compatible with crossgen2</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
+            <Issue>Not compatible with crossgen2</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.
          Exclude these scripts to avoid creating such methods for the superpmicollect dependent test projects
          and running them separately from superpmicollect test. -->


### PR DESCRIPTION
The outer loop Crossgen2 pipeline is now being monitored for failures by our vendor team and needs to run clean. Some of the remaining failing tests are run in special modes we don't enable during crossgen2 (ie, ObjectStackAllocationTests would need COMPlus_JitObjectStackAllocation setting during crossgen, superpmicollect uses an alt-jit).

The remaining failures have issues listed in the project file for further investigation since they look like Crossgen2 bugs.