### PR TITLE
Fix src/libraries to build on clang 10

### DIFF
--- a/src/coreclr/src/inc/slist.h
+++ b/src/coreclr/src/inc/slist.h
@@ -274,7 +274,7 @@ public:
         SLink   *ret = SLink::FindAndRemove(m_pHead, GetLink(pObj), &prior);
 
         if (ret == m_pTail)
-            m_pTail = prior;
+            m_pTail = PTR_SLink(prior);
 
         return GetObject(ret);
     }

--- a/src/libraries/Native/Unix/System.Native/pal_time.c
+++ b/src/libraries/Native/Unix/System.Native/pal_time.c
@@ -117,7 +117,7 @@ int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
     uint64_t resolution = SystemNative_GetTimestampResolution();
     uint64_t timestamp = SystemNative_GetTimestamp();
 
-    uint64_t currentTime = (uint64_t)(timestamp * ((double)SecondsToNanoSeconds / resolution));
+    uint64_t currentTime = (uint64_t)((double)timestamp * ((double)SecondsToNanoSeconds / (double)resolution));
 
     uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;


### PR DESCRIPTION
Clang 10 adds/enables new warnings, some of which is affecting thesrc/libraries code.

Clang 10 has added `-Walloca` to warn about uses of `alloca`. This commit replaces the only non-compliant use of that with a single fixed stack-allocated buffer.

Clang 10 has also added `-Wimplicit-int-float-conversion`. This commit uses explicit casts to double to avoid the warnings.

Fixes #33681

Also contains a small fix for slist.h that was somehow missed in #33096.

After this commit, I can build all of runtime with Clang 10.