### PR TITLE
Fix error logging in referenceFromRuntime.targets

### DIFF
--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -1,6 +1,5 @@
 <Project>
-
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) and '$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+  <PropertyGroup Condition="'$(TargetsNetCoreApp)' == 'true' and '$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <PrepareProjectReferencesDependsOn>
       AddRuntimeProjectReference;
       $(PrepareProjectReferencesDependsOn);
@@ -14,14 +13,15 @@
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <RuntimeProjectFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'restore', 'runtime', 'runtime.depproj'))</RuntimeProjectFile>
+  </PropertyGroup>
 
   <Target Name="AddRuntimeProjectReference"
           Condition="'$(IsTestProject)'!='true' and '@(ReferenceFromRuntime)' != ''">
-    <Error Condition="'$(IsReferenceAssembly)' == 'true' and '$(AllowReferenceFromRuntime)' != 'true'" Text="ReferenceFromRuntime may not be used from reference assemblies." />
-
-    <PropertyGroup>
-      <RuntimeProjectFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'restore', 'runtime', 'runtime.depproj'))</RuntimeProjectFile>
-    </PropertyGroup>
+    <Error Text="ReferenceFromRuntime may not be used from reference assemblies."
+           Condition="'$(IsReferenceAssembly)' == 'true' and '$(AllowReferenceFromRuntime)' != 'true'" />
 
     <ItemGroup>
       <ProjectReference Include="$(RuntimeProjectFile)">


### PR DESCRIPTION
The RuntimeProjectFile property is used in the FilterReferenceFromRuntime target for error logging but is only available in the AddRuntimeProjectReference target. Moving this out onto the project level.

(I'm also doing some minor formatting).