### PR TITLE
Socket.Windows: support ConnectAsync(SocketAsyncEventArgs) for UDP, and Unix sockets

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2088,17 +2088,12 @@ namespace System.Net.Sockets
             return UnsafeBeginConnect(remoteEP, callback, state, flowContext: true);
         }
 
-        private bool CanUseConnectEx(EndPoint remoteEP)
-        {
-            return (_socketType == SocketType.Stream) &&
-                (_rightEndPoint != null || remoteEP.GetType() == typeof(IPEndPoint));
-        }
-
-
+        private static bool CanUseConnectEx(SocketType socketType, EndPoint remoteEP)
+            => (socketType == SocketType.Stream) && (remoteEP.GetType() == typeof(IPEndPoint));
 
         internal IAsyncResult UnsafeBeginConnect(EndPoint remoteEP, AsyncCallback? callback, object? state, bool flowContext = false)
         {
-            if (CanUseConnectEx(remoteEP))
+            if (CanUseConnectEx(_socketType, remoteEP))
             {
                 return BeginConnectEx(remoteEP, flowContext, callback, state);
             }
@@ -3817,8 +3812,7 @@ namespace System.Net.Sockets
                 SocketError socketError = SocketError.Success;
                 try
                 {
-                    bool canUseConnectEx = CanUseConnectEx(endPointSnapshot);
-                    if (canUseConnectEx)
+                    if (CanUseConnectEx(_socketType, endPointSnapshot))
                     {
                         socketError = e.DoOperationConnectEx(this, _handle);
                     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3802,7 +3802,6 @@ namespace System.Net.Sockets
 
                 WildcardBindForConnectIfNecessary(endPointSnapshot.AddressFamily);
 
-                bool canUseConnectEx = CanUseConnectEx(endPointSnapshot);
                 // Save the old RightEndPoint and prep new RightEndPoint.
                 EndPoint? oldEndPoint = _rightEndPoint;
                 if (_rightEndPoint == null)
@@ -3818,6 +3817,7 @@ namespace System.Net.Sockets
                 SocketError socketError = SocketError.Success;
                 try
                 {
+                    bool canUseConnectEx = CanUseConnectEx(endPointSnapshot);
                     if (canUseConnectEx)
                     {
                         socketError = e.DoOperationConnectEx(this, _handle);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3802,6 +3802,7 @@ namespace System.Net.Sockets
 
                 WildcardBindForConnectIfNecessary(endPointSnapshot.AddressFamily);
 
+                bool canUseConnectEx = CanUseConnectEx(endPointSnapshot);
                 // Save the old RightEndPoint and prep new RightEndPoint.
                 EndPoint? oldEndPoint = _rightEndPoint;
                 if (_rightEndPoint == null)
@@ -3817,7 +3818,15 @@ namespace System.Net.Sockets
                 SocketError socketError = SocketError.Success;
                 try
                 {
-                    socketError = e.DoOperationConnect(this, _handle);
+                    if (canUseConnectEx)
+                    {
+                        socketError = e.DoOperationConnectEx(this, _handle);
+                    }
+                    else
+                    {
+                        // For connectionless protocols, Connect is not an I/O call.
+                        socketError = e.DoOperationConnect(this, _handle);
+                    }
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -38,20 +38,6 @@ namespace System.Net.Sockets
 
         private void CompleteCore() { }
 
-        private void FinishOperationSync(SocketError socketError, int bytesTransferred, SocketFlags flags)
-        {
-            Debug.Assert(socketError != SocketError.IOPending);
-
-            if (socketError == SocketError.Success)
-            {
-                FinishOperationSyncSuccess(bytesTransferred, flags);
-            }
-            else
-            {
-                FinishOperationSyncFailure(socketError, bytesTransferred, flags);
-            }
-        }
-
         private void AcceptCompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize, SocketError socketError)
         {
             CompleteAcceptOperation(acceptedFileDescriptor, socketAddress, socketAddressSize, socketError);
@@ -94,6 +80,9 @@ namespace System.Net.Sockets
         {
             CompletionCallback(0, SocketFlags.None, socketError);
         }
+
+        internal unsafe SocketError DoOperationConnectEx(Socket socket, SafeSocketHandle handle)
+            => DoOperationConnect(socket, handle);
 
         internal unsafe SocketError DoOperationConnect(Socket socket, SafeSocketHandle handle)
         {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -780,5 +780,19 @@ namespace System.Net.Sockets
                 ExecutionContext.Run(context, s_executionCallback, this);
             }
         }
+
+        private void FinishOperationSync(SocketError socketError, int bytesTransferred, SocketFlags flags)
+        {
+            Debug.Assert(socketError != SocketError.IOPending);
+
+            if (socketError == SocketError.Success)
+            {
+                FinishOperationSyncSuccess(bytesTransferred, flags);
+            }
+            else
+            {
+                FinishOperationSyncFailure(socketError, bytesTransferred, flags);
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -42,6 +42,22 @@ namespace System.Net.Sockets.Tests
             Assert.True(client.Connected);
         }
 
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public async Task Connect_Dns_Success(IPAddress listenAt)
+        {
+            int port;
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, listenAt, out port))
+            {
+                using (Socket client = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    Task connectTask = ConnectAsync(client, new DnsEndPoint("localhost", port));
+                    await connectTask;
+                    Assert.True(client.Connected);
+                }
+            }
+        }
+
         [OuterLoop]
         [Theory]
         [MemberData(nameof(Loopbacks))]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -30,6 +30,18 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(Loopbacks))]
+        public async Task Connect_Udp_Success(IPAddress listenAt)
+        {
+            using Socket listener = new Socket(listenAt.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            using Socket client = new Socket(listenAt.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            listener.Bind(new IPEndPoint(listenAt, 0));
+
+            await ConnectAsync(client, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
+            Assert.True(client.Connected);
+        }
+
         [OuterLoop]
         [Theory]
         [MemberData(nameof(Loopbacks))]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -46,6 +46,12 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(Loopbacks))]
         public async Task Connect_Dns_Success(IPAddress listenAt)
         {
+            // On some systems (like Ubuntu 16.04 and Ubuntu 18.04) "localhost" doesn't resolve to '::1'.
+            if (Array.IndexOf(Dns.GetHostAddresses("localhost"), listenAt) == -1)
+            {
+                return;
+            }
+
             int port;
             using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, listenAt, out port))
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -21,7 +21,6 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(PlatformSupportsUnixDomainSockets, Socket.OSSupportsUnixDomainSockets);
         }
 
-        [PlatformSpecific(~TestPlatforms.Windows)] // Windows doesn't currently support ConnectEx with domain sockets
         [ConditionalFact(nameof(PlatformSupportsUnixDomainSockets))]
         public async Task Socket_ConnectAsyncUnixDomainSocketEndPoint_Success()
         {
@@ -100,7 +99,7 @@ namespace System.Net.Sockets.Tests
                     }
 
                     Assert.Equal(
-                        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? SocketError.InvalidArgument : SocketError.AddressNotAvailable,
+                        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? SocketError.ConnectionRefused : SocketError.AddressNotAvailable,
                         args.SocketError);
                 }
             }


### PR DESCRIPTION
These are the changes from https://github.com/dotnet/runtime/pull/787 that deal with making `ConnectAsync(SocketAsyncEventArgs)` work for non-stream protocols (like UDP) on Windows.

cc @stephentoub @antonfirsov @dotnet/ncl