### PR TITLE
Delete .NET Framework-specific hosting flags

### DIFF
--- a/src/coreclr/src/debug/daccess/enummem.cpp
+++ b/src/coreclr/src/debug/daccess/enummem.cpp
@@ -268,7 +268,6 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED( g_pEnumClass.EnumMem(); )
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED( g_pThreadClass.EnumMem(); )
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED( g_pFreeObjectMethodTable.EnumMem(); )
-    CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED( g_fHostConfig.EnumMem(); )
 
     // These two static pointers are pointed to static data of byte[]
     // then run constructor in place

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -371,7 +371,7 @@ HRESULT ClrDataAccess::GetThreadStoreData(struct DacpThreadStoreData *threadStor
         threadStoreData->backgroundThreadCount = threadStore->m_BackgroundThreadCount;
         threadStoreData->pendingThreadCount = threadStore->m_PendingThreadCount;
         threadStoreData->deadThreadCount = threadStore->m_DeadThreadCount;
-        threadStoreData->fHostConfig = g_fHostConfig;
+        threadStoreData->fHostConfig = FALSE;
 
         // identify the "important" threads
         threadStoreData->firstThread = HOST_CDADDR(threadStore->m_ThreadList.GetHead());

--- a/src/coreclr/src/inc/cor.h
+++ b/src/coreclr/src/inc/cor.h
@@ -146,16 +146,6 @@ typedef UNALIGNED void const *UVCP_CONSTANT;
 
 #define SWITCHOUT_HANDLE_VALUE ((HANDLE)(LONG_PTR)-2)
 
-//
-// CoInitializeEE flags.
-//
-typedef enum tagCOINITEE
-{
-    COINITEE_DEFAULT        = 0x0,          // Default initialization mode.
-    COINITEE_DLL            = 0x1,          // Initialization mode for loading DLL.
-    COINITEE_MAIN           = 0x2           // Initialize prior to entering the main routine
-} COINITIEE;
-
 //*****************************************************************************
 //*****************************************************************************
 //

--- a/src/coreclr/src/inc/dacvars.h
+++ b/src/coreclr/src/inc/dacvars.h
@@ -202,7 +202,6 @@ DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pObjectFinalizerMD, ::g_pObjec
 
 DEFINE_DACVAR(ULONG, bool, dac__g_fProcessDetach, ::g_fProcessDetach)
 DEFINE_DACVAR(ULONG, DWORD, dac__g_fEEShutDown, ::g_fEEShutDown)
-DEFINE_DACVAR(ULONG, DWORD, dac__g_fHostConfig, ::g_fHostConfig)
 
 DEFINE_DACVAR(ULONG, ULONG, dac__g_CORDebuggerControlFlags, ::g_CORDebuggerControlFlags)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pDebugger, ::g_pDebugger)

--- a/src/coreclr/src/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/src/tools/metainfo/mdinfo.cpp
@@ -20,9 +20,6 @@
 
 #include "mdinfo.h"
 
-#define LEGACY_ACTIVATION_SHIM_LOAD_LIBRARY WszLoadLibrary
-#define LEGACY_ACTIVATION_SHIM_DEFINE_CoInitializeEE
-
 #define ENUM_BUFFER_SIZE 10
 #define TAB_SIZE 8
 

--- a/src/coreclr/src/vm/amd64/UMThunkStub.asm
+++ b/src/coreclr/src/vm/amd64/UMThunkStub.asm
@@ -11,8 +11,6 @@
 include <AsmMacros.inc>
 include AsmConstants.inc
 
-gfHostConfig                            equ ?g_fHostConfig@@3KA
-
 extern CreateThreadBlockThrow:proc
 extern TheUMEntryPrestubWorker:proc
 extern UMEntryPrestubUnwindFrameChainHandler:proc

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -227,7 +227,7 @@ static int GetThreadUICultureId(__out LocaleIDValue* pLocale);  // TODO: This sh
 static HRESULT GetThreadUICultureNames(__inout StringArrayList* pCultureNames);
 #endif // !CROSSGEN_COMPILE
 
-HRESULT EEStartup(COINITIEE fFlags);
+HRESULT EEStartup();
 
 
 #ifndef CROSSGEN_COMPILE
@@ -251,12 +251,6 @@ HRESULT g_EEStartupStatus = S_OK;
 // checking this flag.
 Volatile<BOOL> g_fEEStarted = FALSE;
 
-// Flag indicating if the EE was started up by COM.
-extern BOOL g_fEEComActivatedStartup;
-
-// flag indicating that EE was not started up by IJW, Hosted, COM or my managed exe.
-extern BOOL g_fEEOtherStartup;
-
 // The OS thread ID of the thread currently performing EE startup, or 0 if there is no such thread.
 DWORD   g_dwStartupThreadId = 0;
 
@@ -265,22 +259,12 @@ static CLREvent * g_pEEShutDownEvent;
 
 static DangerousNonHostedSpinLock g_EEStartupLock;
 
-HRESULT InitializeEE(COINITIEE flags)
-{
-    WRAPPER_NO_CONTRACT;
-#ifdef FEATURE_EVENT_TRACE
-    if(!g_fEEComActivatedStartup)
-        g_fEEOtherStartup = TRUE;
-#endif // FEATURE_EVENT_TRACE
-    return EnsureEEStarted(flags);
-}
-
 // ---------------------------------------------------------------------------
 // %%Function: EnsureEEStarted()
 //
 // Description: Ensure the CLR is started.
 // ---------------------------------------------------------------------------
-HRESULT EnsureEEStarted(COINITIEE flags)
+HRESULT EnsureEEStarted()
 {
     CONTRACTL
     {
@@ -334,7 +318,7 @@ HRESULT EnsureEEStarted(COINITIEE flags)
             {
                 g_dwStartupThreadId = GetCurrentThreadId();
 
-                EEStartup(flags);
+                EEStartup();
                 bStarted=g_fEEStarted;
                 hr = g_EEStartupStatus;
 
@@ -575,10 +559,6 @@ BOOL IsGarbageCollectorFullyInitialized()
 // ---------------------------------------------------------------------------
 // %%Function: EEStartupHelper
 //
-// Parameters:
-//  fFlags                  - Initialization flags for the engine.  See the
-//                              EEStartupFlags enumerator for valid values.
-//
 // Returns:
 //  S_OK                    - On success
 //
@@ -628,7 +608,7 @@ void EESocketCleanupHelper()
 #endif // TARGET_UNIX
 #endif // CROSSGEN_COMPILE
 
-void EEStartupHelper(COINITIEE fFlags)
+void EEStartupHelper()
 {
     CONTRACTL
     {
@@ -1128,14 +1108,14 @@ LONG FilterStartupException(PEXCEPTION_POINTERS p, PVOID pv)
 // see code:EEStartup#TableOfContents for more on the runtime in general.
 // see code:#EEShutdown for a analagous routine run during shutdown.
 //
-HRESULT EEStartup(COINITIEE fFlags)
+HRESULT EEStartup()
 {
     // Cannot use normal contracts here because of the PAL_TRY.
     STATIC_CONTRACT_NOTHROW;
 
     _ASSERTE(!g_fEEStarted && !g_fEEInit && SUCCEEDED (g_EEStartupStatus));
 
-    PAL_TRY(COINITIEE *, pfFlags, &fFlags)
+    PAL_TRY(PVOID, p, NULL)
     {
 #ifndef CROSSGEN_COMPILE
         InitializeClrNotifications();
@@ -1145,7 +1125,7 @@ HRESULT EEStartup(COINITIEE fFlags)
 #endif
 #endif // CROSSGEN_COMPILE
 
-        EEStartupHelper(*pfFlags);
+        EEStartupHelper();
     }
     PAL_EXCEPT_FILTER (FilterStartupException)
     {

--- a/src/coreclr/src/vm/ceemain.h
+++ b/src/coreclr/src/vm/ceemain.h
@@ -20,10 +20,7 @@
 class EEDbgInterfaceImpl;
 
 // Ensure the EE is started up.
-HRESULT EnsureEEStarted(COINITIEE flags);
-
-// Wrapper around EnsureEEStarted which also sets startup mode.
-HRESULT InitializeEE(COINITIEE flags);
+HRESULT EnsureEEStarted();
 
 // Enum to control what happens at the end of EE shutdown. There are two options:
 // 1. Call ::ExitProcess to cause the process to terminate gracefully. This is how

--- a/src/coreclr/src/vm/compile.cpp
+++ b/src/coreclr/src/vm/compile.cpp
@@ -110,7 +110,7 @@ HRESULT CEECompileInfo::Startup(  BOOL fForceDebug,
 
         // When NGEN'ing this call may execute EE code, e.g. the managed code to set up
         // the SharedDomain.
-        hr = InitializeEE(COINITEE_DEFAULT);
+        hr = EnsureEEStarted();
     }
 
     //

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -44,8 +44,6 @@
 #endif
 
 
-GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
-
 #ifndef __GNUC__
 EXTERN_C __declspec(thread) ThreadLocalInfo gCurrentThreadInfo;
 #else // !__GNUC__
@@ -62,7 +60,6 @@ UINT32 _tls_index = 0;
 extern void STDMETHODCALLTYPE EEShutDown(BOOL fIsDllUnloading);
 extern void PrintToStdOutA(const char *pszString);
 extern void PrintToStdOutW(const WCHAR *pwzString);
-extern BOOL g_fEEHostedStartup;
 
 //***************************************************************************
 
@@ -133,22 +130,6 @@ STDMETHODIMP CorHost2::Start()
     }
     else
     {
-        // Using managed C++ libraries, its possible that when the runtime is already running,
-        // MC++ will use CorBindToRuntimeEx to make callbacks into specific appdomain of its
-        // choice. Now, CorBindToRuntimeEx results in CorHost2::CreateObject being invoked
-        // that will set runtime hosted flag "g_fHostConfig |= CLRHOSTED".
-        //
-        // For the case when managed code started without CLR hosting and MC++ does a
-        // CorBindToRuntimeEx, setting the CLR hosted flag is incorrect.
-        //
-        // Thus, before we attempt to start the runtime, we save the status of it being
-        // already running or not. Next, if we are able to successfully start the runtime
-        // and ONLY if it was not started earlier will we set the hosted flag below.
-        if (!g_fEEStarted)
-        {
-            g_fHostConfig |= CLRHOSTED;
-        }
-
         hr = CorRuntimeHostBase::Start();
         if (SUCCEEDED(hr))
         {
@@ -172,7 +153,7 @@ STDMETHODIMP CorHost2::Start()
     return hr;
 }
 
-// Starts the runtime. This is equivalent to CoInitializeEE();
+// Starts the runtime.
 HRESULT CorRuntimeHostBase::Start()
 {
     CONTRACTL
@@ -188,10 +169,7 @@ HRESULT CorRuntimeHostBase::Start()
     BEGIN_ENTRYPOINT_NOTHROW;
     {
         m_Started = TRUE;
-#ifdef FEATURE_EVENT_TRACE
-        g_fEEHostedStartup = TRUE;
-#endif // FEATURE_EVENT_TRACE
-        hr = InitializeEE(COINITEE_DEFAULT);
+        hr = EnsureEEStarted();
     }
     END_ENTRYPOINT_NOTHROW;
 

--- a/src/coreclr/src/vm/crossgencompile.cpp
+++ b/src/coreclr/src/vm/crossgencompile.cpp
@@ -106,11 +106,6 @@ BOOL __SwitchToThread(DWORD, DWORD)
 
 GPTR_IMPL(IGCHeap,g_pGCHeap);
 
-BOOL g_fEEOtherStartup=FALSE;
-BOOL g_fEEComActivatedStartup=FALSE;
-
-GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
-
 GVAL_IMPL_INIT(GCHeapType, g_heap_type, GC_HEAP_WKS);
 
 HRESULT GetExceptionHResult(OBJECTREF throwable)

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -39,13 +39,6 @@
 #include "runtimecallablewrapper.h"
 #endif
 
-// Flags used to store some runtime information for Event Tracing
-BOOL g_fEEOtherStartup=FALSE;
-BOOL g_fEEComActivatedStartup=FALSE;
-GUID g_EEComObjectGuid=GUID_NULL;
-
-BOOL g_fEEHostedStartup = FALSE;
-
 #endif // FEATURE_REDHAWK
 
 #include "eventtracepriv.h"
@@ -4939,13 +4932,7 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
             UINT8 startupMode = 0;
             UINT startupFlags = 0;
             PathString dllPath;
-            UINT8 Sku = 0;
-            _ASSERTE(CLRHosted() || g_fEEHostedStartup || // CLR started through one of the Hosting API CLRHosted() returns true if CLR started through the V2 Interface while
-                                                          // g_fEEHostedStartup is true if CLR is hosted through the V1 API.
-                     g_fEEComActivatedStartup ||          //CLR started as a COM object
-                     g_fEEOtherStartup  );                //In case none of the 4 above mentioned cases are true for example ngen, ildasm then we asssume its a "other" startup
-
-            Sku = ETW::InfoLog::InfoStructs::CoreCLR;
+            UINT8 Sku = ETW::InfoLog::InfoStructs::CoreCLR;
 
             //version info for clr.dll
             USHORT vmMajorVersion = CLR_MAJOR_VERSION;
@@ -4959,28 +4946,9 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
             USHORT bclBuildVersion = VER_ASSEMBLYBUILD;
             USHORT bclQfeVersion = VER_ASSEMBLYBUILD_QFE;
 
-            LPCGUID comGUID=&g_EEComObjectGuid;
+            LPCGUID comGUID=&IID_NULL;
 
             PCWSTR lpwszCommandLine = W("");
-
-
-
-            // Determine the startupmode
-            if (CLRHosted() || g_fEEHostedStartup)
-            {
-                //Hosted CLR
-                startupMode = ETW::InfoLog::InfoStructs::HostedCLR;
-            }
-            else if(g_fEEComActivatedStartup)
-            {
-                //com activated
-                startupMode = ETW::InfoLog::InfoStructs::COMActivated;
-            }
-            else if(g_fEEOtherStartup)
-            {
-                //startup type is other
-                startupMode = ETW::InfoLog::InfoStructs::Other;
-            }
 
 
             // if WszGetModuleFileName fails, we return an empty string

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -1032,19 +1032,12 @@ public:
         if(STSGuarantee_Force == fScope)
             return TRUE;
 
+#ifdef DEBUG
         // For debug, always enable setting thread stack guarantee so that we can print the stack trace
-#ifndef DEBUG
-        //The runtime must be hosted to have escalation policy
-        //If escalation policy is enabled but StackOverflow is not part of the policy
-        //   then we don't use SetThreadStackGuarantee
-        if(!CLRHosted() ||
-            GetEEPolicy()->GetActionOnFailure(FAIL_StackOverflow) == eRudeExitProcess)
-        {
-            //FAIL_StackOverflow is ProcessExit so don't use SetThreadStackGuarantee
-            return FALSE;
-        }
-#endif // DEBUG
         return TRUE;
+#else
+        return FALSE;
+#endif
     }
 
 public:

--- a/src/coreclr/src/vm/util.hpp
+++ b/src/coreclr/src/vm/util.hpp
@@ -585,18 +585,6 @@ public:
     }
 };
 
-#define CLRHOSTED           0x80000000
-
-GVAL_DECL(DWORD, g_fHostConfig);
-
-
-inline BOOL CLRHosted()
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return g_fHostConfig;
-}
-
 #ifndef TARGET_UNIX
 HMODULE CLRLoadLibraryEx(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
 #endif // !TARGET_UNIX


### PR DESCRIPTION
There is only one way to host CoreCLR. These hosting flags always ended up being set the same way in CoreCLR.