### PR TITLE
Bring back GenAPI subscription, update to latest and workaround roslyn issue

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,6 +18,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9a9422d109520d942711e07fae8c662c20e7b6e9</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20160.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>9a9422d109520d942711e07fae8c662c20e7b6e9</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.20160.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9a9422d109520d942711e07fae8c662c20e7b6e9</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20160.4</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20160.4</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20160.4</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20153.1</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20160.4</MicrosoftDotNetGenAPIVersion>
     <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20160.4</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20160.4</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20160.4</MicrosoftDotNetXUnitConsoleRunnerVersion>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -28,7 +28,9 @@
     <ShouldUnsetParentConfigurationAndPlatform>false</ShouldUnsetParentConfigurationAndPlatform>
     <!-- TargetOS can be removed after renaming the property in arcade repo-->
     <BuildOS>$(TargetOS)</BuildOS>
-    <AdditionalBuildTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(AdditionalBuildTargetFrameworks);$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-NetBSD;$(NetCoreAppCurrent)-FreeBSD</AdditionalBuildTargetFrameworks>  
+    <AdditionalBuildTargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(AdditionalBuildTargetFrameworks);$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-NetBSD;$(NetCoreAppCurrent)-FreeBSD</AdditionalBuildTargetFrameworks>
+    <!-- Remove once is fixed: https://github.com/dotnet/roslyn/issues/42344 -->
+    <GeneratePlatformNotSupportedAssemblyHeaderFile>$(RepositoryEngineeringDir)LicenseHeader.txt</GeneratePlatformNotSupportedAssemblyHeaderFile>
   </PropertyGroup>
 
   <Import Project="$(RuntimePropsFile)" Condition="Exists('$(RuntimePropsFile)')"/>


### PR DESCRIPTION
This can be removed once we consume a roslyn version with the fix for: https://github.com/dotnet/roslyn/issues/42344

More details in: https://github.com/dotnet/runtime/pull/33230

I decided to use the `LicenseHeader.txt` file in the meantime to avoid adding an empty file into the repo for the time being. I'll work on updating the arcade subscription to roslyn so that we get a compiler with the fix and remove this workaround.
