### PR TITLE
Prevent ArrayPool<RegexOptions>.Shared creation

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -43,11 +43,14 @@ namespace System.Text.RegularExpressions
         private List<string>? _capnamelist;
 
         private RegexOptions _options;
-        private ValueListBuilder<RegexOptions> _optionsStack;
+        // NOTE: _optionsStack is ValueListBuilder<int> to ensure that
+        //       ArrayPool<int>.Shared, not ArrayPool<RegexOptions>.Shared,
+        //       will be created if the stackalloc'd capacity is ever exceeded.
+        private ValueListBuilder<int> _optionsStack;
 
         private bool _ignoreNextParen; // flag to skip capturing a parentheses group
 
-        private RegexParser(string pattern, RegexOptions options, CultureInfo culture, Hashtable caps, int capsize, Hashtable? capnames, Span<RegexOptions> optionSpan)
+        private RegexParser(string pattern, RegexOptions options, CultureInfo culture, Hashtable caps, int capsize, Hashtable? capnames, Span<int> optionSpan)
         {
             Debug.Assert(pattern != null, "Pattern must be set");
             Debug.Assert(culture != null, "Culture must be set");
@@ -59,7 +62,7 @@ namespace System.Text.RegularExpressions
             _capsize = capsize;
             _capnames = capnames;
 
-            _optionsStack = new ValueListBuilder<RegexOptions>(optionSpan);
+            _optionsStack = new ValueListBuilder<int>(optionSpan);
             _stack = default;
             _group = default;
             _alternation = default;
@@ -74,14 +77,14 @@ namespace System.Text.RegularExpressions
             _ignoreNextParen = false;
         }
 
-        private RegexParser(string pattern, RegexOptions options, CultureInfo culture, Span<RegexOptions> optionSpan)
+        private RegexParser(string pattern, RegexOptions options, CultureInfo culture, Span<int> optionSpan)
             : this(pattern, options, culture, new Hashtable(), default, null, optionSpan)
         {
         }
 
         public static RegexTree Parse(string pattern, RegexOptions options, CultureInfo culture)
         {
-            var parser = new RegexParser(pattern, options, culture, stackalloc RegexOptions[OptionStackDefaultSize]);
+            var parser = new RegexParser(pattern, options, culture, stackalloc int[OptionStackDefaultSize]);
 
             parser.CountCaptures();
             parser.Reset(options);
@@ -100,7 +103,7 @@ namespace System.Text.RegularExpressions
         public static RegexReplacement ParseReplacement(string pattern, RegexOptions options, Hashtable caps, int capsize, Hashtable capnames)
         {
             CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
-            var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, stackalloc RegexOptions[OptionStackDefaultSize]);
+            var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, stackalloc int[OptionStackDefaultSize]);
 
             RegexNode root = parser.ScanReplacement();
             var regexReplacement = new RegexReplacement(pattern, root, caps);
@@ -2291,10 +2294,10 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Saves options on a stack.</summary>
-        private void PushOptions() => _optionsStack.Append(_options);
+        private void PushOptions() => _optionsStack.Append((int)_options);
 
         /// <summary>Recalls options from the stack.</summary>
-        private void PopOptions() => _options = _optionsStack.Pop();
+        private void PopOptions() => _options = (RegexOptions)_optionsStack.Pop();
 
         /// <summary>True if options stack is empty.</summary>
         private bool EmptyOptionsStack() => _optionsStack.Length == 0;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -195,7 +195,7 @@ namespace System.Text.RegularExpressions
 
         private static string UnescapeImpl(string input, int i)
         {
-            var parser = new RegexParser(input, RegexOptions.None, CultureInfo.InvariantCulture, stackalloc RegexOptions[OptionStackDefaultSize]);
+            var parser = new RegexParser(input, RegexOptions.None, CultureInfo.InvariantCulture, stackalloc int[OptionStackDefaultSize]);
 
             // In the worst case the escaped string has the same length.
             // For small inputs we use stack allocation.


### PR DESCRIPTION
This change would preclude a very long regular expression resulting in the creation of `ArrayPool<RegexOptions>.Shared`, which would not of much use to anyone.