### PR TITLE
Disable IBCMerge on OSX builds

### DIFF
--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -4,8 +4,10 @@
      <IsEligibleForNgenOptimization>true</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(IsReferenceAssembly)' == 'true'">false</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">false</IsEligibleForNgenOptimization>
-      <!-- There's an issue causing IBCMerge failures across many of our assemblies on Mac, so disable
+      <!-- There's an issue causing IBCMerge failures because of mismatched MVIDs
+           across many of our assemblies on Mac, so disable
            IBCMerge optimizations on Mac for now to unblock the offical build.
+           See issue https://github.com/dotnet/runtime/issues/33303
       -->
       <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX'">false</IsEligibleForNgenOptimization>
   </PropertyGroup>

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -4,6 +4,10 @@
      <IsEligibleForNgenOptimization>true</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(IsReferenceAssembly)' == 'true'">false</IsEligibleForNgenOptimization>
      <IsEligibleForNgenOptimization Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">false</IsEligibleForNgenOptimization>
+      <!-- There's an issue causing IBCMerge failures across many of our assemblies on Mac, so disable
+           IBCMerge optimizations on Mac for now to unblock the offical build.
+      -->
+      <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX'">false</IsEligibleForNgenOptimization>
   </PropertyGroup>
 
   <Target Name="SetApplyNgenOptimization"

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -20,6 +20,12 @@
     <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <ILLinkTrimAssembly>true</ILLinkTrimAssembly>
     <ILLinkTrimXml>$(IntermediateOutputPath)System.Private.CoreLib.xml</ILLinkTrimXml>
+
+    <!-- We don't generate IBC data for the Mac-specific build of System.Private.CoreLib
+         and the Linux one is not valid for the Mac build
+         so we need to disable merging in the IBC data on the Mac build
+    -->
+    <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX'">false</IsEligibleForNgenOptimization>
   </PropertyGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -20,12 +20,6 @@
     <ILLinkClearInitLocals>true</ILLinkClearInitLocals>
     <ILLinkTrimAssembly>true</ILLinkTrimAssembly>
     <ILLinkTrimXml>$(IntermediateOutputPath)System.Private.CoreLib.xml</ILLinkTrimXml>
-
-    <!-- We don't generate IBC data for the Mac-specific build of System.Private.CoreLib
-         and the Linux one is not valid for the Mac build
-         so we need to disable merging in the IBC data on the Mac build
-    -->
-    <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX'">false</IsEligibleForNgenOptimization>
   </PropertyGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->


### PR DESCRIPTION
IBCMerge is crashing because of mismatched MVIDs on our OSX official builds. To unblock official builds, disable IBCMerge on our OSX builds.

Official build link: https://dev.azure.com/dnceng/internal/_build/results?buildId=552689&view=results