### PR TITLE
Respect -runtimeconfiguration with -vs switch

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -14,7 +14,7 @@ Param(
   [string]$arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant(),
   [string]$subsetCategory,
   [string]$subset,
-  [ValidateSet("Debug","Release","Checked")][string]$runtimeConfiguration,
+  [ValidateSet("Debug","Release","Checked")][string]$runtimeConfiguration = "Debug",
   [ValidateSet("Debug","Release")][string]$librariesConfiguration,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -101,6 +101,9 @@ if ($vs) {
 
   # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
   $env:PATH=($env:DOTNET_ROOT + ";" + $env:PATH);
+
+  # Respect the RuntimeConfiguration variable for building inside VS with different runtime configurations
+  $env:RUNTIMECONFIGURATION=$runtimeConfiguration
 
   # Launch Visual Studio with the locally defined environment variables
   ."$vs"


### PR DESCRIPTION
When using the -vs switch, the -runtimeconfiguration value will now be
respected so that building with mixed configurations between libraries
and the runtime inside VS is possible.