### PR TITLE
Fix SuperIlc to work on Linux / OSX in composite mode

### DIFF
--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -117,7 +117,7 @@ namespace ReadyToRun.SuperIlc
         public static BuildFolder FromDirectory(string inputDirectory, IEnumerable<CompilerRunner> compilerRunners, string outputRoot, BuildOptions options)
         {
             List<string> compilationInputFiles = new List<string>();
-            List<string> passThroughFiles = new List<string>();
+            HashSet<string> passThroughFiles = new HashSet<string>();
             List<string> mainExecutables = new List<string>();
             List<string> executionScripts = new List<string>();
 
@@ -171,6 +171,14 @@ namespace ReadyToRun.SuperIlc
                     foreach (string lib in s_runtimeWindowsOnlyLibraries)
                     {
                         passThroughFiles.Add(Path.Combine(options.CoreRootDirectory.FullName, lib.AppendOSDllSuffix()));
+                    }
+                }
+                else
+                {
+                    // Several native lib*.so / dylib are needed by the runtime
+                    foreach (string nativeLib in Directory.EnumerateFiles(options.CoreRootDirectory.FullName, "lib*".AppendOSDllSuffix()))
+                    {
+                        passThroughFiles.Add(nativeLib);
                     }
                 }
             }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -247,7 +247,7 @@ namespace ReadyToRun.SuperIlc
                     foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
                     {
                         string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
-                        if (!FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
+                        if (FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
                         {
                             _frameworkExclusions[simpleName] = reason;
                         }
@@ -277,12 +277,16 @@ namespace ReadyToRun.SuperIlc
                     compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                     foreach (CompilerRunner runner in frameworkRunners)
                     {
-                        if (!FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
+                        if (FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
                         {
                             _frameworkExclusions[simpleName] = reason;
                             continue;
                         }
-                        var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, new string[] { frameworkDll }));
+                        var compilationProcess = new ProcessInfo(
+                            new CompilationProcessConstructor(
+                                runner,
+                                Path.Combine(runner.GetOutputPath(_options.CoreRootDirectory.FullName), Path.GetFileName(frameworkDll)),
+                                new string[] { frameworkDll }));
                         compilationsToRun.Add(compilationProcess);
                         processes[(int)runner.Index] = compilationProcess;
                     }

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -16,33 +16,6 @@ namespace ReadyToRun.SuperIlc
 {
     public class BuildFolderSet
     {
-        class FrameworkExclusion
-        {
-            public readonly string SimpleName;
-            public readonly string Reason;
-            public readonly bool Crossgen2Only;
-
-            public FrameworkExclusion(string simpleName, string reason, bool crossgen2Only = false)
-            {
-                SimpleName = simpleName;
-                Reason = reason;
-                Crossgen2Only = crossgen2Only;
-            }
-        }
-
-        private static readonly FrameworkExclusion[] s_frameworkExclusions =
-        {
-            new FrameworkExclusion("CommandLine", "Not a framework assembly"),
-            new FrameworkExclusion("R2RDump", "Not a framework assembly"),
-            new FrameworkExclusion("System.Runtime.WindowsRuntime", "WinRT is currently not supported"),
-            new FrameworkExclusion("xunit.performance.api", "Not a framework assembly"),
-
-            // TODO (DavidWr): IBC-related failures
-            new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token", crossgen2Only: true),
-            new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef", crossgen2Only: true),
-            new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef", crossgen2Only: true),
-        };
-
         private readonly IEnumerable<BuildFolder> _buildFolders;
 
         private readonly IEnumerable<CompilerRunner> _compilerRunners;
@@ -274,10 +247,9 @@ namespace ReadyToRun.SuperIlc
                     foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
                     {
                         string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
-                        FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
-                        if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                        if (!FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
                         {
-                            _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
+                            _frameworkExclusions[simpleName] = reason;
                         }
                         else
                         {
@@ -300,15 +272,14 @@ namespace ReadyToRun.SuperIlc
                 foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
                 {
                     string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
-                    FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
 
                     ProcessInfo[] processes = new ProcessInfo[(int)CompilerIndex.Count];
                     compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                     foreach (CompilerRunner runner in frameworkRunners)
                     {
-                        if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                        if (!FrameworkExclusion.Exclude(simpleName, runner.Index, out string reason))
                         {
-                            _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
+                            _frameworkExclusions[simpleName] = reason;
                             continue;
                         }
                         var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, new string[] { frameworkDll }));

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -17,6 +18,61 @@ namespace ReadyToRun.SuperIlc
         Jit,
 
         Count
+    }
+
+    public enum ExclusionType
+    {
+        Ignore,
+        DontCrossgen2,
+    }
+
+    public sealed class FrameworkExclusion
+    {
+        private static FrameworkExclusion[] s_list =
+        {
+            new FrameworkExclusion(ExclusionType.Ignore, "CommandLine", "Not a framework assembly"),
+            new FrameworkExclusion(ExclusionType.Ignore, "R2RDump", "Not a framework assembly"),
+            new FrameworkExclusion(ExclusionType.Ignore, "System.Runtime.WindowsRuntime", "WinRT is currently not supported"),
+            new FrameworkExclusion(ExclusionType.Ignore, "xunit.performance.api", "Not a framework assembly"),
+
+            // TODO (DavidWr): IBC-related failures
+            new FrameworkExclusion(ExclusionType.DontCrossgen2, "Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token"),
+            new FrameworkExclusion(ExclusionType.DontCrossgen2, "Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef"),
+            new FrameworkExclusion(ExclusionType.DontCrossgen2, "Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef"),
+        };
+
+        public readonly ExclusionType ExclusionType;
+        public readonly string SimpleName;
+        public readonly string Reason;
+
+        public FrameworkExclusion(ExclusionType exclusionType, string simpleName, string reason)
+        {
+            ExclusionType = exclusionType;
+            SimpleName = simpleName;
+            Reason = reason;
+        }
+
+        public static FrameworkExclusion Find(string simpleName)
+        {
+            return s_list.FirstOrDefault(fe => StringComparer.OrdinalIgnoreCase.Equals(simpleName, fe.SimpleName));
+        }
+
+        public static bool Exclude(string simpleName, CompilerIndex index, out string reason)
+        {
+            FrameworkExclusion exclusion = Find(simpleName);
+            if (exclusion != null &&
+                (exclusion.ExclusionType == ExclusionType.Ignore ||
+                exclusion.ExclusionType == ExclusionType.DontCrossgen2 && index == CompilerIndex.CPAOT))
+            {
+                reason = exclusion.Reason;
+                return true;
+            }
+            else
+            {
+                reason = null;
+                return false;
+            }
+        }
     }
 
     public abstract class CompilerRunner

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -121,7 +121,7 @@ namespace ReadyToRun.SuperIlc
             }
             else
             {
-                processParameters.TimeoutMilliseconds = ProcessParameters.DefaultIlcTimeout;
+                processParameters.TimeoutMilliseconds = (_options.Composite ? ProcessParameters.DefaultIlcCompositeTimeout : ProcessParameters.DefaultIlcTimeout);
             }
             processParameters.LogPath = outputFileName + ".ilc.log";
             processParameters.InputFileNames = inputAssemblyFileNames;

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace ReadyToRun.SuperIlc
 {
-
     /// <summary>
     /// Compiles assemblies using the Cross-Platform AOT compiler
     /// </summary>
@@ -95,9 +94,13 @@ namespace ReadyToRun.SuperIlc
             }
             foreach (string folder in uniqueFolders)
             {
-                foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(folder))
+                foreach (string reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(folder))
                 {
-                    yield return $"-{referenceOption}:{reference}";
+                    string simpleName = Path.GetFileNameWithoutExtension(reference);
+                    if (!FrameworkExclusion.Exclude(simpleName, Index, out string reason))
+                    {
+                        yield return $"-{referenceOption}:{reference}";
+                    }
                 }
             }
 
@@ -116,11 +119,15 @@ namespace ReadyToRun.SuperIlc
         {
             char referenceOption = (_options.Composite ? 'u' : 'r');
             List<string> references = new List<string>();
-            foreach (var referenceFolder in _referenceFolders)
+            foreach (string referenceFolder in _referenceFolders)
             {
-                foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(referenceFolder))
+                foreach (string reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(referenceFolder))
                 {
-                    references.Add($"-{referenceOption}:{reference}");
+                    string simpleName = Path.GetFileNameWithoutExtension(reference);
+                    if (!FrameworkExclusion.Exclude(simpleName, Index, out string reason))
+                    {
+                        references.Add($"-{referenceOption}:{reference}");
+                    }
                 }
             }
             return references;

--- a/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/src/coreclr/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -17,6 +17,11 @@ public class ProcessParameters
     public const int DefaultIlcTimeout = 10 * 60 * 1000;
 
     /// <summary>
+    /// Increase compilation timeout for composite builds.
+    /// </summary>
+    public const int DefaultIlcCompositeTimeout = 30 * 60 * 1000;
+
+    /// <summary>
     /// Test execution timeout.
     /// </summary>
     public const int DefaultExeTimeout = 5 * 60 * 1000;


### PR DESCRIPTION
1) I have generalized the concept of framework exclusions so that
the CPAOT runner can consume it - without it we were picking up
"CommandLine.dll" in the Core_Root folder as a Crossgen2 compilation
input and R2RDump was subsequently failing to dump the file as
CommandLine.dll is one of the stupid assemblies where the assembly
name differs from the PE file name (the assembly name is
'commandline' causing a mismatch on case-sensitive file systems).

2) On Linux / OSX, we need to copy around a bunch of native libraries
to the output, e.g. libSystem.Globalization.Native.so.

With this change, SuperIlc seems to be successfully running a small
set of hand-picked tests. I plan to follow up by preparing the PR
for introducing Crossgen2 composite pipeline jobs to get a more
precise reading on the pass rate.

Thanks

Tomas