### PR TITLE
Fixed heap corruption in HttpListener

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Net
 {
@@ -49,10 +50,10 @@ namespace System.Net
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_backingBuffer != IntPtr.Zero)
+            IntPtr backingBuffer = Interlocked.Exchange(ref _backingBuffer, IntPtr.Zero);
+            if (backingBuffer != IntPtr.Zero)
             {
-                Marshal.FreeHGlobal(_backingBuffer);
-                _backingBuffer = IntPtr.Zero;
+                Marshal.FreeHGlobal(backingBuffer);
             }
         }
 


### PR DESCRIPTION
Fixes #31997 

In non-blocking `HttpListenerResponse.Close`, `RequestContextBase` was being disposed multiple times from different threads. This fix ensures that the underlying `IntPtr` is freed only once, even in multi-threaded scenarios.

Full explanation here: https://github.com/dotnet/runtime/issues/31997#issuecomment-594020740