### PR TITLE
Consolidate objcopy detection

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -1,4 +1,5 @@
 include(CheckPIESupported)
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 #----------------------------------------
 # Detect and set platform variable names

--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -30,6 +30,7 @@ if(NOT WIN32)
       NAMES
       "${TOOLSET_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
       "${TOOLSET_PREFIX}${exec}")
+
     if (EXEC_LOCATION_${exec} STREQUAL "EXEC_LOCATION_${exec}-NOTFOUND")
       message(FATAL_ERROR "Unable to find toolchain executable for: ${exec}.")
     endif()
@@ -40,30 +41,20 @@ if(NOT WIN32)
   locate_toolchain_exec(link CMAKE_LINKER)
   locate_toolchain_exec(nm CMAKE_NM)
 
-  if(NOT APPLE)
-    locate_toolchain_exec(objdump CMAKE_OBJDUMP)
-  endif()
-
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
     locate_toolchain_exec(ranlib CMAKE_RANLIB)
   endif()
 
-  if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    if (CMAKE_CROSSCOMPILING AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
-      if (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
-        find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
-      elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
-        find_program(OBJCOPY objcopy)
-      else()
-        clr_unknown_arch()
-      endif()
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    locate_toolchain_exec(objdump CMAKE_OBJDUMP)
+
+    if(CMAKE_CROSSCOMPILING AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD AND (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR
+       CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm))
+      set(TOOLSET_PREFIX "${TOOLCHAIN}-")
     else()
-      find_program(OBJCOPY objcopy)
+      set(TOOLSET_PREFIX "")
     endif()
 
-    if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND")
-        message(FATAL_ERROR "objcopy not found")
-    endif()
+    locate_toolchain_exec(objcopy CMAKE_OBJCOPY)
   endif()
 endif()

--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -276,9 +276,9 @@ function(strip_symbols targetName outputFilename skipStrip)
             TARGET ${targetName}
             POST_BUILD
             VERBATIM
-            COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-            COMMAND ${OBJCOPY} --strip-debug ${strip_source_file}
-            COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
+            COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
+            COMMAND ${CMAKE_OBJCOPY} --strip-debug ${strip_source_file}
+            COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
             COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
             )
         endif()

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -7,9 +7,6 @@ project(CoreCLR)
 
 include(${CLR_ENG_NATIVE_DIR}/configureplatform.cmake)
 
-# Include cmake functions
-include(${CLR_ENG_NATIVE_DIR}/functions.cmake)
-
 if (CLR_CMAKE_HOST_WIN32)
   message(STATUS "VS_PLATFORM_TOOLSET is ${CMAKE_VS_PLATFORM_TOOLSET}")
   message(STATUS "VS_PLATFORM_NAME is ${CMAKE_VS_PLATFORM_NAME}")

--- a/src/installer/corehost/CMakeLists.txt
+++ b/src/installer/corehost/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14.2)
 
 project(corehost)
 
-include(${CLR_ENG_NATIVE_DIR}/functions.cmake)
 include(${CLR_ENG_NATIVE_DIR}/configuretools.cmake)
 include(${CLR_ENG_NATIVE_DIR}/configureplatform.cmake)
 include(../settings.cmake)

--- a/src/installer/settings.cmake
+++ b/src/installer/settings.cmake
@@ -21,71 +21,14 @@ if (NOT CLR_CMAKE_HOST_WIN32)
         if (STRIP STREQUAL "STRIP-NOTFOUND")
             message(FATAL_ERROR "strip not found")
         endif()
-    else (CLR_CMAKE_HOST_DARWIN)
-        # Ensure that objcopy is present
-        if(DEFINED ENV{ROOTFS_DIR})
-            if(CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_I386)
-                find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
-            else()
-                message(FATAL_ERROR "Only AMD64, X86, ARM64 and ARM are supported")
-            endif()
-        else()
-            find_program(OBJCOPY objcopy)
-        endif()
-        if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND" AND NOT CLR_CMAKE_TARGET_ARCH_I386)
-            message(FATAL_ERROR "objcopy not found")
-        endif()
     endif (CLR_CMAKE_HOST_DARWIN)
 endif ()
-
-function(strip_symbols targetName outputFilename)
-    if(CLR_CMAKE_TARGET_UNIX)
-        if(STRIP_SYMBOLS)
-
-            # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
-            # generator expression doesn't work correctly returning the wrong path and on
-            # the newer cmake versions the LOCATION property isn't supported anymore.
-            if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
-                set(strip_source_file $<TARGET_FILE:${targetName}>)
-            else()
-                get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)
-            endif()
-
-            if(CLR_CMAKE_TARGET_DARWIN)
-                set(strip_destination_file ${strip_source_file}.dwarf)
-
-                add_custom_command(
-                    TARGET ${targetName}
-                    POST_BUILD
-                    VERBATIM
-                    COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
-                    COMMAND ${STRIP} -u -r ${strip_source_file}
-                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-                )
-            else(CLR_CMAKE_TARGET_DARWIN)
-                set(strip_destination_file ${strip_source_file}.dbg)
-
-                add_custom_command(
-                    TARGET ${targetName}
-                    POST_BUILD
-                    VERBATIM
-                    COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-                    COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
-                    COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-                )
-            endif(CLR_CMAKE_TARGET_DARWIN)
-
-            set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
-        endif(STRIP_SYMBOLS)
-    endif(CLR_CMAKE_TARGET_UNIX)
-endfunction()
 
 function(install_symbols targetName destination_path)
     if(CLR_CMAKE_TARGET_WIN32)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${targetName}.pdb DESTINATION ${destination_path})
     else()
-        strip_symbols(${targetName} strip_destination_file)
+        strip_symbols(${targetName} strip_destination_file NO)
         install(FILES ${strip_destination_file} DESTINATION ${destination_path})
     endif()
 endfunction()

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -161,20 +161,6 @@ if(CLR_CMAKE_TARGET_UNIX)
     else (CLR_CMAKE_TARGET_DARWIN)
         add_compile_options($<$<COMPILE_LANGUAGE:ASM>:-Wa,--noexecstack>)
         add_link_options(-Wl,--build-id=sha1 -Wl,-z,relro,-z,now)
-
-        # Ensure that objcopy is present
-        if(DEFINED ENV{CROSSCOMPILE})
-            if(CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_I386)
-                find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
-            else()
-                message(FATAL_ERROR "Only AMD64, X86, ARM64 and ARM are supported")
-            endif()
-        else()
-            find_program(OBJCOPY objcopy)
-        endif()
-        if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND" AND NOT CLR_CMAKE_TARGET_ARCH_I386)
-            message(FATAL_ERROR "objcopy not found")
-        endif()
     endif(CLR_CMAKE_TARGET_DARWIN)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CLR_ADDITIONAL_LINKER_FLAGS}")
@@ -182,51 +168,8 @@ if(CLR_CMAKE_TARGET_UNIX)
     add_compile_options(${CLR_ADDITIONAL_COMPILER_OPTIONS})
 endif(CLR_CMAKE_TARGET_UNIX)
 
-function(strip_symbols targetName outputFilename)
-    if(CLR_CMAKE_TARGET_UNIX)
-        if(STRIP_SYMBOLS)
-
-            # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
-            # generator expression doesn't work correctly returning the wrong path and on
-            # the newer cmake versions the LOCATION property isn't supported anymore.
-            if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
-                set(strip_source_file $<TARGET_FILE:${targetName}>)
-            else()
-                get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)
-            endif()
-
-            if(CLR_CMAKE_TARGET_DARWIN)
-                set(strip_destination_file ${strip_source_file}.dwarf)
-
-                add_custom_command(
-                    TARGET ${targetName}
-                    POST_BUILD
-                    VERBATIM
-                    COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
-                    COMMAND ${STRIP} -u -r ${strip_source_file}
-                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-                )
-            else(CLR_CMAKE_TARGET_DARWIN)
-                set(strip_destination_file ${strip_source_file}.dbg)
-
-                add_custom_command(
-                    TARGET ${targetName}
-                    POST_BUILD
-                    VERBATIM
-                    COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-                    COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
-                    COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-                    COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
-                )
-            endif(CLR_CMAKE_TARGET_DARWIN)
-
-            set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
-        endif(STRIP_SYMBOLS)
-    endif(CLR_CMAKE_TARGET_UNIX)
-endfunction()
-
 function(install_library_and_symbols targetName)
-    strip_symbols(${targetName} strip_destination_file)
+    strip_symbols(${targetName} strip_destination_file NO)
 
     # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
     # generator expression doesn't work correctly returning the wrong path and on


### PR DESCRIPTION
`strip_destination_file` file is defined in `:/eng/native/functions.cmake`, which is already included by top-level cmake scripts in coreclr, installer and libraries. This PR de-duplicates that logic and simplifies condition blocks in `eng/native/configuretool.cmake` (where unified tool detection takes place).