### PR TITLE
Fix JIT crash caused by GetType() == typeof(SealedClass) optimization

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14992,9 +14992,9 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
 
             if (condTree != cond)
             {
-                // Preserve the potentially side effecting part of the comma
+                // Preserve any side effects
                 assert(condTree->OperIs(GT_COMMA));
-                lastStmt->SetRootNode(condTree->AsOp()->gtOp1);
+                lastStmt->SetRootNode(condTree);
             }
             else
             {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14777,8 +14777,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
             }
             else
             {
-                // remove the statement from bbTreelist - No need to update
-                // the reference counts since there are no lcl vars
+                // no side effects, remove the jump entirely
                 fgRemoveStmt(block, lastStmt);
             }
             // block is a BBJ_COND that we are folding the conditional for

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14756,8 +14756,10 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
         /* Did we fold the conditional */
 
         noway_assert(lastStmt->GetRootNode()->AsOp()->gtOp1);
-        GenTree* condTree = lastStmt->GetRootNode()->AsOp()->gtOp1;
-        GenTree* cond     = condTree->gtEffectiveVal(true);
+        GenTree* condTree;
+        condTree = lastStmt->GetRootNode()->AsOp()->gtOp1;
+        GenTree* cond;
+        cond = condTree->gtEffectiveVal(true);
 
         if (cond->OperKind() & GTK_CONST)
         {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14771,9 +14771,9 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
 
             if (condTree != cond)
             {
-                // Preserve the potentially side effecting part of the comma
+                // Preserve any side effects
                 assert(condTree->OperIs(GT_COMMA));
-                lastStmt->SetRootNode(condTree->AsOp()->gtOp1);
+                lastStmt->SetRootNode(condTree);
             }
             else
             {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -14999,8 +14999,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
             }
             else
             {
-                // remove the statement from bbTreelist - No need to update
-                // the reference counts since there are no lcl vars
+                // no side effects, remove the switch entirely
                 fgRemoveStmt(block, lastStmt);
             }
 

--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed.cs
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Make sure optimization works correctly under GT_JTRUE and GT_RETURN nodes
+// Also, if it respects/preserves side-effects and doesn't optimize away
+// possible NREs.
+
+public sealed class SealedClass1
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Type GetTypeInlineable() => GetType();
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary1() => GetTypeInlineable() == typeof(SealedClass1) ? "Ok" : "Fail";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary2() => GetTypeInlineable() == typeof(SealedClass2) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary3() => GetTypeInlineable() == typeof(NotSealedClass1) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary4() => GetType() == typeof(SealedClass1) ? "Ok" : "Fail";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary5() => GetType() == typeof(SealedClass2) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public object TestTernary6() => GetType() == typeof(NotSealedClass1) ? "Fail" : "Ok";
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary7(SealedClass1 instance) => instance.GetType() == typeof(SealedClass1) ? "Ok" : "Fail";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary8(SealedClass1 instance) => instance.GetType() == typeof(SealedClass2) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary9(SealedClass1 instance) => instance.GetType() == typeof(NotSealedClass1) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary10(SealedClass1 instance) => instance.GetTypeInlineable() == typeof(SealedClass1) ? "Ok" : "Fail";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary11(SealedClass1 instance) => instance.GetTypeInlineable() == typeof(SealedClass2) ? "Fail" : "Ok";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object TestTernary12(SealedClass1 instance) => instance.GetTypeInlineable() == typeof(NotSealedClass1) ? "Fail" : "Ok";
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn1() => GetTypeInlineable() == typeof(SealedClass1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn2() => GetTypeInlineable() == typeof(SealedClass2);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn3() => GetTypeInlineable() == typeof(NotSealedClass1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn4() => GetTypeInlineable() != typeof(SealedClass1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn5() => GetTypeInlineable() != typeof(SealedClass2);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn6() => GetTypeInlineable() != typeof(NotSealedClass1);
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn7() => GetType() == typeof(SealedClass1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn8() => GetType() == typeof(SealedClass2);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public bool TestReturn9() => GetType() == typeof(NotSealedClass1);
+}
+
+public sealed class SealedClass2 { }
+public class NotSealedClass1 { }
+
+public static class Program
+{
+    private static int returnCode = 100;
+
+    public static int Main(string[] args)
+    {
+        var tests = new SealedClass1();
+        AssertEquals("Ok", tests.TestTernary1());
+        AssertEquals("Ok", tests.TestTernary2());
+        AssertEquals("Ok", tests.TestTernary3());
+        AssertEquals("Ok", tests.TestTernary4());
+        AssertEquals("Ok", tests.TestTernary5());
+        AssertEquals("Ok", tests.TestTernary6());
+        AssertEquals("Ok", SealedClass1.TestTernary7(new SealedClass1()));
+        AssertEquals("Ok", SealedClass1.TestTernary8(new SealedClass1()));
+        AssertEquals("Ok", SealedClass1.TestTernary9(new SealedClass1()));
+        AssertEquals("Ok", SealedClass1.TestTernary10(new SealedClass1()));
+        AssertEquals("Ok", SealedClass1.TestTernary11(new SealedClass1()));
+        AssertEquals("Ok", SealedClass1.TestTernary12(new SealedClass1()));
+        ThrowsNRE(() => SealedClass1.TestTernary7(null));
+        ThrowsNRE(() => SealedClass1.TestTernary8(null));
+        ThrowsNRE(() => SealedClass1.TestTernary9(null));
+        ThrowsNRE(() => SealedClass1.TestTernary10(null));
+        ThrowsNRE(() => SealedClass1.TestTernary11(null));
+        ThrowsNRE(() => SealedClass1.TestTernary12(null));
+        AssertIsTrue(tests.TestReturn1());
+        AssertIsFalse(tests.TestReturn2());
+        AssertIsFalse(tests.TestReturn3());
+        AssertIsFalse(tests.TestReturn4());
+        AssertIsTrue(tests.TestReturn5());
+        AssertIsTrue(tests.TestReturn6());
+        AssertIsTrue(tests.TestReturn7());
+        AssertIsFalse(tests.TestReturn8());
+        AssertIsFalse(tests.TestReturn9());
+        return returnCode;
+    }
+
+    private static void ThrowsNRE(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (NullReferenceException)
+        {
+            return;
+        }
+
+        returnCode++;
+        Console.WriteLine($"Expected: NullReferenceException");
+    }
+
+    private static void AssertEquals(object expected, object actual, [CallerLineNumber] int line = 0)
+    {
+        if (expected != actual)
+        {
+            returnCode++;
+            Console.WriteLine($"{expected} != {actual}, L:{line}");
+        }
+    }
+
+    private static void AssertIsTrue(bool value, [CallerLineNumber] int line = 0)
+    {
+        if (!value)
+        {
+            returnCode++;
+            Console.WriteLine($"Expected: True, L:{line}");
+        }
+    }
+
+    private static void AssertIsFalse(bool value, [CallerLineNumber] int line = 0)
+    {
+        if (value)
+        {
+            returnCode++;
+            Console.WriteLine($"Expected: False, L:{line}");
+        }
+    }
+}

--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed_r.csproj
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed_r.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TypeEqualitySealed.cs" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed_ro.csproj
+++ b/src/coreclr/tests/src/JIT/Intrinsics/TypeEqualitySealed_ro.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TypeEqualitySealed.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33333 (caused by https://github.com/dotnet/runtime/pull/32790) via patch by @AndyAyersMS 

Is it possible to put runtime handles into a GT_SWITCH (e.g. via raw IL)? And apply a similar fix [here](https://github.com/dotnet/runtime/blob/b41296a37f4bfead66db234e9d14b81fff302567/src/coreclr/src/jit/morph.cpp#L14967-L14984).