### PR TITLE
Fix unexpected exception when enumerating a completely empty drive root

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
         internal const uint STATUS_SOME_NOT_MAPPED        = 0x00000107;
         internal const uint STATUS_NO_MORE_FILES          = 0x80000006;
         internal const uint STATUS_INVALID_PARAMETER      = 0xC000000D;
-        internal const uint STATUS_FILE_NOT_FOUND         = 0xC000000F‬;
+        internal const uint STATUS_FILE_NOT_FOUND         = 0xC000000F;
         internal const uint STATUS_NO_MEMORY              = 0xC0000017;
         internal const uint STATUS_ACCESS_DENIED          = 0xC0000022;
         internal const uint STATUS_OBJECT_NAME_NOT_FOUND  = 0xC0000034;

--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,15 +7,16 @@ internal static partial class Interop
     internal class StatusOptions
     {
         // Error codes from ntstatus.h
-        internal const uint STATUS_SUCCESS = 0x00000000;
-        internal const uint STATUS_SOME_NOT_MAPPED = 0x00000107;
-        internal const uint STATUS_NO_MORE_FILES = 0x80000006;
-        internal const uint STATUS_INVALID_PARAMETER = 0xC000000D;
-        internal const uint STATUS_NO_MEMORY = 0xC0000017;
-        internal const uint STATUS_OBJECT_NAME_NOT_FOUND = 0xC0000034;
-        internal const uint STATUS_NONE_MAPPED = 0xC0000073;
+        internal const uint STATUS_SUCCESS                = 0x00000000;
+        internal const uint STATUS_SOME_NOT_MAPPED        = 0x00000107;
+        internal const uint STATUS_NO_MORE_FILES          = 0x80000006;
+        internal const uint STATUS_INVALID_PARAMETER      = 0xC000000D;
+        internal const uint STATUS_FILE_NOT_FOUND         = 0xC000000F‬;
+        internal const uint STATUS_NO_MEMORY              = 0xC0000017;
+        internal const uint STATUS_ACCESS_DENIED          = 0xC0000022;
+        internal const uint STATUS_OBJECT_NAME_NOT_FOUND  = 0xC0000034;
+        internal const uint STATUS_ACCOUNT_RESTRICTION    = 0xC000006E;
+        internal const uint STATUS_NONE_MAPPED            = 0xC0000073;
         internal const uint STATUS_INSUFFICIENT_RESOURCES = 0xC000009A;
-        internal const uint STATUS_ACCESS_DENIED = 0xC0000022;
-        internal const uint STATUS_ACCOUNT_RESTRICTION = 0xc000006e;
     }
 }

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
@@ -45,8 +45,12 @@ namespace System.IO.Enumeration
                 default:
                     int error = (int)Interop.NtDll.RtlNtStatusToDosError(status);
 
+                    // ERROR_FILE_NOT_FOUND or ERROR_NO_MORE_FILES can be reached when enumerating directories in a completely empty drive root (and there isn't even a System Volume Information folder).
                     // Note that there are many NT status codes that convert to ERROR_ACCESS_DENIED.
-                    if ((error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible) || ContinueOnError(error))
+                    if (error == Interop.Errors.ERROR_FILE_NOT_FOUND ||
+                        error == Interop.Errors.ERROR_NO_MORE_FILES ||
+                        (error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible) ||
+                        ContinueOnError(error))
                     {
                         DirectoryFinished();
                         return false;

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
@@ -42,15 +42,15 @@ namespace System.IO.Enumeration
                 case Interop.StatusOptions.STATUS_SUCCESS:
                     Debug.Assert(statusBlock.Information.ToInt64() != 0);
                     return true;
+                // FILE_NOT_FOUND can occur when there are NO files in a volume root (usually there are hidden system files).
+                case Interop.StatusOptions.STATUS_FILE_NOT_FOUND:
+                    DirectoryFinished();
+                    return false;
                 default:
                     int error = (int)Interop.NtDll.RtlNtStatusToDosError(status);
 
-                    // ERROR_FILE_NOT_FOUND or ERROR_NO_MORE_FILES can be reached when enumerating directories in a completely empty drive root (and there isn't even a System Volume Information folder).
                     // Note that there are many NT status codes that convert to ERROR_ACCESS_DENIED.
-                    if (error == Interop.Errors.ERROR_FILE_NOT_FOUND ||
-                        error == Interop.Errors.ERROR_NO_MORE_FILES ||
-                        (error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible) ||
-                        ContinueOnError(error))
+                    if ((error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible) || ContinueOnError(error))
                     {
                         DirectoryFinished();
                         return false;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/33475

This is a regression from .NET Framework, where we were properly handling the edge case where we called `GetDirectories()` on a drive root that didn't even have the System Volume Information folder:
https://referencesource.microsoft.com/#mscorlib/system/io/filesystemenumerable.cs,280

I am not sure we can have a unit test for this case: we would require to have access to an empty drive, acquire ownership of the "System Volume Information" folder, delete it, then ensure we can call `GetDirectories()` without throwing. The SVI directory could get unexpectedly regenerated by Windows between its deletion and the test of `GetDirectories()`.

I tested this locally and the exception is gone. I made sure the SVI folder was not generated by Windows after running my test.