### PR TITLE
set timeout for tests using remote HTTP servers

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http.Functional.Tests
                 wrappedHandler = new VersionCheckerHttpHandler(httpClientHandler, remoteServer.HttpVersion);
             }
 
-            return new HttpClient(wrappedHandler) { DefaultRequestVersion = remoteServer.HttpVersion };
+            return new HttpClient(wrappedHandler) { DefaultRequestVersion = remoteServer.HttpVersion, Timeout = TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds) };
         }
 
         private sealed class VersionCheckerHttpHandler : DelegatingHandler


### PR DESCRIPTION
I bump to this while running HTTP tests in loop on Linix with strace. The tests runs are bit slower but I encounter this:
```
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:05:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:07:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:09:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:11:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:13:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:15:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:17:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:19:35
   System.Net.Http.Functional.Tests: [Long Running Test] 'System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_AutoRedirect.GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK', Elapsed: 00:21:35
```

the code essentially looks like and I don't see much reason why the test would run so long
```c#
           HttpClientHandler handler = CreateHttpClientHandler();
            handler.Credentials = credentialCache;
            using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer, handler))
            {
                using (HttpResponseMessage response = await client.GetAsync(redirectUri))
                {
                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                    Assert.Equal(uri, response.RequestMessage.RequestUri);
                }
            }
```

There is really no reason why this should run 20+ minutes. If this would be in CI, the test run would be killed and we would not get any test results instead of failing individual test. 

I've seen similar failures with other tests. This is clearly some kind of race condition and I can only reproduce it occasionally. Instead of chasing individual tests, this enables timeout at Httpclient used by many tests. We may consider setting it for all overloads but for now, I updated only  CreateHttpClientForRemoteServer().

