### PR TITLE
Fix HTTP SchSendAuxRecordTest

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/SchSendAuxRecordHttpTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/SchSendAuxRecordHttpTest.cs
@@ -19,9 +19,8 @@ namespace System.Net.Http.Functional.Tests
     {
         public SchSendAuxRecordHttpTest(ITestOutputHelper output) : base(output) { }
 
-        class CircularBuffer
+        private class CircularBuffer
         {
-
             public CircularBuffer(int size) => _buffer = new char[size];
 
             private char[] _buffer;


### PR DESCRIPTION
Explicitly wait for HTTP end fixed flaky test.

Before it failed locally approximately every 10 runs, now it has 11k successful runs.

fixes #24776