### PR TITLE
use YMM registers on x64 for BlkUnroll.

### DIFF
--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -2989,8 +2989,11 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     // Fill as much as possible using SSE2 stores.
     if (size >= XMM_REGSIZE_BYTES)
     {
-        bool useYmm =
-            ((compiler->getSIMDVectorRegisterByteLength() == YMM_REGSIZE_BYTES) && (size >= YMM_REGSIZE_BYTES));
+#ifdef FEATURE_SIMD
+        bool useYmm = (compiler->getSIMDVectorRegisterByteLength() == YMM_REGSIZE_BYTES) && (size >= YMM_REGSIZE_BYTES);
+#else
+        bool useYmm             = false;
+#endif
         regNumber srcXmmReg = node->GetSingleTempReg(RBM_ALLFLOAT);
 
         if (src->gtSkipReloadOrCopy()->IsIntegralConst(0))
@@ -3255,10 +3258,12 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
             // allocate a GPR just for the remainder.
         };
 
+#ifdef FEATURE_SIMD
         if ((compiler->getSIMDVectorRegisterByteLength() == YMM_REGSIZE_BYTES) && (size >= YMM_REGSIZE_BYTES))
         {
             unrollUsingXMM(YMM_REGSIZE_BYTES, tempReg);
         }
+#endif
         if (size >= XMM_REGSIZE_BYTES)
         {
             unrollUsingXMM(XMM_REGSIZE_BYTES, tempReg);

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8173,7 +8173,7 @@ private:
     {
         return false;
     }
-#endif // FEATURE_SIMD
+#endif // !FEATURE_SIMD
 
 public:
     //------------------------------------------------------------------------


### PR DESCRIPTION
PMI SPC diffs:
`Total bytes of diff: -7255 (-0.13% of base)`, 
the actual diff is better, but we start inlining more and that is shown as asm size regression.
<details>

```
Top file improvements (bytes):
       -7255 : System.Private.CoreLib.dasm (-0.13% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.
Top method regressions (bytes):
          61 (1,220.00% of base) : System.Private.CoreLib.dasm - System.Threading.Thread:GetCurrentProcessorId():int
          54 ( 5.49% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[__Canon][System.__Canon]:Return(System.__Canon[],bool):this
          50 ( 5.52% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[ReadOnlyMemory`1][System.ReadOnlyMemory`1[System.Char]]:Rent(int):System.ReadOnlyMemory`1[System.Char][]:this
          50 ( 4.73% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[ReadOnlyMemory`1][System.ReadOnlyMemory`1[System.Char]]:Return(System.ReadOnlyMemory`1[System.Char][],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Char][System.Char]:Rent(int):System.Char[]:this
          50 ( 4.90% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Char][System.Char]:Return(System.Char[],bool):this
          50 ( 5.23% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[__Canon][System.__Canon]:Rent(int):System.__Canon[]:this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Byte][System.Byte]:Rent(int):System.Byte[]:this
          50 ( 4.55% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Byte][System.Byte]:Return(System.Byte[],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int16][System.Int16]:Rent(int):System.Int16[]:this
          50 ( 4.55% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int16][System.Int16]:Return(System.Int16[],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int32][System.Int32]:Rent(int):System.Int32[]:this
          50 ( 4.55% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int32][System.Int32]:Return(System.Int32[],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Double][System.Double]:Rent(int):System.Double[]:this
          50 ( 4.55% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Double][System.Double]:Return(System.Double[],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Vector`1][System.Numerics.Vector`1[System.Single]]:Rent(int):System.Numerics.Vector`1[System.Single][]:this
          50 ( 4.42% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Vector`1][System.Numerics.Vector`1[System.Single]]:Return(System.Numerics.Vector`1[System.Single][],bool):this
          50 ( 5.81% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int64][System.Int64]:Rent(int):System.Int64[]:this
          50 ( 4.55% of base) : System.Private.CoreLib.dasm - System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[Int64][System.Int64]:Return(System.Int64[],bool):this
          50 (46.73% of base) : System.Private.CoreLib.dasm - PerCoreLockedStacks[__Canon][System.__Canon]:TryPush(System.__Canon[]):this
Top method improvements (bytes):
       -1164 (-25.59% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_HM_S_D(byref,ubyte,byref):bool
       -1152 (-25.50% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_HMS_F_D(byref,ubyte,byref):bool
        -190 (-35.98% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:ConditionalSelect(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
        -147 (-14.53% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_D(byref,ubyte,byref):bool
        -146 (-14.46% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_HM(byref,ubyte,byref):bool
        -143 (-14.79% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_DHMSF(byref,ubyte,byref):bool
        -137 (-32.01% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Vector`1][System.Numerics.Vector`1[System.Single]]:ConditionalSelect(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
        -136 (-31.70% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:LessThanOrEqualAll(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):bool
        -136 (-33.01% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:LessThanOrEqualAny(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):bool
        -136 (-31.70% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:GreaterThanOrEqualAll(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):bool
        -136 (-33.01% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:GreaterThanOrEqualAny(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):bool
        -116 (-36.59% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:LessThanOrEqual(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
        -116 (-36.59% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:GreaterThanOrEqual(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
         -84 (-3.24% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanParse:TryParseByFormat(System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Char],int,byref):bool
         -83 (-28.82% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:Equals(System.Object):bool:this
         -81 (-4.33% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttributeData:.ctor(System.Reflection.RuntimeModule,System.Reflection.MetadataToken,byref):this
         -71 (-30.21% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Vector`1][System.Numerics.Vector`1[System.Single]]:GreaterThanOrEqual(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
         -71 (-30.21% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Vector`1][System.Numerics.Vector`1[System.Single]]:LessThanOrEqual(System.Numerics.Vector`1[Vector`1],System.Numerics.Vector`1[Vector`1]):System.Numerics.Vector`1[Vector`1]
         -66 (-4.87% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:TryParseExactMultiple(System.ReadOnlySpan`1[Char],System.String[],System.Globalization.DateTimeFormatInfo,int,byref):bool (2 methods)
         -61 (-6.62% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttributeData:get_NamedArguments():System.Collections.Generic.IList`1[CustomAttributeNamedArgument]:this
```
</details>

frameworks libraries (I used crossgen without check for `compiler->getSIMDVectorRegisterByteLength() == YMM_REGSIZE_BYTES`  to estimate PMI diffs.  PMI takes too long)
`Total bytes of diff: -56175 (-0.17% of base)
`
<details>

```
Top file improvements (bytes):
      -12924 : Microsoft.CodeAnalysis.CSharp.dasm (-0.62% of base)
       -9681 : System.Private.CoreLib.dasm (-0.25% of base)
       -9012 : System.Linq.Parallel.dasm (-1.54% of base)
       -6304 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.28% of base)
       -2213 : Microsoft.CodeAnalysis.dasm (-0.29% of base)
       -2107 : System.Reflection.Metadata.dasm (-0.65% of base)
       -1897 : System.Private.Xml.dasm (-0.06% of base)
       -1247 : System.Security.Cryptography.Pkcs.dasm (-0.37% of base)
       -1169 : System.Collections.Immutable.dasm (-0.54% of base)
        -968 : System.Data.Common.dasm (-0.09% of base)
        -866 : System.Security.Cryptography.Algorithms.dasm (-0.31% of base)
        -853 : System.Net.Http.dasm (-0.14% of base)
        -782 : System.Text.Json.dasm (-0.18% of base)
        -560 : System.Reflection.MetadataLoadContext.dasm (-0.30% of base)
        -541 : System.Diagnostics.PerformanceCounter.dasm (-0.74% of base)
        -467 : System.Security.Cryptography.Cng.dasm (-0.31% of base)
        -406 : System.Security.Cryptography.X509Certificates.dasm (-0.29% of base)
        -405 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.01% of base)
        -291 : ILCompiler.Reflection.ReadyToRun.dasm (-0.15% of base)
        -277 : System.DirectoryServices.dasm (-0.07% of base)
70 total files with Code Size differences (70 improved, 0 regressed), 161 unchanged.
```
</details>

Diffs look like:
before:
```
       vmovdqu  xmm0, xmmword ptr [rcx]
       vmovdqu  xmmword ptr [rsp+118H], xmm0
       vmovdqu  xmm0, xmmword ptr [rcx+16]
       vmovdqu  xmmword ptr [rsp+128H], xmm0
```

after:
```
       vmovdqu  ymm0, ymmword ptr[rcx]
       vmovdqu  ymmword ptr[rsp+118H], ymm0
```

and we are emitting `VZEROUPPER` everywhere now, so adding YMM usage doesn't add any penalty, that could change with https://github.com/dotnet/runtime/issues/11496

Fixes #33617.