### PR TITLE
Add IAsyncDisposable implementation for XmlWriter

### DIFF
--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -633,7 +633,7 @@ namespace System.Xml.Linq
                 }
             }
 
-            using (XmlWriter w = XmlWriter.Create(stream, ws))
+            await using (XmlWriter w = XmlWriter.Create(stream, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
                 await w.FlushAsync().ConfigureAwait(false);
@@ -706,7 +706,7 @@ namespace System.Xml.Linq
 
             ws.Async = true;
 
-            using (XmlWriter w = XmlWriter.Create(textWriter, ws))
+            await using (XmlWriter w = XmlWriter.Create(textWriter, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
                 await w.FlushAsync().ConfigureAwait(false);

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -1080,10 +1080,9 @@ namespace System.Xml.Linq
 
             ws.Async = true;
 
-            using (XmlWriter w = XmlWriter.Create(stream, ws))
+            await using (XmlWriter w = XmlWriter.Create(stream, ws))
             {
                 await SaveAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 
@@ -1142,10 +1141,9 @@ namespace System.Xml.Linq
 
             ws.Async = true;
 
-            using (XmlWriter w = XmlWriter.Create(textWriter, ws))
+            await using (XmlWriter w = XmlWriter.Create(textWriter, ws))
             {
                 await SaveAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -1083,6 +1083,7 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(stream, ws))
             {
                 await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 
@@ -1144,6 +1145,7 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(textWriter, ws))
             {
                 await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/LoadSaveAsyncTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/LoadSaveAsyncTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -186,7 +185,6 @@ namespace CoreXml.Test.XLinq
 
             // Compare to make sure the synchronous and asynchronous results are the same
             Assert.Equal(syncOutput.ToArray(), asyncOutput.ToArray());
-            Console.WriteLine(Encoding.ASCII.GetString(asyncOutput.ToArray()));
         }
 
         // Inputs to the Roundtrip* tests:

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -807,4 +807,7 @@
     <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Unix.cs" />
     <Compile Include="System\Xml\Core\XmlTextReaderImpl.Unix.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -807,7 +807,4 @@
     <Compile Include="System\Xml\Xsl\Runtime\XmlCollation.Unix.cs" />
     <Compile Include="System\Xml\Core\XmlTextReaderImpl.Unix.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
@@ -576,6 +576,12 @@ namespace System.Xml
             _lastTask = task;
             return task;
         }
+
+        public override ValueTask CloseAsync()
+        {
+             CheckAsync();
+             return _coreWriter.CloseAsync();
+        }
         #endregion
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -75,6 +75,64 @@ namespace System.Xml
             return Task.CompletedTask;
         }
 
+        public override async ValueTask CloseAsync()
+        {
+            try
+            {
+                await FlushBufferAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                // Future calls to Close or Flush shouldn't write to Stream or Writer
+                writeToNull = true;
+
+                if (stream != null)
+                {
+                    try
+                    {
+                        await stream.FlushAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (closeOutput)
+                            {
+                                await stream.DisposeAsync().ConfigureAwait(false);
+                            }
+                        }
+                        finally
+                        {
+                            stream = null;
+                        }
+                    }
+                }
+<# if (WriterType == RawTextWriterType.Encoded) { #>
+                else if (writer != null)
+                {
+                    try
+                    {
+                        await writer.FlushAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (closeOutput)
+                            {
+                                await writer.DisposeAsync().ConfigureAwait(false);
+                            }
+                        }
+                        finally
+                        {
+                            writer = null;
+                        }
+                    }
+                }
+<# } #>
+            }
+        }
+
         // Serialize the document type declaration.
         public override async Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset)
         {
@@ -689,7 +747,7 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + bufLen)
@@ -879,7 +937,7 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + bufLen)
@@ -1105,7 +1163,7 @@ namespace System.Xml
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + bufLen)
@@ -1266,7 +1324,7 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + bufLen)
@@ -1454,7 +1512,7 @@ namespace System.Xml
                     <#= BufferType #>* pDst = pDstBegin + bufPos;
 
                     int ch = 0;
-                    for (;;)
+                    while (true)
                     {
                         <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                         if (pDstEnd > pDstBegin + bufLen)
@@ -1630,7 +1688,7 @@ namespace System.Xml
                     <#= BufferType #>* pDst = pDstBegin + bufPos;
 
                     int ch = 0;
-                    for (;;)
+                    while (true)
                     {
                         <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                         if (pDstEnd > pDstBegin + bufLen)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -226,5 +226,10 @@ namespace System.Xml
             // The Flush will call WriteRaw to write out the rest of the encoded characters
             return base64Encoder.FlushAsync();
         }
+
+        internal virtual ValueTask CloseAsync(WriteState currentState)
+        {
+            return CloseAsync();
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -18,7 +18,7 @@ namespace System.Xml
 {
     // Represents a writer that provides fast non-cached forward-only way of generating XML streams containing XML documents
     // that conform to the W3C Extensible Markup Language (XML) 1.0 specification and the Namespaces in XML specification.
-    public abstract partial class XmlWriter : IDisposable
+    public abstract partial class XmlWriter : IDisposable, IAsyncDisposable
     {
         // Write methods
         // Writes out the XML declaration with the version "1.0".
@@ -598,6 +598,22 @@ namespace System.Xml
             {
                 await WriteAttributeStringAsync("xmlns", prefix, XmlReservedNs.NsXmlNs, ns).ConfigureAwait(false);
             }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (WriteState != WriteState.Closed)
+            {
+                return CloseAsync();
+            }
+
+            return default;
+        }
+
+        public virtual ValueTask CloseAsync()
+        {
+            Close();
+            return default;
         }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlWriter/WriteWithEncoding.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml.Xsl;
 using Xunit;
 
@@ -70,6 +71,38 @@ namespace System.Xml.Tests
 
             // Then, last '>' will be cut off in resulting string if BOM is present
             Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-32\"?>", string.Concat(resultString.Take(39)));
+        }
+
+        [Fact]
+        public static async Task AsyncSyncWrite_StreamResult_ShouldMatch()
+        {
+            using (var syncStream = new MemoryStream())
+            using (var asyncStream = new MemoryStream())
+            {
+                await using (var writer = XmlWriter.Create(asyncStream, new XmlWriterSettings() { Async = true }))
+                {
+                    await writer.WriteStartDocumentAsync();
+                    await writer.WriteStartElementAsync(string.Empty, "root", null);
+                    await writer.WriteStartElementAsync(null, "test", null);
+                    await writer.WriteAttributeStringAsync(string.Empty, "abc", string.Empty, "1");
+                    await writer.WriteStringAsync("value");
+                    await writer.WriteEndElementAsync();
+                    await writer.WriteEndElementAsync();
+                }
+
+                using (var writer = XmlWriter.Create(syncStream, new XmlWriterSettings() { Async = false }))
+                {
+                    writer.WriteStartDocument();
+                    writer.WriteStartElement("root");
+                    writer.WriteStartElement("test");
+                    writer.WriteAttributeString("abc", "1");
+                    writer.WriteString("value");
+                    writer.WriteEndElement();
+                    writer.WriteEndElement();
+                }
+
+                Assert.Equal(syncStream.ToArray(), asyncStream.ToArray());
+            }
         }
     }
 }

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -5,6 +5,8 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
+
 namespace System.Xml
 {
     public enum ConformanceLevel
@@ -1201,7 +1203,7 @@ namespace System.Xml
         public override void WriteContentTo(System.Xml.XmlWriter w) { }
         public override void WriteTo(System.Xml.XmlWriter w) { }
     }
-    public abstract partial class XmlWriter : System.IDisposable
+    public abstract partial class XmlWriter : System.IDisposable, System.IAsyncDisposable
     {
         protected XmlWriter() { }
         public virtual System.Xml.XmlWriterSettings Settings { get { throw null; } }
@@ -1306,6 +1308,7 @@ namespace System.Xml
         public virtual void WriteValue(string value) { }
         public abstract void WriteWhitespace(string ws);
         public virtual System.Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
+        public ValueTask DisposeAsync() { throw null; }
     }
     public sealed partial class XmlWriterSettings
     {

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -5,8 +5,6 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System.Threading.Tasks;
-
 namespace System.Xml
 {
     public enum ConformanceLevel
@@ -1308,7 +1306,7 @@ namespace System.Xml
         public virtual void WriteValue(string value) { }
         public abstract void WriteWhitespace(string ws);
         public virtual System.Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
-        public ValueTask DisposeAsync() { throw null; }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
     }
     public sealed partial class XmlWriterSettings
     {


### PR DESCRIPTION
XmlWriter doesn't implemented async disposal, because of that async XmlWriter calls sync `Dispose()` which will eventually call sync `Flush(), Write(...)` which causing probem for [async steams](https://github.com/dotnet/aspnetcore/blob/354d859d50f252526be5a6264434d1765df86450/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseStream.cs#L80-L83) not allowing sync operation. Added IAsyncDisposable  implementation for XmlWriter and its descendants 

Fixes https://github.com/dotnet/runtime/issues/29464