### PR TITLE
[interp][32bit] Fix warning about precedence/parentheses.

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3048,7 +3048,7 @@ interp_emit_ldsflda (TransformData *td, MonoClassField *field, MonoError *error)
 static gboolean
 interp_emit_load_const (TransformData *td, gpointer field_addr, int mt)
 {
-	if (mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4
+	if ((mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4)
 #if SIZEOF_VOID_P == 4
 		|| mt == MINT_TYPE_P
 #endif


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19184,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>/s/mono2/mono/mini/interp/transform.c:3166:25: note: place parentheses around
      the '&&' expression to silence this warning
        if (mt >= MINT_TYPE_I1 && mt <= MINT_TYPE_I4
            ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~