### PR TITLE
Use uname -m for arch detection on Darwin family

### DIFF
--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -16,7 +16,8 @@ esac
 CPUName=$(uname -p)
 
 # Some Linux platforms report unknown for platform, but the arch for machine.
-if [[ "$CPUName" == "unknown" ]]; then
+# On macOS, -p prints the generic processor type, which is i386 and -m prints the machine hardware name.
+if [[ "$CPUName" == "unknown" || "$OSName" == "Darwin" ]]; then
     CPUName=$(uname -m)
 fi
 


### PR DESCRIPTION
Currently the CI as well as my local system is showing this warning on macOS:

```sh
/Users/runner/runners/2.165.0/work/1/s/installer.sh --restore --build --ci --test -configuration Debug /p:StripSymbols=true /p:RuntimeArtifactsPath=/Users/runner/runners/2.165.0/work/1/s/artifacts/transport/coreclr /p:RuntimeConfiguration=release  /p:LibrariesConfiguration=Debug   /p:PortableBuild=true /p:SkipTests=False
========================== Starting Command Output ===========================
/bin/bash --noprofile --norc /Users/runner/runners/2.165.0/work/_temp/88dee7f6-0ef1-4d7a-ae4c-58077dd22fc0.sh
Unsupported CPU i386 detected, build might not succeed!
__DistroRid: osx-x86
__RuntimeId: osx-x86
Downloading 'https://dot.net/v1/dotnet-install.sh'
...
```

PR fixes the warning.