### PR TITLE
[wasm] Fix warnings about unused variables.

### DIFF
--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2884,12 +2884,12 @@ mono_gc_add_memory_pressure (gint64 value)
 void
 sgen_client_degraded_allocation (void)
 {
+	//The WASM target aways triggers degrated allocation before collecting. So no point in printing the warning as it will just confuse users
+#ifndef HOST_WASM
 	static gint32 last_major_gc_warned = -1;
 	static gint32 num_degraded = 0;
 
 	gint32 major_gc_count = mono_atomic_load_i32 (&mono_gc_stats.major_gc_count);
-	//The WASM target aways triggers degrated allocation before collecting. So no point in printing the warning as it will just confuse users
-#if !defined (TARGET_WASM)
 	if (mono_atomic_load_i32 (&last_major_gc_warned) < major_gc_count) {
 		gint32 num = mono_atomic_inc_i32 (&num_degraded);
 		if (num == 1 || num == 3)


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19179,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>/s/mono2/mono/metadata/sgen-mono.c:2883:16: warning: unused variable
      'last_major_gc_warned' [-Wunused-variable]
        static gint32 last_major_gc_warned = -1;
                      ^
/s/mono2/mono/metadata/sgen-mono.c:2884:16: warning: unused variable
      'num_degraded' [-Wunused-variable]
        static gint32 num_degraded = 0;
                      ^
/s/mono2/mono/metadata/sgen-mono.c:2886:9: warning: unused variable
      'major_gc_count' [-Wunused-variable]
        gint32 major_gc_count = mono_atomic_load_i32 (&mono_gc_stats.maj...
               ^



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
