### PR TITLE
GC coverage can now occur in scenarios where a thread doesn't exist.

### DIFF
--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -7979,6 +7979,7 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
     //
     // 1) We have a valid Thread object (implies exception on managed thread)
     // 2) Not a valid Thread object but the IP is in the execution engine (implies native thread within EE faulted)
+    // 3) The exception occurred in a GC marked location when no thread exists (i.e. reverse P/Invoke with NativeCallableAttribute).
     if (pThread || fExceptionInEE)
     {
         if (!bIsGCMarker)
@@ -8065,6 +8066,11 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
         }
 #endif // FEATURE_EH_FUNCLETS
 
+    }
+    else if (bIsGCMarker)
+    {
+        _ASSERTE(pThread == NULL);
+        result = EXCEPTION_CONTINUE_EXECUTION;
     }
 
     SetLastError(dwLastError);

--- a/src/coreclr/src/vm/gccover.cpp
+++ b/src/coreclr/src/vm/gccover.cpp
@@ -1407,7 +1407,8 @@ BOOL OnGcCoverageInterrupt(PCONTEXT regs)
         // where the call could be coming from a thread unknown to the CLR and
         // we haven't created a thread yet - see PreStubWorker_Preemptive().
         _ASSERTE(pMD->HasNativeCallableAttribute());
-        return (FALSE);
+        RemoveGcCoverageInterrupt(instrPtr, savedInstrPtr);
+        return TRUE;
     }
 
 #if defined(USE_REDIRECT_FOR_GCSTRESS) && !defined(TARGET_UNIX)

--- a/src/coreclr/src/vm/gccover.cpp
+++ b/src/coreclr/src/vm/gccover.cpp
@@ -1404,8 +1404,8 @@ BOOL OnGcCoverageInterrupt(PCONTEXT regs)
     {
         // No thread at the moment so we aren't doing coverage for this function.
         // This should only occur for methods with the NativeCallableAttribute,
-        // where the caller could be coming from a thread unknown to the CLR and
-        // we haven't created a thread yet - see PreStubWorker_Premptive().
+        // where the call could be coming from a thread unknown to the CLR and
+        // we haven't created a thread yet - see PreStubWorker_Preemptive().
         _ASSERTE(pMD->HasNativeCallableAttribute());
         return (FALSE);
     }

--- a/src/coreclr/src/vm/gccover.cpp
+++ b/src/coreclr/src/vm/gccover.cpp
@@ -1400,7 +1400,15 @@ BOOL OnGcCoverageInterrupt(PCONTEXT regs)
     }
 
     Thread* pThread = GetThread();
-    _ASSERTE(pThread);
+    if (!pThread)
+    {
+        // No thread at the moment so we aren't doing coverage for this function.
+        // This should only occur for methods with the NativeCallableAttribute,
+        // where the caller could be coming from a thread unknown to the CLR and
+        // we haven't created a thread yet - see PreStubWorker_Premptive().
+        _ASSERTE(pMD->HasNativeCallableAttribute());
+        return (FALSE);
+    }
 
 #if defined(USE_REDIRECT_FOR_GCSTRESS) && !defined(TARGET_UNIX)
     // If we're unable to redirect, then we simply won't test GC at this
@@ -1452,6 +1460,7 @@ void DoGcStress (PCONTEXT regs, NativeCodeVersion nativeCodeVersion)
     DWORD offset = codeInfo.GetRelOffset();
 
     Thread *pThread = GetThread();
+    _ASSERTE(pThread);
 
     if (!IsGcCoverageInterruptInstruction(instrPtr))
     {

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12678,6 +12678,7 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
 
     flags = GetCompileFlags(ftn, flags, &methodInfo);
 
+#ifdef FEATURE_TIERED_COMPILATION
     // Clearing all tier flags and mark as optimized if the reverse P/Invoke
     // flag is used and the function is eligible.
     if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE)
@@ -12689,10 +12690,9 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
         flags.Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
         flags.Clear(CORJIT_FLAGS::CORJIT_FLAG_TIER1);
 
-#ifdef FEATURE_TIERED_COMPILATION
         config->SetJitSwitchedToOptimized();
-#endif // FEATURE_TIERED_COMPILATION
     }
+#endif // FEATURE_TIERED_COMPILATION
 
 #ifdef _DEBUG
     if (!flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_SKIP_VERIFICATION))

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12678,9 +12678,10 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
 
     flags = GetCompileFlags(ftn, flags, &methodInfo);
 
-    // If the reverse P/Invoke flag is used, we aren't going to support
-    // any tiered compilation.
-    if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE))
+    // Clearing all tier flags and mark as optimized if the reverse P/Invoke
+    // flag is used and the function is eligible.
+    if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE)
+        && ftn->IsEligibleForTieredCompilation())
     {
         _ASSERTE(config->GetCallerGCMode() != CallerGCMode::Coop);
 


### PR DESCRIPTION
Properly handle this case and assert some invariant.

Fixes #33612 

/cc @jkotas 