### PR TITLE
Calculate if we're in an instance method in one place to support reverse IL stubs.

### DIFF
--- a/src/coreclr/src/vm/ilmarshalers.h
+++ b/src/coreclr/src/vm/ilmarshalers.h
@@ -353,6 +353,12 @@ protected:
         return (0 != (dwMarshalFlags & MARSHAL_FLAG_RETVAL));
     }
 
+    static inline bool IsInMemberFunction(DWORD dwMarshalFlags)
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (0 != (dwMarshalFlags & MARSHAL_FLAG_IN_MEMBER_FUNCTION));
+    }
+
     static inline bool IsHiddenLengthParam(DWORD dwMarshalFlags)
     {
         LIMITED_METHOD_CONTRACT;
@@ -699,7 +705,7 @@ public:
         bool byrefNativeReturn = false;
         CorElementType typ = ELEMENT_TYPE_VOID;
         UINT32 nativeSize = 0;
-        bool nativeMethodIsMemberFunction = (CorInfoCallConv)m_pslNDirect->GetStubTargetCallingConv() == CORINFO_CALLCONV_THISCALL;
+        bool nativeMethodIsMemberFunction = IsInMemberFunction(dwMarshalFlags);
 
         // we need to convert value type return types to primitives as
         // JIT does not inline P/Invoke calls that return structures

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -1464,6 +1464,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
     CorElementType corElemType      = ELEMENT_TYPE_END;
     m_pMT                           = NULL;
     m_pMD                           = pMD;
+    m_onInstanceMethod              = onInstanceMethod;
 
 #ifdef FEATURE_COMINTEROP
     m_fDispItf                      = FALSE;
@@ -3328,7 +3329,7 @@ DWORD CalculateArgumentMarshalFlags(BOOL byref, BOOL in, BOOL out, BOOL fMngToNa
     return dwMarshalFlags;
 }
 
-DWORD CalculateReturnMarshalFlags(BOOL hrSwap, BOOL fMngToNative)
+DWORD CalculateReturnMarshalFlags(BOOL hrSwap, BOOL fMngToNative, BOOL onInstanceMethod)
 {
     LIMITED_METHOD_CONTRACT;
     DWORD dwMarshalFlags = MARSHAL_FLAG_RETVAL;
@@ -3341,6 +3342,11 @@ DWORD CalculateReturnMarshalFlags(BOOL hrSwap, BOOL fMngToNative)
     if (fMngToNative)
     {
         dwMarshalFlags |= MARSHAL_FLAG_CLR_TO_NATIVE;
+    }
+
+    if (onInstanceMethod)
+    {
+        dwMarshalFlags |= MARSHAL_FLAG_IN_MEMBER_FUNCTION;
     }
 
     return dwMarshalFlags;
@@ -3486,7 +3492,7 @@ void MarshalInfo::GenerateReturnIL(NDirectStubLinker* psl,
         }
 
         NewHolder<ILMarshaler> pMarshaler = CreateILMarshaler(m_type, psl);
-        DWORD dwMarshalFlags = CalculateReturnMarshalFlags(retval, fMngToNative);
+        DWORD dwMarshalFlags = CalculateReturnMarshalFlags(retval, fMngToNative, m_onInstanceMethod);
 
         if (!pMarshaler->SupportsReturnMarshal(dwMarshalFlags, &resID))
         {

--- a/src/coreclr/src/vm/mlinfo.h
+++ b/src/coreclr/src/vm/mlinfo.h
@@ -49,14 +49,15 @@ typedef enum
 
 enum MarshalFlags
 {
-    MARSHAL_FLAG_CLR_TO_NATIVE  = 0x01,
-    MARSHAL_FLAG_IN             = 0x02,
-    MARSHAL_FLAG_OUT            = 0x04,
-    MARSHAL_FLAG_BYREF          = 0x08,
-    MARSHAL_FLAG_HRESULT_SWAP   = 0x10,
-    MARSHAL_FLAG_RETVAL         = 0x20,
-    MARSHAL_FLAG_HIDDENLENPARAM = 0x40,
-    MARSHAL_FLAG_FIELD          = 0x80
+    MARSHAL_FLAG_CLR_TO_NATIVE      = 0x001,
+    MARSHAL_FLAG_IN                 = 0x002,
+    MARSHAL_FLAG_OUT                = 0x004,
+    MARSHAL_FLAG_BYREF              = 0x008,
+    MARSHAL_FLAG_HRESULT_SWAP       = 0x010,
+    MARSHAL_FLAG_RETVAL             = 0x020,
+    MARSHAL_FLAG_HIDDENLENPARAM     = 0x040,
+    MARSHAL_FLAG_FIELD              = 0x080,
+    MARSHAL_FLAG_IN_MEMBER_FUNCTION = 0x100
 };
 
 #include <pshpack1.h>
@@ -714,6 +715,7 @@ private:
     VARTYPE         m_arrayElementType;
     int             m_iArrayRank;
     BOOL            m_nolowerbounds;  // if managed type is SZARRAY, don't allow lower bounds
+    BOOL            m_onInstanceMethod;
 
     // for NT_ARRAY only
     UINT32          m_multiplier;     // multipler for "sizeis"


### PR DESCRIPTION
For reverse stubs, we don't set the calling convention of the stub to the actual calling convention since the JIT doesn't support reading that correctly. As a result, the emit for return values in reverse P/Invokes wasn't correctly detecting that it was a thiscall stub. This PR changes the "are we an instance method" check to live in one place (where we have the knowledge of which calling convention the stub is for).

Contributes to #33129 (fixes the crash, but there's still incorrect behavior from the JIT)