### PR TITLE
Disabled GetTotalAllocatedBytes test.

### DIFF
--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -846,6 +846,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/2280", TestRuntimes.Mono)]
         public static void GetTotalAllocatedBytes()
         {
             byte[] stash;


### PR DESCRIPTION
Disabling this test until I can solve the underlying issue, because it is blocking a clean CI.

Issue: https://github.com/dotnet/runtime/issues/2280