### PR TITLE
Revert "Disable System.Reflection.Emit.Tests in mono (#32201)"

### DIFF
--- a/src/libraries/System.Reflection.Emit/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Reflection.Emit/tests/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/32177", TestRuntimes.Mono)] // Test hangs

--- a/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -4,7 +4,6 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyBuilderTests.cs" />
     <Compile Include="OpCodesTests.cs" />
     <Compile Include="ConstructorBuilder\ConstructorBuilderDefineParameter.cs" />


### PR DESCRIPTION
As https://github.com/dotnet/runtime/issues/32177 is marked resolved, we should be able to re-enable.

This reverts commit 11dcd00c1a77c8da0fe06404609a9c4af9e5da4f
