### PR TITLE
Print Ibc messages only when --verbose is specified

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -145,7 +145,8 @@ namespace ILCompiler.IBC
                         }
                         else
                         {
-                            _logger.Writer.WriteLine($"Multiple copies of data for method '{associatedMethod}' found.");
+                            if (_logger.IsVerbose)
+                                _logger.Writer.WriteLine($"Multiple copies of data for method '{associatedMethod}' found.");
                         }
                     }
                 }
@@ -290,7 +291,8 @@ namespace ILCompiler.IBC
         {
             if (!blobs.TryGetValue(new IBCBlobKey(ibcToken, BlobType.ExternalTypeDef), out BlobEntry externalTypeDefBlob))
             {
-                _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find external typedef");
+                if (_logger.IsVerbose)
+                    _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find external typedef");
                 return Cor.Macros.RidToToken(0, CorTokenType.mdtTypeDef); // Nil TypeDef token
             }
 
@@ -314,7 +316,8 @@ namespace ILCompiler.IBC
 
                 if (!blobs.TryGetValue(new IBCBlobKey(nameSpaceToken, BlobType.ExternalNamespaceDef), out BlobEntry namespaceEntryBlob))
                 {
-                    _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find external namespace blob '{nameSpaceToken:x}");
+                    if (_logger.IsVerbose)
+                        _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find external namespace blob '{nameSpaceToken:x}");
                     return Cor.Macros.RidToToken(0, CorTokenType.mdtTypeDef); // Nil TypeDef token
                 }
 
@@ -328,7 +331,7 @@ namespace ILCompiler.IBC
                     throw new Exception($"Ibc TypeToken {ibcToken:x} has NestedClass token which does not resolve to a type definition");
 
                 enclosingType = MetadataTokens.TypeDefinitionHandle((int)Cor.Macros.RidFromToken(enclosingTypeTokenValue));
-                if (enclosingType.IsNil)
+                if (enclosingType.IsNil && _logger.IsVerbose)
                     _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} has NestedClass token which resolves to a nil token");
             }
 
@@ -358,7 +361,8 @@ namespace ILCompiler.IBC
 
                 if (foundType == null)
                 {
-                    _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} has type token which resolves to a nil token");
+                    if (_logger.IsVerbose)
+                        _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} has type token which resolves to a nil token");
                     return Cor.Macros.RidToToken(0, CorTokenType.mdtTypeDef); // Nil TypeDef token
                 }
 
@@ -377,7 +381,8 @@ namespace ILCompiler.IBC
                     }
                 }
 
-                _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find nested type '{typeName}' on type '{externalModule.MetadataReader.GetToken(enclosingType):x}'");
+                if (_logger.IsVerbose)
+                    _logger.Writer.WriteLine($"Ibc TypeToken {ibcToken:x} unable to find nested type '{typeName}' on type '{externalModule.MetadataReader.GetToken(enclosingType):x}'");
                 return Cor.Macros.RidToToken(0, CorTokenType.mdtTypeDef); // Nil TypeDef token
             }
         }
@@ -425,7 +430,8 @@ namespace ILCompiler.IBC
                 }
             }
 
-            _logger.Writer.WriteLine("Warning: Unable to find exact match for candidate external method");
+            if (_logger.IsVerbose)
+                _logger.Writer.WriteLine("Warning: Unable to find exact match for candidate external method");
             return 0;
         }
 
@@ -675,12 +681,14 @@ namespace ILCompiler.IBC
                     var result = (MetadataType)ecmaModule.GetType(MetadataTokens.EntityHandle((int)token));
                     if ((typ == CorElementType.ELEMENT_TYPE_VALUETYPE) != result.IsValueType)
                     {
-                        _logger.Writer.WriteLine("Mismatch between valuetype and reference type in while parsing generic instantiation");
+                        if (_logger.IsVerbose)
+                            _logger.Writer.WriteLine("Mismatch between valuetype and reference type in while parsing generic instantiation");
                         return null;
                     }
                     return result;
                 default:
-                    _logger.Writer.WriteLine("Unexpected token type parsing ELEMENT_TYPE_GENERICINST");
+                    if (_logger.IsVerbose)
+                        _logger.Writer.WriteLine("Unexpected token type parsing ELEMENT_TYPE_GENERICINST");
                     return null;
             }
         }
@@ -696,7 +704,8 @@ namespace ILCompiler.IBC
             if (Macros.IsSlotUsedInsteadOfToken(flags))
             {
                 int slot = sig.ReadCompressedInteger();
-                _logger.Writer.WriteLine($"Warning: IBC Data for `{methodType}` with slot '{slot}' was ignored");
+                if (_logger.IsVerbose)
+                    _logger.Writer.WriteLine($"Warning: IBC Data for `{methodType}` with slot '{slot}' was ignored");
                 return null; // Unsupported case thought to be used only for array methods, which don't really matter for R2R codegen
             }
             else
@@ -716,7 +725,8 @@ namespace ILCompiler.IBC
                     methodToken = LookupIbcMethodToken(methodMetadataType, ibcToken, ibcModule.Blobs);
                     if (Cor.Macros.RidFromToken(methodToken) == 0)
                     {
-                        _logger.Writer.WriteLine($"Warning: External Method Token {ibcToken:x} on '{methodMetadataType}' could not be found.");
+                        if (_logger.IsVerbose)
+                            _logger.Writer.WriteLine($"Warning: External Method Token {ibcToken:x} on '{methodMetadataType}' could not be found.");
                         return null;
                     }
                 }
@@ -746,13 +756,15 @@ namespace ILCompiler.IBC
 
                 if (Macros.IsUnboxingStub(flags))
                 {
-                    _logger.Writer.WriteLine($"Warning: Skipping IBC data for unboxing stub {methodFound}");
+                    if (_logger.IsVerbose)
+                        _logger.Writer.WriteLine($"Warning: Skipping IBC data for unboxing stub {methodFound}");
                     return null;
                 }
 
                 if (Macros.IsInstantiatingStub(flags))
                 {
-                    _logger.Writer.WriteLine($"Warning: Skipping IBC data for instantiating stub {methodFound}");
+                    if (_logger.IsVerbose)
+                        _logger.Writer.WriteLine($"Warning: Skipping IBC data for instantiating stub {methodFound}");
                     return null;
                 }
 


### PR DESCRIPTION
These messages are mostly spam, but are useful when debugging Ibc issues. Push them to only be output in --verbose mode of crossgen2.