### PR TITLE
WIP: draft - compile and run src/mono/mono/tests tests

### DIFF
--- a/src/mono/mono-test.proj
+++ b/src/mono/mono-test.proj
@@ -7,14 +7,53 @@
     <MonoObjTestsDir>$(MonoObjDir)mono/tests/</MonoObjTestsDir>
   </PropertyGroup>
 
+  <!-- stolen from src/coreclr/tests/src/Directory.Build.props and modified -->
+  <PropertyGroup>
+    <BaseOutputPath>$(ArtifactsDir)\tests\mono</BaseOutputPath>
+    <BaseOutputPath Condition="'$(__TestRootDir)' != ''">$(__TestRootDir)</BaseOutputPath>
+    <BaseOutputPathWithConfig>$(BaseOutputPath)\$(PlatformConfigPathPart)\</BaseOutputPathWithConfig>
+    <BinDir>$(BaseOutputPathWithConfig)</BinDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MonoTestSimpleCsprojTemplateTestDriver>$(MSBuildProjectDirectory)\mono\mini\TestDriver.cs</MonoTestSimpleCsprojTemplateTestDriver>
+    <!-- FIXME: Not sure if I need to set anything up so that Restore in this template does the right thing -->
+    <MonoTestsSimpleCsprojTemplate>
+      <![CDATA[
+<Project>
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <OutputPath>$(__MonoTestsSimpleCsprojTemplateOutputPath)</OutputPath>
+    <IntermediateOutputPath>$([System.IO.Path]::GetDirectoryName($(__MonoTestsSimpleCsprojPath)))\obj\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <ItemGroup>
+    <Compile Include="$(__MonoTestSimpleCsprojTemplateSourceFile)" />
+    <Compile Include="$(MonoTestSimpleCsprojTemplateTestDriver)" Condition="'$(__MonoTestSimpleCsprojTemplateTestType)' == 'TestDriver'" />
+  </ItemGroup>
+
+</Project>
+]]>
+    </MonoTestsSimpleCsprojTemplate>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- one item per test file -->
     <!-- FIXME: use globbing but exclude failing tests, tests comprised of multiple source files, etc -->
-    <MonoTests Include="mono\tests\array-12193.cs">
+    <MonoTests Include="$(MSBuildProjectDirectory)\mono\tests\array-12193.cs">
       <MonoTestType>SingleFile</MonoTestType>
       <MonoTestNeedsLibtest>false</MonoTestNeedsLibtest>
     </MonoTests>
-    <MonoTests Include="mono\tests\debug-casts.cs">
+    <MonoTests Include="$(MSBuildProjectDirectory)\mono\tests\debug-casts.cs">
       <MonoTestType>TestDriver</MonoTestType>
       <MonoTestNeedsLibtest>false</MonoTestNeedsLibtest>
     </MonoTests>
@@ -24,18 +63,33 @@
     <ItemGroup>
       <MonoTestsSimple Include="@(MonoTests)" Condition="'%(MonoTestType)' == 'SingleFile'" />
       <MonoTestsSimple Include="@(MonoTests)" Condition="'%(MonoTestType)' == 'TestDriver'" />
-      <MonoTestsSimpleBaseDir Include="@(MonoTestsSimple -> %(Filename))" />
-      <MonoTestsSimpleCsproj Include="@(MonoTestsSimple -> '%(Filename)\%(Filename).csproj')" />
+      <MonoTestsSimpleWithAttr Include="@(MonoTestsSimple)">
+	<ObjDir>$(MonoObjTestsDir)%(Filename)\</ObjDir>
+	<Csproj>$(MonoObjTestsDir)%(Filename)\%(Filename).csproj</Csproj>
+	<OutputDir>$(BinDir)\%(Filename)\</OutputDir>
+      </MonoTestsSimpleWithAttr>
     </ItemGroup>
   </Target>
-  
-  <Target Name="CompileMonoRuntimeTests" DependsOnTargets="SelectViableMonoRuntimeTests">
-    <Message Text="Compiling mono runtime tests" Importance="High" />
+
+  <Target Name="CreateSingleCsprojFileForMonoRuntimeTest">
+    <WriteLinesToFile File="$(__MonoTestsSimpleCsprojPath)" Lines="$(MonoTestsSimpleCsprojTemplate)" Overwrite="true" />
+  </Target>
+
+  <Target Name="CreateProjFilesForMonoRuntimeTests" DependsOnTargets="SelectViableMonoRuntimeTests">
+    <Message Text="Creating .csproj files for mono runtime tests" Importance="High" />
     <Message Text="Mono obj dir is $(MonoObjDir)" Importance="High" />
     <Message Text="Mono obj tests dir is $(MonoObjTestsDir)" Importance="High" />
-    <Message Text="There are @(MonoTests->Count()) tests, @(MonoTestsSimple->Count()) simple" Importance="High" />
-    <Message Text="  Csproj %(MonoTestsSimpleCsproj.Identity)" Importance="High" />
-    <!-- MakeDir Directories="$(MonoObjDir)" / -->
-    
+    <Message Text="There are @(MonoTests->Count()) tests, @(MonoTestsSimpleWithAttr->Count()) simple" Importance="High" />
+    <Message Text="  Csproj %(MonoTestsSimpleWithAttr.Csproj)" Importance="High" />
+    <Message Text="  Test obj dir full path %(MonoTestsSimpleWithAttr.ObjDir)" Importance="High" />
+    <MakeDir Directories="%(MonoTestsSimpleWithAttr.ObjDir)" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateSingleCsprojFileForMonoRuntimeTest" Properties="__MonoTestsSimpleCsprojTemplateOutputPath=%(MonoTestsSimpleWithAttr.OutputDir);__MonoTestsSimpleCsprojPath=%(MonoTestsSimpleWithAttr.Csproj);__MonoTestSimpleCsprojTemplateSourceFile=%(MonoTestsSimpleWithAttr.FullPath);__MonoTestSimpleCsprojTemplateTestType=%(MonoTestsSimpleWithAttr.MonoTestType)" />
+  </Target>
+  
+  <Target Name="CompileMonoRuntimeTests" DependsOnTargets="CreateProjFilesForMonoRuntimeTests">
+    <Message Text="Compiling mono runtime tests" Importance="High" />
+    <Message Text="There are @(MonoTests->Count()) tests, @(MonoTestsSimpleWithAttr->Count()) simple" Importance="High" />
+    <Message Text="  Csproj %(MonoTestsSimpleWithAttr.Csproj)" Importance="High" />
+    <MSBuild Projects="%(MonoTestsSimpleWithAttr.Csproj)" Targets="Restore;Build" />
   </Target>
 </Project>

--- a/src/mono/mono-test.proj
+++ b/src/mono/mono-test.proj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MonoTestSimpleCsprojTemplateTestDriver>$(MSBuildProjectDirectory)\mono\mini\TestDriver.cs</MonoTestSimpleCsprojTemplateTestDriver>
+    <MonoTestSimpleCsprojTemplateTestDriver>$(MonoProjectRoot)\mono\mini\TestDriver.cs</MonoTestSimpleCsprojTemplateTestDriver>
     <!-- FIXME: Not sure if I need to set anything up so that Restore in this template does the right thing -->
     <MonoTestsSimpleCsprojTemplate>
       <![CDATA[

--- a/src/mono/mono-test.proj
+++ b/src/mono/mono-test.proj
@@ -1,0 +1,41 @@
+<Project>
+  <Import Project="Directory.Build.props" />
+  <Import Project="Directory.Build.targets" />
+
+  <PropertyGroup>
+    <MonoObjDir>$(ArtifactsObjDir)mono/$(PlatformConfigPathPart)/</MonoObjDir>
+    <MonoObjTestsDir>$(MonoObjDir)mono/tests/</MonoObjTestsDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- one item per test file -->
+    <!-- FIXME: use globbing but exclude failing tests, tests comprised of multiple source files, etc -->
+    <MonoTests Include="mono\tests\array-12193.cs">
+      <MonoTestType>SingleFile</MonoTestType>
+      <MonoTestNeedsLibtest>false</MonoTestNeedsLibtest>
+    </MonoTests>
+    <MonoTests Include="mono\tests\debug-casts.cs">
+      <MonoTestType>TestDriver</MonoTestType>
+      <MonoTestNeedsLibtest>false</MonoTestNeedsLibtest>
+    </MonoTests>
+  </ItemGroup>
+
+  <Target Name="SelectViableMonoRuntimeTests">
+    <ItemGroup>
+      <MonoTestsSimple Include="@(MonoTests)" Condition="'%(MonoTestType)' == 'SingleFile'" />
+      <MonoTestsSimple Include="@(MonoTests)" Condition="'%(MonoTestType)' == 'TestDriver'" />
+      <MonoTestsSimpleBaseDir Include="@(MonoTestsSimple -> %(Filename))" />
+      <MonoTestsSimpleCsproj Include="@(MonoTestsSimple -> '%(Filename)\%(Filename).csproj')" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="CompileMonoRuntimeTests" DependsOnTargets="SelectViableMonoRuntimeTests">
+    <Message Text="Compiling mono runtime tests" Importance="High" />
+    <Message Text="Mono obj dir is $(MonoObjDir)" Importance="High" />
+    <Message Text="Mono obj tests dir is $(MonoObjTestsDir)" Importance="High" />
+    <Message Text="There are @(MonoTests->Count()) tests, @(MonoTestsSimple->Count()) simple" Importance="High" />
+    <Message Text="  Csproj %(MonoTestsSimpleCsproj.Identity)" Importance="High" />
+    <!-- MakeDir Directories="$(MonoObjDir)" / -->
+    
+  </Target>
+</Project>

--- a/src/mono/mono-test.proj
+++ b/src/mono/mono-test.proj
@@ -7,6 +7,16 @@
     <MonoObjTestsDir>$(MonoObjDir)mono/tests/</MonoObjTestsDir>
   </PropertyGroup>
 
+  <!-- stolen from mono.proj -->
+  <PropertyGroup>
+    <DotNetExec Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</DotNetExec>
+    <DotNetExec Condition="'$(DotNetExec)' == ''">dotnet</DotNetExec>
+    <LocalDotnetDir>$(RepoRoot).dotnet</LocalDotnetDir>
+    <LocalDotnet>$(LocalDotnetDir)\$(DotNetExec)</LocalDotnet>
+    <LocalMonoDotnetDir>$(RepoRoot).dotnet-mono</LocalMonoDotnetDir>
+    <LocalMonoDotnet>$(LocalMonoDotnetDir)\$(DotNetExec)</LocalMonoDotnet>
+  </PropertyGroup>
+
   <!-- stolen from src/coreclr/tests/src/Directory.Build.props and modified -->
   <PropertyGroup>
     <BaseOutputPath>$(ArtifactsDir)\tests\mono</BaseOutputPath>
@@ -22,6 +32,7 @@
       <![CDATA[
 <Project>
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -75,6 +86,10 @@
     <WriteLinesToFile File="$(__MonoTestsSimpleCsprojPath)" Lines="$(MonoTestsSimpleCsprojTemplate)" Overwrite="true" />
   </Target>
 
+  <!-- For each item in @(MonoTestsSimpleWithAttr) invoke the
+       CreateSingleCsprojFileForMonoRuntimeTest target passing each item's
+       metadata as __MonoTestSimpleCsProjTemplateXYZ properties which will
+       write the template out to each test's csproj file -->
   <Target Name="CreateProjFilesForMonoRuntimeTests" DependsOnTargets="SelectViableMonoRuntimeTests">
     <Message Text="Creating .csproj files for mono runtime tests" Importance="High" />
     <Message Text="Mono obj dir is $(MonoObjDir)" Importance="High" />
@@ -86,10 +101,35 @@
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateSingleCsprojFileForMonoRuntimeTest" Properties="__MonoTestsSimpleCsprojTemplateOutputPath=%(MonoTestsSimpleWithAttr.OutputDir);__MonoTestsSimpleCsprojPath=%(MonoTestsSimpleWithAttr.Csproj);__MonoTestSimpleCsprojTemplateSourceFile=%(MonoTestsSimpleWithAttr.FullPath);__MonoTestSimpleCsprojTemplateTestType=%(MonoTestsSimpleWithAttr.MonoTestType)" />
   </Target>
   
+  <!-- entrypoint: Create .csproj files for tests in src/mono/mono/tests/ in
+       artifacts/obj/mono/<platformconfig>/tests/ then compile the projects and put the results in
+       artifacts/tests/mono/<platformconfig>/ -->
   <Target Name="CompileMonoRuntimeTests" DependsOnTargets="CreateProjFilesForMonoRuntimeTests">
     <Message Text="Compiling mono runtime tests" Importance="High" />
     <Message Text="There are @(MonoTests->Count()) tests, @(MonoTestsSimpleWithAttr->Count()) simple" Importance="High" />
     <Message Text="  Csproj %(MonoTestsSimpleWithAttr.Csproj)" Importance="High" />
     <MSBuild Projects="%(MonoTestsSimpleWithAttr.Csproj)" Targets="Restore;Build" />
   </Target>
+
+  <!-- entrypoint: For each test in @(MonoTestsSimpleWithAttr) run its assembly in
+       artifacts/tests/mono/<platformconfig>/  using .dotnet-mono/dotnet -->
+  <!-- FIXME: actually we want some kinda xunit wrapper to run them so that we can:
+       1. disable tests that are not expected to work.
+       2. Don't fail on the first failing tests, batch up the results, handle timeouts/hangs, etc.
+  -->
+  <Target Name="RunMonoRuntimeTests" DependsOnTargets="SelectViableMonoRuntimeTests">
+    <ItemGroup>
+      <MonoTestsSimpleRunnable Include="@(MonoTestsSimpleWithAttr)">
+	<MainAssemblyPath>%(OutputDir)%(Filename).dll</MainAssemblyPath>
+      </MonoTestsSimpleRunnable>
+    </ItemGroup>
+    <Message Text="Preparing to execute mono runtime tests" Importance="High" />
+    <Message Text="  Assemblies %(MonoTestsSimpleRunnable.MainAssemblyPath)" Importance="High" />
+    <Message Text="  Missing %(MonoTestsSimpleRunnable.MainAssemblyPath)" Condition="!Exists(%(MonoTestsSimpleRunnable.MainAssemblyPath))" Importance="High" />
+    <PropertyGroup>
+      <DotNetCommandLine>$(LocalMonoDotnet)</DotNetCommandLine>
+    </PropertyGroup>
+    <Exec Command="$(DotNetCommandLine) %(MonoTestsSimpleRunnable.MainAssemblyPath)" WorkingDirectory="%(MonoTestsSimpleRunnable.OutputDir)" />
+  </Target>
+
 </Project>

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -80,6 +80,9 @@ aot-testhost-corefx:
 compile-tests-mono-runtime:
 	$(DOTNET) msbuild /t:CompileMonoRuntimeTests $(MONO_TEST_PROJ)
 
+run-tests-mono-runtime: patch-mono-dotnet
+	$(DOTNET) msbuild /t:RunMonoRuntimeTests $(MONO_TEST_PROJ)
+
 # run 'dotnet/performance' benchmarks
 # e.g. 'make run-benchmarks BenchmarksRepo=/prj/performance'
 # you can append BDN parameters at the end, e.g. ` -- --filter Burgers --keepFiles`

--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -20,6 +20,7 @@ ifeq ($(words $(wildcard ../../../artifacts/bin/testhost/*-*-*-*)), 1)
 endif
 
 MONO_PROJ=/p:CoreClrTestConfig=$(CORECLR_TESTS_CONFIG) /p:LibrariesTestConfig=$(LIBRARIES_TESTS_CONFIG) /p:Configuration=$(MONO_RUNTIME_CONFIG) ../mono.proj
+MONO_TEST_PROJ=/p:MonoRuntimeTestConfig=$(MONO_RUNTIME_CONFIG) /p:Configuration=$(MONO_RUNTIME_CONFIG) ../mono-test.proj
 
 # run sample using local .dotnet-mono
 # build it with .dotnet first in order to be able to use LLVM only for the actual sample
@@ -75,6 +76,9 @@ aot-tests-corefx:
 # precompile (AOT) all libraries inside testhost (it's used for libraries' tests)
 aot-testhost-corefx:
 	$(DOTNET) msbuild /t:PrecompileTesthostLibraries $(MONO_PROJ)
+
+compile-tests-mono-runtime:
+	$(DOTNET) msbuild /t:CompileMonoRuntimeTests $(MONO_TEST_PROJ)
 
 # run 'dotnet/performance' benchmarks
 # e.g. 'make run-benchmarks BenchmarksRepo=/prj/performance'


### PR DESCRIPTION
Early draft PR just to get some feedback on the overall approach.

Overall approach:
1. Find all the tests in `src/mono/mono/tests` that are "simple" - a simple test is just a single assembly (perhaps with a dependency on `src/mono/mono/mini/TestDriver.cs`) that uses an exit code to signal success or failure.  It doesn't have a dependency on `libtest.c` and it doesn't require special compilation.
2. Write out a `.csproj` file somewhere under `artifacts/obj/` for each simple test
3. Compile the `.csproj` - it will put a test assembly in `artifacts/tests/mono/os.platform.config/testName/testName.dll`
4. Separate target that invokes each `.dotnet-mono/dotnet .../testName/testName.dll` one by one

---

TODO:
- [ ] Move the item group listing all the tests to a separate .props file so that it's mostly data and separate from the build logic
- [ ] Tests that need `libtest.{so,dylib}`
   - [ ] Add a test type for simple tests that depend on `libtest.c`
   - [ ] Add a target that compiles `libtest.c` (probably by invoking `make -C mono/tests compile-libtest` or something like that)
   - [ ] Add a step to the .csproj that copies the libtest native library to each test that needs it
- [ ] Tests that are comprised of multiple files or assemblies
   - [ ] Add a test type that uses its own `.projitems` and `.targets` files - use those for multi-file tests - the .projitems will have all the extra `Compile` items and the `.targets` can hook into the build for any funny business.  Not sure if this is enough for tests that need to build multiple assemblies
   - [ ] Modify the .csproj template to import the .projitems and .targets
- [ ] Add an xunit runner wrapper.  Probably can borrow a lot of coreclr's logic from their xunit wrapper in  `src/coreclr/tests/src/runtest.proj` .   Or maybe it's less effort to take our babysitter python script and teach it to emit an xunit-compatible output file.  And something about exclusions.
- [ ] Figure out AOT
- [ ] Figure out Helix and the Azure Pipelines