### PR TITLE
Use canonical method in TransitionFrames whenever we parse signatures

### DIFF
--- a/src/coreclr/src/vm/gcenv.os.cpp
+++ b/src/coreclr/src/vm/gcenv.os.cpp
@@ -47,8 +47,8 @@ public:
     GroupProcNo(uint16_t group, uint16_t procIndex) : m_groupProc((group << 6) | procIndex)
     {
         // Making this the same as the # of NUMA node we support.
-        assert(group < 0x40);
-        assert(procIndex <= 0x3f);
+        _ASSERTE(group < 0x40);
+        _ASSERTE(procIndex <= 0x3f);
     }
 
     uint16_t GetGroup() { return m_groupProc >> 6; }
@@ -120,7 +120,7 @@ bool GCToOSInterface::Initialize()
     uint32_t currentProcessCpuCount = PAL_GetLogicalCpuCountFromOS();
     if (PAL_GetCurrentThreadAffinitySet(AffinitySet::BitsetDataSize, g_processAffinitySet.GetBitsetData()))
     {
-        assert(currentProcessCpuCount == g_processAffinitySet.Count());
+        _ASSERTE(currentProcessCpuCount == g_processAffinitySet.Count());
     }
     else
     {
@@ -1322,7 +1322,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        assert(m_event.IsValid());
+        _ASSERTE(m_event.IsValid());
         m_event.CloseEvent();
     }
 
@@ -1330,7 +1330,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        assert(m_event.IsValid());
+        _ASSERTE(m_event.IsValid());
         m_event.Set();
     }
 
@@ -1338,7 +1338,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        assert(m_event.IsValid());
+        _ASSERTE(m_event.IsValid());
         m_event.Reset();
     }
 
@@ -1346,7 +1346,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        assert(m_event.IsValid());
+        _ASSERTE(m_event.IsValid());
         return m_event.Wait(timeout, alertable);
     }
 
@@ -1400,7 +1400,7 @@ void GCEvent::CloseEvent()
 {
     WRAPPER_NO_CONTRACT;
 
-    assert(m_impl != nullptr);
+    _ASSERTE(m_impl != nullptr);
     m_impl->CloseEvent();
 }
 
@@ -1408,7 +1408,7 @@ void GCEvent::Set()
 {
     WRAPPER_NO_CONTRACT;
 
-    assert(m_impl != nullptr);
+    _ASSERTE(m_impl != nullptr);
     m_impl->Set();
 }
 
@@ -1416,7 +1416,7 @@ void GCEvent::Reset()
 {
     WRAPPER_NO_CONTRACT;
 
-    assert(m_impl != nullptr);
+    _ASSERTE(m_impl != nullptr);
     m_impl->Reset();
 }
 
@@ -1424,7 +1424,7 @@ uint32_t GCEvent::Wait(uint32_t timeout, bool alertable)
 {
     WRAPPER_NO_CONTRACT;
 
-    assert(m_impl != nullptr);
+    _ASSERTE(m_impl != nullptr);
     return m_impl->Wait(timeout, alertable);
 }
 
@@ -1435,7 +1435,7 @@ bool GCEvent::CreateManualEventNoThrow(bool initialState)
       GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    assert(m_impl == nullptr);
+    _ASSERTE(m_impl == nullptr);
     NewHolder<GCEvent::Impl> event = new (nothrow) GCEvent::Impl();
     if (!event)
     {
@@ -1454,7 +1454,7 @@ bool GCEvent::CreateAutoEventNoThrow(bool initialState)
       GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    assert(m_impl == nullptr);
+    _ASSERTE(m_impl == nullptr);
     NewHolder<GCEvent::Impl> event = new (nothrow) GCEvent::Impl();
     if (!event)
     {
@@ -1473,7 +1473,7 @@ bool GCEvent::CreateOSAutoEventNoThrow(bool initialState)
       GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    assert(m_impl == nullptr);
+    _ASSERTE(m_impl == nullptr);
     NewHolder<GCEvent::Impl> event = new (nothrow) GCEvent::Impl();
     if (!event)
     {
@@ -1492,7 +1492,7 @@ bool GCEvent::CreateOSManualEventNoThrow(bool initialState)
       GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    assert(m_impl == nullptr);
+    _ASSERTE(m_impl == nullptr);
     NewHolder<GCEvent::Impl> event = new (nothrow) GCEvent::Impl();
     if (!event)
     {

--- a/src/coreclr/src/vm/siginfo.cpp
+++ b/src/coreclr/src/vm/siginfo.cpp
@@ -1356,7 +1356,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                             if (tmpEType == ELEMENT_TYPE_CLASS)
                                 typeHnd = TypeHandle(g_pCanonMethodTableClass);
                         }
-                        else if ((elemType == (CorElementType) ELEMENT_TYPE_CANON_ZAPSIG) ||
+                        else if ((elemType == (CorElementType)ELEMENT_TYPE_CANON_ZAPSIG) ||
                                  (CorTypeInfo::GetGCType_NoThrow(elemType) == TYPE_GC_REF))
                         {
                             typeHnd = TypeHandle(g_pCanonMethodTableClass);
@@ -1388,6 +1388,11 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                         // Indicate failure by setting thisinst to NULL
                         thisinst = NULL;
                         break;
+                    }
+
+                    if (dropGenericArgumentLevel && level == CLASS_LOAD_APPROXPARENTS)
+                    {
+                        typeHnd = ClassLoader::CanonicalizeGenericArg(typeHnd);
                     }
                 }
                 thisinst[i] = typeHnd;

--- a/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.cs
+++ b/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+public struct MyStruct<TRequest, TResponse>
+{
+    int _id;
+    public MyStruct(int id) { _id = id; }
+    public override string ToString() => this.GetType().ToString() + " = " + _id;
+}
+
+public struct GenStruct<T> { }
+
+public sealed class MyStructWrapper<TRequest, TResponse>
+{
+    public MyStruct<TRequest, TResponse> _field;
+
+    public MyStructWrapper(MyStruct<TRequest, TResponse> value)
+    {
+        _field = value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public override string ToString() => _field.ToString();
+}
+
+public abstract class BaseStructCreator
+{
+    public abstract MyStructWrapper<TRequest, TResponse> GetMyStructWrapper<TRequest, TResponse>() where TRequest : class;
+}
+
+public class StructCreator : BaseStructCreator
+{
+    public override MyStructWrapper<TRequest, TResponse> GetMyStructWrapper<TRequest, TResponse>()
+    {
+        return new MyStructWrapper<TRequest, TResponse>(CreateCall<TRequest, TResponse>());
+    }
+    protected virtual MyStruct<TRequest, TResponse> CreateCall<TRequest, TResponse>() where TRequest : class
+    {
+        return new MyStruct<TRequest, TResponse>(123);
+    }
+}
+
+class DerivedCreator : StructCreator
+{
+    protected override MyStruct<TRequest, TResponse> CreateCall<TRequest, TResponse>()
+    {
+        return new MyStruct<TRequest, TResponse>(456);
+    }
+}
+
+public class Test
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static string RunTest()
+    {
+        var creator = new DerivedCreator();
+        var wrapper = creator.GetMyStructWrapper<Exception, GenStruct<string>>();
+        return wrapper.ToString();
+    }
+    public static int Main()
+    {
+        Console.WriteLine("Expected: MyStruct`2[System.Exception,GenStruct`1[System.String]] = 456");
+
+        string result = RunTest();
+        Console.WriteLine("Actual  : " + result);
+        
+        string expected = "MyStruct`2[System.Exception,GenStruct`1[System.String]] = 456";
+        return result == expected ? 100 : -1;
+    }
+}

--- a/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
+++ b/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
@@ -10,13 +10,11 @@
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-set COMPlus_gcServer=1
-set COMPlus_gcStress=7
+set COMPlus_GCStress=f
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-export COMPlus_gcServer=1
-export COMPlus_gcStress=7
+export COMPlus_GCStress=f
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 

--- a/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
+++ b/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
@@ -6,16 +6,4 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
-  
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_GCStress=f
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GCStress=f
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
-
 </Project>

--- a/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
+++ b/src/coreclr/tests/src/GC/Regressions/Github/runtime_32848/runtime_32848.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_gcServer=1
+set COMPlus_gcStress=7
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_gcServer=1
+export COMPlus_gcStress=7
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
I've been investigating the crash dump from #32848, and the main issue is that the GC is calling into the TypeLoader to construct new types. This should never be allowed, and what made it worse in that crash dump is the fact that server GC was being used, so the call to `GetThread()` was returning NULL, causing an AV during type construction.

The AV needs the following conditions to repro:

1. The use of server GC. I also believe it should be possible to use regular GC, and craft a repro test that would hit an assert in the type loader, but may not necessarily AV.
2. Some luck with inlining heuristics
3. Virtual calls into generic methods (or static methods on generic types)
4. The generic method must be using reference types as instantiation arguments (i.e. have a valid canonical method)
5. For that generic method to be executing its PreStub for the first time.
5. And finally, for GC to trigger on another thread, and enumerate that method that is currently executing its Prestub.

cc @dotnet/crossgen-contrib 
