### PR TITLE
Fix warnings about misleading indentation.

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -4007,7 +4007,7 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 				if (is_variant && mono_class_is_variant_compatible_slow (target, candidate_interfaces [i]))
 					return TRUE;
 
-				 if (mono_class_implement_interface_slow (target, candidate_interfaces [i]))
+				if (mono_class_implement_interface_slow (target, candidate_interfaces [i]))
 					return TRUE;
 			}
 		}
@@ -4036,7 +4036,7 @@ mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate)
 	if (MONO_CLASS_IS_INTERFACE_INTERNAL (target))
 		return mono_class_implement_interface_slow (target, candidate);
 
- 	if (m_class_is_delegate (target) && mono_class_has_variant_generic_params (target))
+	if (m_class_is_delegate (target) && mono_class_has_variant_generic_params (target))
 		return mono_class_is_variant_compatible (target, candidate, FALSE);
 
 	if (m_class_get_rank (target)) {

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -2391,7 +2391,7 @@ mono_main (int argc, char* argv[])
 				enable_debugging = FALSE;
 			}
 #endif
- 		} else if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
+		} else if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
 			MonoDebugOptions *opt = mini_get_debug_options ();
 
 			sdb_options = g_strdup (argv [i] + 17);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19186,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is subtle and not actually misleading,
because it tends to be space tab or space tab, not wrong
number of tabs or significant wrong number of spaces.

/s/mono2/mono/metadata/class.c:4010:6: warning: misleading indentation;
      statement is not part of the previous 'if' [-Wmisleading-indentation]
                                 if (mono_class_implement_interface_slo...

/s/mono2/mono/metadata/class.c:4039:3: warning: misleading indentation;
      statement is not part of the previous 'if' [-Wmisleading-indentation]
        if (m_class_is_delegate (target) && mono_class_has_variant_gener...

/s/mono2/mono/mini/driver.c:1780:4: warning: misleading indentation; statement
      is not part of the previous 'if' [-Wmisleading-indentation]
                if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {