### PR TITLE
Fix test for COM + dynamic keyword

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -382,9 +382,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/WinRT/NETClients/Bindings/NETClientBindings/*">
             <Issue>WindowsXamlManager and DesktopWindowXamlSource are supported for apps targeting Windows version 10.0.18226.0 and later.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/Dynamic/Dynamic/*">
-            <Issue>https://github.com/dotnet/runtime/issues/33276</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->

--- a/src/coreclr/tests/src/Interop/COM/Dynamic/Server/BasicTest.cpp
+++ b/src/coreclr/tests/src/Interop/COM/Dynamic/Server/BasicTest.cpp
@@ -343,7 +343,7 @@ namespace
 HRESULT STDMETHODCALLTYPE BasicTest::get_String_Property(
     /* [retval][out] */ BSTR *ret)
 {
-    *ret = _string;
+    *ret = ::SysAllocString(_string);
     return S_OK;
 }
 


### PR DESCRIPTION
🤦‍♀ 

Fix #33276 

I believe this was showing up as failing at different points due to BSTR caching. With caching disabled, when I got local repros, it pointed at this BSTR being the issue.