### PR TITLE
Fixed memory leak in HttpListener WebSocket.

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -280,6 +280,11 @@ namespace System.Net.WebSockets
                     eventArgs.FinishOperationSuccess((int)bytesReturned, true);
                     completedAsynchronouslyOrWithError = false;
                 }
+                else if (statusCode == Interop.HttpApi.ERROR_HANDLE_EOF)
+                {
+                    eventArgs.FinishOperationSuccess(0, true);
+                    completedAsynchronouslyOrWithError = false;
+                }
                 else
                 {
                     completedAsynchronouslyOrWithError = true;


### PR DESCRIPTION
Based on email report of this leak with a repro found a root cause in not freeing `OverlappedData` after getting `Interop.HttpApi.ERROR_HANDLE_EOF` result from native `HttpReceiveRequestEntityBody`. According to this [docs](https://docs.microsoft.com/en-us/windows/win32/api/http/nf-http-httpreceiverequestentitybody) only when `ERROR_IO_PENDING` is returned the callback will be called. Thus, only in such case should the instance of `OverlappedData` be kept around.

Fixed by calling `FinishOperationSuccess` in case of `Interop.HttpApi.ERROR_HANDLE_EOF` result which will free the `OverlappedData`.

Before:
![image](https://user-images.githubusercontent.com/11718369/76425139-7f9f7180-63a9-11ea-8c0b-a524741aebdb.png)
The 121 OverlappedData corresponds to the number of returned Interop.HttpApi.ERROR_HANDLE_EOF.
After:
![image](https://user-images.githubusercontent.com/11718369/76425169-8b8b3380-63a9-11ea-83cc-bbbf5d9dd6f5.png)
And in the log there’s 53 returned Interop.HttpApi.ERROR_HANDLE_EOF.


