### PR TITLE
Use copy_file_range(2) to implement System.Native.CopyFile()

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CopyFile", SetLastError = true)]
-        internal static extern int CopyFile(SafeFileHandle source, string srcPath, string destPath, int overwrite);
+        internal static extern int CopyFile(string srcPath, string destPath, int overwrite);
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -51,6 +51,21 @@ extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
 extern ssize_t  getline(char **, size_t *, FILE *);
 #endif
 
+#if defined(__linux__)
+# include <syscall.h>
+# if defined(__NR_copy_file_range)
+#   define PAL_COPY_FILE_RANGE_SYSCALL __NR_copy_file_range
+# elif defined(__x86_64__)
+#   define PAL_COPY_FILE_RANGE_SYSCALL 326
+# elif defined(__i386__)
+#   define PAL_COPY_FILE_RANGE_SYSCALL 377
+# elif defined(__arm__)
+#   define PAL_COPY_FILE_RANGE_SYSCALL 391
+# elif defined(__aarch64__)
+#   define PAL_COPY_FILE_RANGE_SYSCALL 285
+# endif // __NR_copy_file_range
+#endif // defined(__linux__)
+
 #if HAVE_STAT64
 #define stat_ stat64
 #define fstat_ fstat64
@@ -1296,6 +1311,40 @@ static bool CopyFile_SendFile4(int inFd, int outFd, const struct stat_ *sourceSt
 }
 #endif // HAVE_SENDFILE_4
 
+#if defined(PAL_COPY_FILE_RANGE_SYSCALL)
+static bool CopyFile_CopyFileRange(int inFd, int outFd, const struct stat_ *sourceStat)
+{
+    static bool sCopyFileRangeUnavailable = false;
+    off_t size = sourceStat->st_size;
+
+    if (sCopyFileRangeUnavailable)
+    {
+        return false;
+    }
+
+    while (size)
+    {
+        ssize_t copied = syscall(PAL_COPY_FILE_RANGE_SYSCALL, inFd, NULL, outFd, NULL, (size_t)size, 0);
+
+        if (size < 0)
+        {
+            if (errno == ENOSYS)
+            {
+                sCopyFileRangeUnavailable = true;
+            }
+
+            // No possible error codes other than ENOSYS can be handled here,
+            // so return false to try a legacy read(2)/write(2) copy.
+            return false;
+        }
+
+        size -= copied;
+    }
+
+    return true;
+}
+#endif // defined(PAL_COPY_FILE_RANGE_SYSCALL)
+
 int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char* destPath, int32_t overwrite)
 {
     int inFd = ToFileDescriptor(sourceFd);
@@ -1360,6 +1409,13 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
 
     // Get the stats on the source file.
     bool copied = false;
+
+#if defined(PAL_COPY_FILE_RANGE_SYSCALL)
+    // If copy_file_range(2) is available (Linux), try to use it, as
+    // filesystems might implement better file copying strategies (e.g.
+    // CoW).
+    copied = CopyFile_CopyFileRange(inFd, outFd, &sourceStat);
+#endif // defined(PAL_COPY_FILE_RANGE_SYSCALL)
 
 #if HAVE_SENDFILE_4
     // If sendfile(2) is available (Linux), try to use it, as the whole copy

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1171,14 +1171,14 @@ int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)
 }
 
 // Read all data from inFd and write it to outFd
-static int32_t CopyFile_ReadWrite(int inFd, int outFd)
+static bool CopyFile_ReadWrite(int inFd, int outFd)
 {
     // Allocate a buffer
     const int BufferLength = 80 * 1024 * sizeof(char);
     char* buffer = (char*)malloc(BufferLength);
     if (buffer == NULL)
     {
-        return -1;
+        return false;
     }
 
     // Repeatedly read from the source and write to the destination
@@ -1192,7 +1192,7 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd)
             int tmp = errno;
             free(buffer);
             errno = tmp;
-            return -1;
+            return false;
         }
         if (bytesRead == 0)
         {
@@ -1211,7 +1211,7 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd)
                 int tmp = errno;
                 free(buffer);
                 errno = tmp;
-                return -1;
+                return false;
             }
             assert(bytesWritten >= 0);
             bytesRead -= bytesWritten;
@@ -1220,7 +1220,7 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd)
     }
 
     free(buffer);
-    return 0;
+    return true;
 }
 
 #if HAVE_CLONEFILE
@@ -1314,6 +1314,39 @@ static bool CopyFile_SendFile4(int inFd, int outFd, const struct stat_ *sourceSt
     return true;
 }
 #endif // HAVE_SENDFILE_4
+
+static void CopyFileMetadata(int outFd, const struct stat_ *sourceStat)
+{
+    // Copy over metadata from the source file.  First copy the file times.
+    // If futimes nor futimes are available on this platform, file times
+    // will not be copied over.
+#if HAVE_FUTIMENS
+    // futimens is prefered because it has a higher resolution.
+    struct timespec origTimes[] = {
+        {
+            .tv_sec = (time_t)sourceStat->st_atime,
+            .tv_nsec = ST_ATIME_NSEC(sourceStat),
+        },
+        {
+            .tv_sec = (time_t)sourceStat->st_mtime,
+            .tv_nsec = ST_MTIME_NSEC(sourceStat),
+        }
+    };
+    while (futimens(outFd, origTimes) < 0 && errno == EINTR);
+#elif HAVE_FUTIMES
+    struct timeval origTimes[] = {
+        {
+            .tv_sec = sourceStat->st_atime,
+            .tv_usec = (int32_t)(ST_ATIME_NSEC(sourceStat) / 1000),
+        },
+        {
+            .tv_sec = sourceStat->st_mtime,
+            .tv_usec = (int32_t)(ST_MTIME_NSEC(sourceStat) / 1000),
+        }
+    };
+    while (futimes(outFd, origTimes) < 0 && errno == EINTR);
+#endif
+}
 
 #if defined(PAL_COPY_FILE_RANGE_SYSCALL)
 static bool CopyFile_CopyFileRange(int inFd, int outFd, const struct stat_ *sourceStat)
@@ -1427,40 +1460,22 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     copied = copied || CopyFile_SendFile4(inFd, outFd, &sourceStat);
 #endif // HAVE_SENDFILE_4
 
-    // Manually read all data from the source and write it to the destination.
-    if (!copied && CopyFile_ReadWrite(inFd, outFd) != 0)
-    {
-        tmpErrno = errno;
-        close(outFd);
-        errno = tmpErrno;
-        return -1;
-    }
+    // If there are no better file copying methods, or the previous methods somehow failed, try
+    // an oldschool read/write loop before giving up.
+    // TODO: Distinguish between general I/O errors (where trying read/write wouldn't help anyway),
+    // and method-specific errors (where we should try again -- e.g. cross-volume copies).
+    copied = copied || CopyFile_ReadWrite(inFd, outFd);
 
-    // Now that the data from the file has been copied, copy over metadata
-    // from the source file.  First copy the file times.
-    // If futimes nor futimes are available on this platform, file times will
-    // not be copied over.
-#if HAVE_FUTIMENS
-    // futimens is prefered because it has a higher resolution.
-    struct timespec origTimes[2];
-    origTimes[0].tv_sec = (time_t)sourceStat.st_atime;
-    origTimes[0].tv_nsec = ST_ATIME_NSEC(&sourceStat);
-    origTimes[1].tv_sec = (time_t)sourceStat.st_mtime;
-    origTimes[1].tv_nsec = ST_MTIME_NSEC(&sourceStat);
-    while ((ret = futimens(outFd, origTimes)) < 0 && errno == EINTR);
-#elif HAVE_FUTIMES
-    struct timeval origTimes[2];
-    origTimes[0].tv_sec = sourceStat.st_atime;
-    origTimes[0].tv_usec = (int32_t)(ST_ATIME_NSEC(&sourceStat) / 1000);
-    origTimes[1].tv_sec = sourceStat.st_mtime;
-    origTimes[1].tv_usec = (int32_t)(ST_MTIME_NSEC(&sourceStat) / 1000);
-    while ((ret = futimes(outFd, origTimes)) < 0 && errno == EINTR);
-#endif
+    if (copied)
+    {
+        CopyFileMetadata(outFd, &sourceStat);
+    }
 
     tmpErrno = errno;
     close(outFd);
     errno = tmpErrno;
-    return 0;
+
+    return copied ? 0 : -1;
 }
 
 intptr_t SystemNative_INotifyInit(void)

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1208,6 +1208,94 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd)
     return 0;
 }
 
+#if HAVE_CLONEFILE
+enum CloneFileResult
+{
+    CLONEFILE_SUCCESS,
+    CLONEFILE_TRY_READ_WRITE,
+    CLONEFILE_ERROR
+};
+
+static enum CloneFileResult CopyFile_CloneFile(const char* srcPath, const char* destPath, bool destinationExists)
+{
+    int ret;
+
+    if (destinationExists)
+    {
+        // We need to unlink the destination file first but we need to check
+        // permission first to ensure we don't try to unlink a read-only file.
+        if (access(destPath, W_OK) != 0)
+        {
+            return CLONEFILE_TRY_READ_WRITE;
+        }
+
+        if (unlink(destPath) < 0)
+        {
+            return CLONEFILE_TRY_READ_WRITE;
+        }
+    }
+
+    while ((ret = clonefile(srcPath, destPath, 0)) < 0 && errno == EINTR);
+    if (ret == 0)
+    {
+        return CLONEFILE_SUCCESS;
+    }
+    switch (errno)
+    {
+        case EEXIST:
+            // EEXIST can happen due to race condition between the
+            // access/unlink clonefile() here.  The file could be
+            // (re-)created from another thread or process before we have a
+            // chance to call clonefile.  Handle it by falling back to the
+            // slow path.
+        case ENOTSUP:
+        case EXDEV:
+            return CLONEFILE_TRY_READ_WRITE;
+        default:
+            return CLONEFILE_ERROR;
+    }
+}
+#endif // HAVE_CLONEFILE
+
+#if HAVE_SENDFILE_4
+static bool CopyFile_SendFile4(int inFd, int outFd, const struct stat_ *sourceStat)
+{
+    // On 32-bit, if you use 64-bit offsets, the last argument of `sendfile' will be a
+    // `size_t' a 32-bit integer while the `st_size' field of the stat structure will be off64_t.
+    // So `size' will have to be `uint64_t'. In all other cases, it will be `size_t'.
+    off_t size = sourceStat->st_size;
+
+    // Note that per man page for large files, you have to iterate until the
+    // whole file is copied (Linux has a limit of 0x7ffff000 bytes copied).
+    while (size)
+    {
+        ssize_t sent = sendfile(outFd, inFd, NULL, (size >= SSIZE_MAX ? SSIZE_MAX : (size_t)size));
+
+        if (sent < 0)
+        {
+            if (errno != EINVAL && errno != ENOSYS)
+            {
+                int tmpErrno = errno;
+                close(outFd);
+                errno = tmpErrno;
+            }
+
+            // sendfile couldn't be used. This could happen if we're on an
+            // old kernel, for example, where sendfile could only be used
+            // with sockets and not regular files.
+            return false;
+        }
+        else
+        {
+            assert(sent <= size);
+            size -= (size_t)sent;
+        }
+    }
+
+    return true;
+}
+#endif // HAVE_SENDFILE_4
+
 int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char* destPath, int32_t overwrite)
 {
     int inFd = ToFileDescriptor(sourceFd);
@@ -1240,32 +1328,17 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
             errno = EBUSY;
             return -1;
         }
-
-#if HAVE_CLONEFILE
-        // For clonefile we need to unlink the destination file first but we need to
-        // check permission first to ensure we don't try to unlink read-only file.
-        if (access(destPath, W_OK) != 0)
-        {
-            return -1;
-        }
-
-        ret = unlink(destPath);
-        if (ret != 0)
-        {
-            return ret;
-        }
-#endif
     }
 
 #if HAVE_CLONEFILE
-    while ((ret = clonefile(srcPath, destPath, 0)) < 0 && errno == EINTR);
-    // EEXIST can happen due to race condition between the stat/unlink above
-    // and the clonefile here. The file could be (re-)created from another
-    // thread or process before we have a chance to call clonefile. Handle
-    // it by falling back to the slow path.
-    if (ret == 0 || (errno != ENOTSUP && errno != EXDEV && errno != EEXIST))
+    switch (CopyFile_CloneFile(srcPath, destPath, ret == 0))
     {
-        return ret;
+        case CLONEFILE_SUCCESS:
+            return 0;
+        case CLONEFILE_ERROR:
+            return -1;
+        case CLONEFILE_TRY_READ_WRITE:
+            break;
     }
 #else
     // Unused variable
@@ -1288,47 +1361,10 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     // Get the stats on the source file.
     bool copied = false;
 
-    // If sendfile is available (Linux), try to use it, as the whole copy
-    // can be performed in the kernel, without lots of unnecessary copying.
 #if HAVE_SENDFILE_4
-
-    // On 32-bit, if you use 64-bit offsets, the last argument of `sendfile' will be a
-    // `size_t' a 32-bit integer while the `st_size' field of the stat structure will be off64_t.
-    // So `size' will have to be `uint64_t'. In all other cases, it will be `size_t'.
-    uint64_t size = (uint64_t)sourceStat.st_size;
-
-    // Note that per man page for large files, you have to iterate until the
-    // whole file is copied (Linux has a limit of 0x7ffff000 bytes copied).
-    while (size > 0)
-    {
-        ssize_t sent = sendfile(outFd, inFd, NULL, (size >= SSIZE_MAX ? SSIZE_MAX : (size_t)size));
-        if (sent < 0)
-        {
-            if (errno != EINVAL && errno != ENOSYS)
-            {
-                tmpErrno = errno;
-                close(outFd);
-                errno = tmpErrno;
-                return -1;
-            }
-            else
-            {
-                break;
-            }
-        }
-        else
-        {
-            assert((size_t)sent <= size);
-            size -= (size_t)sent;
-        }
-    }
-    if (size == 0)
-    {
-        copied = true;
-    }
-    // sendfile couldn't be used; fall back to a manual copy below. This could happen
-    // if we're on an old kernel, for example, where sendfile could only be used
-    // with sockets and not regular files.
+    // If sendfile(2) is available (Linux), try to use it, as the whole copy
+    // can be performed in the kernel, without lots of unnecessary copying.
+    copied = copied || CopyFile_SendFile4(inFd, outFd, &sourceStat);
 #endif // HAVE_SENDFILE_4
 
     // Manually read all data from the source and write it to the destination.

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1279,6 +1279,12 @@ static bool CopyFile_SendFile4(int inFd, int outFd, const struct stat_ *sourceSt
     // `size_t' a 32-bit integer while the `st_size' field of the stat structure will be off64_t.
     // So `size' will have to be `uint64_t'. In all other cases, it will be `size_t'.
     off_t size = sourceStat->st_size;
+    static bool sSendFile4Unavailable = false;
+
+    if (sSendFile4Unavailable)
+    {
+        return false;
+    }
 
     // Note that per man page for large files, you have to iterate until the
     // whole file is copied (Linux has a limit of 0x7ffff000 bytes copied).
@@ -1288,11 +1294,9 @@ static bool CopyFile_SendFile4(int inFd, int outFd, const struct stat_ *sourceSt
 
         if (sent < 0)
         {
-            if (errno != EINVAL && errno != ENOSYS)
+            if (errno == ENOSYS)
             {
-                int tmpErrno = errno;
-                close(outFd);
-                errno = tmpErrno;
+                sSendFile4Unavailable = true;
             }
 
             // sendfile couldn't be used. This could happen if we're on an

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1231,12 +1231,28 @@ enum CloneFileResult
     CLONEFILE_ERROR
 };
 
-static enum CloneFileResult CopyFile_CloneFile(const char* srcPath, const char* destPath, bool destinationExists)
+static enum CloneFileResult CopyFile_CloneFile(const char* srcPath, const char* destPath, struct stat_ *sourceStat, int32_t overwrite)
 {
+    struct stat_ destStat;
     int ret;
 
-    if (destinationExists)
+    while ((ret = stat_(destPath, &destStat)) < 0 && errno == EINTR);
+    if (ret == 0)
     {
+        if (!overwrite)
+        {
+            errno = EEXIST;
+            return CLONEFILE_ERROR;
+        }
+
+        if (sourceStat->st_dev == destStat.st_dev && sourceStat->st_ino == destStat.st_ino)
+        {
+            // Attempt to copy file over itself. Fail with the same error code as
+            // open would.
+            errno = EBUSY;
+            return CLONEFILE_ERROR;
+        }
+
         // We need to unlink the destination file first but we need to check
         // permission first to ensure we don't try to unlink a read-only file.
         if (access(destPath, W_OK) != 0)
@@ -1382,74 +1398,74 @@ static bool CopyFile_CopyFileRange(int inFd, int outFd, const struct stat_ *sour
 }
 #endif // defined(PAL_COPY_FILE_RANGE_SYSCALL)
 
-int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char* destPath, int32_t overwrite)
+int32_t SystemNative_CopyFile(const char* srcPath, const char* destPath, int32_t overwrite)
 {
-    int inFd = ToFileDescriptor(sourceFd);
-    int outFd;
+    intptr_t inFd;
+    intptr_t outFd;
     int ret;
     int tmpErrno;
     struct stat_ sourceStat;
+    bool locked = false;
     bool copied = false;
 
-    while ((ret = fstat_(inFd, &sourceStat)) < 0 && errno == EINTR);
-    if (ret != 0)
+    // Not all file copying methods require an open file descriptor for the source file; however,
+    // to provide a behavior similar to Windows, we maintain POSIX advisory locks while the file is
+    // being copied.
+    inFd = SystemNative_Open(srcPath, PAL_O_RDONLY | PAL_O_CLOEXEC, 0);
+    if (inFd < 0)
     {
-        return -1;
+        goto out_no_open;
     }
 
-    struct stat_ destStat;
-    while ((ret = stat_(destPath, &destStat)) < 0 && errno == EINTR);
-    if (ret == 0)
+    if (SystemNative_FLock(inFd, LOCK_EX | LOCK_NB) < 0)
     {
-        if (!overwrite)
-        {
-            errno = EEXIST;
-            return -1;
-        }
+        goto out;
+    }
 
-        if (sourceStat.st_dev == destStat.st_dev && sourceStat.st_ino == destStat.st_ino)
-        {
-            // Attempt to copy file over itself. Fail with the same error code as
-            // open would.
-            errno = EBUSY;
-            return -1;
-        }
+    locked = true;
+
+    while ((ret = fstat_(ToFileDescriptor(inFd), &sourceStat)) < 0 && errno == EINTR);
+    if (ret != 0)
+    {
+        goto out;
     }
 
 #if HAVE_CLONEFILE
-    switch (CopyFile_CloneFile(srcPath, destPath, ret == 0))
+    // If clonefile() is available (macOS), try to use it, as filesystems might implement better
+    // file copying strategies (e.g.  CoW).
+    switch (CopyFile_CloneFile(srcPath, destPath, &sourceStat, overwrite))
     {
         case CLONEFILE_SUCCESS:
-            return 0;
+            copied = true;
+            goto out;
         case CLONEFILE_ERROR:
-            return -1;
+            goto out;
         case CLONEFILE_TRY_READ_WRITE:
             break;
     }
-#else
-    // Unused variable
-    (void)srcPath;
 #endif
 
-    outFd = (int)SystemNative_Open(destPath,
+    // TODO: On Linux, it might be worthwhile creating the file with O_TMPFILE while the copy
+    // operation is pending and, when it's finshed, hardlink it to the final destination path.
+    // This way, if the process is interrupted mid-copy, no files are left on the disk.
+    outFd = SystemNative_Open(destPath,
         PAL_O_WRONLY | PAL_O_TRUNC | PAL_O_CREAT | PAL_O_CLOEXEC | (overwrite ? 0 : PAL_O_EXCL),
         sourceStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
     if (outFd < 0)
     {
-        return ret;
+        goto out;
     }
 
 #if defined(PAL_COPY_FILE_RANGE_SYSCALL)
-    // If copy_file_range(2) is available (Linux), try to use it, as
-    // filesystems might implement better file copying strategies (e.g.
-    // CoW).
-    copied = CopyFile_CopyFileRange(inFd, outFd, &sourceStat);
+    // If copy_file_range(2) is available (Linux), try to use it, as filesystems might implement
+    // better file copying strategies (e.g.  CoW through reflinks).
+    copied = copied || CopyFile_CopyFileRange(ToFileDescriptor(inFd), ToFileDescriptor(outFd), &sourceStat);
 #endif // defined(PAL_COPY_FILE_RANGE_SYSCALL)
 
 #if HAVE_SENDFILE_4
-    // If sendfile(2) is available (Linux), try to use it, as the whole copy
-    // can be performed in the kernel, without lots of unnecessary copying.
-    copied = copied || CopyFile_SendFile4(inFd, outFd, &sourceStat);
+    // If sendfile(2) is available (Linux), try to use it, as the whole copy can be performed in
+    // the kernel, without lots of unnecessary copying.
+    copied = copied || CopyFile_SendFile4(ToFileDescriptor(inFd), ToFileDescriptor(outFd), &sourceStat);
 #endif // HAVE_SENDFILE_4
 
     // If there are no better file copying methods, or the previous methods somehow failed, try
@@ -1460,7 +1476,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
 
     if (copied)
     {
-        ret = CopyFileMetadata(ToFileDescriptor(outFd), &sourceStat);
+        CopyFileMetadata(ToFileDescriptor(outFd), &sourceStat);
     }
     else
     {
@@ -1471,7 +1487,23 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     SystemNative_Close(outFd);
     errno = tmpErrno;
 
-    return ret;
+out:
+    // Closing the file should drop the lock, but be cautious here and issue a flock() anyway.
+    // (Errors are ignored because, at this point, there's nothing that can be done, as the
+    // file is being closed next.)
+    SystemNative_FLock(inFd, LOCK_UN);
+
+    tmpErrno = errno;
+    SystemNative_Close(inFd);
+    errno = tmpErrno;
+
+    if (locked)
+    {
+        return copied ? 0 : errno;
+    }
+
+out_no_open:
+    return -errno;
 }
 
 intptr_t SystemNative_INotifyInit(void)

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1388,8 +1388,8 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     int outFd;
     int ret;
     int tmpErrno;
-    int openFlags;
     struct stat_ sourceStat;
+    bool copied = false;
 
     while ((ret = fstat_(inFd, &sourceStat)) < 0 && errno == EINTR);
     if (ret != 0)
@@ -1431,21 +1431,13 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     (void)srcPath;
 #endif
 
-    openFlags = O_WRONLY | O_TRUNC | O_CREAT | (overwrite ? 0 : O_EXCL);
-#if HAVE_O_CLOEXEC
-    openFlags |= O_CLOEXEC;
-#endif
-    while ((outFd = open(destPath, openFlags, sourceStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO))) < 0 && errno == EINTR);
+    outFd = (int)SystemNative_Open(destPath,
+        PAL_O_WRONLY | PAL_O_TRUNC | PAL_O_CREAT | PAL_O_CLOEXEC | (overwrite ? 0 : PAL_O_EXCL),
+        sourceStat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
     if (outFd < 0)
     {
-        return -1;
+        return ret;
     }
-#if !HAVE_O_CLOEXEC
-    fcntl(outFd, F_SETFD, FD_CLOEXEC);
-#endif
-
-    // Get the stats on the source file.
-    bool copied = false;
 
 #if defined(PAL_COPY_FILE_RANGE_SYSCALL)
     // If copy_file_range(2) is available (Linux), try to use it, as
@@ -1464,18 +1456,22 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char
     // an oldschool read/write loop before giving up.
     // TODO: Distinguish between general I/O errors (where trying read/write wouldn't help anyway),
     // and method-specific errors (where we should try again -- e.g. cross-volume copies).
-    copied = copied || CopyFile_ReadWrite(inFd, outFd);
+    copied = copied || CopyFile_ReadWrite(ToFileDescriptor(inFd), ToFileDescriptor(outFd));
 
     if (copied)
     {
-        CopyFileMetadata(outFd, &sourceStat);
+        ret = CopyFileMetadata(ToFileDescriptor(outFd), &sourceStat);
+    }
+    else
+    {
+        while (unlink(destPath) < 0 && errno == EINTR);
     }
 
     tmpErrno = errno;
-    close(outFd);
+    SystemNative_Close(outFd);
     errno = tmpErrno;
 
-    return copied ? 0 : -1;
+    return ret;
 }
 
 intptr_t SystemNative_INotifyInit(void)

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1493,8 +1493,7 @@ int32_t SystemNative_CopyFile(const char* srcPath, const char* destPath, int32_t
         goto out_close_outfd_infd;
     }
 
-    while ((ret = SystemNative_FTruncate(outFd, 0)) < 0 && errno == EINTR);
-    if (ret < 0)
+    if (SystemNative_FTruncate(outFd, 0) < 0)
     {
         goto out_close_outfd_infd;
     }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1412,7 +1412,7 @@ static bool CopyFile_CopyFileRange(int inFd, int outFd, const struct stat_ *sour
     {
         ssize_t copied = syscall(PAL_COPY_FILE_RANGE_SYSCALL, inFd, NULL, outFd, NULL, (size_t)size, 0);
 
-        if (size < 0)
+        if (copied < 0)
         {
             if (errno == ENOSYS)
             {
@@ -1422,6 +1422,10 @@ static bool CopyFile_CopyFileRange(int inFd, int outFd, const struct stat_ *sour
             // No possible error codes other than ENOSYS can be handled here,
             // so return false to try a legacy read(2)/write(2) copy.
             return false;
+        }
+        else if (copied == 0)
+        {
+            break;
         }
 
         size -= copied;

--- a/src/libraries/Native/Unix/System.Native/pal_io.h
+++ b/src/libraries/Native/Unix/System.Native/pal_io.h
@@ -675,10 +675,12 @@ PALEXPORT int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bu
 
 /**
  * Copies all data from the source file descriptor/path to the destination file path.
+ * Obtains a exclusive advisory lock on the input file while the copy is being performed.
  *
- * Returns 0 on success; otherwise, returns -1 and sets errno.
+ * Returns 0 on success; otherwise, set errno and returns a positive integer if copying failed,
+ * and a negative integer if locking failed.
  */
-PALEXPORT int32_t SystemNative_CopyFile(intptr_t sourceFd, const char* srcPath, const char* destPath, int32_t overwrite);
+PALEXPORT int32_t SystemNative_CopyFile(const char* srcPath, const char* destPath, int32_t overwrite);
 
 /**
 * Initializes a new inotify instance and returns a file

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -21,30 +21,31 @@ namespace System.IO
             }
 
             // Copy the contents of the file from the source to the destination, creating the destination in the process
-            using (var src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.None))
+            int result = Interop.Sys.CopyFile(sourceFullPath, destFullPath, overwrite ? 1 : 0);
+
+            if (result != 0)
             {
-                int result = Interop.Sys.CopyFile(src.SafeFileHandle, sourceFullPath, destFullPath, overwrite ? 1 : 0);
+                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
 
-                if (result < 0)
-                {
-                    Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                // If we fail to open the file due to a path not existing, we need to know whether to blame
+                // the file itself or its directory.  If we're creating the file, then we blame the directory,
+                // otherwise we blame the file.
+                //
+                // When opening, we need to align with Windows, which considers a missing path to be
+                // FileNotFound only if the containing directory exists.
 
-                    // If we fail to open the file due to a path not existing, we need to know whether to blame
-                    // the file itself or its directory.  If we're creating the file, then we blame the directory,
-                    // otherwise we blame the file.
-                    //
-                    // When opening, we need to align with Windows, which considers a missing path to be
-                    // FileNotFound only if the containing directory exists.
+                // Source file is locked by the PAL, and locking can fail (e.g. if we can't open the source
+                // file).  A negative result means the PAL couldn't lock the file; a positive means it couldn't
+                // copy the file.
+                var pathToBlame = result < 0 ? sourceFullPath : destFullPath;
+                bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
+                    (overwrite || !DirectoryExists(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(pathToBlame.AsSpan()))!));
 
-                    bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
-                        (overwrite || !DirectoryExists(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(destFullPath.AsSpan()))!));
-
-                    Interop.CheckIo(
-                        error.Error,
-                        destFullPath,
-                        isDirectory,
-                        errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
-                }
+                Interop.CheckIo(
+                    error.Error,
+                    destFullPath,
+                    isDirectory,
+                    errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -331,5 +331,18 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2, overwrite: true));
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream, overwrite: true));
         }
+
+        [Fact]
+        public void CopyOntoLockedFile()
+        {
+            string testFileSource = GetTestFilePath();
+            string testFileDest = GetTestFilePath();
+            File.Create(testFileSource).Dispose();
+            File.Create(testFileDest).Dispose();
+            using (var stream = new FileStream(testFileDest, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                Assert.Throws<IOException>(() => Copy(testFileSource, testFileDest, overwrite: true));
+            }
+        }
     }
 }


### PR DESCRIPTION
Revival of #1495 and fix for #31429.

This cleans up the file locking code in PAL and the code paths introduced in https://github.com/dotnet/corefx/pull/39235 to support `clonefile` API on macOS. Additionally, it introduces support for the `copy_file_range` API on newer Linux systems:

```
   The  copy_file_range()  system  call performs an in-kernel
   copy between two file descriptors without the addi‐ tional
   cost of transferring data from the kernel to user space and
   then back into the kernel.

   (...)

   copy_file_range()  gives  filesystems  an opportunity to
   implement "copy acceleration" techniques, such as the use of
   reflinks (i.e., two or more inodes that share pointers to the
   same copy-on-write disk blocks) or server-side-copy (in the
   case of NFS).
```

