### PR TITLE
Add libicu65 to DEB deps package

### DIFF
--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -325,7 +325,7 @@
         Include="%SSL_DEPENDENCY_LIST%"
         ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
 
-      <KnownLibIcuVersion Include="63;60;57;55;52" />
+      <KnownLibIcuVersion Include="65;63;60;57;55;52" />
       <SharedFrameworkTokenValue
         Include="%LIBICU_DEPENDENCY_LIST%"
         ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />


### PR DESCRIPTION
Fix for issue https://github.com/dotnet/runtime/issues/32971

Ubuntu Focal, which is in preview, recently updated to a newer version of libicu - libicu65. The dotnet-runtime-deps deb package needs to be updated appropriately so that the libicu dependency is correctly met/installed.
