### PR TITLE
Read the image earlier

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -368,6 +368,11 @@ namespace ILCompiler.Reflection.ReadyToRun
 
                 PEReader = new PEReader(Unsafe.As<byte[], ImmutableArray<byte>>(ref image));
             }
+            else
+            {
+                ImmutableArray<byte> content = PEReader.GetEntireImage().GetContent();
+                Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
+            }
 
             if (metadata == null && PEReader.HasMetadata)
             {
@@ -392,9 +397,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 throw new BadImageFormatException($"ECMA metadata / RTR_HEADER not found in file '{Filename}'");
             }
-
-            ImmutableArray<byte> content = PEReader.GetEntireImage().GetContent();
-            Image = Unsafe.As<ImmutableArray<byte>, byte[]>(ref content);
         }
 
         private void EnsureMethods()


### PR DESCRIPTION
When the `ReadyToRunReader` is constructed by ILSpy, the `PEReader` is not `null`, and therefore we didn't set the `Image` property until the end of the method. Before that, we `Debug.Assert(!Composite)`, that requires reading the image to populate the header, and that would fail with a null reference exception.

The change moves the image reading earlier to avoid that failure, and it also avoids some extra work in case the `ReadyToRunReader` is not constructed by ILSpy.