### PR TITLE
Fix incorrect r2r codegen for hardware instrinsics

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/coreclr/src/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
@@ -40,6 +40,7 @@ namespace ILCompiler
             return false;
         }
 
+#if !READYTORUN
         public static bool IsIsSupportedMethod(MethodDesc method)
         {
             return method.Name == "get_IsSupported";
@@ -188,5 +189,6 @@ namespace ILCompiler
             public const int Popcnt = 0x0040;
             public const int Lzcnt = 0x0080;
         }
+#endif // !READYTORUN
     }
 }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2826,13 +2826,24 @@ namespace Internal.JitInterface
 #endif
                )
             {
+#if !READYTORUN
                 // This list needs to match the list of intrinsics we can generate detection code for
                 // in HardwareIntrinsicHelpers.EmitIsSupportedIL.
+#else
+                // For ReadyToRun, this list needs to match up with the behavior of FilterNamedIntrinsicMethodAttribs
+                // In particular, that this list of supported hardware will not generate non-SSE2 safe instruction
+                // sequences when paired with the behavior in FilterNamedIntrinsicMethodAttribs
+#endif
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_AES);
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_PCLMULQDQ);
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSE3);
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSSE3);
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_LZCNT);
+#if READYTORUN
+                flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSE41);
+                flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSE42);
+                flags.Set(CorJitFlag.CORJIT_FLAG_USE_POPCNT);
+#endif
             }
 
             if (this.MethodBeingCompiled.IsNativeCallable)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1554,6 +1554,37 @@ namespace Internal.JitInterface
                             fTreatAsRegularMethodCall = (methodName == "Round");
                         }
                     }
+                    else if (namespaceName == "System.Numerics")
+                    {
+                        if ((className == "Vector3") || (className == "Vector4"))
+                        {
+                            if (methodName == ".ctor")
+                            {
+                                // Vector3 and Vector4 have constructors which take a smaller Vector and create bolt on
+                                // a larger vector. This uses insertps instruction when compiled with SSE4.1 instruction support
+                                // which must not be generated inline in R2R images that actually support an SSE2 only mode.
+                                if ((method.Signature.Length > 1) && (method.Signature[0].IsValueType && !method.Signature[0].IsPrimitive))
+                                {
+                                    fTreatAsRegularMethodCall = true;
+                                }
+                            }
+                            else if (methodName == "Dot")
+                            {
+                                // The dot product operations uses the dpps instruction when compiled with SSE4.1 instruction
+                                // support. This must not be generated inline in R2R images that actually support an SSE2 only mode.
+                                fTreatAsRegularMethodCall = true;
+                            }
+                        }
+                        else if ((className == "Vector2") || (className == "Vector") || (className == "Vector`1"))
+                        {
+                            if (methodName == "Dot")
+                            {
+                                // The dot product operations uses the dpps instruction when compiled with SSE4.1 instruction
+                                // support. This must not be generated inline in R2R images that actually support an SSE2 only mode.
+                                fTreatAsRegularMethodCall = true;
+                            }
+                        }
+                    }
                 }
 
                 if (fTreatAsRegularMethodCall)

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2102,7 +2102,7 @@ void ZapInfo::GetProfilingHandle(BOOL                      *pbHookFunction,
 //
 // This strips the CORINFO_FLG_JIT_INTRINSIC flag from some of the named intrinsic methods.
 //
-DWORD FilterNamedIntrinsicMethodAttribs(DWORD attribs, CORINFO_METHOD_HANDLE ftn, ICorDynamicInfo* pJitInfo)
+DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINFO_METHOD_HANDLE ftn, ICorDynamicInfo* pJitInfo)
 {
     if (attribs & CORINFO_FLG_JIT_INTRINSIC)
     {
@@ -2179,6 +2179,40 @@ DWORD FilterNamedIntrinsicMethodAttribs(DWORD attribs, CORINFO_METHOD_HANDLE ftn
                 fTreatAsRegularMethodCall = strcmp(methodName, "Round") == 0;
             }
         }
+        else if (strcmp(namespaceName, "System.Numerics") == 0)
+        {
+            if ((strcmp(className, "Vector3") == 0) || (strcmp(className, "Vector4") == 0))
+            {
+                // Vector3 and Vector4 have constructors which take a smaller Vector and create bolt on
+                // a larger vector. This uses insertps instruction when compiled with SSE4.1 instruction support
+                // which must not be generated inline in R2R images that actually support an SSE2 only mode.
+                if (strcmp(methodName, ".ctor") == 0)
+                {
+                    CORINFO_SIG_INFO sig;
+                    pZapInfo->getMethodSig(ftn, &sig, NULL);
+                    CORINFO_CLASS_HANDLE argClass;
+                    if (pZapInfo->getArgType(&sig, sig.args, &argClass) == CORINFO_TYPE_VALUECLASS)
+                    {
+                        fTreatAsRegularMethodCall = TRUE;
+                    }
+                }
+                else if (strcmp(methodName, "Dot") == 0)
+                {
+                    // The dot product operations uses the dpps instruction when compiled with SSE4.1 instruction
+                    // support. This must not be generated inline in R2R images that actually support an SSE2 only mode.
+                    fTreatAsRegularMethodCall = TRUE;
+                }
+            }
+            else if ((strcmp(className, "Vector2") == 0) || (strcmp(className, "Vector") == 0) || (strcmp(className, "Vector`1") == 0))
+            {
+                if (strcmp(methodName, "Dot") == 0)
+                {
+                    // The dot product operations uses the dpps instruction when compiled with SSE4.1 instruction
+                    // support. This must not be generated inline in R2R images that actually support an SSE2 only mode.
+                    fTreatAsRegularMethodCall = TRUE;
+                }
+            }
+        }
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64)
 
         if (fTreatAsRegularMethodCall)
@@ -2216,7 +2250,7 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
                               (CORINFO_CALLINFO_FLAGS)(flags | CORINFO_CALLINFO_KINDONLY),
                               pResult);
 
-    pResult->methodFlags = FilterNamedIntrinsicMethodAttribs(pResult->methodFlags, pResult->hMethod, m_pEEJitInfo);
+    pResult->methodFlags = FilterNamedIntrinsicMethodAttribs(this, pResult->methodFlags, pResult->hMethod, m_pEEJitInfo);
 
 #ifdef FEATURE_READYTORUN_COMPILER
     if (IsReadyToRunCompilation())
@@ -3766,7 +3800,7 @@ unsigned ZapInfo::getMethodHash(CORINFO_METHOD_HANDLE ftn)
 DWORD ZapInfo::getMethodAttribs(CORINFO_METHOD_HANDLE ftn)
 {
     DWORD result = m_pEEJitInfo->getMethodAttribs(ftn);
-    return FilterNamedIntrinsicMethodAttribs(result, ftn, m_pEEJitInfo);
+    return FilterNamedIntrinsicMethodAttribs(this, result, ftn, m_pEEJitInfo);
 }
 
 void ZapInfo::setMethodAttribs(CORINFO_METHOD_HANDLE ftn, CorInfoMethodRuntimeFlags attribs)

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2191,7 +2191,7 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
                     CORINFO_SIG_INFO sig;
                     pZapInfo->getMethodSig(ftn, &sig, NULL);
                     CORINFO_CLASS_HANDLE argClass;
-                    if (pZapInfo->getArgType(&sig, sig.args, &argClass) == CORINFO_TYPE_VALUECLASS)
+                    if ((CorInfoType)pZapInfo->getArgType(&sig, sig.args, &argClass) == CORINFO_TYPE_VALUECLASS)
                     {
                         fTreatAsRegularMethodCall = TRUE;
                     }


### PR DESCRIPTION
Use of Vector dot product and Vector3/4 constructors may generate code that is not compatible with an SSE2 capable CPU.

This fix adjusts the set of rules for filtering the intrinsics when compiling System.Private.CoreLib, and makes the behavior in crossgen2 match that of crossgen1.

Fixes #32175 