### PR TITLE
Remove `AllocLHeap`.

### DIFF
--- a/src/coreclr/src/gc/gc.h
+++ b/src/coreclr/src/gc/gc.h
@@ -261,8 +261,6 @@ public:
 
     virtual ~IGCHeapInternal() {}
 
-private:
-    virtual Object* AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags) = 0;
 public:
     virtual int GetNumberOfHeaps () = 0;
     virtual int GetHomeHeapNumber () = 0;

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -102,8 +102,6 @@ public:
 
     HRESULT Initialize ();
 
-    //flags can be GC_ALLOC_CONTAINS_REF GC_ALLOC_FINALIZE
-    Object*  AllocAlign8 (gc_alloc_context* acontext, size_t size, uint32_t flags);
     Object* Alloc (gc_alloc_context* acontext, size_t size, uint32_t flags);
 
     void FixAllocContext (gc_alloc_context* acontext, void* arg, void *heap);

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -104,10 +104,6 @@ public:
 
     //flags can be GC_ALLOC_CONTAINS_REF GC_ALLOC_FINALIZE
     Object*  AllocAlign8 (gc_alloc_context* acontext, size_t size, uint32_t flags);
-private:
-    Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags);
-public:
-    Object*  AllocLHeap (size_t size, uint32_t flags);
     Object* Alloc (gc_alloc_context* acontext, size_t size, uint32_t flags);
 
     void FixAllocContext (gc_alloc_context* acontext, void* arg, void *heap);

--- a/src/coreclr/src/gc/gcinterface.h
+++ b/src/coreclr/src/gc/gcinterface.h
@@ -7,7 +7,7 @@
 
 // The major version of the GC/EE interface. Breaking changes to this interface
 // require bumps in the major version number.
-#define GC_INTERFACE_MAJOR_VERSION 4
+#define GC_INTERFACE_MAJOR_VERSION 5
 
 // The minor version of the GC/EE interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number
@@ -770,9 +770,6 @@ public:
     // a lock to ensure that the calling thread has unique ownership over this alloc context;
     virtual Object* Alloc(gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
 
-    // Allocates an object on the large object heap with the given size and flags.
-    virtual Object* AllocLHeap(size_t size, uint32_t flags) = 0;
-
     // Allocates an object on the given allocation context, aligned to 64 bits,
     // with the given size and flags.
     // It is the responsibility of the caller to ensure that the passed-in alloc context is
@@ -782,7 +779,7 @@ public:
     virtual Object* AllocAlign8(gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
 
     // This is for the allocator to indicate it's done allocating a large object during a
-    // background GC as the BGC threads also need to walk LOH.
+    // background GC as the BGC threads also need to walk UOH.
     virtual void PublishObject(uint8_t* obj) = 0;
 
     // Signals the WaitForGCEvent event, indicating that a GC has completed.
@@ -910,6 +907,8 @@ enum GC_ALLOC_FLAGS
     GC_ALLOC_ALIGN8_BIAS        = 4,
     GC_ALLOC_ALIGN8             = 8,
     GC_ALLOC_ZEROING_OPTIONAL   = 16,
+    GC_ALLOC_LARGE_OBJECT_HEAP  = 32,
+    GC_ALLOC_PINNED_OBJECT_HEAP = 64,
 };
 
 inline GC_ALLOC_FLAGS operator|(GC_ALLOC_FLAGS a, GC_ALLOC_FLAGS b)

--- a/src/coreclr/src/gc/gcinterface.h
+++ b/src/coreclr/src/gc/gcinterface.h
@@ -770,14 +770,6 @@ public:
     // a lock to ensure that the calling thread has unique ownership over this alloc context;
     virtual Object* Alloc(gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
 
-    // Allocates an object on the given allocation context, aligned to 64 bits,
-    // with the given size and flags.
-    // It is the responsibility of the caller to ensure that the passed-in alloc context is
-    // owned by the thread that is calling this function. If using per-thread alloc contexts,
-    // no lock is needed; callers not using per-thread alloc contexts will need to acquire
-    // a lock to ensure that the calling thread has unique ownership over this alloc context.
-    virtual Object* AllocAlign8(gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
-
     // This is for the allocator to indicate it's done allocating a large object during a
     // background GC as the BGC threads also need to walk UOH.
     virtual void PublishObject(uint8_t* obj) = 0;

--- a/src/coreclr/src/gc/gcinterface.h
+++ b/src/coreclr/src/gc/gcinterface.h
@@ -7,7 +7,7 @@
 
 // The major version of the GC/EE interface. Breaking changes to this interface
 // require bumps in the major version number.
-#define GC_INTERFACE_MAJOR_VERSION 5
+#define GC_INTERFACE_MAJOR_VERSION 4
 
 // The minor version of the GC/EE interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number

--- a/src/coreclr/src/vm/gchelpers.cpp
+++ b/src/coreclr/src/vm/gchelpers.cpp
@@ -440,8 +440,9 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
             orDummyObject->SetMethodTable(g_pObjectClass);
         }
         else
+#endif  // FEATURE_64BIT_ALIGNMENT
         {
-#else   // ! FEATURE_64BIT_ALIGNMENT
+#ifdef FEATURE_64BIT_ALIGNMENT
             MethodTable* pElementMT = pArrayMT->GetArrayElementTypeHandle().GetMethodTable();
             if (pElementMT->RequiresAlign8() && pElementMT->IsValueType())
             {


### PR DESCRIPTION
Fixes:https://github.com/dotnet/runtime/issues/13734

The main difference of `AllocLHeap` is that it uses per-heap allocation context instead of per-thread one. There is no advantage in that and it results in allocation under-reporting in `GetAllocatedBytesForCurrentThread`.

It also came up in POH code reviews as unnecessary inconsistency that we do not want to carry forward.

This change unifies to one allocation entry point - `Alloc` and uses flags to indicate special behaviors.

