### PR TITLE
Add support for previously missing helper Check_FieldOffset

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -40,6 +40,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_fieldDesc);
                 SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
 
+                if (_fixupKind == ReadyToRunFixupKind.Check_FieldOffset)
+                {
+                    dataBuilder.EmitInt(_fieldDesc.Offset.AsInt);
+                }
+
                 dataBuilder.EmitFieldSignature(_fieldDesc, innerContext);
             }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -80,6 +80,14 @@ namespace ILCompiler.DependencyAnalysis
                 );
             });
 
+            _checkFieldOffsetCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
+            {
+                return new PrecodeHelperImport(
+                    _codegenNodeFactory,
+                    new FieldFixupSignature(ReadyToRunFixupKind.Check_FieldOffset, key)
+                );
+            });
+
             _interfaceDispatchCells = new NodeCache<MethodAndCallSite, ISymbolNode>(cellKey =>
             {
                 return new DelayLoadHelperMethodImport(
@@ -374,6 +382,13 @@ namespace ILCompiler.DependencyAnalysis
         public ISymbolNode FieldOffset(FieldDesc fieldDesc)
         {
             return _fieldOffsetCache.GetOrAdd(fieldDesc);
+        }
+
+        private NodeCache<FieldDesc, ISymbolNode> _checkFieldOffsetCache;
+
+        public ISymbolNode CheckFieldOffset(FieldDesc fieldDesc)
+        {
+            return _checkFieldOffsetCache.GetOrAdd(fieldDesc);
         }
 
         private NodeCache<TypeDesc, ISymbolNode> _fieldBaseOffsetCache;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2126,7 +2126,10 @@ namespace Internal.JitInterface
             {
                 if (pMT.IsValueType)
                 {
-                    throw new NotImplementedException("https://github.com/dotnet/runtime/issues/32630: ENCODE_CHECK_FIELD_OFFSET: root field check import");
+                    // ENCODE_CHECK_FIELD_OFFSET
+                    pResult->offset = 0;
+                    pResult->fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE_WITH_BASE;
+                    pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
                 }
                 else
                 {


### PR DESCRIPTION
This failure crashes Crossgen2 build of several framework assemblies
without the large version bubble. I discovered this during my work
on composite build against shared framework where we newly introduce
the notion of two separate large bubbles (app vs. framework).

Thanks

Tomas