### PR TITLE
Fix dump of common methods diff

### DIFF
--- a/src/coreclr/src/tools/r2rdump/R2RDiff.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDiff.cs
@@ -97,7 +97,7 @@ namespace R2RDump
             {
                 leftSectionMethods = new List<ReadyToRunMethod>();
             }
-            if (!_rightDumper.Reader.Methods.TryGetValue(leftSection, out List<ReadyToRunMethod> rightSectionMethods))
+            if (!_rightDumper.Reader.Methods.TryGetValue(rightSection, out List<ReadyToRunMethod> rightSectionMethods))
             {
                 rightSectionMethods = new List<ReadyToRunMethod>();
             }


### PR DESCRIPTION
The DiffMethodsForModule was accidentally trying to get leftSection from
the right dumper.