### PR TITLE
Add License Header to Installer Test Assets

### DIFF
--- a/src/installer/test/Assets/TestProjects/AppWithSubDirs/Program.cs
+++ b/src/installer/test/Assets/TestProjects/AppWithSubDirs/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/installer/test/Assets/TestProjects/AppWithWait/Program.cs
+++ b/src/installer/test/Assets/TestProjects/AppWithWait/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Threading;

--- a/src/installer/test/Assets/TestProjects/ComLibrary/ComLibrary.cs
+++ b/src/installer/test/Assets/TestProjects/ComLibrary/ComLibrary.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/installer/test/Assets/TestProjects/ComLibraryConflictingGuid/ComLibraryConflictingGuid.cs
+++ b/src/installer/test/Assets/TestProjects/ComLibraryConflictingGuid/ComLibraryConflictingGuid.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/installer/test/Assets/TestProjects/ComLibraryMissingGuid/ComLibraryMissingGuid.cs
+++ b/src/installer/test/Assets/TestProjects/ComLibraryMissingGuid/ComLibraryMissingGuid.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/installer/test/Assets/TestProjects/ComponentWithNoDependencies/Component.cs
+++ b/src/installer/test/Assets/TestProjects/ComponentWithNoDependencies/Component.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace Component

--- a/src/installer/test/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/test/Assets/TestProjects/HostApiInvokerApp/HostFXR.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/installer/test/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
+++ b/src/installer/test/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/installer/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/installer/test/Assets/TestProjects/HostApiInvokerApp/Utils.cs
+++ b/src/installer/test/Assets/TestProjects/HostApiInvokerApp/Utils.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/installer/test/Assets/TestProjects/LightupClient/Program.cs
+++ b/src/installer/test/Assets/TestProjects/LightupClient/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/installer/test/Assets/TestProjects/LightupLib/Program.cs
+++ b/src/installer/test/Assets/TestProjects/LightupLib/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reflection;
 

--- a/src/installer/test/Assets/TestProjects/PortableApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace PortableApp

--- a/src/installer/test/Assets/TestProjects/PortableAppWithException/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableAppWithException/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace PortableAppWithException

--- a/src/installer/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/installer/test/Assets/TestProjects/PortableAppWithMissingRef/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableAppWithMissingRef/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using SharedLibrary;
 

--- a/src/installer/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/SharedLibrary.cs
+++ b/src/installer/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/SharedLibrary.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace SharedLibrary
 {

--- a/src/installer/test/Assets/TestProjects/PortableTestApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableTestApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Xunit;
 

--- a/src/installer/test/Assets/TestProjects/ResourceLookup/Program.cs
+++ b/src/installer/test/Assets/TestProjects/ResourceLookup/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace ResourceLookup

--- a/src/installer/test/Assets/TestProjects/RuntimeProperties/Program.cs
+++ b/src/installer/test/Assets/TestProjects/RuntimeProperties/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace RuntimeProperties

--- a/src/installer/test/Assets/TestProjects/SharedFxLookupPortableApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/SharedFxLookupPortableApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace SharedFxLookupPortableApp

--- a/src/installer/test/Assets/TestProjects/StandaloneApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/StandaloneApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace StandaloneApp

--- a/src/installer/test/Assets/TestProjects/StandaloneApp20/Program.cs
+++ b/src/installer/test/Assets/TestProjects/StandaloneApp20/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace StandaloneApp

--- a/src/installer/test/Assets/TestProjects/StandaloneApp21/Program.cs
+++ b/src/installer/test/Assets/TestProjects/StandaloneApp21/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace StandaloneApp

--- a/src/installer/test/Assets/TestProjects/StandaloneTestApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/StandaloneTestApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Xunit;
 

--- a/src/installer/test/Assets/TestProjects/StartupHook/StartupHook.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHook/StartupHook.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace SharedLibrary
 {
     public class SharedType

--- a/src/installer/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/installer/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHook

--- a/src/installer/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.cs
+++ b/src/installer/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 internal class StartupHookWrongType

--- a/src/installer/test/Assets/TestProjects/TestWindowsOsShimsApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/TestWindowsOsShimsApp/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
D:\git\_runtime\src\installer\test\Assets\TestProjects\... files were missing licence headers.
This change adds them.