### PR TITLE
When QuickJit is disabled, fix assertion failures regarding R2R code

### DIFF
--- a/src/coreclr/src/vm/prestub.cpp
+++ b/src/coreclr/src/vm/prestub.cpp
@@ -1048,12 +1048,6 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     {
         _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
         _ASSERTE(pConfig->GetMethodDesc()->IsEligibleForTieredCompilation());
-        _ASSERTE(
-            pConfig
-                ->GetMethodDesc()
-                ->GetLoaderAllocator()
-                ->GetCallCountingManager()
-                ->IsCallCountingEnabled(pConfig->GetCodeVersion()));
 
         if (pConfig->JitSwitchedToOptimized())
         {

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest.cs
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public static class BasicTest
+{
+    private static int Main()
+    {
+        const int Pass = 100;
+
+        PromoteToTier1(Foo);
+        Foo();
+
+        return Pass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo()
+    {
+        Foo2();
+    }
+
+    private static void Foo2()
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void PromoteToTier1(Action action)
+    {
+        // Call the method once to register a call for call counting
+        action();
+
+        // Allow time for call counting to begin
+        Thread.Sleep(500);
+
+        // Call the method enough times to trigger tier 1 promotion
+        for (int i = 0; i < 100; i++)
+        {
+            action();
+        }
+
+        // Allow time for the method to be jitted at tier 1
+        Thread.Sleep(500);
+    }
+}

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_DefaultMode.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_DefaultMode.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_DefaultMode_R2r.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_DefaultMode_R2r.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TC_QuickJitForLoops=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TC_QuickJitForLoops=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+set COMPlus_TC_QuickJitForLoops=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+export COMPlus_TC_QuickJitForLoops=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TC_QuickJitForLoops=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TC_QuickJitForLoops=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+set COMPlus_TC_QuickJitForLoops=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+export COMPlus_TC_QuickJitForLoops=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOff.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOff.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TC_QuickJit=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TC_QuickJit=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+set COMPlus_TC_QuickJit=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+export COMPlus_TC_QuickJit=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOn.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOn.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TC_QuickJit=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TC_QuickJit=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
+++ b/src/coreclr/tests/src/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BasicTest.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+"%CORE_ROOT%\crossgen" -ReadyToRun -Platform_Assemblies_Paths "%CORE_ROOT%" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+set COMPlus_TC_QuickJit=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+"$CORE_ROOT/crossgen" -ReadyToRun -Platform_Assemblies_Paths "$CORE_ROOT" -out $(MSBuildProjectName).ni.dll $(MSBuildProjectName).dll
+export COMPlus_TC_QuickJit=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- When QuickJit is disabled, for precompiled R2R code the initial tier is Optimized instead of the correct Tier0. This causes assertion failures as tiering tries to count calls and promote the method to Tier1.
  - Does not appear to be an issue in release builds, as the methods are still call-counted and promoted despite the incorrect tier
- Add some basic tiering tests for config modes that are exposed and supported through `<app>.runtimeconfig.json`, `QuickJit` and `QuickJitForLoops`, when on and off
- Removed an invalid and redundant assertion that was causing a profiler rejit test to fail, see https://github.com/dotnet/runtime/pull/33492#discussion_r391257466. What the assertion was intending to verify is already verified by an assertion above it that checks the tier, which also covers the default native code version case.