### PR TITLE
Preserve the Authorization header during a redirect

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -52,9 +52,6 @@ namespace System.Net.Http
 
                 response.Dispose();
 
-                // Clear the authorization header.
-                request.Headers.Authorization = null;
-
                 if (NetEventSource.IsEnabled)
                 {
                     Trace($"Redirecting from {request.RequestUri} to {redirectUri} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.", request.GetHashCode());


### PR DESCRIPTION
There are cases where 3rd party APIs set up redirects for their endpoints. These redirects usually happen silently from the perspective of the HttpClient and WebRequest classes, as was with my case.

I was integrating a 3rd Party API into my project. The API requires an Authorization header to be sent with each request. One of the API's endpoints worked as expected, while a second endpoint with the same permission requirements was sending back a 401 Unauthorized response. Analyzing the request before and after the Send revealed that the Authorization header was being stripped somewhere during the execution.

It turns out that the second endpoint was never receiving the Authorization header. This was because the second endpoint I was attempting to call resulted in a redirect. The current implementation of RedirectHandler.SendAsync(..) strips the Authorization header from the request before sending it to the API, meaning that endpoint is effectively inaccessible from .NET Core when using HttpClient and WebRequest.

The Authorization header should be preserved on the request even in the case of a redirect. In the case that there is a security concern I'm unaware of, a request option should be exposed to manually persist the Authorization header in the case of a redirect.