### PR TITLE
Fix running tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -9,7 +9,7 @@
   },
   "native-tools": {
     "cmake": "3.14.2",
-    "python": "2.7.15"
+    "python3": "3.7.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20167.1",

--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -177,7 +177,7 @@ if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
+set NEXTCMD=python3 "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
 echo !NEXTCMD!
 !NEXTCMD!
 

--- a/src/coreclr/tests/runtest.py
+++ b/src/coreclr/tests/runtest.py
@@ -1250,7 +1250,7 @@ if sys.version_info.major < 3:
         return unicode(s, "utf-8")
 else:
     def to_unicode(s):
-        return str(s, "utf-8")
+        return s
 
 def find_test_from_name(host_os, test_location, test_name):
     """ Given a test's name return the location on disk


### PR DESCRIPTION
without that code I have stack trace on Python 3.7.1
when run tests\runtest.cmd /coreclr Top200
```
Traceback (most recent call last):
  File "runtest.py", line 2450, in <module>
    sys.exit(main(args))
  File "runtest.py", line 2423, in main
    lambda path: do_setup(host_os,
  File "runtest.py", line 550, in create_and_use_test_env
    ret_code = func(None)
  File "runtest.py", line 2433, in <lambda>
    test_filter_path))
  File "runtest.py", line 2356, in do_setup
    build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location, None, test_filter_path)
  File "runtest.py", line 1871, in build_test_wrappers
    delete_existing_wrappers(to_unicode(test_location))
  File "runtest.py", line 1822, in to_unicode
    return str(s, "utf-8")
TypeError: decoding str is not supported
```

* Simplify string conversion and update Python
* Fix path to Python3 executable

It was discovered during testing CoreRT in
https://github.com/dotnet/corert/pull/8021