### PR TITLE
Only add the llvm elf headers on Windows for dbgutil

### DIFF
--- a/src/coreclr/src/debug/dbgutil/CMakeLists.txt
+++ b/src/coreclr/src/debug/dbgutil/CMakeLists.txt
@@ -1,11 +1,10 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 if(CLR_CMAKE_HOST_WIN32)
+  include_directories(${CLR_DIR}/src/inc/llvm)
   #use static crt
   add_definitions(-MT)
 endif(CLR_CMAKE_HOST_WIN32)
-
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-include_directories(${CLR_DIR}/src/inc/llvm)
 
 add_definitions(-DPAL_STDCPP_COMPAT)
 


### PR DESCRIPTION
@safern reported a build issue where the ELF magic got defined twice during docker and OSX builds. I was unable to reproduce this locally with the same image he used and CI/PRs don't hit this case either.
```
/home/runtime/src/coreclr/src/debug/dbgutil/elfreader.cpp:41:19: error: redefinition of 'ElfMagic'
static const char ElfMagic[] = { 0x7f, 'E', 'L', 'F', '\0' };
                  ^
/home/runtime/src/coreclr/src/inc/llvm/elf.h:78:19: note: previous definition is here
static const char ElfMagic[] = { 0x7f, 'E', 'L', 'F', '\0' };
                  ^
1 error generated.
```
This is weird as the file in `/home/runtime/src/coreclr/src/inc/llvm/` is `ELF.h`. The includes are not being done in a case sensitive manner. The easy fix suggested by Mike is that dbgutil really only needs the elf header on Windows builds to have elf definitions, only include it there. I still don't know understand how this came to work like this only on some systems nonetheless - confusing the system header with the local upper cased one. 

