### PR TITLE
Fix missing TransitionBlock methods

### DIFF
--- a/src/coreclr/src/vm/callingconvention.h
+++ b/src/coreclr/src/vm/callingconvention.h
@@ -212,7 +212,6 @@ struct TransitionBlock
         return offset >= ofsArgRegs && offset < (int) (ofsArgRegs + ARGUMENTREGISTERS_SIZE);
     }
 
-#ifndef TARGET_X86
     static UINT GetArgumentIndexFromOffset(int offset)
     {
         LIMITED_METHOD_CONTRACT;
@@ -229,8 +228,6 @@ struct TransitionBlock
 
         return (offset - TransitionBlock::GetOffsetOfArgs()) / STACK_ELEM_SIZE;
     }
-
-#endif
 
 #ifdef CALLDESCR_FPARGREGS
     static BOOL IsFloatArgumentRegisterOffset(int offset)


### PR DESCRIPTION
`GetArgLoc` calls `IsStackArgumentOffset` and `GetStackArgumentIndexFromOffset`.

https://github.com/dotnet/runtime/blob/b3f81350c856cfd5079c52349024a8f55d0c009a/src/coreclr/src/vm/callingconvention.h#L215-L233

https://github.com/dotnet/runtime/blob/b3f81350c856cfd5079c52349024a8f55d0c009a/src/coreclr/src/vm/callingconvention.h#L549-L570