### PR TITLE
Fix clean and rebuild targets

### DIFF
--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -10,11 +10,6 @@
 
   <ItemGroup Condition="'$(HasMatchingContract)' == 'true'">
     <ResolvedMatchingContract Condition="Exists('$(ContractAssemblyPath)')" Include="$(ContractAssemblyPath)" />
-    <!-- If the contract doesn't exist in the default contract output path add a project reference to the contract project to resolve -->
-    <ProjectReference Condition="'@(ResolvedMatchingContract)' == ''" Include="$(ContractProject)">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <OutputItemType>ResolvedMatchingContract</OutputItemType>
-    </ProjectReference>
   </ItemGroup>
 
   <!-- intentionally empty since we no longer need a target -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33721

The failure here was that we were automatically adding ProjectReference if the src builds for  X tfm and we dont have corresponding ref.

And we were hitting the error because some of the src tfms dont have a comapatible configs in the ref csproj, rather they depend on restore to resolve those ref assemblies.

Clean target behavior:- it will run for all tfms of the source project