### PR TITLE
Added support for tests to check if they are running under the mono interpreter

### DIFF
--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -20,6 +20,7 @@ namespace System
 
         public static bool IsNetCore => RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
+        public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
 
@@ -200,6 +201,12 @@ namespace System
             }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));
+        }
+
+        private static bool GetIsRunningOnMonoInterpreter()
+        {
+            var val = Environment.GetEnvironmentVariable("MONO_ENV_OPTIONS");
+            return (val != null && val.Contains("--interpreter"));
         }
     }
 }

--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -205,6 +205,8 @@ namespace System
 
         private static bool GetIsRunningOnMonoInterpreter()
         {
+            // This is a temporary solution because mono does not support interpreter detection
+            // within the runtime.  
             var val = Environment.GetEnvironmentVariable("MONO_ENV_OPTIONS");
             return (val != null && val.Contains("--interpreter"));
         }


### PR DESCRIPTION
The mono interpreter is activated by passing --interpreter into the MONO_ENV_OPTIONS
environment variable.