### PR TITLE
Performance improvements in Sum() for Array type

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Sum.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Sum.cs
@@ -18,9 +18,19 @@ namespace System.Linq
             int sum = 0;
             checked
             {
-                foreach (int v in source)
+                if (source is int[] array)
                 {
-                    sum += v;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        sum += array[i];
+                    }
+                }
+                else
+                {
+                    foreach (int v in source)
+                    {
+                        sum += v;
+                    }
                 }
             }
 
@@ -37,11 +47,21 @@ namespace System.Linq
             int sum = 0;
             checked
             {
-                foreach (int? v in source)
+                if (source is int?[] array)
                 {
-                    if (v != null)
+                    for (int i = 0; i < array.Length; i++)
                     {
-                        sum += v.GetValueOrDefault();
+                        sum += array[i].GetValueOrDefault();
+                    }
+                }
+                else
+                {
+                    foreach (int? v in source)
+                    {
+                        if (v != null)
+                        {
+                            sum += v.GetValueOrDefault();
+                        }
                     }
                 }
             }
@@ -59,9 +79,19 @@ namespace System.Linq
             long sum = 0;
             checked
             {
-                foreach (long v in source)
+                if (source is long[] array)
                 {
-                    sum += v;
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        sum += array[i];
+                    }
+                }
+                else
+                {
+                    foreach (long v in source)
+                    {
+                        sum += v;
+                    }
                 }
             }
 
@@ -78,11 +108,21 @@ namespace System.Linq
             long sum = 0;
             checked
             {
-                foreach (long? v in source)
+                if (source is long?[] array)
                 {
-                    if (v != null)
+                    for (int i = 0; i < array.Length; i++)
                     {
-                        sum += v.GetValueOrDefault();
+                        sum += array[i].GetValueOrDefault();
+                    }
+                }
+                else
+                {
+                    foreach (long? v in source)
+                    {
+                        if (v != null)
+                        {
+                            sum += v.GetValueOrDefault();
+                        }
                     }
                 }
             }
@@ -98,9 +138,19 @@ namespace System.Linq
             }
 
             double sum = 0;
-            foreach (float v in source)
+            if (source is float[] array)
             {
-                sum += v;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    sum += array[i];
+                }
+            }
+            else
+            {
+                foreach (float v in source)
+                {
+                    sum += v;
+                }
             }
 
             return (float)sum;
@@ -114,11 +164,21 @@ namespace System.Linq
             }
 
             double sum = 0;
-            foreach (float? v in source)
+            if (source is float?[] array)
             {
-                if (v != null)
+                for (int i = 0; i < array.Length; i++)
                 {
-                    sum += v.GetValueOrDefault();
+                    sum += array[i].GetValueOrDefault();
+                }
+            }
+            else
+            {
+                foreach (float? v in source)
+                {
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
 
@@ -133,9 +193,19 @@ namespace System.Linq
             }
 
             double sum = 0;
-            foreach (double v in source)
+            if (source is double[] array)
             {
-                sum += v;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    sum += array[i];
+                }
+            }
+            else
+            {
+                foreach (double v in source)
+                {
+                    sum += v;
+                }
             }
 
             return sum;
@@ -149,11 +219,21 @@ namespace System.Linq
             }
 
             double sum = 0;
-            foreach (double? v in source)
+            if (source is double?[] array)
             {
-                if (v != null)
+                for (int i = 0; i < array.Length; i++)
                 {
-                    sum += v.GetValueOrDefault();
+                    sum += array[i].GetValueOrDefault();
+                }
+            }
+            else
+            {
+                foreach (double? v in source)
+                {
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
 
@@ -168,9 +248,19 @@ namespace System.Linq
             }
 
             decimal sum = 0;
-            foreach (decimal v in source)
+            if (source is decimal[] array)
             {
-                sum += v;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    sum += array[i];
+                }
+            }
+            else
+            {
+                foreach (decimal v in source)
+                {
+                    sum += v;
+                }
             }
 
             return sum;
@@ -184,11 +274,21 @@ namespace System.Linq
             }
 
             decimal sum = 0;
-            foreach (decimal? v in source)
+            if (source is decimal?[] array)
             {
-                if (v != null)
+                for (int i = 0; i < array.Length; i++)
                 {
-                    sum += v.GetValueOrDefault();
+                    sum += array[i].GetValueOrDefault();
+                }
+            }
+            else
+            {
+                foreach (decimal? v in source)
+                {
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
 


### PR DESCRIPTION
The current performance of the Sum() functions on an Array are "slow". This PR improves the performance with a factor 5 to 7 (depending of the size of the array and the datatype). It also reduces the memory allocation to 0.

Similar optimizations can also be found in the First() and Last() methods. I think it is valid.

I'm not sure if this should also implemented in other aggregate functions like Average(), Min() and Max(). I'm also not sure if we should also improve the performance for the IReadOnlyList<T> type.

**Benchmark**

```
[MemoryDiagnoser]
public class IntBM {

    private int[] _array;

    [Params(10, 100, 1000, 10000)]
    public int Size { get; set; }

    [GlobalSetup]
    public void Setup() {
        _array = new int[Size];
        for (int i = 0; i < _array.Length; i++) {
            _array[i] = i;
        }
    }

    [Benchmark]
    public int Old() => System.Linq.Enumerable.Sum(_array);

    [Benchmark(Baseline = true)]
    public int New() => System.LinqNew.Enumerable.Sum(_array);
}
```
To write this test I moved the new Enumerable.Sum() method to a new (temporary) System.LinqNew namespace.

**Result**
 
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=3.1.200-preview-015002
  [Host]     : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT
  DefaultJob : .NET Core 3.1.2 (CoreCLR 4.700.20.6602, CoreFX 4.700.20.6702), X64 RyuJIT


```
| Method |  Size |          Mean |      Error |     StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |------ |--------------:|-----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
|    **Old** |    **10** |     **46.664 ns** |  **0.3522 ns** |  **0.3122 ns** |  **5.16** |    **0.04** | **0.0038** |     **-** |     **-** |      **32 B** |
|    New |    10 |      9.046 ns |  0.0196 ns |  0.0183 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|        |       |               |            |            |       |         |        |       |       |           |
|    **Old** |   **100** |    **368.172 ns** |  **3.0178 ns** |  **2.8229 ns** |  **6.13** |    **0.06** | **0.0038** |     **-** |     **-** |      **32 B** |
|    New |   100 |     60.092 ns |  0.3095 ns |  0.2895 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|        |       |               |            |            |       |         |        |       |       |           |
|    **Old** |  **1000** |  **3,495.488 ns** | **22.6449 ns** | **21.1820 ns** |  **7.06** |    **0.07** | **0.0038** |     **-** |     **-** |      **32 B** |
|    New |  1000 |    495.273 ns |  4.0798 ns |  3.8162 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|        |       |               |            |            |       |         |        |       |       |           |
|    **Old** | **10000** | **34,857.737 ns** | **52.5984 ns** | **46.6271 ns** |  **7.14** |    **0.04** |      **-** |     **-** |     **-** |      **32 B** |
|    New | 10000 |  4,882.472 ns | 21.6389 ns | 19.1823 ns |  1.00 |    0.00 |      - |     - |     - |         - |
