### PR TITLE
Disable not working test containing RemoteExecutor

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -109,6 +109,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33558")]        
         public void Proxy_UseEnvironmentVariableToSetSystemProxy_RequestGoesThruProxy()
         {
             RemoteExecutor.Invoke(async (useVersionString) =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -397,6 +397,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [PlatformSpecific(~TestPlatforms.Linux)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33558")]
         public void HttpClientUsesSslCertEnvironmentVariables()
         {
             // We set SSL_CERT_DIR and SSL_CERT_FILE to empty locations.


### PR DESCRIPTION
These tests are disabled because of dotnet/arcade#4912
They will be reenabled by #33558
