### PR TITLE
Remove unused variable for System.Net.Requests, as part of #30457

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -411,7 +411,6 @@ namespace System.Net
             // OR parse out the file size or file time, usually a result of sending SIZE/MDTM commands
             else if (status == FtpStatusCode.FileStatus)
             {
-                FtpWebRequest request = (FtpWebRequest)_request;
                 if (entry.Command.StartsWith("SIZE ", StringComparison.Ordinal))
                 {
                     _contentLength = GetContentLengthFrom213Response(response.StatusDescription);


### PR DESCRIPTION
src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs, remove unused variable 'request' in L414.

Partially Fix #30457