### PR TITLE
Add new properties for Obsolete Attribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
@@ -18,36 +18,36 @@ namespace System
     // Error indicates if the compiler should treat usage of such a method as an
     //   error. (this would be used if the actual implementation of the obsolete
     //   method's implementation had changed).
+    // DiagnosticId. Represents the ID the compiler will use when reporting a use of the API.
+    // UrlFormat.The URL that should be used by an IDE for navigating to corresponding documentation. Instead of taking the URL directly,
+    //   the API takes a format string. This allows having a generic URL that includes the diagnostic ID.
     //
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
+       [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
         AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate,
         Inherited = false)]
     public sealed class ObsoleteAttribute : Attribute
     {
-        private readonly string? _message;
-        private readonly bool _error;
-
         public ObsoleteAttribute()
         {
-            _message = null;
-            _error = false;
+            Message = null;
+            IsError = false;
         }
 
         public ObsoleteAttribute(string? message)
         {
-            _message = message;
-            _error = false;
+            Message = message;
+            IsError = false;
         }
 
         public ObsoleteAttribute(string? message, bool error)
         {
-            _message = message;
-            _error = error;
+            Message = message;
+            IsError = error;
         }
 
-        public string? Message => _message;
+        public string? Message { get; }
 
-        public bool IsError => _error;
+        public bool IsError { get; }
 
         public string? DiagnosticId { get; set; }
 

--- a/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
@@ -22,7 +22,7 @@ namespace System
     // UrlFormat.The URL that should be used by an IDE for navigating to corresponding documentation. Instead of taking the URL directly,
     //   the API takes a format string. This allows having a generic URL that includes the diagnostic ID.
     //
-       [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
         AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate,
         Inherited = false)]
     public sealed class ObsoleteAttribute : Attribute

--- a/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ObsoleteAttribute.cs
@@ -48,5 +48,9 @@ namespace System
         public string? Message => _message;
 
         public bool IsError => _error;
+
+        public string? DiagnosticId { get; set; }
+
+        public string? UrlFormat { get; set; }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2899,6 +2899,8 @@ namespace System
         public ObsoleteAttribute(string? message, bool error) { }
         public bool IsError { get { throw null; } }
         public string? Message { get { throw null; } }
+        public string? DiagnosticId { get { throw null; } set { } }
+        public string? UrlFormat { get { throw null; } set { } }
     }
     public sealed partial class OperatingSystem : System.ICloneable, System.Runtime.Serialization.ISerializable
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2898,8 +2898,8 @@ namespace System
         public ObsoleteAttribute(string? message) { }
         public ObsoleteAttribute(string? message, bool error) { }
         public bool IsError { get { throw null; } }
-        public string? Message { get { throw null; } }
         public string? DiagnosticId { get { throw null; } set { } }
+        public string? Message { get { throw null; } }
         public string? UrlFormat { get { throw null; } set { } }
     }
     public sealed partial class OperatingSystem : System.ICloneable, System.Runtime.Serialization.ISerializable

--- a/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests
@@ -14,28 +17,69 @@ namespace System.Tests
             var attribute = new ObsoleteAttribute();
             Assert.Null(attribute.Message);
             Assert.False(attribute.IsError);
+            Assert.Null(attribute.DiagnosticId);
+            Assert.Null(attribute.UrlFormat);
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("message")]
-        public void Ctor_String(string message)
+        [InlineData(null, null)]
+        [InlineData("", "BCL0006")]
+        [InlineData("message", "")]
+        public void Ctor_String_Id(string message, string id)
         {
-            var attribute = new ObsoleteAttribute(message);
+            var attribute = new ObsoleteAttribute(message) { DiagnosticId = id};
             Assert.Equal(message, attribute.Message);
             Assert.False(attribute.IsError);
+            Assert.Equal(id, attribute.DiagnosticId);
+            Assert.Null(attribute.UrlFormat);
         }
 
         [Theory]
-        [InlineData(null, true)]
-        [InlineData("", false)]
-        [InlineData("message", true)]
-        public void Ctor_String_Bool(string message, bool error)
+        [InlineData(null, true, "")]
+        [InlineData("", false, null)]
+        [InlineData("message", true, "https://aka.ms/obsolete/{0}")]
+        public void Ctor_String_Bool_Url(string message, bool error, string url)
         {
-            var attribute = new ObsoleteAttribute(message, error);
+            var attribute = new ObsoleteAttribute(message, error) { UrlFormat = url};
             Assert.Equal(message, attribute.Message);
             Assert.Equal(error, attribute.IsError);
+            Assert.Null(attribute.DiagnosticId);
+            Assert.Equal(url, attribute.UrlFormat);
         }
+
+        [Theory]
+        [MemberData(nameof(TestData_Attributes))]
+        public void TestAttributeValuesWithReflection(Type testType, string message, bool error, string id, string url) {
+
+            Attribute attribute = Attribute.GetCustomAttributes(testType, typeof(Attribute)).Where((e) => e.GetType() == typeof(ObsoleteAttribute)).SingleOrDefault();
+
+            Assert.NotNull(attribute);
+            Assert.Equal(message, attribute.GetType().GetProperty("Message").GetValue(attribute));
+            Assert.Equal(error, attribute.GetType().GetProperty("IsError").GetValue(attribute));
+            Assert.Equal(id, attribute.GetType().GetProperty("DiagnosticId").GetValue(attribute));
+            Assert.Equal(url, attribute.GetType().GetProperty("UrlFormat").GetValue(attribute));
+        }
+
+        public static IEnumerable<object[]> TestData_Attributes()
+        {
+#pragma warning disable
+            yield return new object[] { typeof(ClassMessageAndDiagnosticIdPropertySet), "Don't use", false, "BCL0006", null };
+            yield return new object[] { typeof(ClassEmptyConstructorOptionalPropertiesSet), null, false, "BCL0003", "https://aka.ms/obsolete3/{0}" };
+            yield return new object[] { typeof(ClassMessageAndUrlFormatPropertySet), "Obsolete", false, null, "https://aka.ms/obsolete2/{0}" };
+            yield return new object[] { typeof(ClassAllFieldPropertiesSet), "Deprecated", false, "BCL0001", "https://aka.ms/obsolete1/{0}" };
+#pragma warning restore
+        }
+
+        [Obsolete("Don't use", DiagnosticId = "BCL0006")]
+        private class ClassMessageAndDiagnosticIdPropertySet { }
+
+        [Obsolete( DiagnosticId = "BCL0003", UrlFormat = "https://aka.ms/obsolete3/{0}")]
+        private class ClassEmptyConstructorOptionalPropertiesSet { }
+
+        [Obsolete("Obsolete", UrlFormat = "https://aka.ms/obsolete2/{0}")]
+        private class ClassMessageAndUrlFormatPropertySet { }
+
+        [Obsolete("Deprecated", false, UrlFormat = "https://aka.ms/obsolete1/{0}", DiagnosticId = "BCL0001")]
+        private class ClassAllFieldPropertiesSet { }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Tests

--- a/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
@@ -46,41 +46,5 @@ namespace System.Tests
             Assert.Null(attribute.DiagnosticId);
             Assert.Equal(url, attribute.UrlFormat);
         }
-
-        [Theory]
-        [MemberData(nameof(TestData_Attributes))]
-        public void TestAttributeValuesWithReflection(Type testType, string message, bool error, string id, string url)
-        {
-
-            Attribute attribute = Attribute.GetCustomAttributes(testType, typeof(Attribute)).Where((e) => e.GetType() == typeof(ObsoleteAttribute)).SingleOrDefault();
-
-            Assert.NotNull(attribute);
-            Assert.Equal(message, attribute.GetType().GetProperty("Message").GetValue(attribute));
-            Assert.Equal(error, attribute.GetType().GetProperty("IsError").GetValue(attribute));
-            Assert.Equal(id, attribute.GetType().GetProperty("DiagnosticId").GetValue(attribute));
-            Assert.Equal(url, attribute.GetType().GetProperty("UrlFormat").GetValue(attribute));
-        }
-
-        public static IEnumerable<object[]> TestData_Attributes()
-        {
-#pragma warning disable
-            yield return new object[] { typeof(ClassMessageAndDiagnosticIdPropertySet), "Don't use", false, "BCL0006", null };
-            yield return new object[] { typeof(ClassEmptyConstructorOptionalPropertiesSet), null, false, "BCL0003", "https://aka.ms/obsolete3/{0}" };
-            yield return new object[] { typeof(ClassMessageAndUrlFormatPropertySet), "Obsolete", false, null, "https://aka.ms/obsolete2/{0}" };
-            yield return new object[] { typeof(ClassAllFieldPropertiesSet), "Deprecated", false, "BCL0001", "https://aka.ms/obsolete1/{0}" };
-#pragma warning restore
-        }
-
-        [Obsolete("Don't use", DiagnosticId = "BCL0006")]
-        private class ClassMessageAndDiagnosticIdPropertySet { }
-
-        [Obsolete(DiagnosticId = "BCL0003", UrlFormat = "https://aka.ms/obsolete3/{0}")]
-        private interface ClassEmptyConstructorOptionalPropertiesSet { }
-
-        [Obsolete("Obsolete", UrlFormat = "https://aka.ms/obsolete2/{0}")]
-        private delegate void ClassMessageAndUrlFormatPropertySet();
-
-        [Obsolete("Deprecated", false, UrlFormat = "https://aka.ms/obsolete1/{0}", DiagnosticId = "BCL0001")]
-        private struct ClassAllFieldPropertiesSet { }
     }   
 }

--- a/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
@@ -27,7 +27,7 @@ namespace System.Tests
         [InlineData("message", "")]
         public void Ctor_String_Id(string message, string id)
         {
-            var attribute = new ObsoleteAttribute(message) { DiagnosticId = id};
+            var attribute = new ObsoleteAttribute(message) { DiagnosticId = id };
             Assert.Equal(message, attribute.Message);
             Assert.False(attribute.IsError);
             Assert.Equal(id, attribute.DiagnosticId);
@@ -40,7 +40,7 @@ namespace System.Tests
         [InlineData("message", true, "https://aka.ms/obsolete/{0}")]
         public void Ctor_String_Bool_Url(string message, bool error, string url)
         {
-            var attribute = new ObsoleteAttribute(message, error) { UrlFormat = url};
+            var attribute = new ObsoleteAttribute(message, error) { UrlFormat = url };
             Assert.Equal(message, attribute.Message);
             Assert.Equal(error, attribute.IsError);
             Assert.Null(attribute.DiagnosticId);
@@ -49,7 +49,8 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(TestData_Attributes))]
-        public void TestAttributeValuesWithReflection(Type testType, string message, bool error, string id, string url) {
+        public void TestAttributeValuesWithReflection(Type testType, string message, bool error, string id, string url)
+        {
 
             Attribute attribute = Attribute.GetCustomAttributes(testType, typeof(Attribute)).Where((e) => e.GetType() == typeof(ObsoleteAttribute)).SingleOrDefault();
 
@@ -73,13 +74,13 @@ namespace System.Tests
         [Obsolete("Don't use", DiagnosticId = "BCL0006")]
         private class ClassMessageAndDiagnosticIdPropertySet { }
 
-        [Obsolete( DiagnosticId = "BCL0003", UrlFormat = "https://aka.ms/obsolete3/{0}")]
-        private class ClassEmptyConstructorOptionalPropertiesSet { }
+        [Obsolete(DiagnosticId = "BCL0003", UrlFormat = "https://aka.ms/obsolete3/{0}")]
+        private interface ClassEmptyConstructorOptionalPropertiesSet { }
 
         [Obsolete("Obsolete", UrlFormat = "https://aka.ms/obsolete2/{0}")]
-        private class ClassMessageAndUrlFormatPropertySet { }
+        private delegate void ClassMessageAndUrlFormatPropertySet();
 
         [Obsolete("Deprecated", false, UrlFormat = "https://aka.ms/obsolete1/{0}", DiagnosticId = "BCL0001")]
-        private class ClassAllFieldPropertiesSet { }
-    }
+        private struct ClassAllFieldPropertiesSet { }
+    }   
 }

--- a/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObsoleteAttributeTests.cs
@@ -43,5 +43,5 @@ namespace System.Tests
             Assert.Null(attribute.DiagnosticId);
             Assert.Equal(url, attribute.UrlFormat);
         }
-    }   
+    }
 }


### PR DESCRIPTION
Add `DiagnosticId, UrlFormat` properties for Obsolete Attribute
Related to https://github.com/dotnet/runtime/issues/33089