### PR TITLE
Simplifying the implementation of several Vector2/3/4 methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -116,16 +116,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float ls = Vector2.Dot(this, this);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float ls = X * X + Y * Y;
-                return MathF.Sqrt(ls);
-            }
+            float ls = Vector2.Dot(this, this);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -135,14 +127,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float LengthSquared()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                return Vector2.Dot(this, this);
-            }
-            else
-            {
-                return X * X + Y * Y;
-            }
+            return Vector2.Dot(this, this);
         }
         #endregion Public Instance Methods
 
@@ -156,21 +141,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Distance(Vector2 value1, Vector2 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector2 difference = value1 - value2;
-                float ls = Vector2.Dot(difference, difference);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-
-                float ls = dx * dx + dy * dy;
-
-                return MathF.Sqrt(ls);
-            }
+            Vector2 difference = value1 - value2;
+            float ls = Vector2.Dot(difference, difference);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -182,18 +155,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DistanceSquared(Vector2 value1, Vector2 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector2 difference = value1 - value2;
-                return Vector2.Dot(difference, difference);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-
-                return dx * dx + dy * dy;
-            }
+            Vector2 difference = value1 - value2;
+            return Vector2.Dot(difference, difference);
         }
 
         /// <summary>
@@ -204,20 +167,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 Normalize(Vector2 value)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float length = value.Length();
-                return value / length;
-            }
-            else
-            {
-                float ls = value.X * value.X + value.Y * value.Y;
-                float invNorm = 1.0f / MathF.Sqrt(ls);
-
-                return new Vector2(
-                    value.X * invNorm,
-                    value.Y * invNorm);
-            }
+            float length = value.Length();
+            return value / length;
         }
 
         /// <summary>
@@ -229,19 +180,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 Reflect(Vector2 vector, Vector2 normal)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float dot = Vector2.Dot(vector, normal);
-                return vector - (2 * dot * normal);
-            }
-            else
-            {
-                float dot = vector.X * normal.X + vector.Y * normal.Y;
-
-                return new Vector2(
-                    vector.X - 2.0f * dot * normal.X,
-                    vector.Y - 2.0f * dot * normal.Y);
-            }
+            float dot = Vector2.Dot(vector, normal);
+            return vector - (2 * dot * normal);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -124,16 +124,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float ls = Vector3.Dot(this, this);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float ls = X * X + Y * Y + Z * Z;
-                return MathF.Sqrt(ls);
-            }
+            float ls = Vector3.Dot(this, this);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -143,14 +135,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float LengthSquared()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                return Vector3.Dot(this, this);
-            }
-            else
-            {
-                return X * X + Y * Y + Z * Z;
-            }
+            return Vector3.Dot(this, this);
         }
         #endregion Public Instance Methods
 
@@ -164,22 +149,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Distance(Vector3 value1, Vector3 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector3 difference = value1 - value2;
-                float ls = Vector3.Dot(difference, difference);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-                float dz = value1.Z - value2.Z;
-
-                float ls = dx * dx + dy * dy + dz * dz;
-
-                return MathF.Sqrt(ls);
-            }
+            Vector3 difference = value1 - value2;
+            float ls = Vector3.Dot(difference, difference);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -191,19 +163,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DistanceSquared(Vector3 value1, Vector3 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector3 difference = value1 - value2;
-                return Vector3.Dot(difference, difference);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-                float dz = value1.Z - value2.Z;
-
-                return dx * dx + dy * dy + dz * dz;
-            }
+            Vector3 difference = value1 - value2;
+            return Vector3.Dot(difference, difference);
         }
 
         /// <summary>
@@ -214,17 +175,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Normalize(Vector3 value)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float length = value.Length();
-                return value / length;
-            }
-            else
-            {
-                float ls = value.X * value.X + value.Y * value.Y + value.Z * value.Z;
-                float length = MathF.Sqrt(ls);
-                return new Vector3(value.X / length, value.Y / length, value.Z / length);
-            }
+            float length = value.Length();
+            return value / length;
         }
 
         /// <summary>
@@ -251,20 +203,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float dot = Vector3.Dot(vector, normal);
-                Vector3 temp = normal * dot * 2f;
-                return vector - temp;
-            }
-            else
-            {
-                float dot = vector.X * normal.X + vector.Y * normal.Y + vector.Z * normal.Z;
-                float tempX = normal.X * dot * 2f;
-                float tempY = normal.Y * dot * 2f;
-                float tempZ = normal.Z * dot * 2f;
-                return new Vector3(vector.X - tempX, vector.Y - tempY, vector.Z - tempZ);
-            }
+            float dot = Vector3.Dot(vector, normal);
+            Vector3 temp = normal * dot * 2f;
+            return vector - temp;
         }
 
         /// <summary>
@@ -304,19 +245,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector3 firstInfluence = value1 * (1f - amount);
-                Vector3 secondInfluence = value2 * amount;
-                return firstInfluence + secondInfluence;
-            }
-            else
-            {
-                return new Vector3(
-                    value1.X + (value2.X - value1.X) * amount,
-                    value1.Y + (value2.Y - value1.Y) * amount,
-                    value1.Z + (value2.Z - value1.Z) * amount);
-            }
+            Vector3 firstInfluence = value1 * (1f - amount);
+            Vector3 secondInfluence = value2 * amount;
+            return firstInfluence + secondInfluence;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -130,17 +130,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float Length()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float ls = Vector4.Dot(this, this);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float ls = X * X + Y * Y + Z * Z + W * W;
-
-                return MathF.Sqrt(ls);
-            }
+            float ls = Vector4.Dot(this, this);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -150,14 +141,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float LengthSquared()
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                return Vector4.Dot(this, this);
-            }
-            else
-            {
-                return X * X + Y * Y + Z * Z + W * W;
-            }
+            return Vector4.Dot(this, this);
         }
         #endregion Public Instance Methods
 
@@ -171,23 +155,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Distance(Vector4 value1, Vector4 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector4 difference = value1 - value2;
-                float ls = Vector4.Dot(difference, difference);
-                return MathF.Sqrt(ls);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-                float dz = value1.Z - value2.Z;
-                float dw = value1.W - value2.W;
-
-                float ls = dx * dx + dy * dy + dz * dz + dw * dw;
-
-                return MathF.Sqrt(ls);
-            }
+            Vector4 difference = value1 - value2;
+            float ls = Vector4.Dot(difference, difference);
+            return MathF.Sqrt(ls);
         }
 
         /// <summary>
@@ -199,20 +169,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DistanceSquared(Vector4 value1, Vector4 value2)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                Vector4 difference = value1 - value2;
-                return Vector4.Dot(difference, difference);
-            }
-            else
-            {
-                float dx = value1.X - value2.X;
-                float dy = value1.Y - value2.Y;
-                float dz = value1.Z - value2.Z;
-                float dw = value1.W - value2.W;
-
-                return dx * dx + dy * dy + dz * dz + dw * dw;
-            }
+            Vector4 difference = value1 - value2;
+            return Vector4.Dot(difference, difference);
         }
 
         /// <summary>
@@ -223,22 +181,8 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 Normalize(Vector4 vector)
         {
-            if (Vector.IsHardwareAccelerated)
-            {
-                float length = vector.Length();
-                return vector / length;
-            }
-            else
-            {
-                float ls = vector.X * vector.X + vector.Y * vector.Y + vector.Z * vector.Z + vector.W * vector.W;
-                float invNorm = 1.0f / MathF.Sqrt(ls);
-
-                return new Vector4(
-                    vector.X * invNorm,
-                    vector.Y * invNorm,
-                    vector.Z * invNorm,
-                    vector.W * invNorm);
-            }
+            float length = vector.Length();
+            return vector / length;
         }
 
         /// <summary>


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/19582 and resolves https://github.com/dotnet/runtime/issues/28881 by removing the non `IsHardwareAccelerated` path from several of the Vector2/3/4 methods.