### PR TITLE
Run APICompat against the previous release of NETCoreApp

### DIFF
--- a/eng/ApiCompatExcludeAttributes.txt
+++ b/eng/ApiCompatExcludeAttributes.txt
@@ -1,0 +1,1 @@
+T:System.CLSCompliantAttribute

--- a/eng/DefaultGenApiDocIds.txt
+++ b/eng/DefaultGenApiDocIds.txt
@@ -27,6 +27,7 @@ T:System.Runtime.CompilerServices.NullableAttribute
 T:System.Runtime.CompilerServices.NullableContextAttribute
 T:System.Runtime.CompilerServices.PreserveDependencyAttribute
 T:System.Runtime.CompilerServices.TypeForwardedFromAttribute
+T:System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute
 T:System.Runtime.ConstrainedExecution.ReliabilityContractAttribute
 T:System.Runtime.InteropServices.ClassInterfaceAttribute
 T:System.Runtime.InteropServices.ComDefaultInterfaceAttribute

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
   </ItemGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20160.4</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20161.5</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20160.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20160.4</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20153.1</MicrosoftDotNetGenAPIVersion>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -152,7 +152,7 @@
   <PropertyGroup>
     <RunApiCompatForSrc>$(IsSourceProject)</RunApiCompatForSrc>
     <RunMatchingRefApiCompat>$(IsSourceProject)</RunMatchingRefApiCompat>
-    <ApiCompatExcludeAttributeList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</ApiCompatExcludeAttributeList>
+    <ApiCompatExcludeAttributeList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt,$(RepositoryEngineeringDir)ApiCompatExcludeAttributes.txt</ApiCompatExcludeAttributeList>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/restore/dirs.proj
+++ b/src/libraries/restore/dirs.proj
@@ -4,8 +4,7 @@
   <ItemGroup>
     <Project Condition="'$(DotNetBuildFromSource)' != 'true'" Include="analyzers/analyzers.depproj" />
 
-    <!-- Build for all configurations -->
-    <Project Condition="'$(BuildAllConfigurations)' == 'true'" Include="netcoreapp/netcoreapp.depproj" />
+    <Project Condition="'$(DotNetBuildFromSource)' != 'true'" Include="netcoreapp/netcoreapp.depproj" />
     <Project Include="netstandard/netstandard.depproj" />
     <Project Include="netfx/netfx.depproj" />
     <Project Include="tools/tools.depproj" />

--- a/src/libraries/restore/netcoreapp/netcoreapp.depproj
+++ b/src/libraries/restore/netcoreapp/netcoreapp.depproj
@@ -5,7 +5,7 @@
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
     <BinPlaceRef>true</BinPlaceRef>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp2.'))">

--- a/src/libraries/shims/ApiCompat.proj
+++ b/src/libraries/shims/ApiCompat.proj
@@ -95,7 +95,27 @@
     </Exec>
 
     <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed comparing netstandard to $(ApiCompatTarget)" />
+ 
+    <PropertyGroup>
+      <PreviousNetCoreApp>netcoreapp3.1</PreviousNetCoreApp>
+      <PreviousNetCoreAppRefPath>$([MSBuild]::NormalizeDirectory('$(RefRootPath)', '$(PreviousNetCoreApp)'))</PreviousNetCoreAppRefPath>
+      <_previousNetCoreAppBaselineFile>$(MSBuildThisFileDirectory)ApiCompatBaseline.PreviousNetCoreApp.txt</_previousNetCoreAppBaselineFile>
+      <_previousNetCoreAppBaselineParam>--baseline &quot;$(_previousNetCoreAppBaselineFile)&quot;</_previousNetCoreAppBaselineParam>
+      <_previousNetCoreAppBaselineParam Condition="'$(UpdatePreviousNetCoreAppBaseline)' == 'true'">&gt; &quot;$(_previousNetCoreAppBaselineFile)&quot;</_previousNetCoreAppBaselineParam>
+    </PropertyGroup>
+ 
+    <Error Condition="'$(NetCoreAppCurrent)' != 'netcoreapp5.0'" Text="Update value of PreviousNetCoreApp" />
+    <Error Condition="!Exists($(PreviousNetCoreAppRefPath))" Text="Missing reference assemblies for '$(PreviousNetCoreApp)'" />
+    <Exec Command="$(_ApiCompatCommand) &quot;$(PreviousNetCoreAppRefPath.TrimEnd('\/'))&quot;  @&quot;$(ApiCompatResponseFile)&quot; $(_previousNetCoreAppBaselineParam)"
+          CustomErrorRegularExpression="^[a-zA-Z]+ :"
+          StandardOutputImportance="Low"
+          IgnoreExitCode="true"
+          Condition="'$(DotNetBuildFromSource)' != 'true'"
+    >
+      <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
+    </Exec>
 
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed comparing $(PreviousNetCoreApp) to $(ApiCompatTarget)" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="RunApiCompat" />

--- a/src/libraries/shims/ApiCompat.proj
+++ b/src/libraries/shims/ApiCompat.proj
@@ -110,7 +110,6 @@
           CustomErrorRegularExpression="^[a-zA-Z]+ :"
           StandardOutputImportance="Low"
           IgnoreExitCode="true"
-          Condition="'$(DotNetBuildFromSource)' != 'true'"
     >
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>

--- a/src/libraries/shims/ApiCompatBaseline.PreviousNetCoreApp.txt
+++ b/src/libraries/shims/ApiCompatBaseline.PreviousNetCoreApp.txt
@@ -1,27 +1,10 @@
-Compat issues with assembly mscorlib:
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
 Compat issues with assembly netstandard:
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerReportsProgress' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerSupportsCancellation' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.Process.EnableRaisingEvents' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.Environment' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' on 'System.Diagnostics.ProcessStartInfo.Verb' changed from '[DefaultValueAttribute(null)]' in the contract to '[DefaultValueAttribute("")]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.WindowStyle' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
 Compat issues with assembly System:
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerReportsProgress' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerSupportsCancellation' in the contract but not the implementation.
@@ -37,15 +20,4 @@ CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' 
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.Environment' in the contract but not the implementation.
 CannotChangeAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' on 'System.Diagnostics.ProcessStartInfo.Verb' changed from '[DefaultValueAttribute(null)]' in the contract to '[DefaultValueAttribute("")]' in the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.WindowStyle' in the contract but not the implementation.
-Compat issues with assembly System.Runtime:
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
-Compat issues with assembly System.Runtime.InteropServices:
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
-Compat issues with assembly System.Threading:
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
-Total Issues: 42
+Total Issues: 18

--- a/src/libraries/shims/ApiCompatBaseline.PreviousNetCoreApp.txt
+++ b/src/libraries/shims/ApiCompatBaseline.PreviousNetCoreApp.txt
@@ -1,0 +1,51 @@
+Compat issues with assembly mscorlib:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+Compat issues with assembly netstandard:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerReportsProgress' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerSupportsCancellation' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.Process.EnableRaisingEvents' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.Environment' in the contract but not the implementation.
+CannotChangeAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' on 'System.Diagnostics.ProcessStartInfo.Verb' changed from '[DefaultValueAttribute(null)]' in the contract to '[DefaultValueAttribute("")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.WindowStyle' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+Compat issues with assembly System:
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerReportsProgress' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerSupportsCancellation' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.Process.EnableRaisingEvents' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.Environment' in the contract but not the implementation.
+CannotChangeAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' on 'System.Diagnostics.ProcessStartInfo.Verb' changed from '[DefaultValueAttribute(null)]' in the contract to '[DefaultValueAttribute("")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.WindowStyle' in the contract but not the implementation.
+Compat issues with assembly System.ComponentModel.EventBasedAsync:
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerReportsProgress' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.ComponentModel.BackgroundWorker.WorkerSupportsCancellation' in the contract but not the implementation.
+Compat issues with assembly System.Diagnostics.Process:
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.Process.EnableRaisingEvents' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.Environment' in the contract but not the implementation.
+CannotChangeAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' on 'System.Diagnostics.ProcessStartInfo.Verb' changed from '[DefaultValueAttribute(null)]' in the contract to '[DefaultValueAttribute("")]' in the implementation.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultValueAttribute' exists on 'System.Diagnostics.ProcessStartInfo.WindowStyle' in the contract but not the implementation.
+Compat issues with assembly System.Runtime:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.TypedReference.SetTypedReference(System.TypedReference, System.Object)' in the contract but not the implementation.
+Compat issues with assembly System.Runtime.InteropServices:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToBSTR(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToCoTaskMemUnicode(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocAnsi(System.Security.SecureString)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(System.Security.SecureString)' in the contract but not the implementation.
+Compat issues with assembly System.Threading:
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.Wait(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute' exists on 'System.Threading.SynchronizationContext.WaitHelper(System.IntPtr[], System.Boolean, System.Int32)' in the contract but not the implementation.
+Total Issues: 42


### PR DESCRIPTION
We didn't have explicit coverage to catch APICompat issues with previous versions of netcoreapp.

This adds a basic check for the things in NETCoreApp shared framework.  This does not cover all stand-alone packages.  For those, I think we could add a similar step to either package build or package testing (which are aware of the previous version of the package).