### PR TITLE
In error reporting `load_library` should pass `char*`, not`string_t`

### DIFF
--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -198,7 +198,7 @@ bool pal::load_library(const string_t* path, dll_t* dll)
     *dll = dlopen(path->c_str(), RTLD_LAZY);
     if (*dll == nullptr)
     {
-        trace::error(_X("Failed to load %s, error: %s"), path, dlerror());
+        trace::error(_X("Failed to load %s, error: %s"), path->c_str(), dlerror());
         return false;
     }
     return true;


### PR DESCRIPTION
We rarely see output from this function, only when something is wrong and failed to load.

And then we see:
```
Failed to load À@â;, error: /home/user/linux-arm64/publish/libcoreclr.so: cannot open shared object file: No such file or directory
```
