### PR TITLE
[mono] Make iOS sample simulator friendly

### DIFF
--- a/src/mono/netcore/sample/iOS/CMakeLists.txt
+++ b/src/mono/netcore/sample/iOS/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14.5)
 
 project(HelloiOS)
 
-# make sure "make all" is executed first
 file(GLOB DLLS *.dll)
 file(GLOB DLLS_AOT *.dll.o)
 
@@ -10,7 +9,6 @@ set(APP_RESOURCES
     ${DLLS}
 )
 
-# add the executable
 add_executable(
     HelloiOS
     main.m
@@ -18,6 +16,10 @@ add_executable(
     runtime.m
     ${APP_RESOURCES}
 )
+
+if (MONO_ARCH STREQUAL arm64)
+    add_definitions(-DDEVICE)
+endif()
 
 include_directories("../../../../../artifacts/bin/mono/iOS.${MONO_ARCH}.${MONO_CONFIG}/include/mono-2.0")
 

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -1,33 +1,35 @@
 MONO_CONFIG=Debug
+
+# change to x64 for simulator
+MONO_ARCH=arm64
 ARTIFACTS_BIN=../../../../../artifacts/bin/
-ARTIFACTS_BCL=$(ARTIFACTS_BIN)runtime/netcoreapp5.0-iOS-$(MONO_CONFIG)-arm64
-ARTIFACTS_MONO=$(ARTIFACTS_BIN)/mono/iOS.arm64.$(MONO_CONFIG)
+ARTIFACTS_BCL=$(ARTIFACTS_BIN)runtime/netcoreapp5.0-iOS-$(MONO_CONFIG)-$(MONO_ARCH)
+ARTIFACTS_MONO=$(ARTIFACTS_BIN)/mono/iOS.$(MONO_ARCH).$(MONO_CONFIG)
 
 DOTNET := $(shell cd ../../ && bash init-tools.sh | tail -1)
 SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-# once a new library is added here (e.g. System.Console.dll) it should also be 
-# added in mono_ios_register_modules() (runtime.m) and both lib.dll and lib.dll.o 
-# should be added to xcodeproj 
+# once a new library is added here it should also be 
+# added in mono_ios_register_modules() (runtime.m)
 all: prepare
-	make aot-lib LIB=$(ARTIFACTS_MONO)/System.Private.CoreLib.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Runtime.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Runtime.Extensions.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Collections.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Core.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Threading.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Threading.Tasks.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Linq.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Memory.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Runtime.InteropServices.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Text.Encoding.Extensions.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/Microsoft.Win32.Primitives.dll
-	make aot-lib LIB=$(ARTIFACTS_BCL)/System.Console.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_MONO)/System.Private.CoreLib.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Runtime.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Runtime.Extensions.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Collections.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Core.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Threading.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Threading.Tasks.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Linq.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Memory.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Runtime.InteropServices.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Text.Encoding.Extensions.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/Microsoft.Win32.Primitives.dll
+	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/System.Console.dll
 	make Program.dll.o
 
 # recompile Program.cs AOT
 Program.dll.o: bin/Program.dll Makefile
-	make aot-lib LIB=bin/Program.dll
+	make aot-lib-${MONO_ARCH} LIB=bin/Program.dll
 
 # we need to copy some BCL libs to ARTIFACTS_MONO
 # to be able to aot other bcl libs
@@ -45,7 +47,11 @@ prepare:
 bin/Program.dll: Program.cs
 	$(DOTNET) build -c Debug Program.csproj
 
-aot-lib:
+# we'll use regular jit for simulator
+aot-lib-x64:
+	cp $(LIB) $(notdir $(LIB))
+
+aot-lib-arm64:
 	DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 MONO_PATH=$(ARTIFACTS_MONO) \
 	$(ARTIFACTS_MONO)/cross/./mono-aot-cross -O=gsharedvt,float32 --nollvm --debug \
 	--aot=mtriple=arm64-ios,static,asmonly,direct-icalls,no-direct-calls,dwarfdebug,full $(LIB) && \
@@ -56,10 +62,15 @@ aot-lib:
 xcode: all
 	cmake -S. -BXcode -GXcode \
 	-DCMAKE_SYSTEM_NAME=iOS \
-	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	"-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
 	-DCMAKE_OSX_DEPLOYMENT_TARGET=10.1 \
 	-DCMAKE_INSTALL_PREFIX=`pwd`/_install \
-	-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES \
+	-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO \
 	-DCMAKE_IOS_INSTALL_COMBINED=YES \
 	-DMONO_CONFIG=$(MONO_CONFIG) \
-	-DMONO_ARCH=arm64
+	-DMONO_ARCH=$(MONO_ARCH)
+
+clean:
+	rm -rf *.dll
+	rm -rf *.dll.o
+	rm -rf Xcode

--- a/src/mono/netcore/sample/iOS/Plist.in
+++ b/src/mono/netcore/sample/iOS/Plist.in
@@ -25,10 +25,6 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/src/mono/netcore/sample/iOS/runtime.m
+++ b/src/mono/netcore/sample/iOS/runtime.m
@@ -200,6 +200,7 @@ register_dllmap (void)
 
 void mono_jit_set_aot_mode (MonoAotMode mode);
 
+#if DEVICE
 extern void *mono_aot_module_Program_info;
 extern void *mono_aot_module_System_Private_CoreLib_info;
 extern void *mono_aot_module_System_Runtime_info;
@@ -239,6 +240,7 @@ void mono_ios_setup_execution_mode (void)
 {
     mono_jit_set_aot_mode (MONO_AOT_MODE_FULL);
 }
+#endif
 
 void
 mono_ios_runtime_init (void)
@@ -256,9 +258,11 @@ mono_ios_runtime_init (void)
 
     register_dllmap ();
 
+#if DEVICE
     // register modules
     mono_ios_register_modules ();
     mono_ios_setup_execution_mode ();
+#endif
     
     mono_debug_init (MONO_DEBUG_FORMAT_MONO);
     mono_install_assembly_preload_hook (assembly_preload_hook, NULL);
@@ -274,7 +278,11 @@ mono_ios_runtime_init (void)
         mono_jit_parse_options (1, options);
     }
     mono_jit_init_version ("dotnet.ios", "mobile");
+
+#if DEVICE
+    // device runtimes are configured to use lazy gc thread creation
     mono_gc_init_finalizer_thread ();
+#endif
 
     MonoAssembly *assembly = load_assembly (executable, NULL);
     assert (assembly);


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/33633 introduced a FullAOT sample for iOS arm64. This PR makes it simulator (x64) friendly.

Steps:
```
./build.sh -os iOS -arch x64

cd src/mono/netcore/sample/iOS

make xcode MONO_ARCH=x64
```