### PR TITLE
cross-crossgen job, reduce workitem size

### DIFF
--- a/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
@@ -172,7 +172,7 @@ jobs:
             mkdir -p     $HELIX_WORKITEM_PAYLOAD/log/$(targetFlavor);
             python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py crossgen_framework
             --crossgen   $HELIX_WORKITEM_PAYLOAD/Core_Root/crossgen
-            --il_corelib $HELIX_WORKITEM_PAYLOAD/bin/Core_Root/IL/System.Private.CoreLib.dll
+            --il_corelib $HELIX_WORKITEM_PAYLOAD/Core_Root/IL/System.Private.CoreLib.dll
             --core_root  $HELIX_WORKITEM_PAYLOAD/Core_Root
             --result_dir $HELIX_WORKITEM_PAYLOAD/log/$(targetFlavor);
             python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py compare

--- a/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
@@ -56,6 +56,8 @@ jobs:
         value: $(artifactsDirectory)/bin
       - name: productDirectory
         value: $(binDirectory)/coreclr
+      - name: workItemDirectory
+        value: $(artifactsDirectory)/cross-crossgen
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - name: artifactsDirectory
         value: $(Build.SourcesDirectory)\artifacts
@@ -63,6 +65,8 @@ jobs:
         value: $(artifactsDirectory)\bin
       - name: productDirectory
         value: $(binDirectory)\coreclr
+        - name: workItemDirectory
+        value: $(artifactsDirectory)\cross-crossgen
 
     - ${{ parameters.variables }}
 
@@ -102,17 +106,28 @@ jobs:
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       - script: |
           chmod +x $(productDirectory)/$(targetFlavor)/$(hostArchType)/crossgen
-          mkdir -p $(artifactsDirectory)/log/$(crossFlavor)
+          mkdir -p $(workItemDirectory)/log/$(crossFlavor)
         displayName: Create directories and ensure crossgen is executable
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: |
-          mkdir $(artifactsDirectory)\log\$(crossFlavor)
+          mkdir $(workItemDirectory)\log\$(crossFlavor)
         displayName: Create directories
 
 
     # Populate Core_Root
     - script: $(coreClrRepoRootDir)build-test$(scriptExt) $(buildConfig) $(archType) $(crossArg) generatelayoutonly
       displayName: Populate Core_Root
+
+    # Populate the workitem directory
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: |
+          cp -r $(artifactsDirectory)/tests/coreclr/$(targetFlavor)/Tests/Core_Root $(workItemDirectory)/Core_Root
+        displayName: Populate the workitem directory
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - script: |
+          mkdir $(workItemDirectory)\Core_Root
+          xcopy /s $(artifactsDirectory)\tests\coreclr\$(targetFlavor)\Tests\Core_Root $(workItemDirectory)\Core_Root
+        displayName: Populate the workitem directory
 
 
     # Create baseline output on the host (x64) machine
@@ -127,14 +142,14 @@ jobs:
             --crossgen   $(productDirectory)/$(targetFlavor)/$(hostArchType)/crossgen
             --il_corelib $(productDirectory)/$(targetFlavor)/IL/System.Private.CoreLib.dll
             --core_root  $(artifactsDirectory)/tests/coreclr/$(targetFlavor)/Tests/Core_Root
-            --result_dir $(artifactsDirectory)/log/$(crossFlavor)
+            --result_dir $(workItemDirectory)/log/$(crossFlavor)
         ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
           arguments:
             crossgen_framework
             --crossgen   $(productDirectory)\$(targetFlavor)\$(hostArchType)\crossgen
             --il_corelib $(productDirectory)\$(targetFlavor)\IL\System.Private.CoreLib.dll
             --core_root  $(artifactsDirectory)\tests\coreclr\$(targetFlavor)\Tests\Core_Root
-            --result_dir $(artifactsDirectory)\log\$(crossFlavor)
+            --result_dir $(workItemDirectory)\log\$(crossFlavor)
 
 
     # Send payload to Helix where the native output is generated and compared to the baseline
@@ -149,16 +164,16 @@ jobs:
         ${{ if ne(variables['System.TeamProject'], 'internal') }}:
           Creator: $(Creator)
         WorkItemTimeout: 3:00 # 3 hours
-        WorkItemDirectory: '$(artifactsDirectory)'
+        WorkItemDirectory: '$(workItemDirectory)'
         CorrelationPayloadDirectory: '$(coreClrRepoRoot)/tests/scripts'
         ${{ if ne(parameters.osName, 'Windows_NT') }}:
           WorkItemCommand:
-            chmod +x     $HELIX_WORKITEM_PAYLOAD/bin/coreclr/$(targetFlavor)/crossgen;
+            chmod +x     $HELIX_WORKITEM_PAYLOAD/Core_Root/crossgen;
             mkdir -p     $HELIX_WORKITEM_PAYLOAD/log/$(targetFlavor);
             python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py crossgen_framework
-            --crossgen   $HELIX_WORKITEM_PAYLOAD/bin/coreclr/$(targetFlavor)/crossgen
-            --il_corelib $HELIX_WORKITEM_PAYLOAD/bin/coreclr/$(targetFlavor)/IL/System.Private.CoreLib.dll
-            --core_root  $HELIX_WORKITEM_PAYLOAD/tests/coreclr/$(targetFlavor)/Tests/Core_Root
+            --crossgen   $HELIX_WORKITEM_PAYLOAD/Core_Root/crossgen
+            --il_corelib $HELIX_WORKITEM_PAYLOAD/bin/Core_Root/IL/System.Private.CoreLib.dll
+            --core_root  $HELIX_WORKITEM_PAYLOAD/Core_Root
             --result_dir $HELIX_WORKITEM_PAYLOAD/log/$(targetFlavor);
             python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py compare
             --base_dir   $HELIX_WORKITEM_PAYLOAD/log/$(crossFlavor)
@@ -167,9 +182,9 @@ jobs:
           WorkItemCommand:
             mkdir        %HELIX_WORKITEM_PAYLOAD%\log\$(targetFlavor);
             python -u %HELIX_CORRELATION_PAYLOAD%\crossgen_comparison.py crossgen_framework
-            --crossgen   %HELIX_WORKITEM_PAYLOAD%\bin\coreclr\$(targetFlavor)\crossgen
-            --il_corelib %HELIX_WORKITEM_PAYLOAD%\bin\coreclr\$(targetFlavor)\IL\System.Private.CoreLib.dll
-            --core_root  %HELIX_WORKITEM_PAYLOAD%\tests\coreclr\$(targetFlavor)\Tests\Core_Root
+            --crossgen   %HELIX_WORKITEM_PAYLOAD%\Core_Root\crossgen
+            --il_corelib %HELIX_WORKITEM_PAYLOAD%\Core_Root\IL\System.Private.CoreLib.dll
+            --core_root  %HELIX_WORKITEM_PAYLOAD%\Core_Root
             --result_dir %HELIX_WORKITEM_PAYLOAD%\log\$(targetFlavor);
             python -u %HELIX_CORRELATION_PAYLOAD%\crossgen_comparison.py compare
             --base_dir   %HELIX_WORKITEM_PAYLOAD%\log\$(crossFlavor)
@@ -179,7 +194,7 @@ jobs:
     - task: PublishPipelineArtifact@1
       displayName: Publish log
       inputs:
-        pathtoPublish: $(artifactsDirectory)/log
+        pathtoPublish: $(workItemDirectory)/log
         artifactName: ${{ format('Testlog_crossgen_comparison_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen-comparison-job.yml
@@ -65,7 +65,7 @@ jobs:
         value: $(artifactsDirectory)\bin
       - name: productDirectory
         value: $(binDirectory)\coreclr
-        - name: workItemDirectory
+      - name: workItemDirectory
         value: $(artifactsDirectory)\cross-crossgen
 
     - ${{ parameters.variables }}

--- a/src/coreclr/tests/scripts/crossgen_comparison.py
+++ b/src/coreclr/tests/scripts/crossgen_comparison.py
@@ -92,6 +92,7 @@
 ################################################################################
 
 import argparse
+import datetime
 import glob
 import json
 import hashlib
@@ -694,6 +695,13 @@ def compare_results(args):
 ################################################################################
 
 if __name__ == '__main__':
+    start = datetime.datetime.now()
+
     parser = build_argument_parser()
     args = parser.parse_args()
     func = args.func(args)
+
+    end = datetime.datetime.now()
+    elapsed = end - start
+
+    print("Elapsed time: {}".format(elapsed.total_seconds()))

--- a/src/coreclr/tests/scripts/crossgen_comparison.py
+++ b/src/coreclr/tests/scripts/crossgen_comparison.py
@@ -526,6 +526,12 @@ def crossgen_corelib(args):
     ni_corelib_dirname, debugging_files_dirname = create_output_folders()
     ni_corelib_filename = os.path.join(ni_corelib_dirname, assembly_name)
     platform_assemblies_paths = [os.path.dirname(il_corelib_filename)]
+
+    # Validate the paths are correct.
+    if not os.path.exists(il_corelib_filename):
+        print("IL Corelib path does not exist.")
+        sys.exit(1)
+
     crossgen_results = run_crossgen(args.crossgen_executable_filename, il_corelib_filename, ni_corelib_filename, platform_assemblies_paths, debugging_files_dirname)
     shutil.rmtree(ni_corelib_dirname, ignore_errors=True)
     save_crossgen_results_to_json_files(crossgen_results, args.result_dirname)


### PR DESCRIPTION
The work item should be ~1/2 the size of the older workitem. The largest difference will be the bin/* folder will now be ommitted.

Workitem size goes from 750m to 350m, decided to print the elapsed runtime as well into the console log. Which will help with https://github.com/dotnet/runtime/pull/33175