### PR TITLE
Unconditionally upgrade installed Brew packages on OSX

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -11,6 +11,7 @@ if [ "$1" = "Linux" ]; then
     fi
 elif [ "$1" = "OSX" ]; then
     brew update
+    brew upgrade
     if [ "$?" != "0" ]; then
         exit 1;
     fi


### PR DESCRIPTION
With Apt, if you have X 1.0 installed, 1.1 exists in the package manifest, and say "install X", X is upgraded to 1.1. With Brew, a fatal error is thrown.

Blindly upgrading all previously installed packages is not ideal, and not a perfect mirror for the Apt behaviour, but it should mean that if X is previously installed it gets upgraded (causing a warning during install, when it's asked to be installed again with the same version), and if it's not already installed then it gets installed later.

Closes: https://github.com/dotnet/runtime/issues/33471