### PR TITLE
Fix for issue 32731

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -407,8 +407,6 @@ namespace Internal.TypeSystem
                 FindBaseUnificationGroup(baseType, unificationGroup);
             }
 
-            Debug.Assert(unificationGroup.IsInGroupOrIsDefiningSlot(originalDefiningMethod));
-
             // Now, we have the unification group from the type, or have discovered its defined on the current type.
             // Adjust the group to contain all of the elements that are added to it on this type, remove the components that
             // have seperated themselves from the group

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -407,6 +407,8 @@ namespace Internal.TypeSystem
                 FindBaseUnificationGroup(baseType, unificationGroup);
             }
 
+            Debug.Assert(unificationGroup.IsInGroupOrIsDefiningSlot(originalDefiningMethod));
+
             // Now, we have the unification group from the type, or have discovered its defined on the current type.
             // Adjust the group to contain all of the elements that are added to it on this type, remove the components that
             // have seperated themselves from the group
@@ -417,7 +419,7 @@ namespace Internal.TypeSystem
             foreach (MethodDesc memberMethod in unificationGroup)
             {
                 MethodDesc nameSigMatchMemberMethod = FindMatchingVirtualMethodOnTypeByNameAndSigWithSlotCheck(memberMethod, currentType, reverseMethodSearch: true);
-                if (nameSigMatchMemberMethod != null)
+                if (nameSigMatchMemberMethod != null && nameSigMatchMemberMethod != memberMethod)
                 {
                     if (separatedMethods == null)
                         separatedMethods = new MethodDescHashtable();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -381,7 +381,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                     throw new BadImageFormatException("The file is not a ReadyToRun image");
                 }
 
-                Debug.Assert(!Composite);
                 _assemblyCache.Add(metadata);
 
                 DirectoryEntry r2rHeaderDirectory = PEReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;


### PR DESCRIPTION
Fix for #32731

Couple of fixes here:
1) Remove an assert in the TypeSystem's virtual function resolution (assert is too restrictive). Example: resolving `Base.Func` on an instance of `Derived`:
``` c#
class Base
{
    virtual void Func() { }
    virtual void MethodImplForFunc()
    {
        .override Base.Func()
    }
}
class Derived : Base
{
    override void MethodImplForFunc() { }
}
```
The assert was verifying that Base.Func was in the unification group of `Derived`. It would only be in the unification group of `Base` (where it gets removed later because of the methodImpl, and cause the assert at the derived type's level in the recursion)

2) Port some inlining rules from crossgen1 - One of them fixes an issue where we would incorrectly inline a virtual method that has a MethodImpl associated with it (test = self_override5)

3) Remove an assert from R2RDump related to the composite work (assert needs to be after loading _readyToRunHeaderRVA, and is actually already at the right place a few lines below)