### PR TITLE
[llvm] Don't set the LLVM JIT TLS variable in AOT.

### DIFF
--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -67,19 +67,12 @@ void bzero (void *to, size_t count) { memset (to, 0, count); }
 
 static MonoNativeTlsKey current_cfg_tls_id;
 
-static unsigned char*
+static unsigned char *
 alloc_code (LLVMValueRef function, int size)
 {
-	MonoCompile *cfg;
-
-	cfg = (MonoCompile*)mono_native_tls_get_value (current_cfg_tls_id);
-
-	if (cfg) {
-		// FIXME: dynamic
-		return (unsigned char*)mono_domain_code_reserve (cfg->domain, size);
-	} else {
-		return (unsigned char*)mono_domain_code_reserve (mono_domain_get (), size);
-	}
+	auto cfg = (MonoCompile *)mono_native_tls_get_value (current_cfg_tls_id);
+	g_assert (cfg);
+	return (unsigned char *)mono_domain_code_reserve (cfg->domain, size);
 }
 
 class MonoJitMemoryManager : public RTDyldMemoryManager
@@ -480,11 +473,6 @@ mono_llvm_jit_init ()
 	jit = make_mono_llvm_jit (TM);
 }
 
-void
-mono_llvm_jit_set_tls_cfg (MonoCompile *cfg) {
-	mono_native_tls_set_value (current_cfg_tls_id, cfg);
-}
-
 MonoEERef
 mono_llvm_create_ee (LLVMExecutionEngineRef *ee)
 {
@@ -498,9 +486,12 @@ mono_llvm_create_ee (LLVMExecutionEngineRef *ee)
  * CALLEE_ADDRS. Return the EH frame address in EH_FRAME.
  */
 gpointer
-mono_llvm_compile_method (MonoEERef mono_ee, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame)
+mono_llvm_compile_method (MonoEERef mono_ee, MonoCompile *cfg, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame)
 {
-	return jit->compile (unwrap<Function> (method), nvars, callee_vars, callee_addrs, eh_frame);
+	mono_native_tls_set_value (current_cfg_tls_id, cfg);
+	auto ret = jit->compile (unwrap<Function> (method), nvars, callee_vars, callee_addrs, eh_frame);
+	mono_native_tls_set_value (current_cfg_tls_id, nullptr);
+	return ret;
 }
 
 void
@@ -520,10 +511,6 @@ mono_llvm_jit_init ()
 {
 }
 
-void
-mono_llvm_jit_set_tls_cfg (MonoCompile *cfg) {
-}
-
 MonoEERef
 mono_llvm_create_ee (LLVMExecutionEngineRef *ee)
 {
@@ -532,7 +519,7 @@ mono_llvm_create_ee (LLVMExecutionEngineRef *ee)
 }
 
 gpointer
-mono_llvm_compile_method (MonoEERef mono_ee, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame)
+mono_llvm_compile_method (MonoEERef mono_ee, MonoCompile *cfg, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/src/mono/mono/mini/llvm-jit.h
+++ b/src/mono/mono/mini/llvm-jit.h
@@ -36,9 +36,6 @@ typedef void* MonoEERef;
 void
 mono_llvm_jit_init (void);
 
-void
-mono_llvm_jit_set_tls_cfg (MonoCompile *cfg);
-
 MonoEERef
 mono_llvm_create_ee (LLVMExecutionEngineRef *ee);
 
@@ -46,7 +43,7 @@ void
 mono_llvm_dispose_ee (MonoEERef *mono_ee);
 
 gpointer
-mono_llvm_compile_method (MonoEERef mono_ee, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame);
+mono_llvm_compile_method (MonoEERef mono_ee, MonoCompile *cfg, LLVMValueRef method, int nvars, LLVMValueRef *callee_vars, gpointer *callee_addrs, gpointer *eh_frame);
 
 void
 mono_llvm_set_unhandled_exception_handler (void);

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -8387,9 +8387,6 @@ mono_llvm_emit_method (MonoCompile *cfg)
 	/* The code below might acquire the loader lock, so use it for global locking */
 	mono_loader_lock ();
 
-	/* Used to communicate with the callbacks */
-	mono_llvm_jit_set_tls_cfg (cfg);
-
 	ctx = g_new0 (EmitContext, 1);
 	ctx->cfg = cfg;
 	ctx->mempool = cfg->mempool;
@@ -8488,8 +8485,6 @@ mono_llvm_emit_method (MonoCompile *cfg)
 	}
 
 	free_ctx (ctx);
-
-	mono_llvm_jit_set_tls_cfg (NULL);
 
 	mono_loader_unlock ();
 }
@@ -11213,7 +11208,7 @@ llvm_jit_finalize_method (EmitContext *ctx)
 	while (g_hash_table_iter_next (&iter, NULL, (void**)&var))
 		callee_vars [i ++] = var;
 
-	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
+	cfg->native_code = (guint8*)mono_llvm_compile_method (ctx->module->mono_ee, cfg, ctx->lmethod, nvars, callee_vars, callee_addrs, &eh_frame);
 	mono_llvm_remove_gc_safepoint_poll (ctx->lmodule);
 	if (cfg->verbose_level > 1) {
 		g_print ("\n*** Optimized LLVM IR for %s ***\n", mono_method_full_name (cfg->method, TRUE));


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19127,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Should fix https://github.com/mono/mono/issues/19115. This bug was
introduced in https://github.com/mono/mono/pull/18824, which
conditionally initalized an LLVM JIT-related TLS slot while preserving
unconditonal stores to that same slot.

The value stored in this TLS slot should only be used during JIT
compilation, so set/reset it in `mono_llvm_compile_method` instead of
during IR construction in `mono_llvm_emit_method`. No non-JIT code
should depend on the existence of this TLS variable, so
remove `mono_llvm_jit_set_tls_cfg`.