### PR TITLE
[mono] Disable SIMD support for Windows target

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -59,6 +59,8 @@
     </PropertyGroup>
     <PropertyGroup>
         <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'">$(_MonoConfigureParams) --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
+        <!-- FIXME: Disable SIMD support for Windows, see https://github.com/dotnet/runtime/issues/1933 -->
+        <_MonoConfigureParams Condition="'$(TargetsWindows)' == 'true'">$(_MonoConfigureParams) --mono-feature-disable-simd </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) --enable-maintainer-mode --enable-compile-warnings --with-core=only </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) CFLAGS="$(_MonoExtraCFLAGS)" CXXFLAGS="$(_MonoExtraCXXFLAGS)" LDFLAGS="$(_MonoExtraLDFLAGS)" CCLDFLAGS="$(_MonoExtraCCLDFLAGS)"</_MonoConfigureParams>
     </PropertyGroup>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -59,8 +59,6 @@
     </PropertyGroup>
     <PropertyGroup>
         <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'">$(_MonoConfigureParams) --with-llvm=$(MonoLLVMDir) </_MonoConfigureParams>
-        <!-- FIXME: Disable SIMD support for Windows, see https://github.com/dotnet/runtime/issues/1933 -->
-        <_MonoConfigureParams Condition="'$(TargetsWindows)' == 'true'">$(_MonoConfigureParams) --mono-feature-disable-simd </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) --enable-maintainer-mode --enable-compile-warnings --with-core=only </_MonoConfigureParams>
         <_MonoConfigureParams>$(_MonoConfigureParams) CFLAGS="$(_MonoExtraCFLAGS)" CXXFLAGS="$(_MonoExtraCXXFLAGS)" LDFLAGS="$(_MonoExtraLDFLAGS)" CCLDFLAGS="$(_MonoExtraCCLDFLAGS)"</_MonoConfigureParams>
     </PropertyGroup>

--- a/src/mono/winconfig.h
+++ b/src/mono/winconfig.h
@@ -30,6 +30,10 @@
 #ifndef DISABLE_REMOTING
 #define DISABLE_REMOTING 1
 #endif
+#ifndef DISABLE_SIMD
+// FIXME: disable SIMD support for Windows, see https://github.com/dotnet/runtime/issues/1933
+#define DISABLE_SIMD 1
+#endif
 #ifndef DISABLE_REFLECTION_EMIT_SAVE
 #define DISABLE_REFLECTION_EMIT_SAVE 1
 #endif


### PR DESCRIPTION
A temp fix for https://github.com/dotnet/runtime/issues/1933
to unblock @MaximLipnin 
Still has to be fixed, must be some missing #define etc (It's been broken for quite a while)