### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -70,7 +70,7 @@ Using Visual Studio Code
 ========================
 
 - Install [Visual Studio Code](https://code.visualstudio.com/)
-- Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+- Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - Open the folder containing the source you want to debug in VS Code
 - Open the debug window: `ctrl-shift-D` or click on the button on the left
 - Click the gear button at the top to create a launch configuration, select `.NET Core` from the selection dropdown

--- a/docs/workflow/debugging/libraries/debugging-vscode.md
+++ b/docs/workflow/debugging/libraries/debugging-vscode.md
@@ -1,7 +1,7 @@
 # Debugging Libraries with Visual Studio Code
 
 - Install [Visual Studio Code](https://code.visualstudio.com/)
-- Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+- Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - Open the folder containing the source you want to debug in VS Code - i.e., if you are debugging a test failure in System.Net.Sockets, open `runtime/src/libraries/System.Net.Sockets`
 - Open the debug window: `ctrl-shift-D` or click on the button on the left
 - Click the gear button at the top to create a launch configuration, select `.NET Core` from the selection dropdown


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp".