### PR TITLE
Enhance single method crossgen2 compilation

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/SingleMethodRootProvider.cs
+++ b/src/coreclr/src/tools/Common/Compiler/SingleMethodRootProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -11,16 +12,17 @@ namespace ILCompiler
     /// </summary>
     public class SingleMethodRootProvider : ICompilationRootProvider
     {
-        private MethodDesc _method;
+        private IEnumerable<MethodDesc> _methods;
 
-        public SingleMethodRootProvider(MethodDesc method)
+        public SingleMethodRootProvider(IEnumerable<MethodDesc> methods)
         {
-            _method = method;
+            _methods = methods;
         }
 
         public void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
-            rootProvider.AddCompilationRoot(_method, "Single method root");
+            foreach (var method in _methods)
+                rootProvider.AddCompilationRoot(method, "Single method root");
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
     /// </summary>
     public class SingleMethodCompilationModuleGroup : ReadyToRunCompilationModuleGroupBase
     {
-        private MethodDesc _method;
+        private HashSet<MethodDesc> _methods;
 
         public SingleMethodCompilationModuleGroup(
             TypeSystemContext context,
@@ -23,19 +23,19 @@ namespace ILCompiler
             IEnumerable<EcmaModule> compilationModuleSet,
             IEnumerable<ModuleDesc> versionBubbleModuleSet,
             bool compileGenericDependenciesFromVersionBubbleModuleSet,
-            MethodDesc method) :
+            IEnumerable<MethodDesc> methods) :
                 base(context,
                      isCompositeBuildMode,
                      compilationModuleSet,
                      versionBubbleModuleSet,
                      compileGenericDependenciesFromVersionBubbleModuleSet)
         {
-            _method = method;
+            _methods = new HashSet<MethodDesc>(methods);
         }
 
         public override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
-            return method == _method;
+            return _methods.Contains(method);
         }
 
         public override void ApplyProfilerGuidedCompilationRestriction(ProfileDataManager profileGuidedCompileRestriction)


### PR DESCRIPTION
- Its not just a single method anymore. It can do multiple methods if the arguments are insufficiently specific (This allows compilation of methods that are overloads without requiring full parsing of signatures)
- Add support for multiple methods to be generated by singlemethod argument
- Also adds support for generating all code of a type, not just one method on a type