### PR TITLE
[wasm][interp] Fix warning about unprototyped mono_wasm_interp_to_native_trampoline.

### DIFF
--- a/src/mono/mono/mini/interp/interp.h
+++ b/src/mono/mono/mini/interp/interp.h
@@ -21,7 +21,7 @@ struct _InterpMethodArguments {
 	double *fargs;
 	gpointer *retval;
 	size_t is_float_ret;
-#ifdef TARGET_WASM
+#ifdef TARGET_WASM // FIXME HOST
 	MonoMethodSignature *sig;
 #endif
 };
@@ -41,5 +41,12 @@ typedef struct _InterpMethodArguments InterpMethodArguments;
  *  - xor, before mini_init () is called (embedding scenario).
  */
 MONO_API void mono_ee_interp_init (const char *);
+
+#ifdef TARGET_WASM
+
+void
+mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
+
+#endif
 
 #endif /* __MONO_MINI_INTERPRETER_H__ */

--- a/src/mono/mono/mini/tramp-wasm.c
+++ b/src/mono/mono/mini/tramp-wasm.c
@@ -1,7 +1,6 @@
 #include "mini.h"
 #include "interp/interp.h"
 
-void mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
 void mono_sdb_single_step_trampoline (void);
 
 static void


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19183,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>