### PR TITLE
Additional code coverage in System.Text.Json - no public constructors

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ConcurrentCollections.cs
@@ -11,8 +11,18 @@ namespace System.Text.Json.Serialization.Tests
         private GenericConcurrentQueuePrivateConstructor() { }
     }
 
+    public class GenericConcurrentQueueInternalConstructor<T> : ConcurrentQueue<T>
+    {
+        internal GenericConcurrentQueueInternalConstructor() { }
+    }
+
     public class GenericConcurrentStackPrivateConstructor<T> : ConcurrentStack<T>
     {
         private GenericConcurrentStackPrivateConstructor() { }
+    }
+
+    public class GenericConcurrentStackInternalConstructor<T> : ConcurrentStack<T>
+    {
+        internal GenericConcurrentStackInternalConstructor() { }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.ConcurrentCollections.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public class GenericConcurrentQueuePrivateConstructor<T> : ConcurrentQueue<T>
+    {
+        private GenericConcurrentQueuePrivateConstructor() { }
+    }
+
+    public class GenericConcurrentStackPrivateConstructor<T> : ConcurrentStack<T>
+    {
+        private GenericConcurrentStackPrivateConstructor() { }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -201,6 +201,11 @@ namespace System.Text.Json.Serialization.Tests
         private GenericIEnumerableWrapperPrivateConstructor() { }
     }
 
+    public class GenericIEnumerableWrapperInternalConstructor<T> : GenericIEnumerableWrapper<T>
+    {
+        internal GenericIEnumerableWrapperInternalConstructor() { }
+    }
+
     public class StringICollectionWrapper : ICollection<string>
     {
         private readonly List<string> _list = new List<string>();
@@ -382,6 +387,11 @@ namespace System.Text.Json.Serialization.Tests
         private GenericIListWrapperPrivateConstructor() { }
     }
 
+    public class GenericIListWrapperInternalConstructor<T> : GenericIListWrapper<T>
+    {
+        internal GenericIListWrapperInternalConstructor() { }
+    }
+
     public class GenericICollectionWrapper<T> : ICollection<T>
     {
         private readonly List<T> _list = new List<T>();
@@ -429,6 +439,11 @@ namespace System.Text.Json.Serialization.Tests
     public class GenericICollectionWrapperPrivateConstructor<T> : GenericICollectionWrapper<T>
     {
         private GenericICollectionWrapperPrivateConstructor() { }
+    }
+
+    public class GenericICollectionWrapperInternalConstructor<T> : GenericICollectionWrapper<T>
+    {
+        internal GenericICollectionWrapperInternalConstructor() { }
     }
 
     public class StringIReadOnlyCollectionWrapper : IReadOnlyCollection<string>
@@ -734,6 +749,11 @@ namespace System.Text.Json.Serialization.Tests
         private GenericISetWrapperPrivateConstructor() { }
     }
 
+    public class GenericISetWrapperInternalConstructor<T> : GenericISetWrapper<T>
+    {
+        internal GenericISetWrapperInternalConstructor() { }
+    }
+
     public class StringToStringIDictionaryWrapper : IDictionary<string, string>
     {
         private Dictionary<string, string> _dictionary = new Dictionary<string, string>();
@@ -884,6 +904,11 @@ namespace System.Text.Json.Serialization.Tests
     public class GenericIDictionaryWrapperPrivateConstructor<TKey, TValue> : GenericIDictionaryWrapper<TKey, TValue>
     {
         private GenericIDictionaryWrapperPrivateConstructor() { }
+    }
+
+    public class GenericIDictionaryWrapperInternalConstructor<TKey, TValue> : GenericIDictionaryWrapper<TKey, TValue>
+    {
+        internal GenericIDictionaryWrapperInternalConstructor() { }
     }
 
     public class GenericIDictonaryWrapperThreeGenericParameters<TKey, TValue, TUnused> : GenericIDictionaryWrapper<TKey, TValue> { }
@@ -1085,6 +1110,11 @@ namespace System.Text.Json.Serialization.Tests
         private StringToStringIReadOnlyDictionaryWrapperPrivateConstructor() { }
     }
 
+    public class StringToStringIReadOnlyDictionaryWrapperInternalConstructor : StringToStringIReadOnlyDictionaryWrapper
+    {
+        internal StringToStringIReadOnlyDictionaryWrapperInternalConstructor() { }
+    }
+
     public class StringListWrapper : List<string> { }
 
     class MyMyList<T> : GenericListWrapper<T>
@@ -1100,6 +1130,11 @@ namespace System.Text.Json.Serialization.Tests
     public class GenericListWrapperPrivateConstructor<T> : GenericListWrapper<T>
     {
         private GenericListWrapperPrivateConstructor() { }
+    }
+
+    public class GenericListWrapperInternalConstructor<T> : GenericListWrapper<T>
+    {
+        internal GenericListWrapperInternalConstructor() { }
     }
 
     public class StringStackWrapper : Stack<string>
@@ -1135,6 +1170,11 @@ namespace System.Text.Json.Serialization.Tests
         private GenericStackWrapperPrivateConstructor() { }
     }
 
+    public class GenericStackWrapperInternalConstructor<T> : GenericStackWrapper<T>
+    {
+        internal GenericStackWrapperInternalConstructor() { }
+    }
+
     public class StringQueueWrapper : Queue<string>
     {
         public StringQueueWrapper() { }
@@ -1166,6 +1206,11 @@ namespace System.Text.Json.Serialization.Tests
     public class GenericQueueWrapperPrivateConstructor<T> : GenericQueueWrapper<T>
     {
         private GenericQueueWrapperPrivateConstructor() { }
+    }
+
+    public class GenericQueueWrapperInternalConstructor<T> : GenericQueueWrapper<T>
+    {
+        internal GenericQueueWrapperInternalConstructor() { }
     }
 
     public class StringHashSetWrapper : HashSet<string>
@@ -1283,6 +1328,11 @@ namespace System.Text.Json.Serialization.Tests
     public class StringToGenericDictionaryWrapperPrivateConstructor<T> : StringToGenericDictionaryWrapper<T>
     {
         private StringToGenericDictionaryWrapperPrivateConstructor() { }
+    }
+
+    public class StringToGenericDictionaryWrapperInternalConstructor<T> : StringToGenericDictionaryWrapper<T>
+    {
+        internal StringToGenericDictionaryWrapperInternalConstructor() { }
     }
 
     public class StringToStringSortedDictionaryWrapper : SortedDictionary<string, string>

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -1080,6 +1080,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class StringToStringIReadOnlyDictionaryWrapperPrivateConstructor : StringToStringIReadOnlyDictionaryWrapper
+    {
+        private StringToStringIReadOnlyDictionaryWrapperPrivateConstructor() { }
+    }
+
     public class StringListWrapper : List<string> { }
 
     class MyMyList<T> : GenericListWrapper<T>

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -196,6 +196,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericIEnumerableWrapperPrivateConstructor<T> : GenericIEnumerableWrapper<T>
+    {
+        private GenericIEnumerableWrapperPrivateConstructor() { }
+    }
+
     public class StringICollectionWrapper : ICollection<string>
     {
         private readonly List<string> _list = new List<string>();
@@ -372,6 +377,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericIListWrapperPrivateConstructor<T> : GenericIListWrapper<T>
+    {
+        private GenericIListWrapperPrivateConstructor() { }
+    }
+
     public class GenericICollectionWrapper<T> : ICollection<T>
     {
         private readonly List<T> _list = new List<T>();
@@ -414,6 +424,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((ICollection<T>)_list).GetEnumerator();
         }
+    }
+
+    public class GenericICollectionWrapperPrivateConstructor<T> : GenericICollectionWrapper<T>
+    {
+        private GenericICollectionWrapperPrivateConstructor() { }
     }
 
     public class StringIReadOnlyCollectionWrapper : IReadOnlyCollection<string>
@@ -712,6 +727,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((ISet<T>)_hashset).GetEnumerator();
         }
+    }
+
+    public class GenericISetWrapperPrivateConstructor<T> : GenericISetWrapper<T>
+    {
+        private GenericISetWrapperPrivateConstructor() { }
     }
 
     public class StringToStringIDictionaryWrapper : IDictionary<string, string>
@@ -1072,6 +1092,11 @@ namespace System.Text.Json.Serialization.Tests
 
     public class GenericListWrapper<T> : List<T> { }
 
+    public class GenericListWrapperPrivateConstructor<T> : GenericListWrapper<T>
+    {
+        private GenericListWrapperPrivateConstructor() { }
+    }
+
     public class StringStackWrapper : Stack<string>
     {
         public StringStackWrapper() { }
@@ -1100,6 +1125,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericStackWrapperPrivateConstructor<T> : GenericStackWrapper<T>
+    {
+        private GenericStackWrapperPrivateConstructor() { }
+    }
+
     public class StringQueueWrapper : Queue<string>
     {
         public StringQueueWrapper() { }
@@ -1126,6 +1156,11 @@ namespace System.Text.Json.Serialization.Tests
                 Enqueue(item);
             }
         }
+    }
+
+    public class GenericQueueWrapperPrivateConstructor<T> : GenericQueueWrapper<T>
+    {
+        private GenericQueueWrapperPrivateConstructor() { }
     }
 
     public class StringHashSetWrapper : HashSet<string>
@@ -1238,6 +1273,11 @@ namespace System.Text.Json.Serialization.Tests
                 Add(item.Key, item.Value);
             }
         }
+    }
+
+    public class StringToGenericDictionaryWrapperPrivateConstructor<T> : StringToGenericDictionaryWrapper<T>
+    {
+        private StringToGenericDictionaryWrapperPrivateConstructor() { }
     }
 
     public class StringToStringSortedDictionaryWrapper : SortedDictionary<string, string>

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
@@ -154,6 +154,11 @@ namespace System.Text.Json.Serialization.Tests
         private WrapperForIEnumerablePrivateConstructor() { }
     }
 
+    public class WrapperForIEnumerableInternalConstructor : WrapperForIEnumerable
+    {
+        internal WrapperForIEnumerableInternalConstructor() { }
+    }
+
     public class WrapperForICollection : ICollection
     {
         private readonly List<object> _list = new List<object>();
@@ -188,6 +193,11 @@ namespace System.Text.Json.Serialization.Tests
     public class WrapperForICollectionPrivateConstructor : WrapperForICollection
     {
         private WrapperForICollectionPrivateConstructor() { }
+    }
+
+    public class WrapperForICollectionInternalConstructor : WrapperForICollection
+    {
+        internal WrapperForICollectionInternalConstructor() { }
     }
 
     public class ReadOnlyWrapperForIList : WrapperForIList
@@ -261,6 +271,10 @@ namespace System.Text.Json.Serialization.Tests
     {
         private WrapperForIListPrivateConstructor() { }
     }
+    public class WrapperForIListInternalConstructor : WrapperForIList
+    {
+        internal WrapperForIListInternalConstructor() { }
+    }
 
     public class WrapperForIDictionary : IDictionary
     {
@@ -321,6 +335,11 @@ namespace System.Text.Json.Serialization.Tests
     public class WrapperForIDictionaryPrivateConstructor : WrapperForIDictionary
     {
         private WrapperForIDictionaryPrivateConstructor() { }
+    }
+
+    public class WrapperForIDictionaryInternalConstructor : WrapperForIDictionary
+    {
+        internal WrapperForIDictionaryInternalConstructor() { }
     }
 
     public class StackWrapper : Stack

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
@@ -149,6 +149,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class WrapperForIEnumerablePrivateConstructor : WrapperForIEnumerable
+    {
+        private WrapperForIEnumerablePrivateConstructor() { }
+    }
+
     public class WrapperForICollection : ICollection
     {
         private readonly List<object> _list = new List<object>();
@@ -178,6 +183,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return _list.GetEnumerator();
         }
+    }
+
+    public class WrapperForICollectionPrivateConstructor : WrapperForICollection
+    {
+        private WrapperForICollectionPrivateConstructor() { }
     }
 
     public class ReadOnlyWrapperForIList : WrapperForIList
@@ -247,6 +257,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class WrapperForIListPrivateConstructor : WrapperForIList
+    {
+        private WrapperForIListPrivateConstructor() { }
+    }
+
     public class WrapperForIDictionary : IDictionary
     {
         private readonly Dictionary<string, object> _dictionary = new Dictionary<string, object>();
@@ -301,6 +316,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((IDictionary)_dictionary).GetEnumerator();
         }
+    }
+
+    public class WrapperForIDictionaryPrivateConstructor : WrapperForIDictionary
+    {
+        private WrapperForIDictionaryPrivateConstructor() { }
     }
 
     public class StackWrapper : Stack

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -40,7 +40,9 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData(typeof(GenericConcurrentQueuePrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericConcurrentQueueInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericConcurrentStackPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericConcurrentStackInternalConstructor<string>), @"[""1""]")]
         public static void Read_ConcurrentCollection_NoPublicConstructor_Throws(Type type, string json)
         {
             NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -42,8 +42,13 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Read_ConcurrentCollection_NoPublicConstructor_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentQueuePrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentStackPrivateConstructor<string>>(@"[""1""]"));
+            NotSupportedException ex;
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentQueuePrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericConcurrentQueuePrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentStackPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericConcurrentStackPrivateConstructor<string>).ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -37,11 +37,12 @@ namespace System.Text.Json.Serialization.Tests
 
             // Not supported. Not IList, and we don't detect the add method for this collection.
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ConcurrentBag<string>>(@"[""1""]"));
+        }
 
-            // Not supported. Collection must have a public constructor.
+        [Fact]
+        public static void Read_ConcurrentCollection_NoPublicConstructor_Throws()
+        {
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentQueuePrivateConstructor<string>>(@"[""1""]"));
-
-            // Not supported. Collection must have a public constructor.
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentStackPrivateConstructor<string>>(@"[""1""]"));
         }
     }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -29,30 +29,22 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("1", val);
         }
 
-        [Fact]
-        public static void Read_ConcurrentCollection_Throws()
+        [Theory]
+        [InlineData(typeof(BlockingCollection<string>), @"[""1""]")] // Not supported. Not IList, and we don't detect the add method for this collection.
+        [InlineData(typeof(ConcurrentBag<string>), @"[""1""]")] // Not supported. Not IList, and we don't detect the add method for this collection.
+        public static void Read_ConcurrentCollection_Throws(Type type, string json)
         {
-            NotSupportedException ex;
-
-            // Not supported. Not IList, and we don't detect the add method for this collection.
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<BlockingCollection<string>>(@"[""1""]"));
-            Assert.Contains(typeof(BlockingCollection<string>).ToString(), ex.Message);
-
-            // Not supported. Not IList, and we don't detect the add method for this collection.
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ConcurrentBag<string>>(@"[""1""]"));
-            Assert.Contains(typeof(ConcurrentBag<string>).ToString(), ex.Message);
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(type.ToString(), ex.Message);
         }
 
-        [Fact]
-        public static void Read_ConcurrentCollection_NoPublicConstructor_Throws()
+        [Theory]
+        [InlineData(typeof(GenericConcurrentQueuePrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericConcurrentStackPrivateConstructor<string>), @"[""1""]")]
+        public static void Read_ConcurrentCollection_NoPublicConstructor_Throws(Type type, string json)
         {
-            NotSupportedException ex;
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentQueuePrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericConcurrentQueuePrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentStackPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericConcurrentStackPrivateConstructor<string>).ToString(), ex.Message);
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(type.ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -37,6 +37,12 @@ namespace System.Text.Json.Serialization.Tests
 
             // Not supported. Not IList, and we don't detect the add method for this collection.
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ConcurrentBag<string>>(@"[""1""]"));
+
+            // Not supported. Collection must have a public constructor.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentQueuePrivateConstructor<string>>(@"[""1""]"));
+
+            // Not supported. Collection must have a public constructor.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericConcurrentStackPrivateConstructor<string>>(@"[""1""]"));
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.ConcurrentCollections.cs
@@ -32,11 +32,15 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Read_ConcurrentCollection_Throws()
         {
-            // Not supported. Not IList, and we don't detect the add method for this collection.
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<BlockingCollection<string>>(@"[""1""]"));
+            NotSupportedException ex;
 
             // Not supported. Not IList, and we don't detect the add method for this collection.
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ConcurrentBag<string>>(@"[""1""]"));
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<BlockingCollection<string>>(@"[""1""]"));
+            Assert.Contains(typeof(BlockingCollection<string>).ToString(), ex.Message);
+
+            // Not supported. Not IList, and we don't detect the add method for this collection.
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ConcurrentBag<string>>(@"[""1""]"));
+            Assert.Contains(typeof(ConcurrentBag<string>).ToString(), ex.Message);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1161,5 +1161,20 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("test", JsonSerializer.Deserialize<MyMyList<string>>(json).First());
             Assert.Equal("test", JsonSerializer.Deserialize<MyListString>(json).First());
         }
+
+        [Fact]
+        public static void Read_Generic_NoPublicConstructor_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericICollectionWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIListWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericISetWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIDictionaryWrapperPrivateConstructor<string, string>>(@"{""Key"":""Value""}"));
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericListWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericQueueWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericStackWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToGenericDictionaryWrapperPrivateConstructor<string>>(@"{""Key"":""Value""}"));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1165,17 +1165,37 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Read_Generic_NoPublicConstructor_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericICollectionWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIListWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericISetWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIDictionaryWrapperPrivateConstructor<string, string>>(@"{""Key"":""Value""}"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapperPrivateConstructor>(@"{""Key"":""Value""}"));
+            NotSupportedException ex;
 
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericListWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericQueueWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericStackWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToGenericDictionaryWrapperPrivateConstructor<string>>(@"{""Key"":""Value""}"));
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericIEnumerableWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericICollectionWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericICollectionWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIListWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericIListWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericISetWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericISetWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIDictionaryWrapperPrivateConstructor<string, string>>(@"{""Key"":""Value""}"));
+            Assert.Contains(typeof(GenericIDictionaryWrapperPrivateConstructor<string, string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapperPrivateConstructor>(@"{""Key"":""Value""}"));
+            Assert.Contains(typeof(StringToStringIReadOnlyDictionaryWrapperPrivateConstructor).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericListWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericListWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericQueueWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericQueueWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericStackWrapperPrivateConstructor<string>>(@"[""1""]"));
+            Assert.Contains(typeof(GenericStackWrapperPrivateConstructor<string>).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToGenericDictionaryWrapperPrivateConstructor<string>>(@"{""Key"":""Value""}"));
+            Assert.Contains(typeof(StringToGenericDictionaryWrapperPrivateConstructor<string>).ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1150,22 +1150,15 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains(typeof(StringToStringIReadOnlyDictionaryWrapper).ToString(), ex.Message);
         }
 
-        [Fact]
-        public static void ReadReadOnlyCollections_Throws()
+        [Theory]
+        [InlineData(typeof(ReadOnlyWrapperForIList), @"[""1"", ""2""]")]
+        [InlineData(typeof(ReadOnlyStringIListWrapper), @"[""1"", ""2""]")]
+        [InlineData(typeof(ReadOnlyStringICollectionWrapper), @"[""1"", ""2""]")]
+        [InlineData(typeof(ReadOnlyStringToStringIDictionaryWrapper), @"{""Key"":""key"",""Value"":""value""}")]
+        public static void ReadReadOnlyCollections_Throws(Type type, string json)
         {
-            NotSupportedException ex;
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIList>(@"[""1"", ""2""]"));
-            Assert.Contains(typeof(ReadOnlyWrapperForIList).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
-            Assert.Contains(typeof(ReadOnlyStringIListWrapper).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
-            Assert.Contains(typeof(ReadOnlyStringICollectionWrapper).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
-            Assert.Contains(typeof(ReadOnlyStringToStringIDictionaryWrapper).ToString(), ex.Message);
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(type.ToString(), ex.Message);
         }
 
         [Fact]
@@ -1180,40 +1173,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("test", JsonSerializer.Deserialize<MyListString>(json).First());
         }
 
-        [Fact]
-        public static void Read_Generic_NoPublicConstructor_Throws()
+        [Theory]
+        [InlineData(typeof(GenericIEnumerableWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericICollectionWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericIListWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericISetWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericIDictionaryWrapperPrivateConstructor<string, string>), @"{""Key"":""Value""}")]
+        [InlineData(typeof(StringToStringIReadOnlyDictionaryWrapperPrivateConstructor), @"{""Key"":""Value""}")]
+        [InlineData(typeof(GenericListWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericQueueWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericStackWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(StringToGenericDictionaryWrapperPrivateConstructor<string>), @"{""Key"":""Value""}")]
+        public static void Read_Generic_NoPublicConstructor_Throws(Type type, string json)
         {
-            NotSupportedException ex;
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericIEnumerableWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericICollectionWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericICollectionWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIListWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericIListWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericISetWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericISetWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIDictionaryWrapperPrivateConstructor<string, string>>(@"{""Key"":""Value""}"));
-            Assert.Contains(typeof(GenericIDictionaryWrapperPrivateConstructor<string, string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapperPrivateConstructor>(@"{""Key"":""Value""}"));
-            Assert.Contains(typeof(StringToStringIReadOnlyDictionaryWrapperPrivateConstructor).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericListWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericListWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericQueueWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericQueueWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericStackWrapperPrivateConstructor<string>>(@"[""1""]"));
-            Assert.Contains(typeof(GenericStackWrapperPrivateConstructor<string>).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToGenericDictionaryWrapperPrivateConstructor<string>>(@"{""Key"":""Value""}"));
-            Assert.Contains(typeof(StringToGenericDictionaryWrapperPrivateConstructor<string>).ToString(), ex.Message);
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(type.ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1135,19 +1135,37 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleTestClass_GenericWrappers_NoAddMethod_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIEnumerableWrapper>(SimpleTestClassWithStringIEnumerableWrapper.s_json));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyCollectionWrapper>(SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyListWrapper>(SimpleTestClassWithStringIReadOnlyListWrapper.s_json));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper>(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json));
+            NotSupportedException ex;
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIEnumerableWrapper>(SimpleTestClassWithStringIEnumerableWrapper.s_json));
+            Assert.Contains(typeof(StringIEnumerableWrapper).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyCollectionWrapper>(SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json));
+            Assert.Contains(typeof(StringIReadOnlyCollectionWrapper).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyListWrapper>(SimpleTestClassWithStringIReadOnlyListWrapper.s_json));
+            Assert.Contains(typeof(StringIReadOnlyListWrapper).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper>(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json));
+            Assert.Contains(typeof(StringToStringIReadOnlyDictionaryWrapper).ToString(), ex.Message);
         }
 
         [Fact]
         public static void ReadReadOnlyCollections_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIList>(@"[""1"", ""2""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
+            NotSupportedException ex;
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIList>(@"[""1"", ""2""]"));
+            Assert.Contains(typeof(ReadOnlyWrapperForIList).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
+            Assert.Contains(typeof(ReadOnlyStringIListWrapper).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
+            Assert.Contains(typeof(ReadOnlyStringICollectionWrapper).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
+            Assert.Contains(typeof(ReadOnlyStringToStringIDictionaryWrapper).ToString(), ex.Message);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1170,6 +1170,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIListWrapperPrivateConstructor<string>>(@"[""1""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericISetWrapperPrivateConstructor<string>>(@"[""1""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIDictionaryWrapperPrivateConstructor<string, string>>(@"{""Key"":""Value""}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapperPrivateConstructor>(@"{""Key"":""Value""}"));
 
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericListWrapperPrivateConstructor<string>>(@"[""1""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericQueueWrapperPrivateConstructor<string>>(@"[""1""]"));

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1132,22 +1132,43 @@ namespace System.Text.Json.Serialization.Tests
             obj.Verify();
         }
 
-        [Fact]
-        public static void ReadSimpleTestClass_GenericWrappers_NoAddMethod_Throws()
+        [Theory]
+        [MemberData(nameof(ReadSimpleTestClass_GenericWrappers_NoAddMethod))]
+        public static void ReadSimpleTestClass_GenericWrappers_NoAddMethod_Throws(Type type, string json, Type exceptionMessageType)
         {
-            NotSupportedException ex;
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(exceptionMessageType.ToString(), ex.Message);
+        }
 
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIEnumerableWrapper>(SimpleTestClassWithStringIEnumerableWrapper.s_json));
-            Assert.Contains(typeof(StringIEnumerableWrapper).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyCollectionWrapper>(SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json));
-            Assert.Contains(typeof(StringIReadOnlyCollectionWrapper).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyListWrapper>(SimpleTestClassWithStringIReadOnlyListWrapper.s_json));
-            Assert.Contains(typeof(StringIReadOnlyListWrapper).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper>(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json));
-            Assert.Contains(typeof(StringToStringIReadOnlyDictionaryWrapper).ToString(), ex.Message);
+        public static IEnumerable<object[]> ReadSimpleTestClass_GenericWrappers_NoAddMethod
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithStringIEnumerableWrapper),
+                    SimpleTestClassWithStringIEnumerableWrapper.s_json,
+                    typeof(StringIEnumerableWrapper)
+                };
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithStringIReadOnlyCollectionWrapper),
+                    SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json,
+                    typeof(StringIReadOnlyCollectionWrapper)
+                };
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithStringIReadOnlyListWrapper),
+                    SimpleTestClassWithStringIReadOnlyListWrapper.s_json,
+                    typeof(StringIReadOnlyListWrapper)
+                };
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper),
+                    SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json,
+                    typeof(StringToStringIReadOnlyDictionaryWrapper)
+                };
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1196,15 +1196,25 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData(typeof(GenericIEnumerableWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericIEnumerableWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericICollectionWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericICollectionWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericIListWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericIListWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericISetWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericISetWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericIDictionaryWrapperPrivateConstructor<string, string>), @"{""Key"":""Value""}")]
+        [InlineData(typeof(GenericIDictionaryWrapperInternalConstructor<string, string>), @"{""Key"":""Value""}")]
         [InlineData(typeof(StringToStringIReadOnlyDictionaryWrapperPrivateConstructor), @"{""Key"":""Value""}")]
+        [InlineData(typeof(StringToStringIReadOnlyDictionaryWrapperInternalConstructor), @"{""Key"":""Value""}")]
         [InlineData(typeof(GenericListWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericListWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericQueueWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericQueueWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(GenericStackWrapperPrivateConstructor<string>), @"[""1""]")]
+        [InlineData(typeof(GenericStackWrapperInternalConstructor<string>), @"[""1""]")]
         [InlineData(typeof(StringToGenericDictionaryWrapperPrivateConstructor<string>), @"{""Key"":""Value""}")]
+        [InlineData(typeof(StringToGenericDictionaryWrapperInternalConstructor<string>), @"{""Key"":""Value""}")]
         public static void Read_Generic_NoPublicConstructor_Throws(Type type, string json)
         {
             NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -487,9 +487,13 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData(typeof(WrapperForIEnumerablePrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForIEnumerableInternalConstructor), @"[""1""]")]
         [InlineData(typeof(WrapperForICollectionPrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForICollectionInternalConstructor), @"[""1""]")]
         [InlineData(typeof(WrapperForIListPrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForIListInternalConstructor), @"[""1""]")]
         [InlineData(typeof(WrapperForIDictionaryPrivateConstructor), @"{""Key"":""Value""}")]
+        [InlineData(typeof(WrapperForIDictionaryInternalConstructor), @"{""Key"":""Value""}")]
         public static void Read_NonGeneric_NoPublicConstructor_Throws(Type type, string json)
         {
             NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -464,5 +464,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
         }
+
+        [Fact]
+        public static void Read_NonGeneric_NoPublicConstructor_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIEnumerablePrivateConstructor>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForICollectionPrivateConstructor>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIListPrivateConstructor>(@"[""1""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIDictionaryPrivateConstructor>(@"{""Key"":""Value""}"));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -470,22 +470,15 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains(typeof(WrapperForICollection).ToString(), ex.Message);
         }
 
-        [Fact]
-        public static void Read_NonGeneric_NoPublicConstructor_Throws()
+        [Theory]
+        [InlineData(typeof(WrapperForIEnumerablePrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForICollectionPrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForIListPrivateConstructor), @"[""1""]")]
+        [InlineData(typeof(WrapperForIDictionaryPrivateConstructor), @"{""Key"":""Value""}")]
+        public static void Read_NonGeneric_NoPublicConstructor_Throws(Type type, string json)
         {
-            NotSupportedException ex;
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIEnumerablePrivateConstructor>(@"[""1""]"));
-            Assert.Contains(typeof(WrapperForIEnumerablePrivateConstructor).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForICollectionPrivateConstructor>(@"[""1""]"));
-            Assert.Contains(typeof(WrapperForICollectionPrivateConstructor).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIListPrivateConstructor>(@"[""1""]"));
-            Assert.Contains(typeof(WrapperForIListPrivateConstructor).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIDictionaryPrivateConstructor>(@"{""Key"":""Value""}"));
-            Assert.Contains(typeof(WrapperForIDictionaryPrivateConstructor).ToString(), ex.Message);
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(type.ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -458,16 +458,31 @@ namespace System.Text.Json.Serialization.Tests
             obj.Verify();
         }
 
-        [Fact]
-        public static void ReadSimpleTestClass_NonGenericWrappers_NoAddMethod_Throws()
+        [Theory]
+        [MemberData(nameof(ReadSimpleTestClass_NonGenericWrappers_NoAddMethod))]
+        public static void ReadSimpleTestClass_NonGenericWrappers_NoAddMethod_Throws(Type type, string json, Type exceptionMessageType)
         {
-            NotSupportedException ex;
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Contains(exceptionMessageType.ToString(), ex.Message);
+        }
 
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
-            Assert.Contains(typeof(WrapperForIEnumerable).ToString(), ex.Message);
-
-            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
-            Assert.Contains(typeof(WrapperForICollection).ToString(), ex.Message);
+        public static IEnumerable<object[]> ReadSimpleTestClass_NonGenericWrappers_NoAddMethod
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithIEnumerableWrapper),
+                    SimpleTestClassWithIEnumerableWrapper.s_json,
+                    typeof(WrapperForIEnumerable)
+                };
+                yield return new object[]
+                {
+                    typeof(SimpleTestClassWithICollectionWrapper),
+                    SimpleTestClassWithICollectionWrapper.s_json,
+                    typeof(WrapperForICollection)
+                };
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -468,10 +468,19 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Read_NonGeneric_NoPublicConstructor_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIEnumerablePrivateConstructor>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForICollectionPrivateConstructor>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIListPrivateConstructor>(@"[""1""]"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIDictionaryPrivateConstructor>(@"{""Key"":""Value""}"));
+            NotSupportedException ex;
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIEnumerablePrivateConstructor>(@"[""1""]"));
+            Assert.Contains(typeof(WrapperForIEnumerablePrivateConstructor).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForICollectionPrivateConstructor>(@"[""1""]"));
+            Assert.Contains(typeof(WrapperForICollectionPrivateConstructor).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIListPrivateConstructor>(@"[""1""]"));
+            Assert.Contains(typeof(WrapperForIListPrivateConstructor).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForIDictionaryPrivateConstructor>(@"{""Key"":""Value""}"));
+            Assert.Contains(typeof(WrapperForIDictionaryPrivateConstructor).ToString(), ex.Message);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -461,8 +461,13 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleTestClass_NonGenericWrappers_NoAddMethod_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
+            NotSupportedException ex;
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
+            Assert.Contains(typeof(WrapperForIEnumerable).ToString(), ex.Message);
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
+            Assert.Contains(typeof(WrapperForICollection).ToString(), ex.Message);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Serialization\SpanTests.cs" />
     <Compile Include="Serialization\Stream.ReadTests.cs" />
     <Compile Include="Serialization\Stream.WriteTests.cs" />
+    <Compile Include="Serialization\TestClasses.ConcurrentCollections.cs" />
     <Compile Include="Serialization\TestClasses.cs" />
     <Compile Include="Serialization\TestClasses.GenericCollections.cs" />
     <Compile Include="Serialization\TestClasses.ImmutableCollections.cs" />
@@ -140,9 +141,6 @@
     <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs">
       <Link>CommonTest\System\Buffers\ArrayBufferWriter.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Serialization\TestClasses.ConcurrentCollections.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -82,8 +82,8 @@
     <Compile Include="Serialization\SpanTests.cs" />
     <Compile Include="Serialization\Stream.ReadTests.cs" />
     <Compile Include="Serialization\Stream.WriteTests.cs" />
-    <Compile Include="Serialization\TestClasses.ConcurrentCollections.cs" />
     <Compile Include="Serialization\TestClasses.cs" />
+    <Compile Include="Serialization\TestClasses.ConcurrentCollections.cs" />
     <Compile Include="Serialization\TestClasses.GenericCollections.cs" />
     <Compile Include="Serialization\TestClasses.ImmutableCollections.cs" />
     <Compile Include="Serialization\TestClasses.NonGenericCollections.cs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -142,6 +142,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Serialization\TestClasses.ConcurrentCollections.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Part of #32341

Added tests covering cases where deserializing collections without a public, parameterless constructor should throw a `NotSupportedException`.