### PR TITLE
Use prefixed hex format in asm

### DIFF
--- a/src/coreclr/src/pal/inc/unixasmmacrosx86.inc
+++ b/src/coreclr/src/pal/inc/unixasmmacrosx86.inc
@@ -110,7 +110,7 @@ C_FUNC(\Name\()_End):
 
 .macro CHECK_STACK_ALIGNMENT
 #ifdef _DEBUG
-    test    esp, 0Fh
+    test    esp, 0x0F
     je      0f
     int3
 0:

--- a/src/coreclr/src/vm/i386/asmhelpers.S
+++ b/src/coreclr/src/vm/i386/asmhelpers.S
@@ -99,8 +99,8 @@ LEAF_ENTRY ResetCurrentContext, _TEXT
     mov     ax, [esp - 2]
 
     fninit                // reset FPU
-    and     ax, 0f00h     // preserve precision and rounding control
-    or      ax, 007fh     // mask all exceptions
+    and     ax, 0x0f00     // preserve precision and rounding control
+    or      ax, 0x007f     // mask all exceptions
 
     // preserve precision control
     mov     ax, [esp - 2]
@@ -135,7 +135,7 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
     pushfd
     pop     ecx           // Get the EFLAGS
     mov     eax, ecx      // Save for later testing
-    xor     ecx, 200000h  // Invert the ID bit
+    xor     ecx, 0x200000 // Invert the ID bit
     push    ecx
     popfd                 // Save the updated flags
     pushfd
@@ -144,7 +144,7 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
     push    eax
     popfd                 // Restore the flags
 
-    test    ecx, 200000h
+    test    ecx, 0x200000
     jz      LOCAL_LABEL(Assume486)
 
     xor     eax, eax
@@ -158,12 +158,12 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
 
     // filter out everything except family and model
     // Note that some multi-procs have different stepping number for each proc
-    and     eax, 0ff0h
+    and     eax, 0x0ff0
 
     jmp     LOCAL_LABEL(CpuTypeDone)
 
 LOCAL_LABEL(Assume486):
-    mov     eax, 0400h   // report 486
+    mov     eax, 0x0400  // report 486
 
 LOCAL_LABEL(CpuTypeDone):
     pop     ebx
@@ -178,7 +178,7 @@ LEAF_ENTRY GetSpecificCpuFeaturesAsm, _TEXT
     pushfd
     pop     ecx          // Get the EFLAGS
     mov     eax, ecx     // Save for later testing
-    xor     ecx, 200000h // Invert the ID bit.
+    xor     ecx, 0x200000// Invert the ID bit.
     push    ecx
     popfd                // Save the updated flags.
     pushfd
@@ -187,7 +187,7 @@ LEAF_ENTRY GetSpecificCpuFeaturesAsm, _TEXT
     push    eax
     popfd                // Restore the flags
 
-    test    ecx, 200000h
+    test    ecx, 0x200000
     jz      LOCAL_LABEL(CpuFeaturesFail)
 
     xor     eax, eax
@@ -1291,7 +1291,7 @@ NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
 
     // Check if we need to save off any floating point registers
     fstsw   ax
-    and     ax, 3800h           // Check the top-of-fp-stack bits
+    and     ax, 0x3800          // Check the top-of-fp-stack bits
     cmp     ax, 0               // If non-zero, we have something to save
     jnz     LOCAL_LABEL(SaveFPReg)
 

--- a/src/coreclr/src/vm/i386/jithelp.S
+++ b/src/coreclr/src/vm/i386/jithelp.S
@@ -184,12 +184,12 @@ LOCAL_LABEL(WriteBarrier_ShadowCheckEnd_\rg):
     PREPARE_EXTERNAL_VAR g_card_table, eax
     add     edx, [eax]
     pop     eax
-    cmp     BYTE PTR [edx], 0FFh
+    cmp     BYTE PTR [edx], 0xFF
     jne     LOCAL_LABEL(WriteBarrier_UpdateCardTable_\rg)
     ret
 
 LOCAL_LABEL(WriteBarrier_UpdateCardTable_\rg):
-    mov     BYTE PTR [edx], 0FFh
+    mov     BYTE PTR [edx], 0xFF
     ret
 
 LOCAL_LABEL(WriteBarrier_NotInHeap_\rg):
@@ -351,11 +351,11 @@ LOCAL_LABEL(ByRefWriteBarrier_ShadowCheckEnd):
     PREPARE_EXTERNAL_VAR g_card_table, eax
     add     ecx, [eax]
     pop     eax
-    cmp     BYTE PTR [ecx], 0FFh
+    cmp     BYTE PTR [ecx], 0xFF
     jne     LOCAL_LABEL(ByRefWriteBarrier_UpdateCardTable)
     ret
 LOCAL_LABEL(ByRefWriteBarrier_UpdateCardTable):
-    mov     BYTE PTR [ecx], 0FFh
+    mov     BYTE PTR [ecx], 0xFF
     ret
 
 LOCAL_LABEL(ByRefWriteBarrier_NotInHeap):
@@ -551,11 +551,11 @@ LEAF_ENTRY JIT_Dbl2LngP4x87, _TEXT
     // get some local space
     sub 	esp, 8
 
-    #define arg1 [esp + 0Ch]
+    #define arg1 [esp + 0x0C]
     fld     QWORD PTR arg1          // fetch arg
     fnstcw  WORD PTR arg1           // store FPCW
     movzx   eax, WORD PTR arg1      // zero extend - wide
-    or      ah, 0Ch                 // turn on OE and DE flags
+    or      ah, 0x0C                // turn on OE and DE flags
     mov     DWORD PTR [esp], eax    // store new FPCW bits
     fldcw   WORD PTR  [esp]         // reload FPCW with new bits
     fistp   QWORD PTR [esp]         // convert
@@ -589,7 +589,7 @@ LEAF_ENTRY JIT_Dbl2LngSSE3, _TEXT
     // get some local space
     sub     esp, 8
 
-    fld     QWORD PTR [esp + 0Ch]   // fetch arg
+    fld     QWORD PTR [esp + 0x0C]   // fetch arg
     fisttp  QWORD PTR [esp]         // convert
     mov     eax, DWORD PTR [esp]    // reload FP result
     mov     edx, DWORD PTR [esp + 4]
@@ -670,12 +670,12 @@ NESTED_END JIT_StackProbe, _TEXT
 //
 LEAF_ENTRY JIT_WriteBarrierReg_PreGrow, _TEXT
     mov     DWORD PTR [edx], ecx
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jb      LOCAL_LABEL(NoWriteBarrierPre)
 
     shr     edx, 10
     nop     // padding for alignment of constant
-    cmp     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    cmp     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     jne     LOCAL_LABEL(WriteBarrierPre)
 
 LOCAL_LABEL(NoWriteBarrierPre):
@@ -684,7 +684,7 @@ LOCAL_LABEL(NoWriteBarrierPre):
     nop     // padding for alignment of constant
 
 LOCAL_LABEL(WriteBarrierPre):
-    mov     BYTE PTR [edx+0F0F0F0F0h], 0FFh
+    mov     BYTE PTR [edx+0xF0F0F0F0], 0xFF
     ret
 LEAF_END JIT_WriteBarrierReg_PreGrow, _TEXT
 
@@ -700,14 +700,14 @@ LEAF_END JIT_WriteBarrierReg_PreGrow, _TEXT
 .align 4
 LEAF_ENTRY JIT_WriteBarrierReg_PostGrow, _TEXT
     mov     DWORD PTR [edx], ecx
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jb      LOCAL_LABEL(NoWriteBarrierPost)
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jae     LOCAL_LABEL(NoWriteBarrierPost)
 
     shr     edx, 10
     nop     // padding for alignment of constant
-    cmp     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    cmp     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     jne     LOCAL_LABEL(WriteBarrierPost)
 
 LOCAL_LABEL(NoWriteBarrierPost):
@@ -716,7 +716,7 @@ LOCAL_LABEL(NoWriteBarrierPost):
     nop     // padding for alignment of constant
 
 LOCAL_LABEL(WriteBarrierPost):
-    mov     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    mov     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     ret
 LEAF_END JIT_WriteBarrierReg_PostGrow,_TEXT
 
@@ -738,7 +738,7 @@ LEAF_END JIT_PatchedWriteBarrierGroup, _TEXT
 .align 8
 LEAF_ENTRY JIT_WriteBarrier\rg, _TEXT
     // Just allocate space that will be filled in at runtime
-    .space 0CCH, 48
+    .space 0xCC, 48
 LEAF_END JIT_WriteBarrier\rg, _TEXT
 
 .endm


### PR DESCRIPTION
clang doesn't recognize the postfix pattern.