### PR TITLE
Fix type layout when Cross OS compiling

### DIFF
--- a/src/coreclr/src/inc/daccess.h
+++ b/src/coreclr/src/inc/daccess.h
@@ -2458,4 +2458,16 @@ typedef DPTR(PTR_PCODE) PTR_PTR_PCODE;
 // @dbgtodo : Separating asserts and target consistency checks is tracked by DevDiv Bugs 31674
 #define TARGET_CONSISTENCY_CHECK(expr,msg) _ASSERTE_MSG(expr,msg)
 
+// For cross compilation, controlling type layout is important
+// We add a simple macro here which defines DAC_ALIGNAS to the C++11 alignas operator
+// This helps force the algnment of the next member
+// For most cross compilation cases the layout of types simply works
+// There are a few cases (where this macro is helpful) which are not consistent accross platforms:
+// - Base class whose size is padded to its align size.  On Linux the gcc/clang
+//   layouts will reuse this padding in the derived class for the first member
+// - Class with an vtable pointer and an alignment greater than the pointer size.
+//   The Windows compilers will align the first member to the alignment size of the
+//   class.  Linux will align the first member to its natural alignment
+#define DAC_ALIGNAS(a) alignas(a)
+
 #endif // #ifndef __daccess_h__

--- a/src/coreclr/src/inc/daccess.h
+++ b/src/coreclr/src/inc/daccess.h
@@ -2460,7 +2460,7 @@ typedef DPTR(PTR_PCODE) PTR_PTR_PCODE;
 
 // For cross compilation, controlling type layout is important
 // We add a simple macro here which defines DAC_ALIGNAS to the C++11 alignas operator
-// This helps force the algnment of the next member
+// This helps force the alignment of the next member
 // For most cross compilation cases the layout of types simply works
 // There are a few cases (where this macro is helpful) which are not consistent accross platforms:
 // - Base class whose size is padded to its align size.  On Linux the gcc/clang

--- a/src/coreclr/src/inc/sarray.h
+++ b/src/coreclr/src/inc/sarray.h
@@ -196,7 +196,7 @@ template <typename ELEMENT, COUNT_T SIZE, BOOL BITWISE_COPY = TRUE>
 class EMPTY_BASES_DECL InlineSArray : public SArray<ELEMENT, BITWISE_COPY>
 {
  private:
-#ifdef _MSC_VER
+#ifdef TARGET_WINDOWS
 #pragma warning(push)
 #pragma warning(disable:4200) // zero sized array
 #pragma warning(disable:4324) // don't complain if DECLSPEC_ALIGN actually pads

--- a/src/coreclr/src/inc/stgpool.h
+++ b/src/coreclr/src/inc/stgpool.h
@@ -1105,6 +1105,7 @@ private:
 
 
 private:
+    DAC_ALIGNAS(StgPool) // Align first member to alignment of base class
     CGuidPoolHash m_Hash;                    // Hash table for lookups.
     int            m_bHash;                    // true to keep hash table.
 };  // class StgGuidPool
@@ -1257,6 +1258,7 @@ private:
     __checkReturn
     HRESULT RehashBlobs();
 
+    DAC_ALIGNAS(StgPool) // Align first member to alignment of base class
     CBlobPoolHash m_Hash;                    // Hash table for lookups.
 };  // class StgBlobPool
 

--- a/src/coreclr/src/inc/utilcode.h
+++ b/src/coreclr/src/inc/utilcode.h
@@ -701,7 +701,7 @@ public:
         m_nHashSize = 0;
         m_csMap = NULL;
         m_pResourceFile = NULL;
-#ifdef HOST_UNIX
+#ifdef TARGET_UNIX
         m_pResourceDomain = NULL;
 #endif // HOST_UNIX
 
@@ -775,11 +775,11 @@ private:
     CRITSEC_COOKIE m_csMap;
 
     LPCWSTR m_pResourceFile;
-#ifdef HOST_UNIX
+#ifdef TARGET_UNIX
     // Resource domain is an ANSI string identifying a native resources file
     static LPCSTR  m_pDefaultResourceDomain;
     LPCSTR m_pResourceDomain;
-#endif // HOST_UNIX
+#endif // TARGET_UNIX
 
     // Main accessors for hash
     HRESOURCEDLL LookupNode(LocaleID langId, BOOL &fMissing);

--- a/src/coreclr/src/inc/utilcode.h
+++ b/src/coreclr/src/inc/utilcode.h
@@ -701,10 +701,6 @@ public:
         m_nHashSize = 0;
         m_csMap = NULL;
         m_pResourceFile = NULL;
-#ifdef TARGET_UNIX
-        m_pResourceDomain = NULL;
-#endif // HOST_UNIX
-
     }// CCompRC
 
     HRESULT Init(LPCWSTR pResourceFile);
@@ -775,11 +771,6 @@ private:
     CRITSEC_COOKIE m_csMap;
 
     LPCWSTR m_pResourceFile;
-#ifdef TARGET_UNIX
-    // Resource domain is an ANSI string identifying a native resources file
-    static LPCSTR  m_pDefaultResourceDomain;
-    LPCSTR m_pResourceDomain;
-#endif // TARGET_UNIX
 
     // Main accessors for hash
     HRESOURCEDLL LookupNode(LocaleID langId, BOOL &fMissing);

--- a/src/coreclr/src/md/compiler/regmeta.h
+++ b/src/coreclr/src/md/compiler/regmeta.h
@@ -1987,8 +1987,7 @@ protected:
 #endif //FEATURE_METADATA_INTERNAL_APIS
 
     UTSemReadWrite      *m_pSemReadWrite;
-    bool                m_fOwnSem;
-
+    unsigned    m_fOwnSem : 1;
     unsigned    m_bRemap : 1;               // If true, there is a token mapper.
     unsigned    m_bSaveOptimized : 1;       // If true, save optimization has been done.
     unsigned    m_hasOptimizedRefToDef : 1; // true if we have performed ref to def optimization

--- a/src/coreclr/src/md/inc/liteweightstgdb.h
+++ b/src/coreclr/src/md/inc/liteweightstgdb.h
@@ -190,6 +190,7 @@ public:
         const void **ppv,                   // [OUT] put pointer to MD stream here.
         ULONG   *pcb);                      // [OUT] put size of the stream here.
 
+    DAC_ALIGNAS(CLiteWeightStgdb<CMiniMdRW>) // Align the first member to the alignment of the base class
     UINT32      m_cbSaveSize;               // Size of the saved streams.
     int         m_bSaveCompressed;          // If true, save as compressed stream (#-, not #~)
     VOID*       m_pImage;                   // Set in OpenForRead, NULL for anything but PE files

--- a/src/coreclr/src/md/inc/metamodelro.h
+++ b/src/coreclr/src/md/inc/metamodelro.h
@@ -77,6 +77,7 @@ public:
 #endif //FEATURE_PREJIT
 
 protected:
+    DAC_ALIGNAS(CMiniMdTemplate<CMiniMd>) // Align the first member to the alignment of the base class
     // Table info.
     MetaData::TableRO m_Tables[TBL_COUNT];
 #ifdef FEATURE_PREJIT

--- a/src/coreclr/src/md/inc/metamodelrw.h
+++ b/src/coreclr/src/md/inc/metamodelrw.h
@@ -672,6 +672,7 @@ public:
         return HashToken(tkObject);
     }
 
+    DAC_ALIGNAS(CMiniMdTemplate<CMiniMdRW>) // Align the first member to the alignment of the base class
     CMemberRefHash *m_pMemberRefHash;
 
     // Hash table for Methods and Fields

--- a/src/coreclr/src/md/inc/recordpool.h
+++ b/src/coreclr/src/md/inc/recordpool.h
@@ -154,6 +154,7 @@ public:
         void        **pContext);            // Stored context here.
 
 private:
+    DAC_ALIGNAS(StgPool) // Align first member to alignment of base class
     UINT32 m_cbRec;                // How large is each record?
 
 };  // class RecordPool

--- a/src/coreclr/src/utilcode/ccomprc.cpp
+++ b/src/coreclr/src/utilcode/ccomprc.cpp
@@ -114,10 +114,6 @@ HRESULT CCompRC::AddMapNode(LocaleID langId, HRESOURCEDLL hInst, BOOL fMissing)
 //*****************************************************************************
 LPCWSTR CCompRC::m_pDefaultResource = W("mscorrc.dll");
 
-#ifdef HOST_UNIX
-LPCSTR CCompRC::m_pDefaultResourceDomain = "mscorrc";
-#endif // HOST_UNIX
-
 HRESULT CCompRC::Init(LPCWSTR pResourceFile)
 {
     CONTRACTL
@@ -161,19 +157,6 @@ HRESULT CCompRC::Init(LPCWSTR pResourceFile)
     {
         return E_OUTOFMEMORY;
     }
-
-#ifdef HOST_UNIX
-
-    if (m_pResourceFile == m_pDefaultResource)
-    {
-        m_pResourceDomain = m_pDefaultResourceDomain;
-    }
-    else
-    {
-        _ASSERTE(!"Unsupported resource file");
-    }
-
-#endif // HOST_UNIX
 
     if (m_csMap == NULL)
     {

--- a/src/coreclr/src/vm/class.h
+++ b/src/coreclr/src/vm/class.h
@@ -1950,6 +1950,7 @@ public:
 class LayoutEEClass : public EEClass
 {
 public:
+    DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     EEClassLayoutInfo m_LayoutInfo;
     Volatile<PTR_EEClassNativeLayoutInfo> m_nativeLayoutInfo;
 
@@ -1971,6 +1972,7 @@ struct ComPlusCallInfo;
 class DelegateEEClass : public EEClass
 {
 public:
+    DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     PTR_Stub                         m_pStaticCallStub;
     PTR_Stub                         m_pInstRetBuffCallStub;
     RelativePointer<PTR_MethodDesc>  m_pInvokeMethod;
@@ -2041,6 +2043,7 @@ class ArrayClass : public EEClass
 
 private:
 
+    DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
     unsigned char   m_rank;
     CorElementType  m_ElementType;// Cache of element type in m_ElementTypeHnd
 

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -56,6 +56,7 @@ using namespace clr::fs;
 #define LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR 0x00000100
 #define LOAD_LIBRARY_SEARCH_DEFAULT_DIRS 0x00001000
 
+#ifndef DACCESS_COMPILE
 void AppendEHClause(int nClauses, COR_ILMETHOD_SECT_EH * pEHSect, ILStubEHClause * pClause, int * pCurIdx)
 {
     LIMITED_METHOD_CONTRACT;
@@ -92,6 +93,7 @@ VOID PopulateEHSect(COR_ILMETHOD_SECT_EH * pEHSect, int nClauses, ILStubEHClause
     AppendEHClause(nClauses, pEHSect, pOne, &curIdx);
     AppendEHClause(nClauses, pEHSect, pTwo, &curIdx);
 }
+#endif
 
 StubSigDesc::StubSigDesc(MethodDesc *pMD, PInvokeStaticSigInfo* pSigInfo /*= NULL*/)
 {
@@ -765,6 +767,7 @@ public:
 #endif // FEATURE_COMINTEROP
     }
 
+#ifndef DACCESS_COMPILE
     void FinishEmit(MethodDesc* pStubMD)
     {
         STANDARD_VM_CONTRACT;
@@ -1261,6 +1264,7 @@ public:
             strILStubCode.GetUnicode()                  // StubMethodILCode
             );
     } // EtwOnILStubGenerated
+#endif // DACCESS_COMPILE
 
 #ifdef LOGGING
     //---------------------------------------------------------------------------------------
@@ -2522,6 +2526,7 @@ void NDirectStubLinker::EmitLogNativeArgument(ILCodeStream* pslILEmit, DWORD dwP
     pslILEmit->EmitCALL(METHOD__STUBHELPERS__LOG_PINNED_ARGUMENT, 2, 0);
 }
 
+#ifndef DACCESS_COMPILE
 void NDirectStubLinker::GetCleanupFinallyOffsets(ILStubEHClause * pClause)
 {
     CONTRACTL
@@ -2544,6 +2549,7 @@ void NDirectStubLinker::GetCleanupFinallyOffsets(ILStubEHClause * pClause)
         pClause->cbHandlerLength       = (DWORD)m_pCleanupFinallyEndLabel->GetCodeOffset() - pClause->dwHandlerBeginOffset;
     }
 }
+#endif // DACCESS_COMPILE
 
 void NDirectStubLinker::ClearCode()
 {

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -5586,6 +5586,8 @@ MethodDesc* NDirect::CreateFieldAccessILStub(
 }
 #endif // FEATURE_COMINTEROP
 
+#ifndef DACCESS_COMPILE
+
 MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
 {
     CONTRACT(MethodDesc*)
@@ -5708,6 +5710,8 @@ PCODE NDirect::GetEntryPointForStructMarshalStub(MethodTable* pMT)
 
     return pMD->GetMultiCallableAddrOfCode();
 }
+
+#endif // DACCESS_COMPILE
 
 MethodDesc* NDirect::CreateCLRToNativeILStub(PInvokeStaticSigInfo* pSigInfo,
                          DWORD dwStubFlags,

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -438,6 +438,7 @@ private:
 
 #include "stubgen.h"
 
+#ifndef DACCESS_COMPILE
 class NDirectStubLinker : public ILStubLinker
 {
 public:
@@ -564,6 +565,7 @@ protected:
 
     DWORD               m_dwStubFlags;
 };
+#endif // DACCESS_COMPILE
 
 // This attempts to guess whether a target is an API call that uses SetLastError to communicate errors.
 BOOL HeuristicDoesThisLooksLikeAnApiCall(LPBYTE pTarget);

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -631,8 +631,10 @@ PCODE GetStubForInteropMethod(MethodDesc* pMD, DWORD dwStubFlags = 0, MethodDesc
 HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, MethodDesc **ppRetStubMD);
 #endif // FEATURE_COMINTEROP
 
+#ifndef DACCESS_COMPILE
 void MarshalStructViaILStub(MethodDesc* pStubMD, void* pManagedData, void* pNativeData, StructMarshalStubs::MarshalOperation operation, void** ppCleanupWorkList = nullptr);
 void MarshalStructViaILStubCode(PCODE pStubCode, void* pManagedData, void* pNativeData, StructMarshalStubs::MarshalOperation operation, void** ppCleanupWorkList = nullptr);
+#endif // DACCESS_COMPILE
 
 //
 // Limit length of string field in IL stub ETW events so that the whole

--- a/src/coreclr/src/vm/loaderallocator.hpp
+++ b/src/coreclr/src/vm/loaderallocator.hpp
@@ -151,6 +151,8 @@ protected:
     // Heaps for allocating data that persists for the life of the AppDomain
     // Objects that are allocated frequently should be allocated into the HighFreq heap for
     // better page management
+
+    DAC_ALIGNAS(8) // Align the first member to an 8 byte boundary.  Windows does this by default, force Linux to match.
     BYTE *              m_InitialReservedMemForLoaderHeaps;
     BYTE                m_LowFreqHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_HighFreqHeapInstance[sizeof(LoaderHeap)];
@@ -617,6 +619,7 @@ class GlobalLoaderAllocator : public LoaderAllocator
     VPTR_VTABLE_CLASS(GlobalLoaderAllocator, LoaderAllocator)
     VPTR_UNIQUE(VPTRU_LoaderAllocator+1)
 
+    DAC_ALIGNAS(LoaderAllocator) // Align the first member to the alignment of the base class
     BYTE                m_ExecutableHeapInstance[sizeof(LoaderHeap)];
 
 protected:
@@ -639,6 +642,7 @@ class AssemblyLoaderAllocator : public LoaderAllocator
     VPTR_UNIQUE(VPTRU_LoaderAllocator+3)
 
 protected:
+    DAC_ALIGNAS(LoaderAllocator) // Align the first member to the alignment of the base class
     LoaderAllocatorID  m_Id;
     ShuffleThunkCache* m_pShuffleThunkCache;
 public:

--- a/src/coreclr/src/vm/loaderallocator.hpp
+++ b/src/coreclr/src/vm/loaderallocator.hpp
@@ -152,7 +152,7 @@ protected:
     // Objects that are allocated frequently should be allocated into the HighFreq heap for
     // better page management
 
-    DAC_ALIGNAS(8) // Align the first member to an 8 byte boundary.  Windows does this by default, force Linux to match.
+    DAC_ALIGNAS(UINT64) // Align the first member to alignof(m_nLoaderAllocator). Windows does this by default, force Linux to match.
     BYTE *              m_InitialReservedMemForLoaderHeaps;
     BYTE                m_LowFreqHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_HighFreqHeapInstance[sizeof(LoaderHeap)];

--- a/src/coreclr/src/vm/stubgen.cpp
+++ b/src/coreclr/src/vm/stubgen.cpp
@@ -1910,6 +1910,8 @@ LocalSigBuilder::GetSig(
     }
 }
 
+#ifndef DACCESS_COMPILE
+
 FunctionSigBuilder::FunctionSigBuilder() :
     m_callingConv(IMAGE_CEE_CS_CALLCONV_DEFAULT)
 {
@@ -2138,6 +2140,8 @@ void ILStubLinker::SetStubTargetMethodSig(PCCOR_SIGNATURE pSig, DWORD cSig)
 
     m_nativeFnSigBuilder.SetSig(pSig, cSig);
 }
+
+#endif // DACCESS_COMPILE
 
 static BOOL SigHasVoidReturnType(const Signature &signature)
 {

--- a/src/coreclr/src/vm/stubgen.h
+++ b/src/coreclr/src/vm/stubgen.h
@@ -13,6 +13,10 @@
 
 #include "stublink.h"
 
+struct ILStubEHClause;
+class ILStubLinker;
+
+#ifndef DACCESS_COMPILE
 struct StructMarshalStubs
 {
     static const DWORD MANAGED_STRUCT_ARGIDX = 0;
@@ -205,8 +209,6 @@ public:
 
 };  // class LocalSigBuilder
 
-#ifndef DACCESS_COMPILE
-
 //---------------------------------------------------------------------------------------
 //
 class FunctionSigBuilder : protected StubSigBuilder
@@ -378,6 +380,7 @@ protected:
     CQuickBytesSpecifySize<TOKEN_LOOKUP_MAP_SIZE>   m_qbEntries;
 };
 
+#ifndef DACCESS_COMPILE
 struct ILStubEHClause
 {
     enum Kind { kNone, kTypedCatch, kFinally };
@@ -392,8 +395,6 @@ struct ILStubEHClause
 
 class ILCodeLabel;
 class ILCodeStream;
-class ILStubLinker;
-#ifndef DACCESS_COMPILE
 //---------------------------------------------------------------------------------------
 //
 class ILStubLinker
@@ -556,6 +557,7 @@ protected:
     // SigTypeContext info, if needed.
     MethodDesc * m_pMD;
 };  // class ILStubLinker
+
 
 //---------------------------------------------------------------------------------------
 //

--- a/src/coreclr/src/vm/stubgen.h
+++ b/src/coreclr/src/vm/stubgen.h
@@ -261,6 +261,7 @@ public:
     }
 
 protected:
+    DAC_ALIGNAS(StubSigBuilder) // Align the first member to the alignment of the base class
     CorCallingConvention m_callingConv;
     CQuickBytes          m_qbReturnSig;
 };  // class FunctionSigBuilder

--- a/src/coreclr/src/vm/stubgen.h
+++ b/src/coreclr/src/vm/stubgen.h
@@ -205,6 +205,8 @@ public:
 
 };  // class LocalSigBuilder
 
+#ifndef DACCESS_COMPILE
+
 //---------------------------------------------------------------------------------------
 //
 class FunctionSigBuilder : protected StubSigBuilder
@@ -261,10 +263,11 @@ public:
     }
 
 protected:
-    DAC_ALIGNAS(StubSigBuilder) // Align the first member to the alignment of the base class
     CorCallingConvention m_callingConv;
     CQuickBytes          m_qbReturnSig;
 };  // class FunctionSigBuilder
+
+#endif // DACCESS_COMPILE
 
 #ifdef _DEBUG
 // exercise the resize code
@@ -389,6 +392,8 @@ struct ILStubEHClause
 
 class ILCodeLabel;
 class ILCodeStream;
+class ILStubLinker;
+#ifndef DACCESS_COMPILE
 //---------------------------------------------------------------------------------------
 //
 class ILStubLinker
@@ -551,7 +556,6 @@ protected:
     // SigTypeContext info, if needed.
     MethodDesc * m_pMD;
 };  // class ILStubLinker
-
 
 //---------------------------------------------------------------------------------------
 //
@@ -792,6 +796,7 @@ protected:
     const static UINT32 SPECIAL_VALUE_NAN_64_ON_32 = 0xFFFFFFFF;
 #endif // HOST_64BIT
 };
+#endif // DACCESS_COMPILE
 
 #define TOKEN_ILSTUB_TARGET_SIG (TokenFromRid(0xFFFFFF, mdtSignature))
 

--- a/src/coreclr/src/vm/util.hpp
+++ b/src/coreclr/src/vm/util.hpp
@@ -42,7 +42,7 @@
 #define WszMessageBox __error("Use one of the EEMessageBox APIs (defined in eemessagebox.h) from inside the EE")
 
 // Hot cache lines need to be aligned to cache line size to improve performance
-#if defined(HOST_ARM64)
+#if defined(TARGET_ARM64)
 #define MAX_CACHE_LINE_SIZE 128
 #else
 #define MAX_CACHE_LINE_SIZE 64


### PR DESCRIPTION
This is a result of an audit of mismatching types in the Linux DAC vs the Windows-Linux X DAC. It fixes the _real_ differences identified by the tool.