### PR TITLE
Reduce fixed overhead of some Utf8Parser.TryParse methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
 {
@@ -80,15 +81,15 @@ namespace System.Buffers.Text
         [StackTraceHidden]
         public static bool TryParseThrowFormatException<T>(ReadOnlySpan<byte> source, out T value, out int bytesConsumed) where T : struct
         {
-            // While loop below tells C# compiler to ignore 'out not assigned' errors
-            // and tells JIT that this method never returns. The parameters to this method
-            // are ordered the same as our callers' parameters so as to allow the JIT to
-            // avoid unnecessary register swapping.
+            // The parameters to this method are ordered the same as our callers' parameters
+            // allowing the JIT to avoid unnecessary register swapping or spilling.
 
-            while (true)
-            {
-                ThrowHelper.ThrowFormatException_BadFormatSpecifier();
-            }
+            Unsafe.SkipInit(out value); // bypass language initialization rules since we're about to throw
+            Unsafe.SkipInit(out bytesConsumed);
+            ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+
+            Debug.Fail("Control should never reach this point.");
+            return false;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
@@ -69,6 +71,24 @@ namespace System.Buffers.Text
         {
             value = default;
             return TryParseThrowFormatException(out bytesConsumed);
+        }
+
+        //
+        // Enable use of ThrowHelper from TryParse() routines without introducing dozens of non-code-coveraged "value= default; bytesConsumed = 0; return false" boilerplate.
+        //
+        [DoesNotReturn]
+        [StackTraceHidden]
+        public static bool TryParseThrowFormatException<T>(ReadOnlySpan<byte> source, out T value, out int bytesConsumed) where T : struct
+        {
+            // While loop below tells C# compiler to ignore 'out not assigned' errors
+            // and tells JIT that this method never returns. The parameters to this method
+            // are ordered the same as our callers' parameters so as to allow the JIT to
+            // avoid unnecessary register swapping.
+
+            while (true)
+            {
+                ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
@@ -30,7 +30,7 @@ namespace System.Buffers.Text
         public static bool TryParse(ReadOnlySpan<byte> source, out bool value, out int bytesConsumed, char standardFormat = default)
         {
             if (!(standardFormat == default(char) || standardFormat == 'G' || standardFormat == 'l'))
-                return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                ThrowHelper.ThrowFormatException_BadFormatSpecifier();
 
             if (source.Length >= 4)
             {
@@ -42,7 +42,7 @@ namespace System.Buffers.Text
                     return true;
                 }
 
-                if (source.Length >= 5)
+                if (4 < (uint)source.Length)
                 {
                     if (dw == 0x534c4146 /* 'SLAF' */ && (source[4] & ~0x20) == 'E')
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
@@ -29,19 +29,25 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryParse(ReadOnlySpan<byte> source, out Guid value, out int bytesConsumed, char standardFormat = default)
         {
+        FastPath:
+            if (standardFormat == default)
+            {
+                return TryParseGuidCore(source, out value, out bytesConsumed, ends: default);
+            }
+
             switch (standardFormat)
             {
-                case default(char):
                 case 'D':
-                    return TryParseGuidCore(source, false, ' ', ' ', out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
                 case 'B':
-                    return TryParseGuidCore(source, true, '{', '}', out value, out bytesConsumed);
+                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '{' | '}' << 8);
                 case 'P':
-                    return TryParseGuidCore(source, true, '(', ')', out value, out bytesConsumed);
+                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '(' | ')' << 8);
                 case 'N':
                     return TryParseGuidN(source, out value, out bytesConsumed);
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -97,9 +103,9 @@ namespace System.Buffers.Text
         }
 
         // {8-4-4-4-12}, where number is the number of hex digits, and {/} are ends.
-        private static bool TryParseGuidCore(ReadOnlySpan<byte> source, bool ends, char begin, char end, out Guid value, out int bytesConsumed)
+        private static bool TryParseGuidCore(ReadOnlySpan<byte> source, out Guid value, out int bytesConsumed, int ends)
         {
-            int expectedCodingUnits = 36 + (ends ? 2 : 0); // 32 hex digits + 4 delimiters + 2 optional ends
+            int expectedCodingUnits = 36 + ((ends != default) ? 2 : 0); // 32 hex digits + 4 delimiters + 2 optional ends
 
             if (source.Length < expectedCodingUnits)
             {
@@ -108,9 +114,16 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            if (ends)
+            // The 'ends' parameter is a 16-bit value where the byte denoting the starting
+            // brace is at byte position 0 and the byte denoting the closing brace is at
+            // byte position 1. If no braces are expected, has value 0.
+            // Default: ends = 0
+            //  Braces: ends = "}{"
+            //  Parens: ends = ")("
+
+            if (ends != default)
             {
-                if (source[0] != begin)
+                if (source[0] != (byte)ends)
                 {
                     value = default;
                     bytesConsumed = 0;
@@ -118,6 +131,7 @@ namespace System.Buffers.Text
                 }
 
                 source = source.Slice(1); // skip beginning
+                ends >>= 8; // shift the closing brace to byte position 0
             }
 
             if (!TryParseUInt32X(source, out uint i1, out int justConsumed))
@@ -226,7 +240,7 @@ namespace System.Buffers.Text
                 return false; // 12 digits
             }
 
-            if (ends && source[justConsumed] != end)
+            if (ends != default && source[justConsumed] != (byte)ends)
             {
                 value = default;
                 bytesConsumed = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
@@ -32,7 +32,7 @@ namespace System.Buffers.Text
         FastPath:
             if (standardFormat == default)
             {
-                return TryParseGuidCore(source, out value, out bytesConsumed, ends: default);
+                return TryParseGuidCore(source, out value, out bytesConsumed, ends: 0);
             }
 
             switch (standardFormat)
@@ -41,9 +41,9 @@ namespace System.Buffers.Text
                     standardFormat = default;
                     goto FastPath;
                 case 'B':
-                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '{' | '}' << 8);
+                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '{' | ('}' << 8));
                 case 'P':
-                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '(' | ')' << 8);
+                    return TryParseGuidCore(source, out value, out bytesConsumed, ends: '(' | (')' << 8));
                 case 'N':
                     return TryParseGuidN(source, out value, out bytesConsumed);
                 default:
@@ -105,7 +105,7 @@ namespace System.Buffers.Text
         // {8-4-4-4-12}, where number is the number of hex digits, and {/} are ends.
         private static bool TryParseGuidCore(ReadOnlySpan<byte> source, out Guid value, out int bytesConsumed, int ends)
         {
-            int expectedCodingUnits = 36 + ((ends != default) ? 2 : 0); // 32 hex digits + 4 delimiters + 2 optional ends
+            int expectedCodingUnits = 36 + ((ends != 0) ? 2 : 0); // 32 hex digits + 4 delimiters + 2 optional ends
 
             if (source.Length < expectedCodingUnits)
             {
@@ -121,7 +121,7 @@ namespace System.Buffers.Text
             //  Braces: ends = "}{"
             //  Parens: ends = ")("
 
-            if (ends != default)
+            if (ends != 0)
             {
                 if (source[0] != (byte)ends)
                 {
@@ -240,7 +240,7 @@ namespace System.Buffers.Text
                 return false; // 12 digits
             }
 
-            if (ends != default && source[justConsumed] != (byte)ends)
+            if (ends != 0 && source[justConsumed] != (byte)ends)
             {
                 value = default;
                 bytesConsumed = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
@@ -35,26 +35,28 @@ namespace System.Buffers.Text
         [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> source, out sbyte value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseSByteD(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseSByteD(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseSByteN(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
-                    value = default;
+                    Unsafe.SkipInit(out value); // will be populated by TryParseByteX
                     return TryParseByteX(source, out Unsafe.As<sbyte, byte>(ref value), out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -81,26 +83,28 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryParse(ReadOnlySpan<byte> source, out short value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseInt16D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseInt16D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseInt16N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
-                    value = default;
+                    Unsafe.SkipInit(out value); // will be populated by TryParseUInt16X
                     return TryParseUInt16X(source, out Unsafe.As<short, ushort>(ref value), out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -127,26 +131,28 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryParse(ReadOnlySpan<byte> source, out int value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseInt32D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseInt32D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseInt32N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
-                    value = default;
+                    Unsafe.SkipInit(out value); // will be populated by TryParseUInt32X
                     return TryParseUInt32X(source, out Unsafe.As<int, uint>(ref value), out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -173,26 +179,28 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryParse(ReadOnlySpan<byte> source, out long value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseInt64D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseInt64D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseInt64N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
-                    value = default;
+                    Unsafe.SkipInit(out value); // will be populated by TryParseUInt64X
                     return TryParseUInt64X(source, out Unsafe.As<long, ulong>(ref value), out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
@@ -41,6 +41,9 @@ namespace System.Buffers.Text
                 return TryParseSByteD(source, out value, out bytesConsumed);
             }
 
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
+
             switch (standardFormat | 0x20) // convert to lowercase
             {
                 case 'g':
@@ -88,6 +91,9 @@ namespace System.Buffers.Text
             {
                 return TryParseInt16D(source, out value, out bytesConsumed);
             }
+
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
 
             switch (standardFormat | 0x20) // convert to lowercase
             {
@@ -137,6 +143,9 @@ namespace System.Buffers.Text
                 return TryParseInt32D(source, out value, out bytesConsumed);
             }
 
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
+
             switch (standardFormat | 0x20) // convert to lowercase
             {
                 case 'g':
@@ -184,6 +193,9 @@ namespace System.Buffers.Text
             {
                 return TryParseInt64D(source, out value, out bytesConsumed);
             }
+
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
 
             switch (standardFormat | 0x20) // convert to lowercase
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -29,25 +29,27 @@ namespace System.Buffers.Text
         /// </exceptions>
         public static bool TryParse(ReadOnlySpan<byte> source, out byte value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseByteD(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseByteD(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseByteN(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
                     return TryParseByteX(source, out value, out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -75,25 +77,27 @@ namespace System.Buffers.Text
         [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> source, out ushort value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseUInt16D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseUInt16D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseUInt16N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
                     return TryParseUInt16X(source, out value, out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -121,25 +125,27 @@ namespace System.Buffers.Text
         [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> source, out uint value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseUInt32D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseUInt32D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseUInt32N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
                     return TryParseUInt32X(source, out value, out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
 
@@ -167,25 +173,27 @@ namespace System.Buffers.Text
         [CLSCompliant(false)]
         public static bool TryParse(ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed, char standardFormat = default)
         {
-            switch (standardFormat)
+        FastPath:
+            if (standardFormat == default)
             {
-                case default(char):
+                return TryParseUInt64D(source, out value, out bytesConsumed);
+            }
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
                 case 'g':
-                case 'G':
                 case 'd':
-                case 'D':
-                    return TryParseUInt64D(source, out value, out bytesConsumed);
+                    standardFormat = default;
+                    goto FastPath;
 
                 case 'n':
-                case 'N':
                     return TryParseUInt64N(source, out value, out bytesConsumed);
 
                 case 'x':
-                case 'X':
                     return TryParseUInt64X(source, out value, out bytesConsumed);
 
                 default:
-                    return ParserHelpers.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -35,6 +35,9 @@ namespace System.Buffers.Text
                 return TryParseByteD(source, out value, out bytesConsumed);
             }
 
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
+
             switch (standardFormat | 0x20) // convert to lowercase
             {
                 case 'g':
@@ -82,6 +85,9 @@ namespace System.Buffers.Text
             {
                 return TryParseUInt16D(source, out value, out bytesConsumed);
             }
+
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
 
             switch (standardFormat | 0x20) // convert to lowercase
             {
@@ -131,6 +137,9 @@ namespace System.Buffers.Text
                 return TryParseUInt32D(source, out value, out bytesConsumed);
             }
 
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
+
             switch (standardFormat | 0x20) // convert to lowercase
             {
                 case 'g':
@@ -178,6 +187,9 @@ namespace System.Buffers.Text
             {
                 return TryParseUInt64D(source, out value, out bytesConsumed);
             }
+
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
 
             switch (standardFormat | 0x20) // convert to lowercase
             {


### PR DESCRIPTION
This builds atop the work that Andy did as part of https://github.com/dotnet/runtime/pull/33004. There are no behavioral changes here - only slight refactorings that produce better codegen at the entry points to some of the `Utf8Parser.TryParse` methods. In particular, this does _not_ include many of the optimizations discussed at https://github.com/dotnet/runtime/pull/32843.

### Integral types

For the `TryParse` methods that work with integral types, reflowing the logic in this fashion moves the "default" behavior into a fast-path and reduces the total amount of logic in the switch statement. We're now able to tail-call into the workhorse methods without performing any register shuffling or stack spilling

|        Method | Toolchain |     Mean |   Error |  StdDev | Ratio |
|-------------- |---------- |---------:|--------:|--------:|------:|
| TryParseInt32 |    master | 976.3 ns | 5.34 ns | 4.73 ns |  1.00 |
| TryParseInt32 |  tryparse | 913.9 ns | 8.03 ns | 6.71 ns |  0.94 |

```asm
;;; OLD CODEGEN ;;;
00007fff`4803cb40 56           push    rsi
00007fff`4803cb41 4883ec20     sub     rsp, 20h
00007fff`4803cb45 410fb7f1     movzx   esi, r9w
00007fff`4803cb49 83fe4e       cmp     esi, 4Eh
00007fff`4803cb4c 772c         ja      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299ba (00007fff`4803cb7a)
00007fff`4803cb4e 83fe44       cmp     esi, 44h
00007fff`4803cb51 7713         ja      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299a6 (00007fff`4803cb66)
00007fff`4803cb53 85f6         test    esi, esi
00007fff`4803cb55 7405         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e2999c (00007fff`4803cb5c)
00007fff`4803cb57 83fe44       cmp     esi, 44h
00007fff`4803cb5a 754c         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299e8 (00007fff`4803cba8)
00007fff`4803cb5c 4883c420     add     rsp, 20h
00007fff`4803cb60 5e           pop     rsi
00007fff`4803cb61 e97acaffff   jmp     CLRStub[MethodDescPrestub]@7fff480395e0 (00007fff`480395e0)
00007fff`4803cb66 83fe47       cmp     esi, 47h
00007fff`4803cb69 74f1         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e2999c (00007fff`4803cb5c)
00007fff`4803cb6b 83fe4e       cmp     esi, 4Eh
00007fff`4803cb6e 7538         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299e8 (00007fff`4803cba8)
00007fff`4803cb70 4883c420     add     rsp, 20h
00007fff`4803cb74 5e           pop     rsi
00007fff`4803cb75 e986caffff   jmp     CLRStub[MethodDescPrestub]@7fff48039600 (00007fff`48039600)
00007fff`4803cb7a 83fe64       cmp     esi, 64h
00007fff`4803cb7d 770c         ja      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299cb (00007fff`4803cb8b)
00007fff`4803cb7f 83fe58       cmp     esi, 58h
00007fff`4803cb82 7416         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299da (00007fff`4803cb9a)
00007fff`4803cb84 83fe64       cmp     esi, 64h
00007fff`4803cb87 751f         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299e8 (00007fff`4803cba8)
00007fff`4803cb89 ebd1         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e2999c (00007fff`4803cb5c)
00007fff`4803cb8b 83fe67       cmp     esi, 67h
00007fff`4803cb8e 74cc         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e2999c (00007fff`4803cb5c)
00007fff`4803cb90 83fe6e       cmp     esi, 6Eh
00007fff`4803cb93 74db         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299b0 (00007fff`4803cb70)
00007fff`4803cb95 83fe78       cmp     esi, 78h
00007fff`4803cb98 750e         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e299e8 (00007fff`4803cba8)
00007fff`4803cb9a 33c0         xor     eax, eax
00007fff`4803cb9c 8902         mov     dword ptr [rdx], eax
00007fff`4803cb9e 4883c420     add     rsp, 20h
00007fff`4803cba2 5e           pop     rsi
00007fff`4803cba3 e9d8caffff   jmp     CLRStub[MethodDescPrestub]@7fff48039680 (00007fff`48039680)
00007fff`4803cba8 33c0         xor     eax, eax
00007fff`4803cbaa 8902         mov     dword ptr [rdx], eax
00007fff`4803cbac 418900       mov     dword ptr [r8], eax
00007fff`4803cbaf e8dcd8d8ff   call    CLRStub[MethodDescPrestub]@7fff47dca490 (00007fff`47dca490)
00007fff`4803cbb4 cc           int     3

;;; NEW CODEGEN ;;;
00007fff`4802cc60 410fb7c1     movzx   eax, r9w
00007fff`4802cc64 85c0         test    eax, eax
00007fff`4802cc66 7505         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199bd (00007fff`4802cc6d)
00007fff`4802cc68 e97bc9ffff   jmp     CLRStub[MethodDescPrestub]@7fff480295e8 (00007fff`480295e8)
00007fff`4802cc6d 410fb7c1     movzx   eax, r9w
00007fff`4802cc71 83c820       or      eax, 20h
00007fff`4802cc74 83f867       cmp     eax, 67h
00007fff`4802cc77 7f0c         jg      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199d5 (00007fff`4802cc85)
00007fff`4802cc79 83f864       cmp     eax, 64h
00007fff`4802cc7c 74ea         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199b8 (00007fff`4802cc68)
00007fff`4802cc7e 83f867       cmp     eax, 67h
00007fff`4802cc81 74e5         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199b8 (00007fff`4802cc68)
00007fff`4802cc83 eb16         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199eb (00007fff`4802cc9b)
00007fff`4802cc85 83f86e       cmp     eax, 6Eh
00007fff`4802cc88 7407         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199e1 (00007fff`4802cc91)
00007fff`4802cc8a 83f878       cmp     eax, 78h
00007fff`4802cc8d 7407         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199e6 (00007fff`4802cc96)
00007fff`4802cc8f eb0a         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  Int32 ByRef,  Int32 ByRef,  Char)+0xffffffff`a9e199eb (00007fff`4802cc9b)
00007fff`4802cc91 e972c9ffff   jmp     CLRStub[MethodDescPrestub]@7fff48029608 (00007fff`48029608)
00007fff`4802cc96 e9edc9ffff   jmp     CLRStub[MethodDescPrestub]@7fff48029688 (00007fff`48029688)
00007fff`4802cc9b e9a0fdffff   jmp     CLRStub[MethodDescPrestub]@7fff4802ca40 (00007fff`4802ca40)
```

### `TryParse(..., out bool, ...)`

Minor improvement here to avoid the range check when dereferencing `source[4]`. There's also less register shuffling in the error path. Avoiding this shuffling doesn't impact the success case, but I saw it as low-hanging fruit since it reduces the overall method codegen size by a little bit.

### `TryParse(..., out Guid, ...)`

Similar to the integral types, the switch statement has been restructured to have the common case go through a fast path. Additionally, by changing the signature of the `TryParseGuidCore` method, we can avoid the stack spillage that would normally result on Win64 from passing so many parameters to the workhorse routine.

|            Method | Toolchain |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |
|------------------ |---------- |-----------:|----------:|----------:|-----------:|------:|--------:|
| ParseGuid_Default |    master | 5,881.1 ns |  58.94 ns |  55.14 ns | 5,876.8 ns |  1.00 |    0.00 |
| ParseGuid_Default |  tryparse | 5,545.2 ns |  88.36 ns |  82.65 ns | 5,517.9 ns |  0.94 |    0.02 |
|                   |           |            |           |           |            |       |         |
|  ParseGuid_Braces |    master | 6,154.5 ns | 119.47 ns | 132.79 ns | 6,137.5 ns |  1.00 |    0.00 |
|  ParseGuid_Braces |  tryparse | 5,821.1 ns |  67.85 ns |  63.47 ns | 5,803.3 ns |  0.95 |    0.02 |

```asm
;;; OLD CODEGEN ;;;
00007fff`3ccccdd0 56           push    rsi
00007fff`3ccccdd1 4883ec40     sub     rsp, 40h
00007fff`3ccccdd5 c5f877       vzeroupper 
00007fff`3ccccdd8 33c0         xor     eax, eax
00007fff`3ccccdda 4889442430   mov     qword ptr [rsp+30h], rax
00007fff`3ccccddf 410fb7f1     movzx   esi, r9w
00007fff`3ccccde3 83fe42       cmp     esi, 42h
00007fff`3ccccde6 7745         ja      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a5ad (00007fff`3cccce2d)
00007fff`3ccccde8 85f6         test    esi, esi
00007fff`3ccccdea 0f8481000000 je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a5f1 (00007fff`3cccce71)
00007fff`3ccccdf0 83fe42       cmp     esi, 42h
00007fff`3ccccdf3 0f85c3000000 jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a63c (00007fff`3ccccebc)
00007fff`3ccccdf9 c5fa6f01     vmovdqu xmm0, xmmword ptr [rcx]
00007fff`3ccccdfd c5fa7f442430 vmovdqu xmmword ptr [rsp+30h], xmm0
00007fff`3cccce03 4889542420   mov     qword ptr [rsp+20h], rdx
00007fff`3cccce08 4c89442428   mov     qword ptr [rsp+28h], r8
00007fff`3cccce0d 488d4c2430   lea     rcx, [rsp+30h]
00007fff`3cccce12 ba01000000   mov     edx, 1
00007fff`3cccce17 41b87b000000 mov     r8d, 7Bh
00007fff`3cccce1d 41b97d000000 mov     r9d, 7Dh
00007fff`3cccce23 e888c7ffff   call    CLRStub[MethodDescPrestub]@7fff3ccc95b0 (00007fff`3ccc95b0)
00007fff`3cccce28 e986000000   jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a633 (00007fff`3cccceb3)
00007fff`3cccce2d 83fe44       cmp     esi, 44h
00007fff`3cccce30 743f         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a5f1 (00007fff`3cccce71)
00007fff`3cccce32 83fe4e       cmp     esi, 4Eh
00007fff`3cccce35 7468         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a61f (00007fff`3cccce9f)
00007fff`3cccce37 83fe50       cmp     esi, 50h
00007fff`3cccce3a 0f857c000000 jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a63c (00007fff`3ccccebc)
00007fff`3cccce40 c5fa6f01     vmovdqu xmm0, xmmword ptr [rcx]
00007fff`3cccce44 c5fa7f442430 vmovdqu xmmword ptr [rsp+30h], xmm0
00007fff`3cccce4a 4889542420   mov     qword ptr [rsp+20h], rdx
00007fff`3cccce4f 4c89442428   mov     qword ptr [rsp+28h], r8
00007fff`3cccce54 488d4c2430   lea     rcx, [rsp+30h]
00007fff`3cccce59 ba01000000   mov     edx, 1
00007fff`3cccce5e 41b828000000 mov     r8d, 28h
00007fff`3cccce64 41b929000000 mov     r9d, 29h
00007fff`3cccce6a e841c7ffff   call    CLRStub[MethodDescPrestub]@7fff3ccc95b0 (00007fff`3ccc95b0)
00007fff`3cccce6f eb42         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a633 (00007fff`3cccceb3)
00007fff`3cccce71 c5fa6f01     vmovdqu xmm0, xmmword ptr [rcx]
00007fff`3cccce75 c5fa7f442430 vmovdqu xmmword ptr [rsp+30h], xmm0
00007fff`3cccce7b 4889542420   mov     qword ptr [rsp+20h], rdx
00007fff`3cccce80 4c89442428   mov     qword ptr [rsp+28h], r8
00007fff`3cccce85 488d4c2430   lea     rcx, [rsp+30h]
00007fff`3cccce8a 33d2         xor     edx, edx
00007fff`3cccce8c 41b820000000 mov     r8d, 20h
00007fff`3cccce92 41b920000000 mov     r9d, 20h
00007fff`3cccce98 e813c7ffff   call    CLRStub[MethodDescPrestub]@7fff3ccc95b0 (00007fff`3ccc95b0)
00007fff`3cccce9d eb14         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a633 (00007fff`3cccceb3)
00007fff`3cccce9f c5fa6f01     vmovdqu xmm0, xmmword ptr [rcx]
00007fff`3ccccea3 c5fa7f442430 vmovdqu xmmword ptr [rsp+30h], xmm0
00007fff`3ccccea9 488d4c2430   lea     rcx, [rsp+30h]
00007fff`3cccceae e8f5c6ffff   call    CLRStub[MethodDescPrestub]@7fff3ccc95a8 (00007fff`3ccc95a8)
00007fff`3cccceb3 0fb6c0       movzx   eax, al
00007fff`3cccceb6 4883c440     add     rsp, 40h
00007fff`3cccceba 5e           pop     rsi
00007fff`3ccccebb c3           ret     
00007fff`3ccccebc c5f857c0     vxorps  xmm0, xmm0, xmm0
00007fff`3ccccec0 c5fa7f02     vmovdqu xmmword ptr [rdx], xmm0
00007fff`3ccccec4 33c0         xor     eax, eax
00007fff`3ccccec6 418900       mov     dword ptr [r8], eax
00007fff`3ccccec9 e8c2d5d8ff   call    CLRStub[MethodDescPrestub]@7fff3ca5a490 (00007fff`3ca5a490)
00007fff`3ccccece cc           int     3

;;; NEW CODEGEN ;;;
00007fff`3cccccc0 410fb7c1     movzx   eax, r9w
00007fff`3cccccc4 85c0         test    eax, eax
00007fff`3cccccc6 7508         jne     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a370 (00007fff`3cccccd0)
00007fff`3cccccc8 4533c9       xor     r9d, r9d
00007fff`3ccccccb e9a8d1ffff   jmp     CLRStub[MethodDescPrestub]@7fff3ccc9e78 (00007fff`3ccc9e78)
00007fff`3cccccd0 450fb7c9     movzx   r9d, r9w
00007fff`3cccccd4 4183f944     cmp     r9d, 44h
00007fff`3cccccd8 770e         ja      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a388 (00007fff`3ccccce8)
00007fff`3cccccda 4183f942     cmp     r9d, 42h
00007fff`3cccccde 7416         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a396 (00007fff`3cccccf6)
00007fff`3ccccce0 4183f944     cmp     r9d, 44h
00007fff`3ccccce4 74e2         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a368 (00007fff`3cccccc8)
00007fff`3ccccce6 eb29         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a3b1 (00007fff`3ccccd11)
00007fff`3ccccce8 4183f94e     cmp     r9d, 4Eh
00007fff`3cccccec 741e         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a3ac (00007fff`3ccccd0c)
00007fff`3cccccee 4183f950     cmp     r9d, 50h
00007fff`3cccccf2 740d         je      System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a3a1 (00007fff`3ccccd01)
00007fff`3cccccf4 eb1b         jmp     System_Private_CoreLib!System.Buffers.Text.Utf8Parser.TryParse(System.ReadOnlySpan`1<Byte>,  System.Guid ByRef,  Int32 ByRef,  Char)+0xffffffff`a0c9a3b1 (00007fff`3ccccd11)
00007fff`3cccccf6 41b97b7d0000 mov     r9d, 7D7Bh
00007fff`3cccccfc e977d1ffff   jmp     CLRStub[MethodDescPrestub]@7fff3ccc9e78 (00007fff`3ccc9e78)
00007fff`3ccccd01 41b928290000 mov     r9d, 2928h
00007fff`3ccccd07 e96cd1ffff   jmp     CLRStub[MethodDescPrestub]@7fff3ccc9e78 (00007fff`3ccc9e78)
00007fff`3ccccd0c e95fd1ffff   jmp     CLRStub[MethodDescPrestub]@7fff3ccc9e70 (00007fff`3ccc9e70)
00007fff`3ccccd11 e91afdffff   jmp     CLRStub[MethodDescPrestub]@7fff3cccca30 (00007fff`3cccca30)
```