### PR TITLE
Enable crossgen2smoke test for ARM64

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -620,6 +620,7 @@ namespace ILCompiler.PEWriter
                 machine: target.MachineFromTarget(),
                 sectionAlignment: sectionAlignment,
                 fileAlignment: fileAlignment,
+                imageBase: imageBase,
                 majorLinkerVersion: PEHeaderConstants.MajorLinkerVersion,
                 minorLinkerVersion: PEHeaderConstants.MinorLinkerVersion,
                 majorOperatingSystemVersion: PEHeaderConstants.MajorOperatingSystemVersion,

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1211,9 +1211,7 @@ internal class Program
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());
-        // TODO: enabling this test requires fixes to IsManagedSequential I'm going to send out
-        // in a subsequent PR together with removal of this temporary clause [trylek]
-        // RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
+        RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
         RunTest("CastClassWithCharTest", CastClassWithCharTest());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());

--- a/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -18,18 +18,13 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <PropertyGroup>
-    <CrossArchBatchArguments />
-    <CrossArchBatchArguments Condition="'$(BuildArch)' == 'arm64'">--targetarch $(BuildArch) --jitpath %Core_Root%\x64\clrjit.dll</CrossArchBatchArguments>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll $(CrossArchBatchArguments) -r:%Core_Root%\*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></CLRTestBatchPreCommands>
-
-    <CrossArchBashArguments />
-    <CrossArchBashArguments Condition="'$(BuildArch)' == 'arm64'">--targetarch $(BuildArch) --jitpath %Core_Root%/x64/clrjit.dll</CrossArchBashArguments>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll $(CrossArchBashArguments) -r:$CORE_ROOT/*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll -r:$CORE_ROOT/*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -5,8 +5,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 
-    <!-- Crossgen2 currently targets only x64 -->
-    <DisableProjectBuild Condition="'$(BuildArch)' != 'x64'">true</DisableProjectBuild>
+    <!-- Crossgen2 currently targets x64 and ARM64 only -->
+    <DisableProjectBuild Condition="'$(BuildArch)' != 'x64' and '$(BuildArch)' != 'arm64'">true</DisableProjectBuild>
 
     <!-- Generate ILDLL so that the DLL can be the crossgenned assembly -->
     <TargetExt>.ildll</TargetExt>
@@ -18,13 +18,18 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <PropertyGroup>
+    <CrossArchBatchArguments />
+    <CrossArchBatchArguments Condition="'$(BuildArch)' == 'arm64'">--targetarch $(BuildArch) --jitpath %Core_Root%\x64\clrjit.dll</CrossArchBatchArguments>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll $(CrossArchBatchArguments) -r:%Core_Root%\*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></CLRTestBatchPreCommands>
+
+    <CrossArchBashArguments />
+    <CrossArchBashArguments Condition="'$(BuildArch)' == 'arm64'">--targetarch $(BuildArch) --jitpath %Core_Root%/x64/clrjit.dll</CrossArchBashArguments>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll -r:$CORE_ROOT/*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll $(CrossArchBashArguments) -r:$CORE_ROOT/*.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* Enable crossgen2smoke test for ARM64.
* Re-enable NullableWithExplicitLayoutTest sub-test.
* Restore setting the image base removed by #31663.