### PR TITLE
[mono] Improve how EnumBuilder handles type attributes

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
@@ -57,7 +57,7 @@ namespace System.Reflection.Emit {
 				typeof(Enum), null, PackingSize.Unspecified, 0, null);
 			_underlyingType = underlyingType;
 			_underlyingField = _tb.DefineField ("value__", underlyingType,
-				(FieldAttributes.SpecialName | FieldAttributes.Private | FieldAttributes.RTSpecialName));
+				FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName);
 			setup_enum_type (_tb);
 		}
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
@@ -64,7 +64,7 @@ namespace System.Reflection.Emit {
 			if (type == null)
 				throw new ArgumentNullException ("type");
 
-			attrs = attributes;
+			attrs = attributes & ~FieldAttributes.ReservedMask;
 			name = fieldName;
 			this.type = type;
 			this.modReq = modReq;


### PR DESCRIPTION
Literally copy set of attributes from https://github.com/dotnet/runtime/blob/dc62dd61071c239401ef6397a4d7ae29161d10a7/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.cs#L330, and mask reserved attributes in FieldBuilder

contributes to #2389