### PR TITLE
Don't inline StelemRef_Helper.

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -558,6 +558,7 @@ namespace System.Runtime.CompilerServices
         [DebuggerHidden]
         [StackTraceHidden]
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void StelemRef_Helper(ref object? element, void* elementType, object obj)
         {
             CastResult result = TryGet((nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)elementType);


### PR DESCRIPTION
Under some jit stress modes the jit tries to inline StelemRef_Helper into
StelemRef. StelemRef is jitted very early and the jit is not yet prepared
to handle this inline.

Fixes #33298.