### PR TITLE
Remove "virtual" from two methods in GregorianCalendarHelper

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
@@ -211,7 +211,7 @@ namespace System.Globalization
 
         // Returns a given date part of this DateTime. This method is used
         // to compute the year, day-of-year, month, or day part.
-        internal virtual int GetDatePart(long ticks, int part)
+        internal int GetDatePart(long ticks, int part)
         {
             CheckTicksRange(ticks);
             // n = number of days since 1/1/0001
@@ -624,7 +624,7 @@ namespace System.Globalization
             return new DateTime(ticks);
         }
 
-        public virtual int GetWeekOfYear(DateTime time, CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
+        public int GetWeekOfYear(DateTime time, CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
         {
             CheckTicksRange(time.Ticks);
             // Use GregorianCalendar to get around the problem that the implmentation in Calendar.GetWeekOfYear()


### PR DESCRIPTION
These "virtual" access modifiers look weird, the type is internal and doesn't have subclasses.
https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs#L49