### PR TITLE
Try UsePythonVersion to work around py2 removal

### DIFF
--- a/eng/pipelines/coreclr/templates/format-job.yml
+++ b/eng/pipelines/coreclr/templates/format-job.yml
@@ -26,7 +26,11 @@ jobs:
     name: ${{ format('format_{0}{1}_{2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}
     displayName: ${{ format('Formatting {0}{1} {2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}
     helixType: 'format'
-    pool: ${{ parameters.pool }}
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      pool: 
+        vmImage: 'windows-2019'
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      pool: ${{ parameters.pool }}
     variables: ${{ parameters.variables }}
     condition: ${{ parameters.condition }}
     steps:
@@ -38,6 +42,12 @@ jobs:
         version: '3.x'
         includePreviewVersions: true
         installationPath: $(Agent.ToolsDirectory)/dotnet
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.x' 
+        addToPath: true 
+        architecture: 'x64'
+      condition: ${{ eq(parameters.osGroup, 'Windows_NT') }}
     - task: PythonScript@0
       displayName: Run tests/scripts/format.py
       inputs:

--- a/eng/pipelines/coreclr/templates/format-job.yml
+++ b/eng/pipelines/coreclr/templates/format-job.yml
@@ -26,10 +26,10 @@ jobs:
     name: ${{ format('format_{0}{1}_{2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}
     displayName: ${{ format('Formatting {0}{1} {2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}
     helixType: 'format'
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+    ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       pool: 
         vmImage: 'windows-2019'
-    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+    ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       pool: ${{ parameters.pool }}
     variables: ${{ parameters.variables }}
     condition: ${{ parameters.condition }}


### PR DESCRIPTION
Fixes: #33693 

As @safern noted, runtime uses python scripts that assume python is on the path.  With python2's removal from our machines (EOL), there is no longer a python on the machine's path.