### PR TITLE
Add -msse2 compile option

### DIFF
--- a/src/coreclr/configurecompiler.cmake
+++ b/src/coreclr/configurecompiler.cmake
@@ -391,6 +391,10 @@ if(CLR_CMAKE_HOST_UNIX_ARM)
    endif(ARM_SOFTFP)
 endif(CLR_CMAKE_HOST_UNIX_ARM)
 
+if(CLR_CMAKE_HOST_UNIX_X86)
+  add_compile_options(-msse2)
+endif()
+
 if(CLR_CMAKE_HOST_UNIX)
   add_compile_options(${CLR_ADDITIONAL_COMPILER_OPTIONS})
 endif(CLR_CMAKE_HOST_UNIX)

--- a/src/coreclr/src/pal/inc/rt/cpp/emmintrin.h
+++ b/src/coreclr/src/pal/inc/rt/cpp/emmintrin.h
@@ -40,7 +40,7 @@ typedef char __v16qi __attribute__((__vector_size__(16)));
 
 
 /* Define the default attribute for the functions in this file. */
-#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, NODEBUG_ATTRIBUTE, __target__("sse2")))
+#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, NODEBUG_ATTRIBUTE))
 
 /// \brief Performs a bitwise OR of two 128-bit integer vectors.
 ///

--- a/src/coreclr/src/vm/nativeformatreader.h
+++ b/src/coreclr/src/vm/nativeformatreader.h
@@ -666,7 +666,11 @@ namespace NativeFormat
             return false;
         }
 
-        bool MayExist(UInt32 hashcode, UInt16 fingerprint)
+        bool
+#ifdef USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER
+        __attribute__((__target__("sse2")))
+#endif
+        MayExist(UInt32 hashcode, UInt16 fingerprint)
         {
             if ((_base == NULL) || (_disableFilter))
                 return true;

--- a/src/coreclr/src/vm/nativeformatreader.h
+++ b/src/coreclr/src/vm/nativeformatreader.h
@@ -667,7 +667,7 @@ namespace NativeFormat
         }
 
         bool
-#if defined(USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER) && defined(__GNUC__)
+#ifdef USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER
         __attribute__((__target__("sse2")))
 #endif
         MayExist(UInt32 hashcode, UInt16 fingerprint)

--- a/src/coreclr/src/vm/nativeformatreader.h
+++ b/src/coreclr/src/vm/nativeformatreader.h
@@ -667,7 +667,7 @@ namespace NativeFormat
         }
 
         bool
-#ifdef USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER
+#if defined(USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER) && defined(__GNUC__)
         __attribute__((__target__("sse2")))
 #endif
         MayExist(UInt32 hashcode, UInt16 fingerprint)

--- a/src/coreclr/src/vm/nativeformatreader.h
+++ b/src/coreclr/src/vm/nativeformatreader.h
@@ -666,11 +666,7 @@ namespace NativeFormat
             return false;
         }
 
-        bool
-#ifdef USE_INTEL_INTRINSICS_FOR_CUCKOO_FILTER
-        __attribute__((__target__("sse2")))
-#endif
-        MayExist(UInt32 hashcode, UInt16 fingerprint)
+        bool MayExist(UInt32 hashcode, UInt16 fingerprint)
         {
             if ((_base == NULL) || (_disableFilter))
                 return true;


### PR DESCRIPTION
```
~/runtime/src/coreclr/src/vm/nativeformatreader.h:688:31: error: always_inline function '_mm_loadu_si128' requires target feature 'sse2', but would
      be inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i bucketA = _mm_loadu_si128(&((__m128i*)_base)[bucketAIndex]);
                              ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:689:31: error: always_inline function '_mm_loadu_si128' requires target feature 'sse2', but would
      be inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i bucketB = _mm_loadu_si128(&((__m128i*)_base)[bucketBIndex]);
                              ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:690:39: error: always_inline function '_mm_set1_epi16' requires target feature 'sse2', but would
      be inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i fingerprintSIMD = _mm_set1_epi16(fingerprint);
                                      ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:691:38: error: always_inline function '_mm_cmpeq_epi16' requires target feature 'sse2', but would
      be inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i bucketACompare = _mm_cmpeq_epi16(bucketA, fingerprintSIMD);
                                     ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:692:38: error: always_inline function '_mm_cmpeq_epi16' requires target feature 'sse2', but would
      be inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i bucketBCompare = _mm_cmpeq_epi16(bucketB, fingerprintSIMD);
                                     ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:693:35: error: always_inline function '_mm_or_si128' requires target feature 'sse2', but would be
      inlined into function 'MayExist' that is compiled without support for 'sse2'
            __m128i bothCompare = _mm_or_si128(bucketACompare, bucketBCompare);
                                  ^
~/runtime/src/coreclr/src/vm/nativeformatreader.h:694:22: error: always_inline function '_mm_movemask_epi8' requires target feature 'sse2', but
      would be inlined into function 'MayExist' that is compiled without support for 'sse2'
            return !!_mm_movemask_epi8(bothCompare);
```