### PR TITLE
Fix misleading-indentation compilation error under clang 10

### DIFF
--- a/src/coreclr/src/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/src/tools/metainfo/mdinfo.cpp
@@ -1945,11 +1945,11 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
         VWrite(" :: %S", qSigName.Ptr());
 
     // Keep track of coff overhead.
-        if (!wcscmp(W("__DecoratedName"), rcName))
-        {
-            bCoffSymbol = true;
-            g_cbCoffNames += cbValue + 6;
-        }
+    if (!wcscmp(W("__DecoratedName"), rcName))
+    {
+        bCoffSymbol = true;
+        g_cbCoffNames += cbValue + 6;
+    }
     WriteLine("");
 
     VWriteLine("%s\tLength: %ld", preFix, cbValue);


### PR DESCRIPTION
The error looks like this (seen in dotnet/coreclr repo):

    In file included from /root/coreclr/src/ildasm/dasm_mi.cpp:7:
    /root/coreclr/src/ildasm/exe/../../tools/metainfo/mdinfo.cpp:1951:9: error: misleading indentation; statement is not part of the previous 'if' [-Werror,-Wmisleading-indentation]
        if (!wcscmp(W("__DecoratedName"), rcName))
        ^
    /root/coreclr/src/ildasm/exe/../../tools/metainfo/mdinfo.cpp:1947:5: note: previous statement is here
	if (pSig && pMethName)
	^
    1 error generated.