### PR TITLE
Adding separate 2.1 SDK yaml

### DIFF
--- a/src/installer/pkg/packaging/snaps/dotnet-sdk-2.1/snap/snapcraft.yaml
+++ b/src/installer/pkg/packaging/snaps/dotnet-sdk-2.1/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: dotnet-sdk
+version: 2.1.804
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/9ba4d9b0-3fca-40ed-b5a2-1552dfa4f89e/8e5e555b543a7afd8fd764e080d25671/dotnet-sdk-2.1.804-linux-x64.tar.gz
+      source-checksum: sha512/82b039856dadd2b47fa56a262d1a1a389132f0db037d4ee5c0872f2949c2cd447c33a978e1f532783119aa416860e03f26b840863ca3a97392a4b77f8df5bf66
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+        - lldb
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+


### PR DESCRIPTION
This will avoid repurposing 3.1 yaml for 2.1 for every release. 