### PR TITLE
Change minimum required OSX version to 10.13

### DIFF
--- a/src/installer/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/src/installer/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -7,7 +7,7 @@
     <conclusion file="conclusion.html" mime-type="text/html" />
     <volume-check>
         <allowed-os-versions>
-            <os-version min="10.12" />
+            <os-version min="10.13" />
         </allowed-os-versions>
     </volume-check>
     <choices-outline>


### PR DESCRIPTION
A simple fix for minimum required OSX version.

Fixes the issue: https://github.com/dotnet/runtime/issues/439
