### PR TITLE
Update SDK to 5.0.100-preview.2.20157.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.2.20155.14"
+    "dotnet": "5.0.100-preview.2.20157.1"
   },
   "native-tools": {
     "cmake": "3.14.2",


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32764

This contains the Microsoft.Build.NuGetSdkResolver change with the commit https://github.com/NuGet/NuGet.Client/commits/64f2febf7d1de8b0228eca5afed97a96c5a30bba. This fixes the flaky nuget restore issues.