### PR TITLE
HostModel: Remove deprecated API

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/BinaryUtils.cs
@@ -174,14 +174,5 @@ namespace Microsoft.NET.HostModel.AppHost
             // Copy file to destination path so it inherits the same attributes/permissions.
             File.Copy(sourcePath, destinationPath, overwrite: true);
         }
-
-        // The SDK calls into BinaryUtils.GetWindowsGraphicalUserInterfaceBit()
-        // Keep this method until the HostModel changes reach SDK repo, and the code there
-        // is updated to use PEUtils.GetWindowsGraphicalUserInterfaceBit()
-        public static unsafe UInt16 GetWindowsGraphicalUserInterfaceBit(string filePath)
-        {
-            return PEUtils.GetWindowsGraphicalUserInterfaceBit(filePath);
-        }
-
     }
 }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -33,17 +33,6 @@ namespace Microsoft.NET.HostModel.Bundle
         // Assemblies are 16 bytes aligned, so that their sections can be memory-mapped cache aligned.
         public const int AssemblyAlignment = 16;
 
-        // This constructor will be deleted once the SDK is changed to use the new constructor
-        public Bundler(string hostName,
-                       string outputDir,
-                       bool embedPDBs,
-                       bool diagnosticOutput)
-            :this(hostName, outputDir,
-                  BundleOptions.BundleAllContent | ((embedPDBs) ? BundleOptions.BundleSymbolFiles : BundleOptions.None),
-                  diagnosticOutput: diagnosticOutput)
-        {
-        }
-
         public Bundler(string hostName,
                        string outputDir,
                        BundleOptions options = BundleOptions.None,
@@ -279,42 +268,6 @@ namespace Microsoft.NET.HostModel.Bundle
             HostWriter.SetAsBundle(bundlePath, headerOffset);
 
             return bundlePath;
-        }
-
-        string RelativePath(string dirFullPath, string fileFullPath)
-        {
-            // This function is used in lieu of Path.GetRelativePath because
-            //   * Path.GetRelativePath() doesn't exist in netstandard2.0
-            //   * This implementation is pretty much only intended for testing.
-            //     SDK integration invokes GenerateBundle(fileSpecs) directly.
-            // 
-            // In later revisions, we should target netstandard2.1, and replace 
-            // this function with Path.GetRelativePath().
-
-            return fileFullPath.Substring(dirFullPath.TrimEnd(Path.DirectorySeparatorChar).Length).TrimStart(Path.DirectorySeparatorChar);
-        }
-
-        /// <summary>
-        /// Generate a bundle containind the (embeddable) files in sourceDir
-        /// </summary>
-        public string GenerateBundle(string sourceDir)
-        {
-            // Convert sourceDir to absolute path
-            sourceDir = Path.GetFullPath(sourceDir);
-
-            // Get all files in the source directory and all sub-directories.
-            string[] sources = Directory.GetFiles(sourceDir, searchPattern: "*", searchOption: SearchOption.AllDirectories);
-
-            // Sort the file names to keep the bundle construction deterministic.
-            Array.Sort(sources, StringComparer.Ordinal);
-
-            List<FileSpec> fileSpecs = new List<FileSpec>(sources.Length);
-            foreach (var file in sources)
-            {
-                fileSpecs.Add(new FileSpec(file, RelativePath(sourceDir, file)));
-            }
-
-            return GenerateBundle(fileSpecs);
         }
     }
 }

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -35,7 +35,7 @@ namespace AppHost.Bundle.Tests
             // Publish the bundle
             var bundleDir = BundleHelper.GetBundleDir(fixture);
             var bundler = new Bundler(hostName, bundleDir.FullName, BundleOptions.BundleAllContent);
-            string singleFile = bundler.GenerateBundle(publishPath);
+            string singleFile = BundleHelper.GenerateBundle(bundler, publishPath);
 
             // Compute bundled files
             var bundledFiles = bundler.BundleManifest.Files.Select(file => file.RelativePath).ToList();
@@ -77,7 +77,7 @@ namespace AppHost.Bundle.Tests
             // Publish the bundle
             var bundleDir = BundleHelper.GetBundleDir(fixture);
             var bundler = new Bundler(hostName, bundleDir.FullName, BundleOptions.BundleAllContent);
-            string singleFile = bundler.GenerateBundle(publishPath);
+            string singleFile = BundleHelper.GenerateBundle(bundler, publishPath);
 
             // Create a directory for extraction.
             var extractBaseDir = BundleHelper.GetExtractDir(fixture);
@@ -130,7 +130,7 @@ namespace AppHost.Bundle.Tests
             // Publish the bundle
             var bundleDir = BundleHelper.GetBundleDir(fixture);
             var bundler = new Bundler(hostName, bundleDir.FullName, BundleOptions.BundleAllContent);
-            string singleFile = bundler.GenerateBundle(publishPath);
+            string singleFile = BundleHelper.GenerateBundle(bundler, publishPath);
 
             // Compute bundled files
             List<string> bundledFiles = bundler.BundleManifest.Files.Select(file => file.RelativePath).ToList();

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -33,17 +33,17 @@ namespace Microsoft.NET.HostModel.Tests
                 .HaveStdOutContaining("Wow! We now say hello to the big world and you.");
         }
 
-        private void BundleRun(TestProjectFixture fixture, string publishDir, string singleFileDir)
+        private void BundleRun(TestProjectFixture fixture, string publishPath, string singleFileDir)
         {
             var hostName = BundleHelper.GetHostName(fixture);
 
             // Run the App normally
-            RunTheApp(Path.Combine(publishDir, hostName));
+            RunTheApp(Path.Combine(publishPath, hostName));
 
             // Bundle to a single-file
             // Bundle all content, until the host can handle other scenarios.
             Bundler bundler = new Bundler(hostName, singleFileDir, BundleOptions.BundleAllContent);
-            string singleFile = bundler.GenerateBundle(publishDir);
+            string singleFile = BundleHelper.GenerateBundle(bundler, publishPath);
 
             // Run the extracted app
             RunTheApp(singleFile);

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.NET.HostModel.Tests
             var bundleDir = BundleHelper.GetBundleDir(fixture);
 
             var bundler = new Bundler(hostName, bundleDir.FullName, options);
-            bundler.GenerateBundle(publishPath);
+            BundleHelper.GenerateBundle(bundler, publishPath);
 
             bundler.BundleManifest.Contains($"{appName}.dll").Should().BeTrue();
             bundler.BundleManifest.Contains($"{appName}.deps.json").Should().BeTrue();
@@ -125,8 +125,8 @@ namespace Microsoft.NET.HostModel.Tests
             File.Copy(Path.Combine(publishPath, $"{appName}.runtimeconfig.json"), 
                       Path.Combine(publishPath, $"{appName}.runtimeconfig.dev.json"));
 
-            var bundler = new Bundler(hostName, bundleDir.FullName, options); 
-            bundler.GenerateBundle(publishPath);
+            var bundler = new Bundler(hostName, bundleDir.FullName, options);
+            BundleHelper.GenerateBundle(bundler, publishPath);
 
             bundler.BundleManifest.Contains($"{appName}.runtimeconfig.dev.json").Should().BeFalse();
         }
@@ -144,7 +144,7 @@ namespace Microsoft.NET.HostModel.Tests
             var bundleDir = BundleHelper.GetBundleDir(fixture);
 
             var bundler = new Bundler(hostName, bundleDir.FullName, options);
-            bundler.GenerateBundle(publishPath);
+            BundleHelper.GenerateBundle(bundler, publishPath);
 
             bundler.BundleManifest.Contains($"{appName}.pdb").Should().Be(options.HasFlag(BundleOptions.BundleSymbolFiles));
         }
@@ -162,7 +162,7 @@ namespace Microsoft.NET.HostModel.Tests
             var bundleDir = BundleHelper.GetBundleDir(fixture);
 
             var bundler = new Bundler(hostName, bundleDir.FullName, options);
-            bundler.GenerateBundle(publishPath);
+            BundleHelper.GenerateBundle(bundler, publishPath);
 
             bundler.BundleManifest.Contains($"{hostfxr}").Should().Be(options.HasFlag(BundleOptions.BundleNativeBinaries));
         }
@@ -178,7 +178,7 @@ namespace Microsoft.NET.HostModel.Tests
             var bundleDir = BundleHelper.GetBundleDir(fixture);
 
             var bundler = new Bundler(hostName, bundleDir.FullName, BundleOptions.BundleAllContent);
-            bundler.GenerateBundle(BundleHelper.GetPublishPath(fixture));
+            BundleHelper.GenerateBundle(bundler, publishPath);
 
             bundler.BundleManifest.Files.ForEach(file => 
                 Assert.True((file.Type != FileType.Assembly) || (file.Offset % Bundler.AssemblyAlignment == 0)));
@@ -191,9 +191,10 @@ namespace Microsoft.NET.HostModel.Tests
 
             var hostName = BundleHelper.GetHostName(fixture);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
+            string publishPath = BundleHelper.GetPublishPath(fixture);
 
             var bundler = new Bundler(hostName, bundleDir.FullName, BundleOptions.BundleAllContent);
-            string singleFile = bundler.GenerateBundle(BundleHelper.GetPublishPath(fixture));
+            string singleFile = BundleHelper.GenerateBundle(bundler, publishPath);
 
             using (var file = File.OpenWrite(singleFile))
             {


### PR DESCRIPTION
Some depricated APIs were maintained in #33413 so that SDK build is green.
Now that the SDK is updated https://github.com/dotnet/sdk/pull/10849, remove the unused APIs.

Also move out a test-only methods from the product to the test helpers.