### PR TITLE
Reverse P/Invoke methods do not support tailcalls.

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4329,6 +4329,12 @@ bool Compiler::fgMayExplicitTailCall()
         return false;
     }
 
+    if (opts.IsReversePInvoke())
+    {
+        // Reverse P/Invoke
+        return false;
+    }
+
 #if !FEATURE_FIXED_OUT_ARGS
     if (info.compIsVarArgs)
     {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -5040,7 +5040,7 @@ bool Compiler::verCheckTailCallConstraint(
 
     assert(impOpcodeIsCallOpcode(opcode));
 
-    if (compIsForInlining())
+    if (compIsForInlining() || opts.IsReversePInvoke())
     {
         return false;
     }

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -5040,7 +5040,7 @@ bool Compiler::verCheckTailCallConstraint(
 
     assert(impOpcodeIsCallOpcode(opcode));
 
-    if (compIsForInlining() || opts.IsReversePInvoke())
+    if (compIsForInlining())
     {
         return false;
     }
@@ -7344,10 +7344,17 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     // Also, popping arguments in a varargs function is more work and NYI
     // If we have a security object, we have to keep our frame around for callers
     // to see any imperative security.
+    // Reverse P/Invokes need a call to CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT
+    // at the end, so tailcalls should be disabled.
     if (info.compFlags & CORINFO_FLG_SYNCH)
     {
         canTailCall             = false;
         szCanTailCallFailReason = "Caller is synchronized";
+    }
+    else if (opts.IsReversePInvoke())
+    {
+        canTailCall             = false;
+        szCanTailCallFailReason = "Caller is Reverse P/Invoke";
     }
 #if !FEATURE_FIXED_OUT_ARGS
     else if (info.compIsVarArgs)
@@ -11477,6 +11484,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     /* CEE_JMP does not make sense in some "protected" regions. */
 
                     BADCODE("Jmp not allowed in protected region");
+                }
+
+                if (opts.IsReversePInvoke())
+                {
+                    BADCODE("Jmp not allowed in reverse P/Invoke");
                 }
 
                 if (verCurrentState.esStackDepth != 0)

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1809,6 +1809,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
     // Most of these checks are already done by importer or fgMorphTailCall().
     // This serves as a double sanity check.
     assert((comp->info.compFlags & CORINFO_FLG_SYNCH) == 0); // tail calls from synchronized methods
+    assert(!comp->opts.IsReversePInvoke());                  // tail calls reverse pinvoke
     assert(!call->IsUnmanaged());                            // tail calls to unamanaged methods
     assert(!comp->compLocallocUsed);                         // tail call from methods that also do localloc
 

--- a/src/coreclr/src/jit/patchpoint.cpp
+++ b/src/coreclr/src/jit/patchpoint.cpp
@@ -231,6 +231,12 @@ void Compiler::fgTransformPatchpoints()
         return;
     }
 
+    if (opts.IsReversePInvoke())
+    {
+        JITDUMP(" -- unable to handle Reverse P/Invoke\n");
+        return;
+    }
+
     PatchpointTransformer ppTransformer(this);
     int                   count = ppTransformer.Run();
     JITDUMP("\n*************** After fgTransformPatchpoints() [%d patchpoints transformed]\n", count);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33663

The change here was the most obvious way to address the associated issue. I am open to other more general ways though. It also doesn't look like this will generally block the tailcall prefix, which is what I was hoping for. I was thinking that if the JIT is compiling Reverse P/Invoke and discovered the prefix then it should throw something, but I am unsure if that is correct so I opted for the minimal.

/cc @dotnet/jit-contrib 