### PR TITLE
Making /p:TargetFramework for tests and other platforms

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -355,6 +355,7 @@
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(BuildAllProjects)' != 'true' and '$(TargetFramework)' != '$(NetCoreAppCurrent)'"></BinPlaceTestSharedFramework>
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 
     <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>

--- a/src/libraries/restore/Directory.Build.props
+++ b/src/libraries/restore/Directory.Build.props
@@ -11,7 +11,7 @@
     <OutputPath>$(BaseOutputPath)$(TargetFramework)-$(TargetFrameworkSuffix)-$(Configuration)</OutputPath>
     <OutputPath Condition="'$(TargetFrameworkSuffix)' == ''">$(BaseOutputPath)$(TargetFramework)-$(Configuration)</OutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <AdditionalBuildTargetFrameworks Condition="'$(BuildAllProjects)' == 'true'">netstandard2.0-$(TargetFrameworkSuffix)</AdditionalBuildTargetFrameworks>
+    <AdditionalBuildTargetFrameworks Condition="'$(BuildAllProjects)' == 'true'">netstandard2.0-$(BuildOS)</AdditionalBuildTargetFrameworks>
   </PropertyGroup>
   
   <!-- don't bring in props/targets from packages, we're not consuming them we're


### PR DESCRIPTION
Working towards https://github.com/dotnet/runtime/issues/33059


```
C:\git\runtime\src\libraries\System.Text.RegularExpressions\tests>dotnet build /t:BuildAndTest  /p:TargetFramework=net472
Microsoft (R) Build Engine version 16.4.0+e901037fe for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 35.69 ms for C:\git\runtime\src\libraries\Common\tests\CoreFx.Private.TestUtilities\CoreFx.Private.TestUtilities.csproj.
  Restore completed in 35.69 ms for C:\git\runtime\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj.
  CoreFx.Private.TestUtilities -> C:\git\runtime\artifacts\bin\CoreFx.Private.TestUtilities\net472-Debug\CoreFx.Private.TestUtilities.dll
  System.Text.RegularExpressions.Tests -> C:\git\runtime\artifacts\bin\System.Text.RegularExpressions.Tests\net472-Debug\System.Text.RegularExpressions.Tests.dll
  ----- start Mon 03/02/2020 14:26:30.61 ===============  To repro directly: =====================================================
  pushd C:\git\runtime\artifacts\bin\System.Text.RegularExpressions.Tests\net472-Debug\
  set DEVPATH=C:\git\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64
  xunit.console.exe System.Text.RegularExpressions.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing -notrait category=nonnetfxtests -notrait category=nonwindowstests
  popd
  ===========================================================================================================
    Discovering: System.Text.RegularExpressions.Tests (app domain = on [no shadow copy], method display = ClassAndMethod, method display options = None)
    Discovered:  System.Text.RegularExpressions.Tests (found 109 of 139 test cases)
    Starting:    System.Text.RegularExpressions.Tests (parallel test collections = on, max threads = 12)
    Finished:    System.Text.RegularExpressions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Text.RegularExpressions.Tests  Total: 6696, Errors: 0, Failed: 0, Skipped: 0, Time: 5.488s
  ----- end Mon 03/02/2020 14:26:40.11 ----- exit code 0 ----------------------------------------------------------
```

Issues Still Left
- Devpath variable not set properly in net472
- not able to run tests using -f switch


Issues resolved
- able to run using /p:TargetFramework=net472 property


