### PR TITLE
Implement building the repo for multiple configurations and architectures with a single command on Windows.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,5 +4,5 @@ setlocal
 set _args=%*
 if "%~1"=="-?" set _args=-help
 
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %_args%
+powershell -ExecutionPolicy ByPass -NoProfile -Command "%~dp0eng\build.ps1" %_args%
 exit /b %ERRORLEVEL%

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -158,7 +158,7 @@ $failedBuilds = @()
 foreach ($config in $configuration) {
   $argumentsWithConfig = $arguments + " -configuration $((Get-Culture).TextInfo.ToTitleCase($config))";
   foreach ($singleArch in $arch) {
-    $argumentsWithArch = $argumentsWithConfig + " /p:ArchGroup=$singleArch /p:TargetArchitecture=$singleArch"
+    $argumentsWithArch =  "/p:ArchGroup=$singleArch /p:TargetArchitecture=$singleArch " + $argumentsWithConfig
     $env:__DistroRid="win-$singleArch"
     Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $argumentsWithArch"
     if ($lastExitCode -ne 0) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -25,7 +25,7 @@ function Get-Help() {
   Write-Host "  -subsetCategory           Build a subsetCategory, print available subsetCategories with -subset help"
   Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
   Write-Host "  -os                       Build operating system: Windows_NT or Unix"
-  Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -r). Pass a comma-separated list to build for multiple architectures."
+  Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -a). Pass a comma-separated list to build for multiple architectures."
   Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
   Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked"
   Write-Host "  -librariesConfiguration   Libraries build configuration: Debug or Release"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -153,6 +153,8 @@ foreach ($argument in $PSBoundParameters.Keys)
   }
 }
 
+$failedBuilds = @()
+
 foreach ($config in $configuration) {
   $argumentsWithConfig = $arguments + " -configuration $((Get-Culture).TextInfo.ToTitleCase($config))";
   foreach ($singleArch in $arch) {
@@ -160,9 +162,17 @@ foreach ($config in $configuration) {
     $env:__DistroRid="win-$singleArch"
     Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $argumentsWithArch"
     if ($lastExitCode -ne 0) {
-        exit $lastExitCode
+        $failedBuilds += "Configuration: $config, Architecture: $singleArch"
     }
   }
+}
+
+if ($failedBuilds.Count -ne 0) {
+    echo "Some builds failed:"
+    foreach ($failedBuild in $failedBuilds) {
+        echo "`t$failedBuild"
+    }
+    exit 1
 }
 
 exit 0

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -11,7 +11,7 @@ Param(
   [switch]$allconfigurations,
   [switch]$coverage,
   [string]$testscope,
-  [string[]]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+  [string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
   [string]$subsetCategory,
   [string]$subset,
   [ValidateSet("Debug","Release","Checked")][string]$runtimeConfiguration,
@@ -25,8 +25,8 @@ function Get-Help() {
   Write-Host "  -subsetCategory           Build a subsetCategory, print available subsetCategories with -subset help"
   Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
   Write-Host "  -os                       Build operating system: Windows_NT or Unix"
-  Write-Host "  -arch                     Build platform: x86, x64, arm or arm64"
-  Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c)"
+  Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -r). Pass a comma-separated list to build for multiple architectures."
+  Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
   Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked"
   Write-Host "  -librariesConfiguration   Libraries build configuration: Debug or Release"
   Write-Host "  -verbosity                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
@@ -168,9 +168,9 @@ foreach ($config in $configuration) {
 }
 
 if ($failedBuilds.Count -ne 0) {
-    echo "Some builds failed:"
+    Write-Host "Some builds failed:"
     foreach ($failedBuild in $failedBuilds) {
-        echo "`t$failedBuild"
+        Write-Host "`t$failedBuild"
     }
     exit 1
 }


### PR DESCRIPTION
This change allows developers to specify multiple configurations and architectures to build for in a single command by passing comma-separated lists to each parameter (PowerShell makes it comma separated instead of multiple instances of the option sadly). This feature is currently Windows only unless we also want to add support to the bash script.

For example:
```
./build -subset coreclr -a x64,arm,x86 -c debug,checked,release
```

This should enable users of the old `./src/coreclr/build.cmd all ...` command to be able to generally keep their workflow when moving to the root script.

cc: @BruceForstall 