### PR TITLE
Use lib prefix in all native library names

### DIFF
--- a/eng/native/naming.props
+++ b/eng/native/naming.props
@@ -1,0 +1,41 @@
+<Project>
+  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
+  <Choose>
+    <When Condition=" '$(_runtimeOSFamily)' == 'win' OR $(RuntimeIdentifier.StartsWith('win')) ">
+      <PropertyGroup>
+        <ApplicationFileExtension>.exe</ApplicationFileExtension>
+        <LibraryFilePrefix></LibraryFilePrefix>
+        <LibraryFileExtension>.dll</LibraryFileExtension>
+        <SymbolFileExtension>.pdb</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <When Condition=" '$(_runtimeOSFamily)' == 'osx' OR $(RuntimeIdentifier.StartsWith('osx')) ">
+      <PropertyGroup>
+        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <When Condition=" '$(_runtimeOSFamily)' == 'android' ">
+      <PropertyGroup>
+        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <!--symbols included in .so, like Linux, but can be generated externally and if so, uses .debug ext-->
+        <SymbolFileExtension>.debug</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <LibraryFilePrefix Condition=" '$(SkipLibraryPrefixFromUnix)' == '' ">lib</LibraryFilePrefix>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup>
+    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
+
+</Project>

--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -12,6 +12,9 @@
     <!-- build the transport package which includes product and symbols in addition to standard packages -->
     <CreatePackedPackage Condition="'$(CreatePackedPackage)' == ''">true</CreatePackedPackage>
 
+    <!-- indicates that lib prefix is not added to library names for Unix-like operating systems -->
+    <SkipLibraryPrefixFromUnix>true</SkipLibraryPrefixFromUnix>
+
     <!-- Distro rid is passed as runtimeos-arch-->
     <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
     <_parseDistroRid Condition="'$(_parseDistroRid)' == '' and '$(__BuildOS)' == 'OSX'">osx.10.12-x64</_parseDistroRid>
@@ -129,29 +132,7 @@
     </Otherwise>
   </Choose>
 
-  <!-- Determine per-platform native binary extensions. -->
-  <Choose>
-    <When Condition="'$(_runtimeOSFamily)' == 'win'" />
-    <When Condition="'$(_runtimeOSFamily)' == 'osx'">
-      <PropertyGroup>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'android'">
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <!--symbols included in .so, like Linux, but can be generated externally and if so, uses .debug ext-->
-        <SymbolFileExtension>.debug</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <Import Project="$(RepoRoot)eng\native\naming.props" />
 
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
     <OfficialBuildRID Include="linux-x64" />

--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
 
   <PropertyGroup>
@@ -169,36 +168,5 @@
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
 
-  <Choose>
-    <When Condition="$(RuntimeIdentifier.StartsWith('win'))">
-      <PropertyGroup>
-        <ApplicationFileExtension>.exe</ApplicationFileExtension>
-        <LibraryFilePrefix></LibraryFilePrefix>
-        <LibraryFileExtension>.dll</LibraryFileExtension>
-        <SymbolFileExtension>.pdb</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(RuntimeIdentifier.StartsWith('osx'))">
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <ItemGroup>
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
-  </ItemGroup>
-
+  <Import Project="$(RepoRoot)eng\native\naming.props" />
 </Project>

--- a/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -7,12 +7,12 @@ internal static partial class Interop
     internal static partial class Libraries
     {
         // Shims
-        internal const string SystemNative = "System.Native";
-        internal const string GlobalizationNative = "System.Globalization.Native";
-        internal const string NetSecurityNative = "System.Net.Security.Native";
-        internal const string CryptoNative = "System.Security.Cryptography.Native.OpenSsl";
-        internal const string CompressionNative = "System.IO.Compression.Native";
-        internal const string IOPortsNative = "System.IO.Ports.Native";
+        internal const string SystemNative = "libSystem.Native";
+        internal const string GlobalizationNative = "libSystem.Globalization.Native";
+        internal const string NetSecurityNative = "libSystem.Net.Security.Native";
+        internal const string CryptoNative = "libSystem.Security.Cryptography.Native.OpenSsl";
+        internal const string CompressionNative = "libSystem.IO.Compression.Native";
+        internal const string IOPortsNative = "libSystem.IO.Ports.Native";
         internal const string Libdl = "libdl";
     }
 }

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_MACOSX_RPATH ON)
 set(CMAKE_INSTALL_PREFIX $ENV{__CMakeBinDir})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(VERSION_FILE_PATH "${CMAKE_BINARY_DIR}/version.c")
 
 # We mark the function which needs exporting with PALEXPORT

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -79,8 +79,6 @@ add_library(System.Globalization.Native-Static
     ${NATIVEGLOBALIZATION_SOURCES}
 )
 
-# Disable the "lib" prefix and override default name
-set_target_properties(System.Globalization.Native-Static PROPERTIES PREFIX "")
 set_target_properties(System.Globalization.Native-Static PROPERTIES OUTPUT_NAME System.Globalization.Native  CLEAN_DIRECT_OUTPUT 1)
 
 install (TARGETS System.Globalization.Native-Static DESTINATION .)

--- a/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -61,8 +61,6 @@ add_library(System.IO.Compression.Native-Static
     ${NATIVECOMPRESSION_SOURCES}
 )
 
-# Disable the "lib" prefix and override default name
-set_target_properties(System.IO.Compression.Native-Static PROPERTIES PREFIX "")
 set_target_properties(System.IO.Compression.Native-Static PROPERTIES OUTPUT_NAME System.IO.Compression.Native  CLEAN_DIRECT_OUTPUT 1)
 
 install (TARGETS System.IO.Compression.Native-Static DESTINATION .)

--- a/src/libraries/Native/Unix/System.IO.Ports.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Ports.Native/CMakeLists.txt
@@ -13,8 +13,6 @@ add_library(System.IO.Ports.Native-Static
     pal_serial.c
 )
 
-# Disable the "lib" prefix and override default name
-set_target_properties(System.IO.Ports.Native-Static PROPERTIES PREFIX "")
 set_target_properties(System.IO.Ports.Native-Static PROPERTIES OUTPUT_NAME System.IO.Ports.Native  CLEAN_DIRECT_OUTPUT 1)
 
 install_library_and_symbols (System.IO.Ports.Native)

--- a/src/libraries/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Native/CMakeLists.txt
@@ -62,8 +62,6 @@ add_library(System.Native-Static
     ${NATIVE_SOURCES}
 )
 
-# Disable the "lib" prefix and override default name
-set_target_properties(System.Native-Static PROPERTIES PREFIX "")
 set_target_properties(System.Native-Static PROPERTIES OUTPUT_NAME System.Native CLEAN_DIRECT_OUTPUT 1)
 
 install (TARGETS System.Native-Static DESTINATION .)

--- a/src/libraries/Native/Unix/System.Net.Security.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Net.Security.Native/CMakeLists.txt
@@ -36,8 +36,6 @@ add_library(System.Net.Security.Native-Static
     ${NATIVEGSS_SOURCES}
 )
 
-# Disable the "lib" prefix and override default name
-set_target_properties(System.Net.Security.Native-Static PROPERTIES PREFIX "")
 set_target_properties(System.Net.Security.Native-Static PROPERTIES OUTPUT_NAME System.Net.Security.Native CLEAN_DIRECT_OUTPUT 1)
 
 target_link_libraries(System.Net.Security.Native

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -32,11 +32,6 @@ add_library(System.Security.Cryptography.Native.Apple-Static
     ${NATIVECRYPTO_SOURCES}
 )
 
-# Disable the "lib" prefix.
-set_target_properties(System.Security.Cryptography.Native.Apple PROPERTIES PREFIX "")
-
-# Disable the "lib" prefix and override default name
-set_target_properties(System.Security.Cryptography.Native.Apple-Static PROPERTIES PREFIX "")
 set_target_properties(System.Security.Cryptography.Native.Apple-Static PROPERTIES OUTPUT_NAME System.Security.Cryptography.Native.Apple CLEAN_DIRECT_OUTPUT 1)
 
 target_link_libraries(System.Security.Cryptography.Native.Apple

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -75,11 +75,6 @@ add_library(System.Security.Cryptography.Native.OpenSsl-Static
     $<TARGET_OBJECTS:objlib>
 )
 
-# Disable the "lib" prefix.
-set_target_properties(System.Security.Cryptography.Native.OpenSsl PROPERTIES PREFIX "")
-
-# Disable the "lib" prefix and override default name
-set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERTIES PREFIX "")
 set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERTIES OUTPUT_NAME System.Security.Cryptography.Native.OpenSsl CLEAN_DIRECT_OUTPUT 1)
 
 if (FEATURE_DISTRO_AGNOSTIC_SSL)

--- a/src/libraries/pkg/Directory.Build.props
+++ b/src/libraries/pkg/Directory.Build.props
@@ -35,30 +35,11 @@
     <Project Include="@(_project->'$(MSBuildProjectName).pkgproj')" />
   </ItemGroup>
 
-  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
-  <Choose>
-    <When Condition="$(PackageTargetRuntime.StartsWith('win'))"/>
-    <When Condition="$(PackageTargetRuntime.StartsWith('osx'))">
-      <PropertyGroup>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <ItemGroup>
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
-  </ItemGroup>
-
   <PropertyGroup>
     <!-- SuppressFinalPackageVersion on private packages by default -->
     <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(MSBuildProjectName.Contains('Private'))">true</SuppressFinalPackageVersion>
   </PropertyGroup>
+
+  <Import Project="$(RepoRoot)eng\native\naming.props" />
 
 </Project>

--- a/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
+++ b/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
@@ -5,7 +5,7 @@
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackageTargetRuntime)' == 'linux-arm' or '$(PackageTargetRuntime)' == 'linux-arm64' or '$(PackageTargetRuntime)' == 'linux-x64' or '$(PackageTargetRuntime)' == 'osx-x64' or '$(PackageTargetRuntime)' == 'freebsd-x64'">
-    <File Include="$(NativeBinDir)\System.IO.Ports.Native$(LibraryFileExtension)" >
+    <File Include="$(NativeBinDir)\$(LibraryFilePrefix)System.IO.Ports.Native$(LibraryFileExtension)" >
       <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
     </File>
   </ItemGroup>

--- a/src/mono/netcore/nuget/Directory.Build.props
+++ b/src/mono/netcore/nuget/Directory.Build.props
@@ -32,6 +32,7 @@
     <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
     <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
     <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' == '-1'">$(RuntimeOS)</_runtimeOSFamily>
+    <PackageTargetRuntime>$(_runtimeOSFamily)</PackageTargetRuntime>
     <_isSupportedOSGroup>true</_isSupportedOSGroup>
   </PropertyGroup>
 
@@ -114,29 +115,7 @@
     </Otherwise>
   </Choose>
 
-  <!-- Determine per-platform native binary extensions. -->
-  <Choose>
-    <When Condition="'$(_runtimeOSFamily)' == 'win'" />
-    <When Condition="'$(_runtimeOSFamily)' == 'osx'">
-      <PropertyGroup>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(_runtimeOSFamily)' == 'android'">
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <!--symbols included in .so, like Linux, but can be generated externally and if so, uses .debug ext-->
-        <SymbolFileExtension>.debug</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <Import Project="$(RepoRoot)eng\native\naming.props" />
 
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
     <OfficialBuildRID Include="linux-x64" />


### PR DESCRIPTION
Also consolidated related MSBuild properties in
`/eng/native/naming.props` file.

Fixes #33118