### PR TITLE
Remove bad calls to ReferenceEquals

### DIFF
--- a/src/libraries/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementScope.cs
@@ -1178,11 +1178,8 @@ namespace System.Management
         }
         internal int GetObject_(string strObjectPath, int lFlags, IWbemContext pCtx, ref IWbemClassObjectFreeThreaded ppObject, IntPtr ppCallResult)
         {
-            //It is assumed that caller always passes ppCallResult as IntPtr.Zero.
-            //If it changes let this call go through wminet_utils.dll. Check implementation of CreateInstanceEnum_ for more information.
             int status = (int)tag_WBEMSTATUS.WBEM_E_FAILED;
-            if (!object.ReferenceEquals(ppCallResult, IntPtr.Zero))
-                status = pWbemServiecsSecurityHelper.GetObject_(strObjectPath, lFlags, pCtx, out ppObject, ppCallResult);
+            status = pWbemServiecsSecurityHelper.GetObject_(strObjectPath, lFlags, pCtx, out ppObject, ppCallResult);
             return status;
         }
 
@@ -1220,11 +1217,8 @@ namespace System.Management
         }
         internal int DeleteClass_(string strClass, int lFlags, IWbemContext pCtx, IntPtr ppCallResult)
         {
-            //It is assumed that caller always passes ppCallResult as IntPtr.Zero.
-            //If it changes let this call go through wminet_utils.dll. Check implementation of CreateInstanceEnum_ for more information.
             int status = (int)tag_WBEMSTATUS.WBEM_E_FAILED;
-            if (!object.ReferenceEquals(ppCallResult, IntPtr.Zero))
-                status = pWbemServiecsSecurityHelper.DeleteClass_(strClass, lFlags, pCtx, ppCallResult);
+            status = pWbemServiecsSecurityHelper.DeleteClass_(strClass, lFlags, pCtx, ppCallResult);
             return status;
         }
         internal int DeleteClassAsync_(string strClass, int lFlags, IWbemContext pCtx, IWbemObjectSink pResponseHandler)
@@ -1287,11 +1281,8 @@ namespace System.Management
         }
         internal int DeleteInstance_(string strObjectPath, int lFlags, IWbemContext pCtx, IntPtr ppCallResult)
         {
-            //It is assumed that caller always passes ppCallResult as IntPtr.Zero.
-            //If it changes let this call go through wminet_utils.dll. Check implementation of CreateInstanceEnum_ for more information.
             int status = (int)tag_WBEMSTATUS.WBEM_E_FAILED;
-            if (!object.ReferenceEquals(ppCallResult, IntPtr.Zero))
-                status = pWbemServiecsSecurityHelper.DeleteInstance_(strObjectPath, lFlags, pCtx, ppCallResult);
+            status = pWbemServiecsSecurityHelper.DeleteInstance_(strObjectPath, lFlags, pCtx, ppCallResult);
             return status;
         }
         internal int DeleteInstanceAsync_(string strObjectPath, int lFlags, IWbemContext pCtx, IWbemObjectSink pResponseHandler)
@@ -1383,11 +1374,8 @@ namespace System.Management
         }
         internal int ExecMethod_(string strObjectPath, string strMethodName, int lFlags, IWbemContext pCtx, IWbemClassObjectFreeThreaded pInParams, ref IWbemClassObjectFreeThreaded ppOutParams, IntPtr ppCallResult)
         {
-            //It is assumed that caller always passes ppCallResult as IntPtr.Zero.
-            //If it changes let this call go through wminet_utils.dll. Check implementation of CreateInstanceEnum_ for more information.
             int status = (int)tag_WBEMSTATUS.WBEM_E_FAILED;
-            if (!object.ReferenceEquals(ppCallResult, IntPtr.Zero))
-                status = pWbemServiecsSecurityHelper.ExecMethod_(strObjectPath, strMethodName, lFlags, pCtx, pInParams, out ppOutParams, ppCallResult);
+            status = pWbemServiecsSecurityHelper.ExecMethod_(strObjectPath, strMethodName, lFlags, pCtx, pInParams, out ppOutParams, ppCallResult);
             return status;
         }
         internal int ExecMethodAsync_(string strObjectPath, string strMethodName, int lFlags, IWbemContext pCtx, IWbemClassObjectFreeThreaded pInParams, IWbemObjectSink pResponseHandler)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonDataContract.cs
@@ -270,32 +270,29 @@ namespace System.Runtime.Serialization.Json
                 {
                     foreach (KeyValuePair<XmlQualifiedName, DataContract> knownDataContract in _traditionalDataContract.KnownDataContracts)
                     {
-                        if (!object.ReferenceEquals(knownDataContract, null))
+                        CollectionDataContract collectionDataContract = knownDataContract.Value as CollectionDataContract;
+                        while (collectionDataContract != null)
                         {
-                            CollectionDataContract collectionDataContract = knownDataContract.Value as CollectionDataContract;
-                            while (collectionDataContract != null)
+                            DataContract itemContract = collectionDataContract.ItemContract;
+                            if (_knownDataContracts == null)
                             {
-                                DataContract itemContract = collectionDataContract.ItemContract;
-                                if (_knownDataContracts == null)
-                                {
-                                    _knownDataContracts = new Dictionary<XmlQualifiedName, DataContract>();
-                                }
-
-                                _knownDataContracts.TryAdd(itemContract.StableName, itemContract);
-
-                                if (collectionDataContract.ItemType.IsGenericType
-                                    && collectionDataContract.ItemType.GetGenericTypeDefinition() == typeof(KeyValue<,>))
-                                {
-                                    DataContract itemDataContract = DataContract.GetDataContract(Globals.TypeOfKeyValuePair.MakeGenericType(collectionDataContract.ItemType.GenericTypeArguments));
-                                    _knownDataContracts.TryAdd(itemDataContract.StableName, itemDataContract);
-                                }
-
-                                if (!(itemContract is CollectionDataContract))
-                                {
-                                    break;
-                                }
-                                collectionDataContract = itemContract as CollectionDataContract;
+                                _knownDataContracts = new Dictionary<XmlQualifiedName, DataContract>();
                             }
+
+                            _knownDataContracts.TryAdd(itemContract.StableName, itemContract);
+
+                            if (collectionDataContract.ItemType.IsGenericType
+                                && collectionDataContract.ItemType.GetGenericTypeDefinition() == typeof(KeyValue<,>))
+                            {
+                                DataContract itemDataContract = DataContract.GetDataContract(Globals.TypeOfKeyValuePair.MakeGenericType(collectionDataContract.ItemType.GenericTypeArguments));
+                                _knownDataContracts.TryAdd(itemDataContract.StableName, itemDataContract);
+                            }
+
+                            if (!(itemContract is CollectionDataContract))
+                            {
+                                break;
+                            }
+                            collectionDataContract = itemContract as CollectionDataContract;
                         }
                     }
                 }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -650,13 +650,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
                         ParseString(pr, objectPr);
                         var = pr._value;
                     }
-                    else if (ReferenceEquals(pr._dtTypeCode, InternalPrimitiveTypeE.Invalid))
-                    {
-                        Debug.Assert(pr._dtType != null);
-                        CheckSerializable(pr._dtType);
-                        // Not nested and invalid, so it is an empty object
-                        var = FormatterServices.GetUninitializedObject(pr._dtType);
-                    }
                     else
                     {
                         var = pr._varValue != null ?


### PR DESCRIPTION
All of these calls to ReferenceEquals pass a value type, which gets boxed, and
ReferenceEquals returns false.
Further, all of the calls originated in .NET Framework, so the moderately
expensive way of saying "false" has been there for a while.

* Inline the expression to `false`
* Further inline and remove dead blocks or unnecessary ifs.
* Delete any comments explaining the code, since they're not relevant.