### PR TITLE
SList::Init: add missing constructor

### DIFF
--- a/src/coreclr/src/inc/slist.h
+++ b/src/coreclr/src/inc/slist.h
@@ -160,13 +160,13 @@ public:
     void Init()
     {
         LIMITED_METHOD_CONTRACT;
-        m_pHead = &m_link;
+        m_pHead = PTR_SLink(&m_link);
         // NOTE :: fHead variable is template argument
         // the following code is a compiled in, only if the fHead flag
         // is set to false,
         if (!fHead)
         {
-            m_pTail = &m_link;
+            m_pTail = PTR_SLink(&m_link);
         }
     }
 


### PR DESCRIPTION
SList::Init uses an assignment operator that doesn't exist.
Because this template class method doesn't get used during
default compilation, most compilers don't detect the issue.
clang 10 detects the issue and gives an error.

Fixes https://github.com/dotnet/runtime/issues/32875

cc @omajid @janvorli 