### PR TITLE
Ignore register unwinder callback for empty patch_info data table on Windows Mono Runtime.

### DIFF
--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -1407,7 +1407,7 @@ mono_arch_unwindinfo_insert_range_in_table (const gpointer code_block, gsize blo
 	AcquireSRWLockExclusive (&g_dynamic_function_table_lock);
 	init_table_no_lock ();
 	new_entry = find_range_in_table_no_lock (code_block, block_size);
-	if (new_entry == NULL) {
+	if (new_entry == NULL && block_size != 0) {
 		// Allocate new entry.
 		new_entry = g_new0 (DynamicFunctionTableEntry, 1);
 		if (new_entry != NULL) {


### PR DESCRIPTION
Running System.Runtime.Serialization.Xml test suite triggers calls to mono_code_manager_reserve with 0 size code block. On Windows, allocating code regions from code manager will also add callback for code region into unwinder function table, but since region could be 0 length, it will be causing a crash in RtlInstallFunctionTableCallback OS call.

Fix hardens code to not try to register callbacks for code regions of size 0, since that is considered a critical error by Windows OS API.