### PR TITLE
Enable HTTP/2 client cert authentication in WinHttpHandler

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -148,9 +148,11 @@ internal partial class Interop
 
         public const uint WINHTTP_OPTION_ASSURED_NON_BLOCKING_CALLBACKS = 111;
 
+        public const uint WINHTTP_OPTION_ENABLE_HTTP2_PLUS_CLIENT_CERT = 161;
         public const uint WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL = 133;
         public const uint WINHTTP_OPTION_HTTP_PROTOCOL_USED = 134;
         public const uint WINHTTP_PROTOCOL_FLAG_HTTP2 = 0x1;
+        public const uint WINHTTP_HTTP2_PLUS_CLIENT_CERT_FLAG = 0x1;
 
         public const uint WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET = 114;
         public const uint WINHTTP_OPTION_WEB_SOCKET_CLOSE_TIMEOUT = 115;

--- a/src/libraries/Common/tests/System/Net/Http/ByteAtATimeContent.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ByteAtATimeContent.cs
@@ -33,7 +33,11 @@ namespace System.Net.Http.Functional.Tests
             for (int i = 0; i < _length; i++)
             {
                 buffer[0] = (byte)i;
+#if !NETFRAMEWORK
                 await stream.WriteAsync(buffer);
+#else
+                await stream.WriteAsync(buffer, 0, buffer.Length);
+#endif
                 await stream.FlushAsync();
                 await Task.Delay(_millisecondDelayBetweenBytes);
             }

--- a/src/libraries/Common/tests/System/Net/Http/ByteAtATimeContent.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ByteAtATimeContent.cs
@@ -33,11 +33,7 @@ namespace System.Net.Http.Functional.Tests
             for (int i = 0; i < _length; i++)
             {
                 buffer[0] = (byte)i;
-#if !NETFRAMEWORK
                 await stream.WriteAsync(buffer);
-#else
-                await stream.WriteAsync(buffer, 0, buffer.Length);
-#endif
                 await stream.FlushAsync();
                 await Task.Delay(_millisecondDelayBetweenBytes);
             }

--- a/src/libraries/Common/tests/System/Net/Http/DefaultCredentialsTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/DefaultCredentialsTest.cs
@@ -336,11 +336,7 @@ namespace System.Net.Http.Functional.Tests
                     // Send a response in the JSON format that the client expects
                     string username = context.User.Identity.Name;
                     byte[] bytes = System.Text.Encoding.UTF8.GetBytes($"{{\"authenticated\": \"true\", \"user\": \"{username}\" }}");
-#if !NETFRAMEWORK
                     await context.Response.OutputStream.WriteAsync(bytes);
-#else
-                    await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
-#endif
 
                     context.Response.Close();
                 }

--- a/src/libraries/Common/tests/System/Net/Http/DefaultCredentialsTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/DefaultCredentialsTest.cs
@@ -335,7 +335,12 @@ namespace System.Net.Http.Functional.Tests
 
                     // Send a response in the JSON format that the client expects
                     string username = context.User.Identity.Name;
-                    await context.Response.OutputStream.WriteAsync(System.Text.Encoding.UTF8.GetBytes($"{{\"authenticated\": \"true\", \"user\": \"{username}\" }}"));
+                    byte[] bytes = System.Text.Encoding.UTF8.GetBytes($"{{\"authenticated\": \"true\", \"user\": \"{username}\" }}");
+#if !NETFRAMEWORK
+                    await context.Response.OutputStream.WriteAsync(bytes);
+#else
+                    await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
+#endif
 
                     context.Response.Close();
                 }

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -86,7 +86,7 @@ namespace System.Net.Test.Common
         public IPAddress Address { get; set; } = IPAddress.Loopback;
         public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
         public SslProtocols SslProtocols { get; set; } =
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
                 SslProtocols.Tls13 |
 #endif
                 SslProtocols.Tls12;

--- a/src/libraries/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2Frames.cs
@@ -548,10 +548,19 @@ namespace System.Net.Test.Common
             BinaryPrimitives.WriteUInt16BigEndian(buffer, checked((ushort)Origin.Length));
             buffer = buffer.Slice(2);
 
+#if !NETFRAMEWORK
             Encoding.ASCII.GetBytes(Origin, buffer);
             buffer = buffer.Slice(Origin.Length);
 
             Encoding.ASCII.GetBytes(AltSvc, buffer);
+#else
+            var tmpBuffer = Encoding.ASCII.GetBytes(Origin);
+            tmpBuffer.CopyTo(buffer);
+            buffer = buffer.Slice(Origin.Length);
+
+            tmpBuffer = Encoding.ASCII.GetBytes(AltSvc);
+            tmpBuffer.CopyTo(buffer);
+#endif
         }
 
         public override string ToString() => $"{base.ToString()}\n{nameof(Origin)}: {Origin}\n{nameof(AltSvc)}: {AltSvc}";

--- a/src/libraries/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2Frames.cs
@@ -548,19 +548,12 @@ namespace System.Net.Test.Common
             BinaryPrimitives.WriteUInt16BigEndian(buffer, checked((ushort)Origin.Length));
             buffer = buffer.Slice(2);
 
-#if !NETFRAMEWORK
-            Encoding.ASCII.GetBytes(Origin, buffer);
-            buffer = buffer.Slice(Origin.Length);
-
-            Encoding.ASCII.GetBytes(AltSvc, buffer);
-#else
             var tmpBuffer = Encoding.ASCII.GetBytes(Origin);
             tmpBuffer.CopyTo(buffer);
             buffer = buffer.Slice(Origin.Length);
 
             tmpBuffer = Encoding.ASCII.GetBytes(AltSvc);
             tmpBuffer.CopyTo(buffer);
-#endif
         }
 
         public override string ToString() => $"{base.ToString()}\n{nameof(Origin)}: {Origin}\n{nameof(AltSvc)}: {AltSvc}";

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -51,7 +51,7 @@ namespace System.Net.Test.Common
 
                     options.ServerCertificate = cert;
 
-                    options.ClientCertificateRequired = false;
+                    options.ClientCertificateRequired = httpOptions.ClientCertificateRequired;
 
                     sslStream.AuthenticateAsServerAsync(options, CancellationToken.None).Wait();
                 }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Functional.Tests;
 using System.Net.Security;
@@ -28,6 +27,7 @@ namespace System.Net.Test.Common
         private readonly byte[] _prefix;
         public string PrefixString => Encoding.UTF8.GetString(_prefix, 0, _prefix.Length);
         public bool IsInvalid => _connectionSocket == null;
+        public Stream Stream => _connectionStream;
 
         public Http2LoopbackConnection(Socket socket, Http2Options httpOptions)
         {

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -69,6 +69,10 @@ namespace System.Net.Test.Common
             {
                 throw new Exception("Connection stream closed while attempting to read connection preface.");
             }
+            else if (Text.Encoding.ASCII.GetString(_prefix).Contains("HTTP/1.1"))
+            {
+                throw new Exception("HTTP 1.1 request received.");
+            }
         }
 
         public async Task SendConnectionPrefaceAsync()

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -149,10 +149,8 @@ namespace System.Net.Test.Common
 
         public async Task<Frame> ReadFrameAsync(TimeSpan timeout)
         {
-            using (CancellationTokenSource timeoutCts = new CancellationTokenSource(timeout))
-            {
-                return await ReadFrameAsync(timeoutCts.Token).ConfigureAwait(false);
-            }
+            using CancellationTokenSource timeoutCts = new CancellationTokenSource(timeout);
+            return await ReadFrameAsync(timeoutCts.Token).ConfigureAwait(false);
         }
 
         private async Task<Frame> ReadFrameAsync(CancellationToken cancellationToken)

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -57,7 +57,7 @@ namespace System.Net.Test.Common
 
                     sslStream.AuthenticateAsServerAsync(options, CancellationToken.None).Wait();
 #else
-                    sslStream.AuthenticateAsServerAsync(cert, httpOptions.ClientCertificateRequired, httpOptions.SslProtocols, false).Wait();
+                    sslStream.AuthenticateAsServerAsync(cert, httpOptions.ClientCertificateRequired, httpOptions.SslProtocols, checkCertificateRevocation: false).Wait();
 #endif
                 }
 

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -181,9 +181,14 @@ namespace System.Net.Test.Common
             }
         }
 
-        public static async Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<Http2LoopbackServer, Task> serverFunc, int timeout = 60_000)
+        public static Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<Http2LoopbackServer, Task> serverFunc, int timeout = 60_000)
         {
-            using (var server = Http2LoopbackServer.CreateServer())
+            return CreateClientAndServerAsync(clientFunc, serverFunc, null, timeout);
+        }
+
+        public static async Task CreateClientAndServerAsync(Func<Uri, Task> clientFunc, Func<Http2LoopbackServer, Task> serverFunc, Http2Options http2Options, int timeout = 60_000)
+        {
+            using (var server = Http2LoopbackServer.CreateServer(http2Options ?? new Http2Options()))
             {
                 Task clientTask = clientFunc(server.Address);
                 Task serverTask = serverFunc(server);
@@ -196,6 +201,8 @@ namespace System.Net.Test.Common
     public class Http2Options : GenericLoopbackOptions
     {
         public int ListenBacklog { get; set; } = 1;
+
+        public bool ClientCertificateRequired { get; set; }
 
         public Http2Options()
         {

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -267,10 +267,6 @@ namespace System.Net.Test.Common
 
     public static class HttpVersion20
     {
-#if !NETFRAMEWORK
-        public static readonly Version Value = HttpVersion.Version20;
-#else
         public static readonly Version Value = new Version(2, 0);
-#endif
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -244,7 +244,7 @@ namespace System.Net.Test.Common
             }
         }
 
-        public override Version Version => HttpVersion.Version20;
+    public override Version Version => HttpVersion20.Value;
     }
 
     public enum ProtocolErrors
@@ -263,5 +263,14 @@ namespace System.Net.Test.Common
         ENHANCE_YOUR_CALM = 0xb,
         INADEQUATE_SECURITY = 0xc,
         HTTP_1_1_REQUIRED = 0xd
+    }
+
+    public static class HttpVersion20
+    {
+#if !NETFRAMEWORK
+        public static readonly Version Value = HttpVersion.Version20;
+#else
+        public static readonly Version Value = new Version(2, 0);
+#endif
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -39,8 +39,10 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SslProtocols.Tls, true)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
+#if !NETFRAMEWORK
         [InlineData(SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
         [InlineData(SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, true)]
+#endif
         [InlineData(SslProtocols.None, false)]
         [InlineData(SslProtocols.None, true)]
         public async Task SetDelegate_ConnectionSucceeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
@@ -64,7 +66,11 @@ namespace System.Net.Http.Functional.Tests
                     // restrictions on minimum TLS/SSL version
                     // We currently know that some platforms like Debian 10 OpenSSL
                     // will by default block < TLS 1.2
+#if !NETFRAMEWORK
                     handler.SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+#else
+                    handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+#endif
                 }
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
@@ -602,6 +602,12 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("Negotiate")]
         public async Task Credentials_ServerChallengesWithWindowsAuth_ClientSendsWindowsAuthHeader(string authScheme)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs
@@ -603,7 +603,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task Credentials_ServerChallengesWithWindowsAuth_ClientSendsWindowsAuthHeader(string authScheme)
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion.Version11)
+            if (UseVersion > HttpVersion.Version11)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -522,6 +522,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
         public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationTokenSource cancellationTokenSource)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion > HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -528,6 +528,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if !NETFRAMEWORK
         [OuterLoop("Uses Task.Delay")]
         [Theory]
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
@@ -556,6 +557,7 @@ namespace System.Net.Http.Functional.Tests
                     catch (Exception) { }
                 });
         }
+#endif
 
         private async Task ValidateClientCancellationAsync(Func<Task> clientBodyAsync)
         {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -87,7 +87,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(OneBoolAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseHeadersReceived_TaskCanceledQuickly(bool connectionClose, CancellationMode mode)
         {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true, CancellationMode.Token)]
         public async Task PostAsync_CancelDuringRequestContentSend_TaskCanceledQuickly(bool chunkedTransfer, CancellationMode mode)
         {
-            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && chunkedTransfer)
+            if (LoopbackServerFactory.Version >= HttpVersion20.Value && chunkedTransfer)
             {
                 // There is no chunked encoding in HTTP/2 and later
                 return;
@@ -80,7 +80,7 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(OneBoolAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseHeadersReceived_TaskCanceledQuickly(bool connectionClose, CancellationMode mode)
         {
-            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && connectionClose)
+            if (LoopbackServerFactory.Version >= HttpVersion20.Value && connectionClose)
             {
                 // There is no Connection header in HTTP/2 and later
                 return;
@@ -130,7 +130,7 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {
-            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && (chunkedTransfer || connectionClose))
+            if (LoopbackServerFactory.Version >= HttpVersion20.Value && (chunkedTransfer || connectionClose))
             {
                 // There is no chunked encoding or connection header in HTTP/2 and later
                 return;
@@ -186,7 +186,7 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(ThreeBools))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Unbuffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, bool readOrCopyToAsync)
         {
-            if (LoopbackServerFactory.Version >= HttpVersion.Version20 && (chunkedTransfer || connectionClose))
+            if (LoopbackServerFactory.Version >= HttpVersion20.Value && (chunkedTransfer || connectionClose))
             {
                 // There is no chunked encoding or connection header in HTTP/2 and later
                 return;
@@ -312,7 +312,7 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact]
         public async Task MaxConnectionsPerServer_WaitingConnectionsAreCancelable()
         {
-            if (LoopbackServerFactory.Version >= HttpVersion.Version20)
+            if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
                 // HTTP/2 does not use connection limits.
                 throw new SkipTestException("Not supported on HTTP/2 and later");

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -518,7 +518,7 @@ namespace System.Net.Http.Functional.Tests
 
 #if !NETFRAMEWORK
         [OuterLoop("Uses Task.Delay")]
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
         public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationTokenSource cancellationTokenSource)
         {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -97,6 +97,13 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
+
             using (HttpClient client = CreateHttpClient())
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http.Functional.Tests
             }
 
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }
@@ -98,7 +98,7 @@ namespace System.Net.Http.Functional.Tests
             }
 
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }
@@ -215,7 +215,7 @@ namespace System.Net.Http.Functional.Tests
             }
 
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }
@@ -278,7 +278,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task GetAsync_CancelPendingRequests_DoesntCancelReadAsyncOnResponseStream(CancellationMode mode, bool copyToAsync)
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -28,7 +28,11 @@ namespace System.Net.Http.Functional.Tests
     {
         public HttpClientHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [InlineData(false, CancellationMode.Token)]
         [InlineData(true, CancellationMode.Token)]
         public async Task PostAsync_CancelDuringRequestContentSend_TaskCanceledQuickly(bool chunkedTransfer, CancellationMode mode)
@@ -38,6 +42,13 @@ namespace System.Net.Http.Functional.Tests
                 // There is no chunked encoding in HTTP/2 and later
                 return;
             }
+
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
 
             var serverRelease = new TaskCompletionSource<bool>();
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -182,7 +193,11 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [MemberData(nameof(ThreeBools))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Unbuffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, bool readOrCopyToAsync)
         {
@@ -191,6 +206,13 @@ namespace System.Net.Http.Functional.Tests
                 // There is no chunked encoding or connection header in HTTP/2 and later
                 return;
             }
+
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
 
             using (HttpClient client = CreateHttpClient())
             {
@@ -237,14 +259,23 @@ namespace System.Net.Http.Functional.Tests
                 });
             }
         }
-
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [InlineData(CancellationMode.CancelPendingRequests, false)]
         [InlineData(CancellationMode.DisposeHttpClient, false)]
         [InlineData(CancellationMode.CancelPendingRequests, true)]
         [InlineData(CancellationMode.DisposeHttpClient, true)]
         public async Task GetAsync_CancelPendingRequests_DoesntCancelReadAsyncOnResponseStream(CancellationMode mode, bool copyToAsync)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             using (HttpClient client = CreateHttpClient())
             {
                 client.Timeout = Timeout.InfiniteTimeSpan;

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -28,11 +28,7 @@ namespace System.Net.Http.Functional.Tests
     {
         public HttpClientHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [InlineData(false, CancellationMode.Token)]
         [InlineData(true, CancellationMode.Token)]
         public async Task PostAsync_CancelDuringRequestContentSend_TaskCanceledQuickly(bool chunkedTransfer, CancellationMode mode)
@@ -200,11 +196,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [MemberData(nameof(ThreeBools))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Unbuffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, bool readOrCopyToAsync)
         {
@@ -266,11 +258,7 @@ namespace System.Net.Http.Functional.Tests
                 });
             }
         }
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [InlineData(CancellationMode.CancelPendingRequests, false)]
         [InlineData(CancellationMode.DisposeHttpClient, false)]
         [InlineData(CancellationMode.CancelPendingRequests, true)]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -114,13 +114,9 @@ namespace System.Net.Http.Functional.Tests
                         SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
                         if (serverExpectsClientCertificate)
                         {
-#if !NETFRAMEWORK
                             _output.WriteLine(
                                 "Client cert: {0}",
-                                ((X509Certificate2)sslStream.RemoteCertificate).GetNameInfo(X509NameType.SimpleName, false));
-#else
-                            _output.WriteLine("Client cert: {0}", sslStream.RemoteCertificate.Subject);
-#endif
+                                new X509Certificate2(sslStream.RemoteCertificate.Export(X509ContentType.Cert)).GetNameInfo(X509NameType.SimpleName, false));
                             Assert.Equal(cert, sslStream.RemoteCertificate);
                         }
                         else

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -73,9 +73,6 @@ namespace System.Net.Http.Functional.Tests
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             Assert.NotNull(cert);
             handler.ClientCertificates.Add(cert);
-//#if WINHTTPHANDLER_TEST
-            handler.ClientCertificateOption = ClientCertificateOption.Manual;
-//#endif
             Assert.True(handler.ClientCertificates.Contains(cert));
 
             return CreateHttpClient(handler);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -73,6 +73,9 @@ namespace System.Net.Http.Functional.Tests
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             Assert.NotNull(cert);
             handler.ClientCertificates.Add(cert);
+//#if WINHTTPHANDLER_TEST
+            handler.ClientCertificateOption = ClientCertificateOption.Manual;
+//#endif
             Assert.True(handler.ClientCertificates.Contains(cert));
 
             return CreateHttpClient(handler);
@@ -111,9 +114,13 @@ namespace System.Net.Http.Functional.Tests
                         SslStream sslStream = Assert.IsType<SslStream>(connection.Stream);
                         if (serverExpectsClientCertificate)
                         {
+#if !NETFRAMEWORK
                             _output.WriteLine(
                                 "Client cert: {0}",
                                 ((X509Certificate2)sslStream.RemoteCertificate).GetNameInfo(X509NameType.SimpleName, false));
+#else
+                            _output.WriteLine("Client cert: {0}", sslStream.RemoteCertificate.Subject);
+#endif
                             Assert.Equal(cert, sslStream.RemoteCertificate);
                         }
                         else

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -182,7 +182,11 @@ namespace System.Net.Http.Functional.Tests
 
         private string GetCookieValue(HttpRequestData request)
         {
+#if !NETFRAMEWORK
             if (LoopbackServerFactory.Version < HttpVersion.Version20)
+#else
+            if (LoopbackServerFactory.Version < HttpVersion20.Value)
+#endif
             {
                 // HTTP/1.x must have only one value.
                 return request.GetSingleHeaderValue("Cookie");
@@ -334,6 +338,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (HttpClient client = CreateHttpClient(handler))
                 {
+                    //System.Diagnostics.Debugger.Launch();
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<HttpRequestData> serverTask = server.HandleRequestAsync(
                         HttpStatusCode.OK, new HttpHeaderData[] { new HttpHeaderData("Set-Cookie", GetCookieHeaderValue(cookieName, cookieValue)) }, s_simpleContent);
@@ -603,7 +608,9 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { "ABC", "123", useCookies };
                 yield return new object[] { "Hello", "World", useCookies };
                 yield return new object[] { "foo", "bar", useCookies };
+#if !WINHTTPHANDLER_TEST
                 yield return new object[] { "Hello World", "value", useCookies };
+#endif
                 yield return new object[] { ".AspNetCore.Session", "RAExEmXpoCbueP_QYM", useCookies };
 
                 yield return new object[]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -608,7 +608,7 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { "ABC", "123", useCookies };
                 yield return new object[] { "Hello", "World", useCookies };
                 yield return new object[] { "foo", "bar", useCookies };
-#if !WINHTTPHANDLER_TEST
+#if !NETFRAMEWORK
                 yield return new object[] { "Hello World", "value", useCookies };
 #endif
                 yield return new object[] { ".AspNetCore.Session", "RAExEmXpoCbueP_QYM", useCookies };

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -338,7 +338,6 @@ namespace System.Net.Http.Functional.Tests
 
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    //System.Diagnostics.Debugger.Launch();
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
                     Task<HttpRequestData> serverTask = server.HandleRequestAsync(
                         HttpStatusCode.OK, new HttpHeaderData[] { new HttpHeaderData("Set-Cookie", GetCookieHeaderValue(cookieName, cookieValue)) }, s_simpleContent);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
@@ -95,11 +95,7 @@ namespace System.Net.Http.Functional.Tests
                     await connection.Writer.WriteAsync($"HTTP/1.1 200 OK\r\nContent-Encoding: {encodingName}\r\n\r\n");
                     using (Stream compressedStream = compress(connection.Stream))
                     {
-#if !NETFRAMEWORK
                         await compressedStream.WriteAsync(expectedContent);
-#else
-                        await compressedStream.WriteAsync(expectedContent, 0, expectedContent.Length);
-#endif
                     }
                 });
             });
@@ -140,11 +136,7 @@ namespace System.Net.Http.Functional.Tests
             var compressedContentStream = new MemoryStream();
             using (Stream s = compress(compressedContentStream))
             {
-#if !NETFRAMEWORK
                 await s.WriteAsync(expectedContent);
-#else
-                await s.WriteAsync(expectedContent, 0, expectedContent.Length);
-#endif
             }
             byte[] compressedContent = compressedContentStream.ToArray();
 
@@ -162,13 +154,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await connection.ReadRequestHeaderAsync();
                     string text = $"HTTP/1.1 200 OK\r\nContent-Encoding: {encodingName}\r\n\r\n";
-#if !NETFRAMEWORK
                     await connection.Writer.WriteAsync(text);
                     await connection.Stream.WriteAsync(compressedContent);
-#else
-                    await connection.Writer.WriteAsync(text.ToCharArray(), 0, text.Length);
-                    await connection.Stream.WriteAsync(compressedContent, 0, compressedContent.Length);
-#endif
                 });
             });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
@@ -153,8 +153,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestHeaderAsync();
-                    string text = $"HTTP/1.1 200 OK\r\nContent-Encoding: {encodingName}\r\n\r\n";
-                    await connection.Writer.WriteAsync(text);
+                    await connection.Writer.WriteAsync($"HTTP/1.1 200 OK\r\nContent-Encoding: {encodingName}\r\n\r\n");
                     await connection.Stream.WriteAsync(compressedContent);
                 });
             });

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -55,7 +55,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task SetAfterUse_Throws()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -7,6 +7,7 @@ using System.Net.Test.Common;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -46,9 +47,19 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task SetAfterUse_Throws()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using HttpClientHandler handler = CreateHttpClientHandler();

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -47,11 +47,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task SetAfterUse_Throws()
         {
 #if WINHTTPHANDLER_TEST

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -26,11 +26,7 @@ namespace System.Net.Http.Functional.Tests
     {
         public HttpClientHandler_Proxy_Test(ITestOutputHelper output) : base(output) { }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task Dispose_HandlerWithProxy_ProxyNotDisposed()
         {
 #if WINHTTPHANDLER_TEST

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -26,9 +26,19 @@ namespace System.Net.Http.Functional.Tests
     {
         public HttpClientHandler_Proxy_Test(ITestOutputHelper output) : base(output) { }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task Dispose_HandlerWithProxy_ProxyNotDisposed()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             var proxy = new TrackDisposalProxy();
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task Dispose_HandlerWithProxy_ProxyNotDisposed()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion20.Value && !PlatformDetection.IsWindows10Version1607OrGreater)
+            if (UseVersion >= HttpVersion20.Value)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http.Functional.Tests
         public void Ctor_ExpectedDefaultValues()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion.Version11)
+            if (UseVersion > HttpVersion.Version11)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }
@@ -51,7 +51,7 @@ namespace System.Net.Http.Functional.Tests
         public void ServerCertificateCustomValidationCallback_SetGet_Roundtrips()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion.Version11)
+            if (UseVersion > HttpVersion.Version11)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -13,6 +13,7 @@ using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,9 +31,15 @@ namespace System.Net.Http.Functional.Tests
 
         public HttpClientHandler_ServerCertificates_Test(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
+        [ConditionalFact]
         public void Ctor_ExpectedDefaultValues()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             using (HttpClientHandler handler = CreateHttpClientHandler())
             {
                 Assert.Null(handler.ServerCertificateCustomValidationCallback);
@@ -40,9 +47,16 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void ServerCertificateCustomValidationCallback_SetGet_Roundtrips()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
+
             using (HttpClientHandler handler = CreateHttpClientHandler())
             {
                 Assert.Null(handler.ServerCertificateCustomValidationCallback);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -43,11 +43,13 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SslProtocols.Tls11 | SslProtocols.Tls12)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls12)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
+#if !NETFRAMEWORK
         [InlineData(SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls11 | SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls13)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13)]
+#endif
         public void SetGetProtocols_Roundtrips(SslProtocols protocols)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())
@@ -90,7 +92,9 @@ namespace System.Net.Http.Functional.Tests
 #pragma warning disable 0618
             if (PlatformDetection.SupportsSsl3)
             {
+#if !NETFRAMEWORK
                 yield return new object[] { SslProtocols.Ssl3, true };
+#endif
             }
             if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater)
             {
@@ -100,8 +104,10 @@ namespace System.Net.Http.Functional.Tests
             // These protocols are new, and might not be enabled everywhere yet
             if (PlatformDetection.IsUbuntu1810OrHigher)
             {
+#if !NETFRAMEWORK
                 yield return new object[] { SslProtocols.Tls13, false };
                 yield return new object[] { SslProtocols.Tls13, true };
+#endif
             }
         }
 
@@ -124,7 +130,11 @@ namespace System.Net.Http.Functional.Tests
                     // restrictions on minimum TLS/SSL version
                     // We currently know that some platforms like Debian 10 OpenSSL
                     // will by default block < TLS 1.2
+#if !NETFRAMEWORK
                     handler.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
+#else
+                    handler.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+#endif
                 }
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -757,7 +757,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task PostAsync_ManyDifferentRequestHeaders_SentCorrectly()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion.Version11)
+            if (UseVersion > HttpVersion.Version11)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2244,6 +2244,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if !NETFRAMEWORK
         [OuterLoop("Uses external server")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task PostAsync_ReuseRequestContent_Success(Configuration.Http.RemoteServer remoteServer)
@@ -2262,6 +2263,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+#endif
 
         [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
@@ -2415,6 +2417,12 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SendAsync_RequestVersion10_ServerReceivesVersion10Request()
         {
+            // Test is not supported for WinHttpHandler and HTTP/2
+            if(IsWinHttpHandler && UseVersion >= HttpVersion20.Value)
+            {
+                return;
+            }
+
             Version receivedRequestVersion = await SendRequestAndGetRequestVersionAsync(new Version(1, 0));
             Assert.Equal(new Version(1, 0), receivedRequestVersion);
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -735,9 +735,15 @@ namespace System.Net.Http.Functional.Tests
                    server.AcceptConnectionSendCustomResponseAndCloseAsync("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhe"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PostAsync_ManyDifferentRequestHeaders_SentCorrectly()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             const string content = "hello world";
 
             // Using examples from https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -226,6 +226,12 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact]
         public async Task GetAsync_IPv6LinkLocalAddressUri_Success()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             using (HttpClient client = CreateHttpClient())
             {
                 var options = new GenericLoopbackOptions { Address = TestHelper.GetIPv6LinkLocalAddress() };
@@ -1265,6 +1271,12 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(null)]
         public async Task ReadAsStreamAsync_HandlerProducesWellBehavedResponseStream(bool? chunked)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             if (LoopbackServerFactory.Version >= HttpVersion20.Value && chunked == true)
             {
                 throw new SkipTestException("Chunking is not supported on HTTP/2 and later.");
@@ -1415,9 +1427,19 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task ReadAsStreamAsync_EmptyResponseBody_HandlerProducesWellBehavedResponseStream()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using (var client = new HttpMessageInvoker(CreateHttpClientHandler()))
@@ -1500,10 +1522,19 @@ namespace System.Net.Http.Functional.Tests
             },
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
-
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateServerAsync(async (server1, url1) =>
             {
                 await LoopbackServerFactory.CreateServerAsync(async (server2, url2) =>
@@ -2551,12 +2582,22 @@ namespace System.Net.Http.Functional.Tests
 
             return receivedRequestVersion;
         }
-#endregion
+        #endregion
 
-#region Uri wire transmission encoding tests
+        #region Uri wire transmission encoding tests
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task SendRequest_UriPathHasReservedChars_ServerReceivedExpectedPath()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateServerAsync(async (server, rootUrl) =>
             {
                 var uri = new Uri($"{rootUrl.Scheme}://{rootUrl.Host}:{rootUrl.Port}/test[]");

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -250,11 +250,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
         public async Task GetAsync_IPBasedUri_Success(IPAddress address)
         {
@@ -572,11 +568,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [InlineData("WWW-Authenticate", "CustomAuth")]
         [InlineData("", "")] // RFC7235 requires servers to send this header with 401 but some servers don't.
         public async Task GetAsync_ServerNeedsNonStandardAuthAndSetCredential_StatusCodeUnauthorized(string authHeadrName, string authHeaderValue)
@@ -1447,11 +1439,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task ReadAsStreamAsync_EmptyResponseBody_HandlerProducesWellBehavedResponseStream()
         {
 #if WINHTTPHANDLER_TEST
@@ -1542,11 +1530,7 @@ namespace System.Net.Http.Functional.Tests
             },
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task Dispose_DisposingHandlerCancelsActiveOperationsWithoutResponses()
         {
 #if WINHTTPHANDLER_TEST
@@ -1917,11 +1901,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task GetAsync_ExpectContinueTrue_NoContent_StillSendsHeader()
         {
 #if WINHTTPHANDLER_TEST
@@ -1966,11 +1946,7 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { (HttpStatusCode) 199 };
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [MemberData(nameof(Interim1xxStatusCode))]
         public async Task SendAsync_1xxResponsesWithHeaders_InterimResponsesHeadersIgnored(HttpStatusCode responseStatusCode)
         {
@@ -2040,11 +2016,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalTheory]
-#else
-        [Theory]
-#endif
         [MemberData(nameof(Interim1xxStatusCode))]
         public async Task SendAsync_Unexpected1xxResponses_DropAllInterimResponses(HttpStatusCode responseStatusCode)
         {
@@ -2090,11 +2062,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task SendAsync_MultipleExpected100Responses_ReceivesCorrectResponse()
         {
 #if WINHTTPHANDLER_TEST
@@ -2139,11 +2107,7 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task SendAsync_No100ContinueReceived_RequestBodySentEventually()
         {
 #if WINHTTPHANDLER_TEST
@@ -2578,11 +2542,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task SendAsync_RequestVersion20_HttpNotHttps_NoUpgradeRequest()
         {
 #if WINHTTPHANDLER_TEST
@@ -2665,11 +2625,7 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Uri wire transmission encoding tests
-#if WINHTTPHANDLER_TEST
         [ConditionalFact]
-#else
-        [Fact]
-#endif
         public async Task SendRequest_UriPathHasReservedChars_ServerReceivedExpectedPath()
         {
 #if WINHTTPHANDLER_TEST

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -250,10 +250,20 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [MemberData(nameof(GetAsync_IPBasedUri_Success_MemberData))]
         public async Task GetAsync_IPBasedUri_Success(IPAddress address)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             using (HttpClient client = CreateHttpClient())
             {
                 var options = new GenericLoopbackOptions { Address = address };
@@ -562,11 +572,21 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [InlineData("WWW-Authenticate", "CustomAuth")]
         [InlineData("", "")] // RFC7235 requires servers to send this header with 401 but some servers don't.
         public async Task GetAsync_ServerNeedsNonStandardAuthAndSetCredential_StatusCodeUnauthorized(string authHeadrName, string authHeaderValue)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();
@@ -1897,9 +1917,19 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task GetAsync_ExpectContinueTrue_NoContent_StillSendsHeader()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             const string ExpectedContent = "Hello, expecting and continuing world.";
             var clientCompleted = new TaskCompletionSource<bool>();
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -1936,10 +1966,20 @@ namespace System.Net.Http.Functional.Tests
             yield return new object[] { (HttpStatusCode) 199 };
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [MemberData(nameof(Interim1xxStatusCode))]
         public async Task SendAsync_1xxResponsesWithHeaders_InterimResponsesHeadersIgnored(HttpStatusCode responseStatusCode)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             var clientFinished = new TaskCompletionSource<bool>();
             const string TestString = "test";
             const string CookieHeaderExpected = "yummy_cookie=choco";
@@ -2000,10 +2040,20 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalTheory]
+#else
         [Theory]
+#endif
         [MemberData(nameof(Interim1xxStatusCode))]
         public async Task SendAsync_Unexpected1xxResponses_DropAllInterimResponses(HttpStatusCode responseStatusCode)
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             var clientFinished = new TaskCompletionSource<bool>();
             const string TestString = "test";
 
@@ -2040,9 +2090,19 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task SendAsync_MultipleExpected100Responses_ReceivesCorrectResponse()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             var clientFinished = new TaskCompletionSource<bool>();
             const string TestString = "test";
 
@@ -2079,9 +2139,19 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task SendAsync_No100ContinueReceived_RequestBodySentEventually()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             var clientFinished = new TaskCompletionSource<bool>();
             const string RequestString = "request";
             const string ResponseString = "response";
@@ -2508,9 +2578,19 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+#if WINHTTPHANDLER_TEST
+        [ConditionalFact]
+#else
         [Fact]
+#endif
         public async Task SendAsync_RequestVersion20_HttpNotHttps_NoUpgradeRequest()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion20.Value)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using (HttpClient client = CreateHttpClient())

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -32,13 +32,21 @@ namespace System.Net.Http.Functional.Tests
         protected virtual HttpClient CreateHttpClient() => CreateHttpClient(CreateHttpClientHandler());
 
         protected HttpClient CreateHttpClient(HttpMessageHandler handler) =>
-            new HttpClient(handler) { DefaultRequestVersion = UseVersion };
+            new HttpClient(handler) {
+#if !NETFRAMEWORK
+                DefaultRequestVersion = UseVersion
+#endif
+            };
 
         protected static HttpClient CreateHttpClient(string useVersionString) =>
             CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>
-            new HttpClient(handler) { DefaultRequestVersion = Version.Parse(useVersionString) };
+            new HttpClient(handler) {
+#if !NETFRAMEWORK
+                DefaultRequestVersion = Version.Parse(useVersionString)
+#endif
+            };
 
         protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion);
 
@@ -51,7 +59,7 @@ namespace System.Net.Http.Functional.Tests
         {
             return useVersion.Major switch
             {
-#if NETCOREAPP
+#if NETCOREAPP || WINHTTPHANDLER_TEST
 #if HTTP3
                 3 => Http3LoopbackServerFactory.Singleton,
 #endif
@@ -81,7 +89,11 @@ namespace System.Net.Http.Functional.Tests
                 wrappedHandler = new VersionCheckerHttpHandler(httpClientHandler, remoteServer.HttpVersion);
             }
 
-            return new HttpClient(wrappedHandler) { DefaultRequestVersion = remoteServer.HttpVersion };
+            return new HttpClient(wrappedHandler) {
+#if !NETFRAMEWORK
+                DefaultRequestVersion = remoteServer.HttpVersion
+#endif
+            };
         }
 
         private sealed class VersionCheckerHttpHandler : DelegatingHandler

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http.Functional.Tests
 #endif
             };
 
-        protected static HttpClient CreateHttpClient(string useVersionString) =>
+        protected HttpClient CreateHttpClient(string useVersionString) =>
             CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>
@@ -50,7 +50,7 @@ namespace System.Net.Http.Functional.Tests
 
         protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion);
 
-        protected static HttpClientHandler CreateHttpClientHandler(string useVersionString) =>
+        protected HttpClientHandler CreateHttpClientHandler(string useVersionString) =>
             CreateHttpClientHandler(Version.Parse(useVersionString));
 
         protected LoopbackServerFactory LoopbackServerFactory => GetFactoryForVersion(UseVersion);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http.Functional.Tests
 #endif
             };
 
-        protected HttpClient CreateHttpClient(string useVersionString) =>
+        protected static HttpClient CreateHttpClient(string useVersionString) =>
             CreateHttpClient(CreateHttpClientHandler(useVersionString), useVersionString);
 
         protected static HttpClient CreateHttpClient(HttpMessageHandler handler, string useVersionString) =>
@@ -50,7 +50,7 @@ namespace System.Net.Http.Functional.Tests
 
         protected HttpClientHandler CreateHttpClientHandler() => CreateHttpClientHandler(UseVersion);
 
-        protected HttpClientHandler CreateHttpClientHandler(string useVersionString) =>
+        protected static HttpClientHandler CreateHttpClientHandler(string useVersionString) =>
             CreateHttpClientHandler(Version.Parse(useVersionString));
 
         protected LoopbackServerFactory LoopbackServerFactory => GetFactoryForVersion(UseVersion);

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -460,7 +460,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 using (HttpMessageInvoker client = new HttpMessageInvoker(CreateHttpClientHandler()))
-                using (HttpResponseMessage resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, CancellationToken.None))
+                using (HttpResponseMessage resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = base.UseVersion }, CancellationToken.None))
                 using (Stream respStream = await resp.Content.ReadAsStreamAsync())
                 {
                     var actualData = new MemoryStream();
@@ -491,12 +491,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await connection.ReadRequestHeaderAsync();
 
-                    string text = $"HTTP/1.1 200 OK{lineEnding}Transfer-Encoding: chunked{lineEnding}{lineEnding}";
-#if !NETFRAMEWORK
-                    await connection.Writer.WriteAsync(text);
-#else
-                    await connection.Writer.WriteAsync(text.ToCharArray(), 0, text.Length);
-#endif
+                    await connection.Writer.WriteAsync($"HTTP/1.1 200 OK{lineEnding}Transfer-Encoding: chunked{lineEnding}{lineEnding}");
                     for (int bytesSent = 0; bytesSent < expectedData.Length;)
                     {
                         int bytesRemaining = expectedData.Length - bytesSent;

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -502,11 +502,7 @@ namespace System.Net.Http.Functional.Tests
                         int bytesRemaining = expectedData.Length - bytesSent;
                         int bytesToSend = rand.Next(1, Math.Min(bytesRemaining, maxChunkSize + 1));
                         await connection.Writer.WriteAsync(bytesToSend.ToString("X") + lineEnding);
-#if !NETFRAMEWORK
                         await connection.Stream.WriteAsync(new Memory<byte>(expectedData, bytesSent, bytesToSend));
-#else
-                        await connection.Stream.WriteAsync(expectedData, bytesSent, bytesToSend);
-#endif
                         await connection.Writer.WriteAsync(lineEnding);
                         bytesSent += bytesToSend;
                     }

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -20,9 +20,15 @@ namespace System.Net.Http.Functional.Tests
 
         public HttpProtocolTests(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GetAsync_RequestVersion10_Success()
         {
+#if WINHTTPHANDLER_TEST
+            if (UseVersion >= HttpVersion.Version11)
+            {
+                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+            }
+#endif
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClient client = CreateHttpClient())

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -24,7 +24,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task GetAsync_RequestVersion10_Success()
         {
 #if WINHTTPHANDLER_TEST
-            if (UseVersion >= HttpVersion.Version11)
+            if (UseVersion > HttpVersion.Version11)
             {
                 throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
@@ -131,11 +131,7 @@ namespace System.Net.Http.Functional.Tests
                 _sendingContent.SetResult(true);
                 await _connectionClosed;
                 byte[] bytes = Encoding.UTF8.GetBytes(_longContent);
-#if !NETFRAMEWORK
                 await stream.WriteAsync(bytes);
-#else
-                await stream.WriteAsync(bytes, 0, bytes.Length);
-#endif
             }
 
             protected override bool TryComputeLength(out long length)

--- a/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
@@ -130,7 +130,12 @@ namespace System.Net.Http.Functional.Tests
             {
                 _sendingContent.SetResult(true);
                 await _connectionClosed;
-                await stream.WriteAsync(Encoding.UTF8.GetBytes(_longContent));
+                byte[] bytes = Encoding.UTF8.GetBytes(_longContent);
+#if !NETFRAMEWORK
+                await stream.WriteAsync(bytes);
+#else
+                await stream.WriteAsync(bytes, 0, bytes.Length);
+#endif
             }
 
             protected override bool TryComputeLength(out long length)

--- a/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpRetryProtocolTests.cs
@@ -130,8 +130,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 _sendingContent.SetResult(true);
                 await _connectionClosed;
-                byte[] bytes = Encoding.UTF8.GetBytes(_longContent);
-                await stream.WriteAsync(bytes);
+                await stream.WriteAsync(Encoding.UTF8.GetBytes(_longContent));
             }
 
             protected override bool TryComputeLength(out long length)

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -394,7 +394,7 @@ namespace System.Net.Test.Common
             {
                 UseSsl = false;
                 SslProtocols =
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
                 SslProtocols.Tls13 |
 #endif
                 SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
@@ -451,6 +451,11 @@ namespace System.Net.Test.Common
                 }
 
                 return readLength;
+#elif NETFRAMEWORK
+                var tmpBuffer = new byte[buffer.Length];
+                int readBytes = await _stream.ReadAsync(tmpBuffer, offset, size).ConfigureAwait(false);
+                tmpBuffer.CopyTo(buffer);
+                return readBytes;
 #else
                 return await _stream.ReadAsync(buffer.Slice(offset, size)).ConfigureAwait(false);
 #endif

--- a/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
@@ -28,6 +28,7 @@ namespace System.Net.Http.Functional.Tests
 
         public PostScenarioTest(ITestOutputHelper output) : base(output) { }
 
+#if !NETFRAMEWORK
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task PostRewindableStreamContentMultipleTimes_StreamContentFullySent(Configuration.Http.RemoteServer remoteServer)
@@ -50,6 +51,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+#endif
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]

--- a/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Numerics;
 using System.Text;
 
@@ -72,7 +73,12 @@ namespace System.Net.Test.Common
             }
 
             (int varIntLength, int stringLength) = DecodeInteger(buffer, prefixMask);
-            string value = Encoding.ASCII.GetString(buffer.Slice(varIntLength, stringLength));
+#if !NETFRAMEWORK
+            ReadOnlySpan<byte> bytes = buffer.Slice(varIntLength, stringLength);
+#else
+            byte[] bytes = buffer.Slice(varIntLength, stringLength).ToArray();
+#endif
+            string value = Encoding.ASCII.GetString(bytes);
 
             return (varIntLength + stringLength, value);
         }
@@ -203,6 +209,32 @@ namespace System.Net.Test.Common
             new HttpHeaderData("x-frame-options", "deny"),
             new HttpHeaderData("x-frame-options", "sameorigin"),
         };
-    }
 
+//#if NETFRAMEWORK
+        private static class BitOperations
+        {
+            public static int LeadingZeroCount(byte value)
+            {
+                int count = 0;
+                while ((value & 0b1000_0000) != 0)
+                {
+                    count++;
+                    value <<= 1;
+                }
+                return count;
+            }
+
+            public static int TrailingZeroCount(int value)
+            {
+                int count = 0;
+                while ((value & 1) != 0)
+                {
+                    count++;
+                    value >>= 1;
+                }
+                return count;
+            }
+        }
+//#endif
+    }
 }

--- a/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
@@ -210,7 +210,7 @@ namespace System.Net.Test.Common
             new HttpHeaderData("x-frame-options", "sameorigin"),
         };
 
-//#if NETFRAMEWORK
+#if NETFRAMEWORK
         private static class BitOperations
         {
             public static int LeadingZeroCount(byte value)
@@ -235,6 +235,6 @@ namespace System.Net.Test.Common
                 return count;
             }
         }
-//#endif
+#endif
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -80,7 +80,11 @@ namespace System.Net.Http.Functional.Tests
 
                         case 4:
                             // Individual calls to Read(Span)
+#if !NETFRAMEWORK
                             while ((bytesRead = stream.Read(new Span<byte>(buffer))) != 0)
+#else
+                            while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) != 0)
+#endif
                             {
                                 ms.Write(buffer, 0, bytesRead);
                             }
@@ -173,7 +177,9 @@ namespace System.Net.Http.Functional.Tests
             using (Stream stream = await client.GetStreamAsync(remoteServer.EchoUri))
             {
                 Assert.Equal(0, stream.Read(new byte[1], 0, 0));
+#if !NETFRAMEWORK
                 Assert.Equal(0, stream.Read(new Span<byte>(new byte[1], 0, 0)));
+#endif
                 Assert.Equal(0, await stream.ReadAsync(new byte[1], 0, 0));
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -227,7 +227,7 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
-
+#if NETCOREAPP
         [Theory]
         [InlineData(TransferType.ContentLength, TransferError.ContentLengthTooLarge)]
         [InlineData(TransferType.Chunked, TransferError.MissingChunkTerminator)]
@@ -255,6 +255,7 @@ namespace System.Net.Http.Functional.Tests
                 await ReadAsStreamHelper(uri);
             });
         }
+#endif
 
         public enum TransferType
         {

--- a/src/libraries/Common/tests/System/Net/StreamArrayExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/StreamArrayExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -22,6 +23,14 @@ namespace System.Net
         public static ValueTask WriteAsync(this StreamWriter writer, string text)
         {
             return new ValueTask(writer.WriteAsync(text.ToCharArray(), 0, text.Length));
+        }
+
+        public static ValueTask<int> ReadAsync(this Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            bool isArray = MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment);
+            Assert.True(isArray);
+
+            return new ValueTask<int>(stream.ReadAsync(segment.Array, segment.Offset, segment.Count, cancellationToken));
         }
     }
 }

--- a/src/libraries/Common/tests/System/Net/StreamArrayExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/StreamArrayExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net
+{
+    public static class StreamArrayExtensions
+    {
+        public static ValueTask WriteAsync(this Stream stream, ReadOnlyMemory<byte> memory)
+        {
+            bool isArray = MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment);
+            Assert.True(isArray);
+
+            return new ValueTask(stream.WriteAsync(segment.Array, segment.Offset, segment.Count));
+        }
+
+        public static ValueTask WriteAsync(this StreamWriter writer, string text)
+        {
+            return new ValueTask(writer.WriteAsync(text.ToCharArray(), 0, text.Length));
+        }
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BaseCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BaseCertificateTest.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
+{
+    public abstract class BaseCertificateTest
+    {
+        protected readonly ValidationCallbackHistory _validationCallbackHistory;
+
+        public BaseCertificateTest()
+        {
+            _validationCallbackHistory = new ValidationCallbackHistory();
+        }
+
+        public class ValidationCallbackHistory
+        {
+            public bool ThrowException;
+            public bool ReturnFailure;
+            public bool WasCalled;
+            public SslPolicyErrors SslPolicyErrors;
+            public string CertificateSubject;
+            public X509CertificateCollection CertificateChain;
+            public X509ChainStatus[] ChainStatus;
+
+            public ValidationCallbackHistory()
+            {
+                ThrowException = false;
+                ReturnFailure = false;
+                WasCalled = false;
+                SslPolicyErrors = SslPolicyErrors.None;
+                CertificateSubject = null;
+                CertificateChain = new X509CertificateCollection();
+                ChainStatus = null;
+            }
+        }
+
+        protected bool CustomServerCertificateValidationCallback(
+            HttpRequestMessage sender,
+            X509Certificate2 certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            _validationCallbackHistory.WasCalled = true;
+            _validationCallbackHistory.CertificateSubject = certificate.Subject;
+            foreach (var element in chain.ChainElements)
+            {
+                _validationCallbackHistory.CertificateChain.Add(element.Certificate);
+            }
+            _validationCallbackHistory.ChainStatus = chain.ChainStatus;
+            _validationCallbackHistory.SslPolicyErrors = sslPolicyErrors;
+
+            if (_validationCallbackHistory.ThrowException)
+            {
+                throw new CustomException();
+            }
+
+            if (_validationCallbackHistory.ReturnFailure)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public class CustomException : Exception
+        {
+            public CustomException()
+            {
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BaseCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BaseCertificateTest.cs
@@ -4,16 +4,20 @@
 
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     public abstract class BaseCertificateTest
     {
+        private readonly ITestOutputHelper _output;
+
         protected readonly ValidationCallbackHistory _validationCallbackHistory;
 
-        public BaseCertificateTest()
+        public BaseCertificateTest(ITestOutputHelper output)
         {
+            _output = output;
             _validationCallbackHistory = new ValidationCallbackHistory();
         }
 
@@ -65,6 +69,14 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
 
             return true;
+        }
+
+        protected void ConfirmValidCertificate(string expectedHostName)
+        {
+            Assert.Equal(SslPolicyErrors.None, _validationCallbackHistory.SslPolicyErrors);
+            Assert.True(_validationCallbackHistory.CertificateChain.Count > 0);
+            _output.WriteLine("Certificate.Subject: {0}", _validationCallbackHistory.CertificateSubject);
+            _output.WriteLine("Expected HostName: {0}", expectedHostName);
         }
 
         public class CustomException : Exception

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Security;
+using System.Net.Test.Common;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.WinHttpHandlerFunctional.Tests
+{
+    public class ClientCertificateTest : BaseCertificateTest
+    {
+        public static bool DowngradeToHTTP1IfClientCertSet => PlatformDetection.WindowsVersion < 2004;
+
+        [ConditionalFact(typeof(ServerCertificateTest), nameof(DowngradeToHTTP1IfClientCertSet))]
+        public async Task UseClientCertOnHttp2_DowngradedToHttp1MutualAuth_Success()
+        {
+            using X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate();
+            await LoopbackServer.CreateClientAndServerAsync(
+                async address =>
+                {
+                    var handler = new WinHttpHandler();
+                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
+                    handler.ClientCertificates.Add(clientCert);
+                    handler.ClientCertificateOption = ClientCertificateOption.Manual;
+                    using (var client = new HttpClient(handler))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        Assert.True(_validationCallbackHistory.WasCalled);
+                        Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
+                        Assert.Equal(Test.Common.Configuration.Certificates.GetServerCertificate(), _validationCallbackHistory.CertificateChain[0]);
+                    }
+                },
+                async s =>
+                {
+                    using (LoopbackServer.Connection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
+                    {
+                        SslStream sslStream = connection.Stream as SslStream;
+                        Assert.NotNull(sslStream);
+                        Assert.True(sslStream.IsMutuallyAuthenticated);
+                        Assert.Equal(clientCert, sslStream.RemoteCertificate);
+                        await connection.ReadRequestHeaderAndSendResponseAsync(HttpStatusCode.OK);
+                    }
+                }, new LoopbackServer.Options { UseSsl = true });
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004OrGreater))]
+        public async Task UseClientCertOnHttp2_OSSupportsIt_Success()
+        {
+            using X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate();
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async address =>
+                {
+                    var handler = new WinHttpHandler();
+                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
+                    handler.ClientCertificates.Add(clientCert);
+                    handler.ClientCertificateOption = ClientCertificateOption.Manual;
+                    using (var client = new HttpClient(handler))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        Assert.True(_validationCallbackHistory.WasCalled);
+                        Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
+                        Assert.Equal(Test.Common.Configuration.Certificates.GetServerCertificate(), _validationCallbackHistory.CertificateChain[0]);
+                    }
+                },
+                async s =>
+                {
+                    using (Http2LoopbackConnection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
+                    {
+                        SslStream sslStream = connection.Stream as SslStream;
+                        Assert.NotNull(sslStream);
+                        Assert.True(sslStream.IsMutuallyAuthenticated);
+                        Assert.Equal(clientCert, sslStream.RemoteCertificate);
+
+                        int streamId = await connection.ReadRequestHeaderAsync();
+                        await connection.SendDefaultResponseAsync(streamId);
+                    }
+                }, new Http2Options { ClientCertificateRequired = true });
+        }
+
+        [Fact]
+        public async Task UseClientCertOnHttp2_OSSupportsItButCertNotSet_SuccessWithOneWayAuth()
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async address =>
+                {
+                    var handler = new WinHttpHandler();
+                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
+                    using (var client = new HttpClient(handler))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        Assert.True(_validationCallbackHistory.WasCalled);
+                        Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
+                        Assert.Equal(Test.Common.Configuration.Certificates.GetServerCertificate(), _validationCallbackHistory.CertificateChain[0]);
+                    }
+                },
+                async s =>
+                {
+                    using (Http2LoopbackConnection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
+                    {
+                        SslStream sslStream = connection.Stream as SslStream;
+                        Assert.NotNull(sslStream);
+                        Assert.False(sslStream.IsMutuallyAuthenticated);
+                        Assert.Null(sslStream.RemoteCertificate);
+
+                        int streamId = await connection.ReadRequestHeaderAsync();
+                        await connection.SendDefaultResponseAsync(streamId);
+                    }
+                }, new Http2Options { ClientCertificateRequired = true });
+        }
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     handler.ClientCertificates.Add(clientCert);
                     handler.ClientCertificateOption = ClientCertificateOption.Manual;
                     using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion20.Value }))
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         Assert.True(_validationCallbackHistory.WasCalled);
@@ -59,7 +59,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     handler.ClientCertificates.Add(clientCert);
                     handler.ClientCertificateOption = ClientCertificateOption.Manual;
                     using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion20.Value }))
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         Assert.True(_validationCallbackHistory.WasCalled);
@@ -91,7 +91,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     var handler = new WinHttpHandler();
                     handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
                     using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion.Version20 }))
+                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion20.Value }))
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         Assert.True(_validationCallbackHistory.WasCalled);
@@ -111,7 +111,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                         int streamId = await connection.ReadRequestHeaderAsync();
                         await connection.SendDefaultResponseAsync(streamId);
                     }
-                }, new Http2Options { ClientCertificateRequired = true });
+                }, new Http2Options { ClientCertificateRequired = false });
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -5,14 +5,20 @@
 using System.Net.Security;
 using System.Net.Test.Common;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     public class ClientCertificateTest : BaseCertificateTest
     {
         public static bool DowngradeToHTTP1IfClientCertSet => PlatformDetection.WindowsVersion < 2004;
+
+        public ClientCertificateTest(ITestOutputHelper output) : base(output)
+        { }
 
         [ConditionalFact(typeof(ServerCertificateTest), nameof(DowngradeToHTTP1IfClientCertSet))]
         public async Task UseClientCertOnHttp2_DowngradedToHttp1MutualAuth_Success()
@@ -47,6 +53,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 }, new LoopbackServer.Options { UseSsl = true });
         }
 
+// Disabling it for full .Net Framework due to a missing ALPN API which leads to a protocol downgrade
+#if !NETFRAMEWORK
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004OrGreater))]
         public async Task UseClientCertOnHttp2_OSSupportsIt_Success()
         {
@@ -81,70 +89,31 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     }
                 }, new Http2Options { ClientCertificateRequired = true });
         }
-
-#if NETFRAMEWORK
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
-        public async Task UseClientCertOnHttp2_OSSupportsItButCertNotSet_SuccessWithOneWayAuth()
-        {
-            await LoopbackServer.CreateClientAndServerAsync(
-                async address =>
-                {
-                    var handler = new WinHttpHandler();
-                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
-                    using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion20.Value }))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                        Assert.True(_validationCallbackHistory.WasCalled);
-                        Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
-                        Assert.Equal(Test.Common.Configuration.Certificates.GetServerCertificate(), _validationCallbackHistory.CertificateChain[0]);
-                    }
-                },
-                async s =>
-                {
-                    using (LoopbackServer.Connection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
-                    {
-                        SslStream sslStream = connection.Stream as SslStream;
-                        Assert.NotNull(sslStream);
-                        Assert.False(sslStream.IsMutuallyAuthenticated);
-                        Assert.Null(sslStream.RemoteCertificate);
-
-                        await connection.ReadRequestHeaderAndSendResponseAsync(HttpStatusCode.OK);
-                    }
-                }, new LoopbackServer.Options { UseSsl = true });
-        }
-#else
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
-        public async Task UseClientCertOnHttp2_OSSupportsItButCertNotSet_SuccessWithOneWayAuth()
-        {
-            await Http2LoopbackServer.CreateClientAndServerAsync(
-                async address =>
-                {
-                    var handler = new WinHttpHandler();
-                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
-                    using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) { Version = HttpVersion20.Value }))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                        Assert.True(_validationCallbackHistory.WasCalled);
-                        Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
-                        Assert.Equal(Test.Common.Configuration.Certificates.GetServerCertificate(), _validationCallbackHistory.CertificateChain[0]);
-                    }
-                },
-                async s =>
-                {
-                    using (Http2LoopbackConnection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
-                    {
-                        SslStream sslStream = connection.Stream as SslStream;
-                        Assert.NotNull(sslStream);
-                        Assert.False(sslStream.IsMutuallyAuthenticated);
-                        Assert.Null(sslStream.RemoteCertificate);
-
-                        int streamId = await connection.ReadRequestHeaderAsync();
-                        await connection.SendDefaultResponseAsync(streamId);
-                    }
-                }, new Http2Options { ClientCertificateRequired = false });
-        }
 #endif
+        [OuterLoop]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
+        public async Task UseClientCertOnHttp2_OSSupportsItButCertNotSet_SuccessWithOneWayAuth()
+        {
+            WinHttpHandler handler = new WinHttpHandler();
+            handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
+            string payload = "Mutual Authentication Test";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, Test.Common.Configuration.Http.Http2RemoteEchoServer) { Version = HttpVersion20.Value };
+            request.Content = new StringContent(payload);
+            using (var client = new HttpClient(handler))
+            using (HttpResponseMessage response = await client.SendAsync(request))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(HttpVersion20.Value, response.Version);
+                string responsePayload = await response.Content.ReadAsStringAsync();
+                var responseContent = JsonConvert.DeserializeAnonymousType(responsePayload, new { Method = "_", BodyContent = "_", ClientCertificatePresent = "_", ClientCertificate = "_" });
+                Assert.Equal("POST", responseContent.Method);
+                Assert.Equal(payload, responseContent.BodyContent);
+                Assert.Equal("false", responseContent.ClientCertificatePresent);
+                Assert.Null(responseContent.ClientCertificate);
+                Assert.True(_validationCallbackHistory.WasCalled);
+                Assert.NotEmpty(_validationCallbackHistory.CertificateChain);
+                ConfirmValidCertificate("*.azurewebsites.net");
+            };
+        }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http.Functional.Tests
         {
             useVersion ??= HttpVersion.Version11;
 
-            WinHttpClientHandler handler = new WinHttpClientHandler();
+            WinHttpClientHandler handler = new WinHttpClientHandler(useVersion);
 
             if (useVersion >= HttpVersion20.Value)
             {

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -11,13 +11,15 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
+        protected virtual bool AllowAllCertificates => true;
+
+        protected WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
             useVersion ??= HttpVersion.Version11;
 
             WinHttpClientHandler handler = new WinHttpClientHandler(useVersion);
 
-            if (useVersion >= HttpVersion20.Value)
+            if (useVersion >= HttpVersion20.Value && AllowAllCertificates)
             {
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -11,9 +11,9 @@ namespace System.Net.Http.Functional.Tests
     {
         protected static bool IsWinHttpHandler => true;
 
-        protected virtual bool AllowAllCertificates => true;
+        protected static bool AllowAllCertificates { get; set; } = true;
 
-        protected WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
+        protected static WinHttpClientHandler CreateHttpClientHandler(Version useVersion = null)
         {
             useVersion ??= HttpVersion.Version11;
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/HttpClientHandlerTestBase.WinHttpHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Net.Test.Common;
 using System.IO;
 
 namespace System.Net.Http.Functional.Tests
@@ -16,7 +17,7 @@ namespace System.Net.Http.Functional.Tests
 
             WinHttpClientHandler handler = new WinHttpClientHandler();
 
-            if (useVersion >= HttpVersion.Version20)
+            if (useVersion >= HttpVersion20.Value)
             {
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -275,9 +275,9 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override Version UseVersion => HttpVersion20.Value;
 
-        protected override bool AllowAllCertificates => false;
-
-        public PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test(ITestOutputHelper output) : base(output) { }
+        public PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test(ITestOutputHelper output) : base(output) {
+            AllowAllCertificates = false;
+        }
     }
 
     public sealed class PlatformHandler_PostScenario_Http2_Test : PostScenarioTest

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -275,6 +275,8 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override Version UseVersion => HttpVersion20.Value;
 
+        protected override bool AllowAllCertificates => false;
+
         public PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -313,7 +313,7 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_SchSendAuxRecordHttp_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandler_HttpClientHandler_Http2_Test : HttpClientHandlerTest
     {
         protected override Version UseVersion => HttpVersion20.Value;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -194,14 +194,16 @@ namespace System.Net.Http.Functional.Tests
 
     // Enable this to run HTTP2 tests on platform handler
 #if PLATFORM_HANDLER_HTTP2_TESTS
-    public sealed class PlatformHandlerTest_Http2 : HttpClientHandlerTest_Http2
+    /*public sealed class PlatformHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
-    }
+    }*/
     
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
-        protected override bool UseHttp2LoopbackServer => true;
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandlerTest_Cookies_Http2(ITestOutputHelper output) : base(output) { }
     }
 #endif
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -192,18 +192,190 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_HttpClientHandler_Authentication_Test(ITestOutputHelper output) : base(output) { }
     }
 
-    // Enable this to run HTTP2 tests on platform handler
-#if PLATFORM_HANDLER_HTTP2_TESTS
-    /*public sealed class PlatformHandlerTest_Http2 : HttpClientHandlerTest_Http2
-    {
-    }*/
-    
+#if NETCOREAPP
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
         protected override Version UseVersion => HttpVersion20.Value;
 
         public PlatformHandlerTest_Cookies_Http2(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Asynchrony_Http2_Test : HttpClientHandler_Asynchrony_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Asynchrony_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpProtocol_Http2_Tests : HttpProtocolTests
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpProtocol_Http2_Tests(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpProtocolTests_Http2_Dribble : HttpProtocolTests_Dribble
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpProtocolTests_Http2_Dribble(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClient_SelectedSites_Http2_Test : HttpClient_SelectedSites_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClient_SelectedSites_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientEKU_Http2_Test : HttpClientEKUTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientEKU_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Decompression_Http2_Tests : HttpClientHandler_Decompression_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Decompression_Http2_Tests(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Http2_Test : HttpClientHandler_DangerousAcceptAllCertificatesValidator_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_DangerousAcceptAllCertificatesValidator_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_ClientCertificates_Http2_Test : HttpClientHandler_ClientCertificates_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_ClientCertificates_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_DefaultProxyCredentials_Http2_Test : HttpClientHandler_DefaultProxyCredentials_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_DefaultProxyCredentials_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_MaxConnectionsPerServer_Http2_Test : HttpClientHandler_MaxConnectionsPerServer_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_MaxConnectionsPerServer_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test : HttpClientHandler_ServerCertificates_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_ServerCertificates_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_PostScenario_Http2_Test : PostScenarioTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_PostScenario_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_ResponseStream_Http2_Test : ResponseStreamTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_ResponseStream_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_SslProtocols_Http2_Test : HttpClientHandler_SslProtocols_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_SslProtocols_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Proxy_Http2_Test : HttpClientHandler_Proxy_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Proxy_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_SchSendAuxRecordHttp_Http2_Test : SchSendAuxRecordHttpTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_SchSendAuxRecordHttp_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Http2_Test : HttpClientHandlerTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandlerTest_AutoRedirect_Http2 : HttpClientHandlerTest_AutoRedirect
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandlerTest_AutoRedirect_Http2(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_DefaultCredentials_Http2_Test : DefaultCredentialsTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_DefaultCredentials_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_IdnaProtocol_Http2_Tests : IdnaProtocolTests
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_IdnaProtocol_Http2_Tests(ITestOutputHelper output) : base(output) { }
+        // WinHttp on Win7 does not support IDNA
+        protected override bool SupportsIdna => !PlatformDetection.IsWindows7;
+    }
+
+    public sealed class PlatformHandler_HttpRetryProtocol_Http2_Tests : HttpRetryProtocolTests
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpRetryProtocol_Http2_Tests(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandlerTest_Cookies_Http11_Http2 : HttpClientHandlerTest_Cookies_Http11
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandlerTest_Cookies_Http11_Http2(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_MaxResponseHeadersLength_Http2_Test : HttpClientHandler_MaxResponseHeadersLength_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_MaxResponseHeadersLength_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Cancellation_Http2_Test : HttpClientHandler_Cancellation_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Cancellation_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class PlatformHandler_HttpClientHandler_Authentication_Http2_Test : HttpClientHandler_Authentication_Test
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_HttpClientHandler_Authentication_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 #endif
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -285,13 +285,6 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_PostScenario_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 
-    public sealed class PlatformHandler_ResponseStream_Http2_Test : ResponseStreamTest
-    {
-        protected override Version UseVersion => HttpVersion20.Value;
-
-        public PlatformHandler_ResponseStream_Http2_Test(ITestOutputHelper output) : base(output) { }
-    }
-
     public sealed class PlatformHandler_HttpClientHandler_SslProtocols_Http2_Test : HttpClientHandler_SslProtocols_Test
     {
         protected override Version UseVersion => HttpVersion20.Value;
@@ -379,4 +372,10 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_HttpClientHandler_Authentication_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 #endif
+    public sealed class PlatformHandler_ResponseStream_Http2_Test : ResponseStreamTest
+    {
+        protected override Version UseVersion => HttpVersion20.Value;
+
+        public PlatformHandler_ResponseStream_Http2_Test(ITestOutputHelper output) : base(output) { }
+    }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -193,7 +193,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
 #if NETCOREAPP
-    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
         protected override Version UseVersion => HttpVersion20.Value;
@@ -313,6 +313,7 @@ namespace System.Net.Http.Functional.Tests
         public PlatformHandler_SchSendAuxRecordHttp_Http2_Test(ITestOutputHelper output) : base(output) { }
     }
 
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandler_HttpClientHandler_Http2_Test : HttpClientHandlerTest
     {
         protected override Version UseVersion => HttpVersion20.Value;

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -2,31 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Net.Security;
-using System.Net.Test.Common;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
-    public class ServerCertificateTest
+    public class ServerCertificateTest : BaseCertificateTest
     {
         private readonly ITestOutputHelper _output;
-        private readonly ValidationCallbackHistory _validationCallbackHistory;
 
         public ServerCertificateTest(ITestOutputHelper output)
         {
             _output = output;
-            _validationCallbackHistory = new ValidationCallbackHistory();
         }
+
+        public static bool DowngradeToHTTP1IfClientCertSet => PlatformDetection.WindowsVersion < 2004;
 
         [OuterLoop]
         [Fact]
@@ -34,7 +28,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         {
             var handler = new WinHttpHandler();
             using (var client = new HttpClient(handler))
-            using (HttpResponseMessage response = await client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer))
+            using (HttpResponseMessage response = await client.GetAsync(Test.Common.Configuration.Http.SecureRemoteEchoServer))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.False(_validationCallbackHistory.WasCalled);
@@ -48,7 +42,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
-            using (HttpResponseMessage response = await client.GetAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer))
+            using (HttpResponseMessage response = await client.GetAsync(Test.Common.Configuration.Http.RemoteEchoServer))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.False(_validationCallbackHistory.WasCalled);
@@ -67,7 +61,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.True(_validationCallbackHistory.WasCalled);
 
-                ConfirmValidCertificate(System.Net.Test.Common.Configuration.Http.Host);
+                ConfirmValidCertificate(Test.Common.Configuration.Http.Host);
             }
         }
 
@@ -75,7 +69,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         [Fact]
         public async Task UseCallback_RedirectandValidCertificate_ExpectedValuesDuringCallback()
         {
-            Uri uri = System.Net.Test.Common.Configuration.Http.RemoteSecureHttp11Server.RedirectUriForDestinationUri(302, System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer, 1);
+            Uri uri = Test.Common.Configuration.Http.RemoteSecureHttp11Server.RedirectUriForDestinationUri(302, System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer, 1);
 
             var handler = new WinHttpHandler();
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
@@ -85,7 +79,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.True(_validationCallbackHistory.WasCalled);
 
-                ConfirmValidCertificate(System.Net.Test.Common.Configuration.Http.Host);
+                ConfirmValidCertificate(Test.Common.Configuration.Http.Host);
             }
         }
 
@@ -99,7 +93,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
             using (var client = new HttpClient(handler))
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer);
+                var request = new HttpRequestMessage(HttpMethod.Get, Test.Common.Configuration.Http.SecureRemoteEchoServer);
                 _validationCallbackHistory.ReturnFailure = true;
                 HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
                     client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer));
@@ -123,100 +117,12 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
             }
         }
 
-        [Fact]
-        public async Task UseClientCertOnHttp2_ClientCertValid_Success()
-        {
-            //Debugger.Launch();
-            await Http2LoopbackServer.CreateClientAndServerAsync(
-                async address =>
-                {
-                    var handler = new WinHttpHandler();
-                    handler.ServerCertificateValidationCallback = CustomServerCertificateValidationCallback;
-                    handler.ClientCertificates.Add(Test.Common.Configuration.Certificates.GetClientCertificate());
-                    handler.ClientCertificateOption = ClientCertificateOption.Manual;
-                    using (var client = new HttpClient(handler))
-                    using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, address) {Version = HttpVersion.Version20 }))
-                    {
-                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                        Assert.True(_validationCallbackHistory.WasCalled);
-
-                        //ConfirmValidCertificate(System.Net.Test.Common.Configuration.Http.Host);
-                    }
-                },
-                async s =>
-                {
-                    using (Http2LoopbackConnection connection = await s.EstablishConnectionAsync().ConfigureAwait(false))
-                    {
-                        int streamId = await connection.ReadRequestHeaderAsync();
-
-                        await connection.SendDefaultResponseAsync(streamId);
-                    }
-                }, new Http2Options { ClientCertificateRequired = false });
-        }
-
         private void ConfirmValidCertificate(string expectedHostName)
         {
                 Assert.Equal(SslPolicyErrors.None, _validationCallbackHistory.SslPolicyErrors);
                 Assert.True(_validationCallbackHistory.CertificateChain.Count > 0);
                 _output.WriteLine("Certificate.Subject: {0}", _validationCallbackHistory.CertificateSubject);
                 _output.WriteLine("Expected HostName: {0}", expectedHostName);
-        }
-
-        private bool CustomServerCertificateValidationCallback(
-            HttpRequestMessage sender,
-            X509Certificate2 certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            _validationCallbackHistory.WasCalled = true;
-            _validationCallbackHistory.CertificateSubject = certificate.Subject;
-            foreach (var element in chain.ChainElements)
-            {
-                _validationCallbackHistory.CertificateChain.Add(element.Certificate);
-            }
-            _validationCallbackHistory.ChainStatus = chain.ChainStatus;
-            _validationCallbackHistory.SslPolicyErrors = sslPolicyErrors;
-
-            if (_validationCallbackHistory.ThrowException)
-            {
-                throw new CustomException();
-            }
-
-            if (_validationCallbackHistory.ReturnFailure)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public class CustomException : Exception
-        {
-            public CustomException()
-            {
-            }
-        }
-
-        public class ValidationCallbackHistory
-        {
-            public bool ThrowException;
-            public bool ReturnFailure;
-            public bool WasCalled;
-            public SslPolicyErrors SslPolicyErrors;
-            public string CertificateSubject;
-            public X509CertificateCollection CertificateChain;
-            public X509ChainStatus[] ChainStatus;
-
-            public ValidationCallbackHistory()
-            {
-                ThrowException = false;
-                ReturnFailure = false;
-                WasCalled = false;
-                SslPolicyErrors = SslPolicyErrors.None;
-                CertificateSubject = null;
-                CertificateChain = new X509CertificateCollection();
-                ChainStatus = null;
-            }
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -13,12 +13,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 {
     public class ServerCertificateTest : BaseCertificateTest
     {
-        private readonly ITestOutputHelper _output;
-
-        public ServerCertificateTest(ITestOutputHelper output)
-        {
-            _output = output;
-        }
+        public ServerCertificateTest(ITestOutputHelper output) : base(output)
+        { }
 
         public static bool DowngradeToHTTP1IfClientCertSet => PlatformDetection.WindowsVersion < 2004;
 
@@ -115,14 +111,6 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                     client.GetAsync(System.Net.Test.Common.Configuration.Http.SecureRemoteEchoServer));
                 Assert.True(ex.GetBaseException() is CustomException);
             }
-        }
-
-        private void ConfirmValidCertificate(string expectedHostName)
-        {
-                Assert.Equal(SslPolicyErrors.None, _validationCallbackHistory.SslPolicyErrors);
-                Assert.True(_validationCallbackHistory.CertificateChain.Count > 0);
-                _output.WriteLine("Certificate.Subject: {0}", _validationCallbackHistory.CertificateSubject);
-                _output.WriteLine("Expected HostName: {0}", expectedHostName);
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetFrameworkCurrent)-Windows_NT</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
@@ -14,9 +14,7 @@
     <Compile Include="BaseCertificateTest.cs" />
     <Compile Include="ServerCertificateTest.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />
-    <Compile Include="XunitTestAssemblyAtrributes.cs" />
-  </ItemGroup>  
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetsNetFx)' != 'true' ">  
+    <Compile Include="XunitTestAssemblyAtrributes.cs" /> 
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetFrameworkCurrent)-Windows_NT</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <DefineConstants>$(DefineConstants);WINHTTPHANDLER_TEST</DefineConstants>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs">

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -193,6 +193,10 @@
     <Compile Include="HttpClientHandlerTestBase.WinHttpHandler.cs" />
     <Compile Include="WinHttpClientHandler.cs" />
     <Compile Include="PlatformHandlerTest.cs" />
+  </ItemGroup>  
+  <ItemGroup>
+    <Compile Include="BaseCertificateTest.cs" />
+    <Compile Include="ClientCertificateTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs">
       <Link>Common\System\Net\Configuration.Http.cs</Link>
     </Compile>
+    <Compile Include="BaseCertificateTest.cs" />
     <Compile Include="ServerCertificateTest.cs" />
     <Compile Include="WinHttpHandlerTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
@@ -193,9 +194,6 @@
     <Compile Include="HttpClientHandlerTestBase.WinHttpHandler.cs" />
     <Compile Include="WinHttpClientHandler.cs" />
     <Compile Include="PlatformHandlerTest.cs" />
-  </ItemGroup>  
-  <ItemGroup>
-    <Compile Include="BaseCertificateTest.cs" />
     <Compile Include="ClientCertificateTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -51,6 +51,9 @@
     <Compile Include="$(CommonTestPath)System\Net\TestWebProxies.cs">
       <Link>Common\System\Net\TestWebProxies.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)System\Net\StreamArrayExtensions.cs">
+      <Link>Common\System\Net\StreamArrayExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)System\Net\Http\ByteAtATimeContent.cs">
       <Link>Common\System\Net\Http\ByteAtATimeContent.cs</Link>
     </Compile>

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpClientHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpClientHandler.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -18,8 +19,9 @@ namespace System.Net.Http
     public class WinHttpClientHandler : WinHttpHandler
     {
         private bool _useProxy;
+        private readonly Version _requestVersion;
 
-        public WinHttpClientHandler()
+        public WinHttpClientHandler(Version requestVersion)
         {
             // Adjust defaults to match current .NET Desktop HttpClientHandler (based on HWR stack).
             AllowAutoRedirect = true;
@@ -41,6 +43,8 @@ namespace System.Net.Http
             ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan;
             ReceiveDataTimeout = Timeout.InfiniteTimeSpan;
             SendTimeout = Timeout.InfiniteTimeSpan;
+
+            _requestVersion = requestVersion;
         }
 
         public virtual bool SupportsAutomaticDecompression => true;
@@ -176,6 +180,11 @@ namespace System.Net.Http
                 {
                     base.WindowsProxyUsePolicy = WindowsProxyUsePolicy.DoNotUseProxy;
                 }
+            }
+
+            if(_requestVersion >= HttpVersion20.Value)
+            {
+                request.Version = _requestVersion;
             }
 
             return base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
Pre-release WinHTTP's version supports client cert authentication over HTTP/2, but the feature must be explicitly opted-in. PR sets WINHTTP_OPTION_ENABLE_HTTP2_PLUS_CLIENT_CERT to TRUE before invoking WinHttpConnect if the request's protocol is HTTP/2 and scheme is HTTPS.