### PR TITLE
Fix typo

### DIFF
--- a/src/coreclr/src/inc/crosscomp.h
+++ b/src/coreclr/src/inc/crosscomp.h
@@ -362,7 +362,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 #endif
 
-#if defined(DAC_COMPILE) && defined(TARGET_UNIX)
+#if defined(DACCESS_COMPILE) && defined(TARGET_UNIX)
 // This is a TARGET oriented copy of CRITICAL_SECTION and PAL_CS_NATIVE_DATA_SIZE
 // It is configured based on TARGET configuration rather than HOST configuration
 // There is validation code in src/coreclr/src/vm/crst.cpp to keep these from

--- a/src/coreclr/src/vm/crst.cpp
+++ b/src/coreclr/src/vm/crst.cpp
@@ -22,7 +22,7 @@
 #include <crsttypes.h>
 #undef __IN_CRST_CPP
 
-#if defined(DAC_COMPILE) && defined(TARGET_UNIX) && !defined(CROSS_COMPILE)
+#if defined(DACCESS_COMPILE) && defined(TARGET_UNIX) && !defined(CROSS_COMPILE)
     // Validate the DAC T_CRITICAL_SECTION matches the runtime CRITICAL section when we are not cross compiling.
     // This is important when we are cross OS compiling the DAC
     static_assert(PAL_CS_NATIVE_DATA_SIZE == DAC_CS_NATIVE_DATA_SIZE,     T_CRITICAL_SECTION_VALIDATION_MESSAGE);
@@ -33,7 +33,7 @@
     static_assert(offsetof(CRITICAL_SECTION, RecursionCount) == offsetof(T_CRITICAL_SECTION, RecursionCount), T_CRITICAL_SECTION_VALIDATION_MESSAGE);
     static_assert(offsetof(CRITICAL_SECTION, OwningThread)   == offsetof(T_CRITICAL_SECTION, OwningThread),   T_CRITICAL_SECTION_VALIDATION_MESSAGE);
     static_assert(offsetof(CRITICAL_SECTION, SpinCount)      == offsetof(T_CRITICAL_SECTION, SpinCount),      T_CRITICAL_SECTION_VALIDATION_MESSAGE);
-#endif // defined(DAC_COMPILE) && defined(TARGET_UNIX) && !defined(CROSS_COMPILE)
+#endif // defined(DACCESS_COMPILE) && defined(TARGET_UNIX) && !defined(CROSS_COMPILE)
 
 #ifndef DACCESS_COMPILE
 Volatile<LONG> g_ShutdownCrstUsageCount = 0;


### PR DESCRIPTION
DAC_COMPILE -> DACCESS_COMPILE

While the former makes more sense to me, it is actually not the correct macro name...