### PR TITLE
[interp] Attempt to aid WebAssembly JIT.

### DIFF
--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -8,8 +8,6 @@
 
 /* OPDEF (opsymbol, opstring, oplength (in uint16s), pop_n, push_n, optype) */
 
-OPDEF(MINT_NOP, "nop", 0, Pop0, Push0, MintOpNoArgs)
-OPDEF(MINT_NIY, "niy", 1, Pop0, Push0, MintOpNoArgs)
 OPDEF(MINT_BREAK, "break", 1, Pop0, Push0, MintOpNoArgs)
 OPDEF(MINT_BREAKPOINT, "breakpoint", 1, Pop0, Push0, MintOpNoArgs)
 OPDEF(MINT_LDNULL, "ldnull", 1, Pop0, Push1, MintOpNoArgs)
@@ -723,7 +721,6 @@ OPDEF(MINT_CALLI, "calli", 2, VarPop, VarPush, MintOpMethodToken)
 OPDEF(MINT_CALLI_NAT, "calli.nat", 3, VarPop, VarPush, MintOpMethodToken)
 OPDEF(MINT_CALLI_NAT_FAST, "calli.nat.fast", 4, VarPop, VarPush, MintOpMethodToken)
 OPDEF(MINT_CALL_VARARG, "call.vararg", 3, VarPop, VarPush, MintOpMethodToken)
-OPDEF(MINT_CALLRUN, "callrun", 3, VarPop, VarPush, MintOpNoArgs)
 
 OPDEF(MINT_ICALL_V_V, "mono_icall_v_v", 2, Pop0, Push0, MintOpClassToken) /* not really */
 OPDEF(MINT_ICALL_V_P, "mono_icall_v_p", 2, Pop0, Push1, MintOpClassToken)
@@ -789,3 +786,20 @@ OPDEF(MINT_INTRINS_BYREFERENCE_GET_VALUE, "intrins_byreference_get_value", 1, Po
 OPDEF(MINT_INTRINS_UNSAFE_ADD_BYTE_OFFSET, "intrins_unsafe_add_byte_offset", 1, Pop2, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_UNSAFE_BYTE_OFFSET, "intrins_unsafe_byte_offset", 1, Pop2, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE, "intrins_runtimehelpers_object_has_component_size", 1, Pop1, Push1, MintOpNoArgs)
+
+// This is placed at the end instead of with other calls, so that the internal
+// opcodes have the same value independent of ifndef, even though there is not
+// compatibility requirement. Just to aid people looking at the values
+// in a debugger.
+#ifndef ENABLE_NETCORE
+OPDEF(MINT_CALLRUN, "callrun", 3, VarPop, VarPush, MintOpNoArgs)
+#endif
+
+// These are placed last to possibly aid codegen.
+// In particular, to keep them out of the valid range of the switch.
+// Otherwise, for example, if they are first, there might be a range check,
+// and then a subtraction, and another range check. By placing them
+// outside the switched range entirely, it is hoped to have just one
+// range check and no subtraction.
+OPDEF(MINT_NOP, "nop", 0, Pop0, Push0, MintOpNoArgs)
+OPDEF(MINT_NIY, "niy", 1, Pop0, Push0, MintOpNoArgs)


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19165,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>In particular, look at
https://gist.githubusercontent.com/kg/4b54c7692be9472657577ee2600e996d/raw/b151f98744073cbea82e2a7eb66951724be9069b/interp_exec_method

and notice the switch:

```

00019A56  mov eax, dword ptr [rsp + 0x48]
00019A5A  movzx ecx, word ptr [r15 + rax]
00019A5F  mov dword ptr [rsp + 0x44], ecx
00019A63  cmp ecx, 0x293
00019A69  ja 0x0002A573 (interp_exec_method + 0x11133)

00019A6F  mov ecx, dword ptr [rsp + 0x44] ; huh?
00019A73  sub ecx, 2
00019A76  mov edx, ecx

Seems almost like the same range check twice.
00019A78  cmp edx, 0x292
00019A7E  jae 0x0002A3CE (interp_exec_method + 0x10F8E)

00019A84  movabs rbx, 0x3fda2f218818
00019A8E  jmp qword ptr [rbx + rdx*8]

```

The intent is to optimize some of this.
However I wonder if this is an -O0 or -O2 runtime.