### PR TITLE
Use HW-intrinsics in BitConverter for double <-> long / float <-> int

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -451,6 +451,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe long DoubleToInt64Bits(double value)
         {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
             if (Sse2.X64.IsSupported)
             {
                 Vector128<long> vec = Vector128.CreateScalarUnsafe(value).AsInt64();
@@ -463,6 +464,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe double Int64BitsToDouble(long value)
         {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
             if (Sse2.X64.IsSupported)
             {
                 Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
@@ -475,6 +477,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int SingleToInt32Bits(float value)
         {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
             if (Sse2.IsSupported)
             {
                 Vector128<int> vec = Vector128.CreateScalarUnsafe(value).AsInt32();
@@ -487,6 +490,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe float Int32BitsToSingle(int value)
         {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
             if (Sse2.IsSupported)
             {
                 Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -4,6 +4,8 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 using Internal.Runtime.CompilerServices;
 
@@ -449,24 +451,48 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe long DoubleToInt64Bits(double value)
         {
+            if (Sse2.X64.IsSupported)
+            {
+                Vector128<long> vec = Vector128.CreateScalarUnsafe(value).AsInt64();
+                return Sse2.X64.ConvertToInt64(vec);
+            }
+
             return *((long*)&value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe double Int64BitsToDouble(long value)
         {
+            if (Sse2.X64.IsSupported)
+            {
+                Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
+                return vec.ToScalar();
+            }
+
             return *((double*)&value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int SingleToInt32Bits(float value)
         {
+            if (Sse2.IsSupported)
+            {
+                Vector128<int> vec = Vector128.CreateScalarUnsafe(value).AsInt32();
+                return Sse2.ConvertToInt32(vec);
+            }
+
             return *((int*)&value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe float Int32BitsToSingle(int value)
         {
+            if (Sse2.IsSupported)
+            {
+                Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();
+                return vec.ToScalar();
+            }
+
             return *((float*)&value);
         }
     }


### PR DESCRIPTION
... to emit `movd` instead of using the stack on hardware that has `SSE2`.

Ideally the JIT would emit code like this, so this workaround isn't needed. 
(But my knowledge of JIT-programming is too limited to make the proper change over there.)

Cf. https://github.com/dotnet/runtime/issues/12733#issuecomment-495709826 and https://github.com/dotnet/runtime/issues/33057#issuecomment-597111314

<details>
  <summary>Code used for generating the asm-dumps</summary>

```c#
using System;
using System.Runtime.CompilerServices;

namespace ConsoleApp4
{
    class Program
    {
        static int Main(string[] args)
        {
            long lval   = Double2Long(Math.PI);
            double dval = Long2Double(lval);

            int ival   = Float2Int(MathF.PI);
            float fval = Int2Float(ival);

            return dval == Math.PI && fval == MathF.PI ? 0 : 1;
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        private static long Double2Long(double value) => BitConverter.DoubleToInt64Bits(value);

        [MethodImpl(MethodImplOptions.NoInlining)]
        private static double Long2Double(long value) => BitConverter.Int64BitsToDouble(value);

        [MethodImpl(MethodImplOptions.NoInlining)]
        private static int Float2Int(float value) => BitConverter.SingleToInt32Bits(value);

        [MethodImpl(MethodImplOptions.NoInlining)]
        private static float Int2Float(int value) => BitConverter.Int32BitsToSingle(value);
    }
}
```
</details>

<details>
  <summary>asm before</summary>

```asm
; Assembly listing for method ConsoleApp4.Program:Double2Long(double):long
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )  double  ->  mm0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  4   )  double  ->  [rsp+0x00]   do-not-enreg[F] ld-addr-op "Inlining Arg"
;
; Lcl frame size = 8

G_M41745_IG01:
       50                   push     rax
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 2.00
G_M41745_IG02:
       C5FB110424           vmovsd   qword ptr [rsp], xmm0
       488B0424             mov      rax, qword ptr [rsp]
                        ;; bbWeight=1    PerfScore 1.50
G_M41745_IG03:
       4883C408             add      rsp, 8
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.25

; Total bytes of code 18, prolog size 4, PerfScore 6.65, (MethodHash=784c5cee) for method ConsoleApp4.Program:Double2Long(double):long
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Long2Double(long):double
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rdi
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  4   )    long  ->  [rsp+0x00]   do-not-enreg[F] ld-addr-op "Inlining Arg"
;
; Lcl frame size = 8

G_M5681_IG01:
       50                   push     rax
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 2.00
G_M5681_IG02:
       48893C24             mov      qword ptr [rsp], rdi
       C5FB100424           vmovsd   xmm0, qword ptr [rsp]
                        ;; bbWeight=1    PerfScore 3.00
G_M5681_IG03:
       4883C408             add      rsp, 8
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.25

; Total bytes of code 18, prolog size 4, PerfScore 8.15, (MethodHash=79fee9ce) for method ConsoleApp4.Program:Long2Double(long):double
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Float2Int(float):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )   float  ->  mm0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  4   )   float  ->  [rsp+0x04]   do-not-enreg[F] ld-addr-op "Inlining Arg"
;
; Lcl frame size = 8

G_M977_IG01:
       50                   push     rax
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 2.00
G_M977_IG02:
       C5FA11442404         vmovss   dword ptr [rsp+04H], xmm0
       8B442404             mov      eax, dword ptr [rsp+04H]
                        ;; bbWeight=1    PerfScore 1.50
G_M977_IG03:
       4883C408             add      rsp, 8
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.25

; Total bytes of code 19, prolog size 4, PerfScore 6.75, (MethodHash=2cd6fc2e) for method ConsoleApp4.Program:Float2Int(float):int
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Int2Float(int):float
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rdi
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  4   )     int  ->  [rsp+0x04]   do-not-enreg[F] ld-addr-op "Inlining Arg"
;
; Lcl frame size = 8

G_M15857_IG01:
       50                   push     rax
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 2.00
G_M15857_IG02:
       897C2404             mov      dword ptr [rsp+04H], edi
       C5FA10442404         vmovss   xmm0, dword ptr [rsp+04H]
                        ;; bbWeight=1    PerfScore 3.00
G_M15857_IG03:
       4883C408             add      rsp, 8
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.25

; Total bytes of code 19, prolog size 4, PerfScore 8.25, (MethodHash=ce7cc20e) for method ConsoleApp4.Program:Int2Float(int):float
; ============================================================
```
</details>

<details>
  <summary>asm after</summary>

```asm
; Assembly listing for method ConsoleApp4.Program:Double2Long(double):long
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T01] (  3,  3   )  double  ->  mm0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T00] (  2,  2   )    long  ->  rax         "Inline return value spill temp"
;* V03 tmp2         [V03    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
;
; Lcl frame size = 0

G_M41745_IG01:
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 1.00
G_M41745_IG02:
       C4E1F97EC0           vmovd    rax, xmm0
                        ;; bbWeight=1    PerfScore 1.00
G_M41745_IG03:
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.00

; Total bytes of code 9, prolog size 3, PerfScore 3.90, (MethodHash=784c5cee) for method ConsoleApp4.Program:Double2Long(double):long
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Long2Double(long):double
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rdi
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  2   )  double  ->  mm0         "Inline return value spill temp"
;* V03 tmp2         [V03    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op "Inlining Arg"
;
; Lcl frame size = 0

G_M5681_IG01:
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 1.00
G_M5681_IG02:
       C4E1F96EC7           vmovd    xmm0, rdi
                        ;; bbWeight=1    PerfScore 1.00
G_M5681_IG03:
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.00

; Total bytes of code 9, prolog size 3, PerfScore 3.90, (MethodHash=79fee9ce) for method ConsoleApp4.Program:Long2Double(long):double
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Float2Int(float):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T01] (  3,  3   )   float  ->  mm0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T00] (  2,  2   )     int  ->  rax         "Inline return value spill temp"
;* V03 tmp2         [V03    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
;
; Lcl frame size = 0

G_M977_IG01:
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 1.00
G_M977_IG02:
       C5F97EC0             vmovd    eax, xmm0
                        ;; bbWeight=1    PerfScore 1.00
G_M977_IG03:
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.00

; Total bytes of code 8, prolog size 3, PerfScore 3.90, (MethodHash=2cd6fc2e) for method ConsoleApp4.Program:Float2Int(float):int
; ============================================================

; Assembly listing for method ConsoleApp4.Program:Int2Float(int):float
; Emitting BLENDED_CODE for X64 CPU with AVX - Unix
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rdi
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  2,  2   )   float  ->  mm0         "Inline return value spill temp"
;* V03 tmp2         [V03    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op "Inlining Arg"
;
; Lcl frame size = 0

G_M15857_IG01:
       C5F877               vzeroupper
                        ;; bbWeight=1    PerfScore 1.00
G_M15857_IG02:
       C5F96EC7             vmovd    xmm0, edi
                        ;; bbWeight=1    PerfScore 1.00
G_M15857_IG03:
       C3                   ret
                        ;; bbWeight=1    PerfScore 1.00

; Total bytes of code 8, prolog size 3, PerfScore 3.90, (MethodHash=ce7cc20e) for method ConsoleApp4.Program:Int2Float(int):float
; ============================================================
```
</details>

/cc: @tannergooding 