### PR TITLE
Return the original value in Interlocked.Or/And

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -132,7 +132,7 @@ namespace System.Threading
         /// <summary>Bitwise "ands" two 32-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int And(ref int location1, int value)
@@ -144,7 +144,7 @@ namespace System.Threading
                 int oldValue = CompareExchange(ref location1, newValue, current);
                 if (oldValue == current)
                 {
-                    return newValue;
+                    return oldValue;
                 }
                 current = oldValue;
             }
@@ -153,7 +153,7 @@ namespace System.Threading
         /// <summary>Bitwise "ands" two 32-bit unsigned integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
@@ -163,7 +163,7 @@ namespace System.Threading
         /// <summary>Bitwise "ands" two 64-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long And(ref long location1, long value)
@@ -175,7 +175,7 @@ namespace System.Threading
                 long oldValue = CompareExchange(ref location1, newValue, current);
                 if (oldValue == current)
                 {
-                    return newValue;
+                    return oldValue;
                 }
                 current = oldValue;
             }
@@ -184,7 +184,7 @@ namespace System.Threading
         /// <summary>Bitwise "ands" two 64-bit unsigned integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
@@ -196,7 +196,7 @@ namespace System.Threading
         /// <summary>Bitwise "ors" two 32-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Or(ref int location1, int value)
@@ -208,7 +208,7 @@ namespace System.Threading
                 int oldValue = CompareExchange(ref location1, newValue, current);
                 if (oldValue == current)
                 {
-                    return newValue;
+                    return oldValue;
                 }
                 current = oldValue;
             }
@@ -217,7 +217,7 @@ namespace System.Threading
         /// <summary>Bitwise "ors" two 32-bit unsigned integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
@@ -227,7 +227,7 @@ namespace System.Threading
         /// <summary>Bitwise "ors" two 64-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long Or(ref long location1, long value)
@@ -239,7 +239,7 @@ namespace System.Threading
                 long oldValue = CompareExchange(ref location1, newValue, current);
                 if (oldValue == current)
                 {
-                    return newValue;
+                    return oldValue;
                 }
                 current = oldValue;
             }
@@ -248,7 +248,7 @@ namespace System.Threading
         /// <summary>Bitwise "ors" two 64-bit unsigned integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
         /// <param name="value">The value to be combined with the integer at <paramref name="location1"/>.</param>
-        /// <returns>The new value stored at <paramref name="location1"/>.</returns>
+        /// <returns>The original value in <paramref name="location1"/>.</returns>
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]

--- a/src/libraries/System.Threading/tests/InterlockedTests.cs
+++ b/src/libraries/System.Threading/tests/InterlockedTests.cs
@@ -242,7 +242,7 @@ namespace System.Threading.Tests
         public void InterlockedAnd_Int32()
         {
             int value = 0x12345670;
-            Assert.Equal(0x02244220, Interlocked.And(ref value, 0x7654321));
+            Assert.Equal(0x12345670, Interlocked.And(ref value, 0x7654321));
             Assert.Equal(0x02244220, value);
         }
 
@@ -250,7 +250,7 @@ namespace System.Threading.Tests
         public void InterlockedAnd_UInt32()
         {
             uint value = 0x12345670u;
-            Assert.Equal(0x02244220u, Interlocked.And(ref value, 0x7654321));
+            Assert.Equal(0x12345670u, Interlocked.And(ref value, 0x7654321));
             Assert.Equal(0x02244220u, value);
         }
 
@@ -258,7 +258,7 @@ namespace System.Threading.Tests
         public void InterlockedAnd_Int64()
         {
             long value = 0x12345670;
-            Assert.Equal(0x02244220, Interlocked.And(ref value, 0x7654321));
+            Assert.Equal(0x12345670, Interlocked.And(ref value, 0x7654321));
             Assert.Equal(0x02244220, value);
         }
 
@@ -266,7 +266,7 @@ namespace System.Threading.Tests
         public void InterlockedAnd_UInt64()
         {
             ulong value = 0x12345670u;
-            Assert.Equal(0x02244220u, Interlocked.And(ref value, 0x7654321));
+            Assert.Equal(0x12345670u, Interlocked.And(ref value, 0x7654321));
             Assert.Equal(0x02244220u, value);
         }
 
@@ -274,7 +274,7 @@ namespace System.Threading.Tests
         public void InterlockedOr_Int32()
         {
             int value = 0x12345670;
-            Assert.Equal(0x17755771, Interlocked.Or(ref value, 0x7654321));
+            Assert.Equal(0x12345670, Interlocked.Or(ref value, 0x7654321));
             Assert.Equal(0x17755771, value);
         }
 
@@ -282,7 +282,7 @@ namespace System.Threading.Tests
         public void InterlockedOr_UInt32()
         {
             uint value = 0x12345670u;
-            Assert.Equal(0x17755771u, Interlocked.Or(ref value, 0x7654321));
+            Assert.Equal(0x12345670u, Interlocked.Or(ref value, 0x7654321));
             Assert.Equal(0x17755771u, value);
         }
 
@@ -290,7 +290,7 @@ namespace System.Threading.Tests
         public void InterlockedOr_Int64()
         {
             long value = 0x12345670;
-            Assert.Equal(0x17755771, Interlocked.Or(ref value, 0x7654321));
+            Assert.Equal(0x12345670, Interlocked.Or(ref value, 0x7654321));
             Assert.Equal(0x17755771, value);
         }
 
@@ -298,7 +298,7 @@ namespace System.Threading.Tests
         public void InterlockedOr_UInt64()
         {
             ulong value = 0x12345670u;
-            Assert.Equal(0x17755771u, Interlocked.Or(ref value, 0x7654321));
+            Assert.Equal(0x12345670u, Interlocked.Or(ref value, 0x7654321));
             Assert.Equal(0x17755771u, value);
         }
 


### PR DESCRIPTION
From [discussion in #33042](https://github.com/dotnet/runtime/pull/33042#discussion_r386962984) make `Interlocked.Or` and `Interlocked.And` return the original value instead of the updated one.

There aren't yet any usages in libraries that look at the returned value.

cc: @jkotas, @GrabYourPitchforks, @tannergooding