### PR TITLE
Fix assertion failure when running some composite CoreCLR tests

### DIFF
--- a/src/coreclr/src/vm/codeman.cpp
+++ b/src/coreclr/src/vm/codeman.cpp
@@ -6495,7 +6495,7 @@ UINT32 ReadyToRunJitManager::JitTokenToGCInfoVersion(const METHODTOKEN& MethodTo
         SUPPORTS_DAC;
     } CONTRACTL_END;
 
-    READYTORUN_HEADER * header = JitTokenToReadyToRunInfo(MethodToken)->GetImage()->GetReadyToRunHeader();
+    READYTORUN_HEADER * header = JitTokenToReadyToRunInfo(MethodToken)->GetReadyToRunHeader();
 
     return GCInfoToken::ReadyToRunVersionToGcInfoVersion(header->MajorVersion);
 }

--- a/src/coreclr/src/vm/readytoruninfo.h
+++ b/src/coreclr/src/vm/readytoruninfo.h
@@ -88,6 +88,8 @@ public:
 
     bool IsComponentAssembly() const { return m_isComponentAssembly; }
 
+    PTR_READYTORUN_HEADER GetReadyToRunHeader() const { return m_pHeader; }
+
     PTR_NativeImage GetNativeImage() const { return m_pNativeImage; }
 
     PTR_PEImageLayout GetImage() const { return m_pComposite->GetImage(); }


### PR DESCRIPTION
In composite testing, ReadyToRunInfo::GetImage() returns the
composite image layout (NativeImageLayout) for which
PEDecoder::GetReadyToRunHeader doesn't work (we decided we don't
want to modify the general PEDecoder logic). A simple fix is not
to go through GetImage() and expose the header on the R2R info
directly instead.

Thanks

Tomas