### PR TITLE
Delete support for old GCInfo version from the runtime

### DIFF
--- a/src/coreclr/src/inc/gcdecoder.cpp
+++ b/src/coreclr/src/inc/gcdecoder.cpp
@@ -196,7 +196,6 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
                 header->syncStartOffset ^= HAS_SYNC_OFFSET;
                 break;
             case FLIP_REV_PINVOKE_FRAME:
-                _ASSERTE(GCInfoEncodesRevPInvokeFrame(version));
                 header->revPInvokeOffset ^= HAS_REV_PINVOKE_FRAME_OFFSET;
                 break;
 
@@ -206,15 +205,8 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
                 encoding = nextByte & ADJ_ENCODING_MAX;
                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
 
-                if (encoding < SET_RET_KIND_MAX)
-                {
-                    _ASSERTE(GCInfoEncodesReturnKind(version));
-                    header->returnKind = (ReturnKind)encoding;
-                }
-                else
-                {
-                    assert(!"Unexpected encoding");
-                }
+                _ASSERTE(encoding < SET_RET_KIND_MAX);
+                header->returnKind = (ReturnKind)encoding;
                 break;
             }
         }

--- a/src/coreclr/src/inc/gcinfo.h
+++ b/src/coreclr/src/inc/gcinfo.h
@@ -41,19 +41,6 @@ const unsigned   this_OFFSET_FLAG  = 0x2;  // the offset is "this"
 
 #define GCINFO_VERSION 2
 
-#define MIN_GCINFO_VERSION_WITH_RETURN_KIND 2
-#define MIN_GCINFO_VERSION_WITH_REV_PINVOKE_FRAME 2
-
-inline BOOL GCInfoEncodesReturnKind(UINT32 version=GCINFO_VERSION)
-{
-    return version >= MIN_GCINFO_VERSION_WITH_RETURN_KIND;
-}
-
-inline BOOL GCInfoEncodesRevPInvokeFrame(UINT32 version=GCINFO_VERSION)
-{
-    return version >= MIN_GCINFO_VERSION_WITH_REV_PINVOKE_FRAME;
-}
-
 //-----------------------------------------------------------------------------
 // GCInfoToken: A wrapper that contains the GcInfo data and version number.
 //
@@ -73,20 +60,10 @@ struct GCInfoToken
     PTR_VOID Info;
     UINT32 Version;
 
-    BOOL IsReturnKindAvailable()
-    {
-        return GCInfoEncodesReturnKind(Version);
-    }
-    BOOL IsReversePInvokeFrameAvailable()
-    {
-        return GCInfoEncodesRevPInvokeFrame(Version);
-    }
-
     static UINT32 ReadyToRunVersionToGcInfoVersion(UINT32 readyToRunMajorVersion)
     {
-        // GcInfo version is 1 up to ReadyTorun version 1.x
         // GcInfo version is current from  ReadyToRun version 2.0
-        return (readyToRunMajorVersion == 1) ? 1 : GCINFO_VERSION;
+        return GCINFO_VERSION;
     }
 };
 

--- a/src/coreclr/src/jit/gcencode.cpp
+++ b/src/coreclr/src/jit/gcencode.cpp
@@ -924,7 +924,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
         goto DO_RETURN;
     }
 
-    if (GCInfoEncodesReturnKind() && (state->returnKind != header.returnKind))
+    if (state->returnKind != header.returnKind)
     {
         state->returnKind = header.returnKind;
         codeSet           = 2; // Two byte encoding
@@ -973,7 +973,7 @@ BYTE FASTCALL encodeHeaderNext(const InfoHdr& header, InfoHdr* state, BYTE& code
         }
     }
 
-    if (GCInfoEncodesRevPInvokeFrame() && (state->revPInvokeOffset != header.revPInvokeOffset))
+    if (state->revPInvokeOffset != header.revPInvokeOffset)
     {
         assert(state->revPInvokeOffset == INVALID_REV_PINVOKE_OFFSET ||
                state->revPInvokeOffset == HAS_REV_PINVOKE_FRAME_OFFSET);
@@ -1587,14 +1587,11 @@ size_t GCInfo::gcInfoBlockHdrSave(
     header->genericsContextIsMethodDesc =
         header->genericsContext && (compiler->info.compMethodInfo->options & (CORINFO_GENERICS_CTXT_FROM_METHODDESC));
 
-    if (GCInfoEncodesReturnKind())
-    {
-        ReturnKind returnKind = getReturnKind();
-        _ASSERTE(IsValidReturnKind(returnKind) && "Return Kind must be valid");
-        _ASSERTE(!IsStructReturnKind(returnKind) && "Struct Return Kinds Unexpected for JIT32");
-        _ASSERTE(((int)returnKind < (int)SET_RET_KIND_MAX) && "ReturnKind has no legal encoding");
-        header->returnKind = returnKind;
-    }
+    ReturnKind returnKind = getReturnKind();
+    _ASSERTE(IsValidReturnKind(returnKind) && "Return Kind must be valid");
+    _ASSERTE(!IsStructReturnKind(returnKind) && "Struct Return Kinds Unexpected for JIT32");
+    _ASSERTE(((int)returnKind < (int)SET_RET_KIND_MAX) && "ReturnKind has no legal encoding");
+    header->returnKind = returnKind;
 
     header->gsCookieOffset = INVALID_GS_COOKIE_OFFSET;
     if (compiler->getNeedsGSSecurityCookie())

--- a/src/coreclr/src/vm/eetwain.cpp
+++ b/src/coreclr/src/vm/eetwain.cpp
@@ -5741,11 +5741,6 @@ ReturnKind EECodeManager::GetReturnKind(GCInfoToken gcInfoToken)
     SUPPORTS_DAC;
     } CONTRACTL_END;
 
-    if (!gcInfoToken.IsReturnKindAvailable())
-    {
-        return RT_Illegal;
-    }
-
 #ifndef USE_GC_INFO_DECODER
     hdrInfo info;
 

--- a/src/coreclr/src/vm/gcinfodecoder.cpp
+++ b/src/coreclr/src/vm/gcinfodecoder.cpp
@@ -138,25 +138,11 @@ GcInfoDecoder::GcInfoDecoder(
     m_HasTailCalls             = ((headerFlags & GC_INFO_HAS_TAILCALLS) != 0);
 #endif // TARGET_AMD64
     int hasSizeOfEditAndContinuePreservedArea = headerFlags & GC_INFO_HAS_EDIT_AND_CONTINUE_PRESERVED_SLOTS;
+    int hasReversePInvokeFrame = headerFlags & GC_INFO_REVERSE_PINVOKE_FRAME;
 
-    int hasReversePInvokeFrame = false;
-    if (gcInfoToken.IsReversePInvokeFrameAvailable())
-    {
-        hasReversePInvokeFrame = headerFlags & GC_INFO_REVERSE_PINVOKE_FRAME;
-    }
-
-    if (gcInfoToken.IsReturnKindAvailable())
-    {
-        int returnKindBits = (slimHeader) ? SIZE_OF_RETURN_KIND_IN_SLIM_HEADER : SIZE_OF_RETURN_KIND_IN_FAT_HEADER;
-        m_ReturnKind =
-            (ReturnKind)((UINT32)m_Reader.Read(returnKindBits));
-    }
-    else
-    {
-#ifndef TARGET_X86
-        m_ReturnKind = RT_Unset;
-#endif // ! TARGET_X86
-    }
+    int returnKindBits = (slimHeader) ? SIZE_OF_RETURN_KIND_IN_SLIM_HEADER : SIZE_OF_RETURN_KIND_IN_FAT_HEADER;
+    m_ReturnKind =
+        (ReturnKind)((UINT32)m_Reader.Read(returnKindBits));
 
     if (flags == DECODE_RETURN_KIND) {
         // Bail, if we've decoded enough,

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -4708,8 +4708,6 @@ private:
 
     // By the time a frame is scanned by the runtime, m_pHijackReturnKind always
     // identifies the gc-ness of the return register(s)
-    // If the ReturnKind information is not available from the GcInfo, the runtime
-    // computes it using the return types's class handle.
 
     ReturnKind m_HijackReturnKind;
 


### PR DESCRIPTION
We do not support old R2R images anymore