### PR TITLE
Remove Array.IsValueOfElementType internal call

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -478,8 +478,11 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern CorElementType GetCorElementTypeOfElementType();
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool IsValueOfElementType(object value);
+        private unsafe bool IsValueOfElementType(object value)
+        {
+            MethodTable* thisMT = RuntimeHelpers.GetMethodTable(this);
+            return (IntPtr)thisMT->ElementType == (IntPtr)RuntimeHelpers.GetMethodTable(value);
+        }
 
         // if this is an array of value classes and that value class has a default constructor
         // then this calls this default constructor on every element in the value class array.

--- a/src/coreclr/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/coreclr/src/classlibnative/bcltype/arraynative.cpp
@@ -29,15 +29,6 @@ FCIMPL1(INT32, ArrayNative::GetCorElementTypeOfElementType, ArrayBase* arrayUNSA
 }
 FCIMPLEND
 
-FCIMPL2(FC_BOOL_RET, ArrayNative::IsValueOfElementType, ArrayBase* arrayUNSAFE, Object* valueUNSAFE)
-{
-    _ASSERTE(arrayUNSAFE != NULL);
-    _ASSERTE(valueUNSAFE != NULL);
-
-    FC_RETURN_BOOL(arrayUNSAFE->GetArrayElementTypeHandle() == valueUNSAFE->GetTypeHandle());
-}
-FCIMPLEND
-
 // array is GC protected by caller
 void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
                            MethodTable* pArrayMT,

--- a/src/coreclr/src/classlibnative/bcltype/arraynative.h
+++ b/src/coreclr/src/classlibnative/bcltype/arraynative.h
@@ -26,7 +26,6 @@ class ArrayNative
 {
 public:
     static FCDECL1(INT32, GetCorElementTypeOfElementType, ArrayBase* arrayUNSAFE);
-    static FCDECL2(FC_BOOL_RET, IsValueOfElementType, ArrayBase* arrayUNSAFE, Object* valueUNSAFE);
 
     static FCDECL1(void, Initialize, ArrayBase* pArray);
 

--- a/src/coreclr/src/vm/ecalllist.h
+++ b/src/coreclr/src/vm/ecalllist.h
@@ -723,7 +723,6 @@ FCFuncEnd()
 
 FCFuncStart(gArrayFuncs)
     FCFuncElement("GetCorElementTypeOfElementType", ArrayNative::GetCorElementTypeOfElementType)
-    FCFuncElement("IsValueOfElementType", ArrayNative::IsValueOfElementType)
     FCFuncElement("Initialize", ArrayNative::Initialize)
     FCFuncElement("IsSimpleCopy", ArrayNative::IsSimpleCopy)
     FCFuncElement("CopySlow", ArrayNative::CopySlow)


### PR DESCRIPTION
Just a minor change to remove an internal call that can be easily implemented in C#.