### PR TITLE
Update SDK in global.json to 5.0.100-preview.3.20168.11

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.2.20157.1"
+    "dotnet": "5.0.100-preview.3.20168.11"
   },
   "native-tools": {
     "cmake": "3.14.2",

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -578,7 +578,7 @@
 
   <Target Name="ValidateLocalDotnet">
     <Error Condition="$([System.IO.Directory]::GetDirectories('$(LocalDotnetDir)\shared\Microsoft.NETCore.App').Length) > 1" Text="$(LocalDotnetDir) contains more than one SDK, please delete unused ones." />
-    <Error Condition="$([System.IO.Directory]::GetDirectories('$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App').Length) > 1" Text="$(LocalMonoDotnetDir) contains more than one SDK, please delete unused ones." />
+    <Error Condition="Exists('$(LocalMonoDotnetDir)') AND $([System.IO.Directory]::GetDirectories('$(LocalMonoDotnetDir)\shared\Microsoft.NETCore.App').Length) > 1" Text="$(LocalMonoDotnetDir) contains more than one SDK, please delete unused ones." />
     <Error Condition="!Exists('$(LocalDotnet)')" Text="'$(LocalDotnet)' doesn't exist." />
   </Target>
 


### PR DESCRIPTION
We use `.dotnet` for local experiments  and master now expects all the native libs to be prefixed with `lib` (e.g. `libSystem.Native.dylib`) see https://github.com/dotnet/runtime/pull/33236. This `5.0.100-preview.3.20168.11` SDK contains that PR.

Also, fix a minor issue in `mono.proj`.

cc @ViktorHofer @akoeplinger 
