### PR TITLE
Update bootstrapped SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.1.20112.7"
+    "dotnet": "5.0.100-preview.2.20153.3"
   },
   "native-tools": {
     "cmake": "3.14.2",


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32764

Updating the bootstrapped SDK to fix a [NuGet restore issue during EvaluateCacheFile](https://github.com/NuGet/Home/issues/9199).