### PR TITLE
[merp] Remove unnecessary call to msync in mono_state_free_mem

### DIFF
--- a/src/mono/mono/utils/mono-state.c
+++ b/src/mono/mono/utils/mono-state.c
@@ -327,7 +327,6 @@ mono_state_free_mem (MonoStateMem *mem)
 	if (!mem->mem)
 		return;
 
-  msync(mem->mem, mem->size, MS_SYNC);
 	munmap (mem->mem, mem->size);
 
 	// Note: We aren't calling msync on this file.


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19167,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Closes https://github.com/mono/mono/issues/19136



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
