### PR TITLE
Fix an assert in ReadyToRunReader constructor

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -381,11 +381,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                     throw new BadImageFormatException("The file is not a ReadyToRun image");
                 }
 
-                Debug.Assert(!Composite);
                 _assemblyCache.Add(metadata);
 
                 DirectoryEntry r2rHeaderDirectory = PEReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;
                 _readyToRunHeaderRVA = r2rHeaderDirectory.RelativeVirtualAddress;
+                Debug.Assert(!Composite);
             }
             else if (!TryLocateNativeReadyToRunHeader())
             {


### PR DESCRIPTION
`Composite` will call `EnsureHeader`

https://github.com/dotnet/runtime/blob/170834ef7d30095bc7f76c061bb6144c70426a61/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#L177-L190

and `EnsureHeader` will assert `_readyToRunHeaderRVA != 0`.

https://github.com/dotnet/runtime/blob/170834ef7d30095bc7f76c061bb6144c70426a61/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#L501

But we haven't set it yet, so I moved the assert a bit later after we have computed the `_readyToRunHeaderRVA`.