### PR TITLE
Include apphost_version parameter in download URLs for both GUI and CLI apps

### DIFF
--- a/docs/design/features/host-download-urls.md
+++ b/docs/design/features/host-download-urls.md
@@ -21,8 +21,8 @@ It's also part of the error when an SDK command is executed and there's no SDK i
 ```
 
 ## Install prerequisites link
-> https://go.microsoft.com/fwlink/?linkid=798306  for Windows  
-> https://go.microsoft.com/fwlink/?linkid=2063366 for OSX  
+> https://go.microsoft.com/fwlink/?linkid=798306  for Windows
+> https://go.microsoft.com/fwlink/?linkid=2063366 for OSX
 > https://go.microsoft.com/fwlink/?linkid=2063370 for Linux
 
 This URL is part of the error message when the host fails to load `hostfxr`.
@@ -45,7 +45,7 @@ This will happen when the host can't find `hostfxr`, typically when there's no .
 
 In this case the URL will contain these parameters:
 * `missing_runtime=true` - this marks the case of missing runtime.
-* `apphost_version=<Version>` - the version of the `apphost` which was used to create the executable for the app. For example `apphost_version=5.0.0-preview.2.20155.1`. Currently this is only included if the host is a GUI app - see dotnet/runtime#33569 to include it always.
+* `apphost_version=<Version>` - the version of the `apphost` which was used to create the executable for the app. For example `apphost_version=5.0.0-preview.2.20155.1`. This is included in all cases in 5.0 and above and it may be included in 3.1 only for GUI apps.
 
 In this case the `apphost_version` parameter could be used by the website to determine the major version of the runtime to offer (using latest minor/patch). Also if there's a `gui=true` we should offer the `WindowsDesktop` runtime installer.
 

--- a/src/installer/corehost/cli/apphost/apphost.windows.cpp
+++ b/src/installer/corehost/cli/apphost/apphost.windows.cpp
@@ -63,9 +63,19 @@ namespace
 
         pal::string_t dialogMsg = _X("To run this application, you must install .NET Core.\n\n");
         pal::string_t url;
+        const pal::string_t url_prefix = _X("  - ") DOTNET_CORE_APPLAUNCH_URL _X("?");
         if (error_code == StatusCode::CoreHostLibMissingFailure)
         {
-            url = get_download_url();
+            pal::string_t line;
+            pal::stringstream_t ss(g_buffered_errors);
+            while (std::getline(ss, line, _X('\n'))) {
+                if (starts_with(line, url_prefix, true))
+                {
+                    size_t offset = url_prefix.length() - pal::strlen(DOTNET_CORE_APPLAUNCH_URL) - 1;
+                    url = line.substr(offset, line.length() - offset);
+                    break;
+                }
+            }
         }
         else if (error_code == StatusCode::FrameworkMissingFailure)
         {
@@ -77,7 +87,6 @@ namespace
                 const pal::string_t prefix = _X("The framework '");
                 const pal::string_t suffix = _X("' was not found.");
                 const pal::string_t custom_prefix = _X("  _ ");
-                const pal::string_t url_prefix = _X("  - ") DOTNET_CORE_APPLAUNCH_URL _X("?");
                 if (starts_with(line, prefix, true) && ends_with(line, suffix, true))
                 {
                     dialogMsg.append(line);
@@ -101,12 +110,8 @@ namespace
         dialogMsg.append(_X("Would you like to download it now?"));
 
         assert(url.length() > 0);
-        if (is_gui_application())
-        {
-            url.append(_X("&gui=true"));
-        }
-        url.append(_X("&apphost_version="));
-        url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
+        assert(is_gui_application());
+        url.append(_X("&gui=true"));
 
         trace::verbose(_X("Showing error dialog for application: '%s' - error code: 0x%x - url: '%s'"), executable_name, error_code, url.c_str());
         if (::MessageBoxW(nullptr, dialogMsg.c_str(), executable_name, MB_ICONERROR | MB_YESNO) == IDYES)

--- a/src/installer/corehost/cli/fxr_resolver.cpp
+++ b/src/installer/corehost/cli/fxr_resolver.cpp
@@ -119,7 +119,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
             self_registered_message.c_str());
         trace::error(_X(""));
         trace::error(_X("The .NET Core runtime can be found at:"));
-        trace::error(_X("  - %s"), get_download_url().c_str());
+        trace::error(_X("  - %s&apphost_version=%s"), get_download_url().c_str(), _STRINGIFY(COMMON_HOST_PKG_VER));
         return false;
     }
 


### PR DESCRIPTION
So far the code only included the `&apphost_version=<version>` URL parameter in the URL used by the error dialog in GUI apps. The error written to stderr/trace would not have that parameter in its URL.

This change include this parameter in all cases. This also means that comhost/ijwhost and so on will also include the `apphost_version` parameter in their error codes and it will be the version of the comhost/ijwhost and so on. This is not 100% correct, but for the purposed of the website this should be enough (for now we don't see a reason to differentiate between the various hosting scenarios).

Adds a new test to cover this case.

Fixes #33569 