### PR TITLE
Remove asserts that were firing during rejit tests

### DIFF
--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -448,7 +448,7 @@ bool CallCountingManager::IsCallCountingEnabled(NativeCodeVersion codeVersion)
     CONTRACTL_END;
 
     _ASSERTE(!codeVersion.IsNull());
-    _ASSERTE(codeVersion.IsDefaultVersion());
+    _ASSERTE(codeVersion.IsDefaultVersion() || codeVersion.GetILCodeVersionId() != 0);
     _ASSERTE(codeVersion.GetMethodDesc()->IsEligibleForTieredCompilation());
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;

--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -448,7 +448,7 @@ bool CallCountingManager::IsCallCountingEnabled(NativeCodeVersion codeVersion)
     CONTRACTL_END;
 
     _ASSERTE(!codeVersion.IsNull());
-    _ASSERTE(codeVersion.IsDefaultVersion() || codeVersion.GetILCodeVersionId() != 0);
+    _ASSERTE(codeVersion.IsDefaultVersion());
     _ASSERTE(codeVersion.GetMethodDesc()->IsEligibleForTieredCompilation());
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;

--- a/src/coreclr/src/vm/rejit.cpp
+++ b/src/coreclr/src/vm/rejit.cpp
@@ -657,7 +657,6 @@ HRESULT ReJitManager::UpdateActiveILVersions(
                 // ThreadStore crsts
                 SystemDomain::LockHolder lh;
 
-                _ASSERTE(ThreadStore::HoldingThreadStore());
                 hr = pCodeVersionManager->SetActiveILCodeVersions(pCodeActivationBatch->m_methodsToActivate.Ptr(), pCodeActivationBatch->m_methodsToActivate.Count(), &errorRecords);
                 if (FAILED(hr))
                     break;


### PR DESCRIPTION
#32250 had some asserts that would fire under certain situations with our rejit tests. The rejit path no longer suspends the runtime so that assert was removed, and call counting can happen for a non default code version with rejit since the IL is updated, so that assert was updated.