### PR TITLE
Close issues fixed by serializer refactoring

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -770,12 +770,16 @@ namespace System.Text.Json.Serialization.Tests
             public GenericIImmutableDictionaryWrapper<string, JsonElement> MyOverflow { get; set; }
         }
 
-        [Fact]
-        public static void DeserializeIntoGenericDictionaryParameterCount()
+        [Theory]
+        [InlineData(typeof(ClassWithExtensionPropertyNoGenericParameters))]
+        [InlineData(typeof(ClassWithExtensionPropertyOneGenericParameter))]
+        [InlineData(typeof(ClassWithExtensionPropertyThreeGenericParameters))]
+        public static void DeserializeIntoGenericDictionaryParameterCount(Type type)
         {
-            JsonSerializer.Deserialize<ClassWithExtensionPropertyNoGenericParameters>("{\"hello\":\"world\"}");
-            JsonSerializer.Deserialize<ClassWithExtensionPropertyOneGenericParameter>("{\"hello\":\"world\"}");
-            JsonSerializer.Deserialize<ClassWithExtensionPropertyThreeGenericParameters>("{\"hello\":\"world\"}");
+            object obj = JsonSerializer.Deserialize("{\"hello\":\"world\"}", type);
+
+            IDictionary<string, object> extData = (IDictionary<string, object>)type.GetProperty("MyOverflow").GetValue(obj)!;
+            Assert.Equal("world", ((JsonElement)extData["hello"]).GetString());
         }
 
         private class ClassWithExtensionPropertyNoGenericParameters

--- a/src/libraries/System.Text.Json/tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NullableTests.cs
@@ -394,5 +394,47 @@ namespace System.Text.Json.Serialization.Tests
                 return ((IDictionary<string, TValue>)dict).GetEnumerator();
             }
         }
+
+        [Fact]
+        public static void NullableCustomStructRoundtrip()
+        {
+            string serialized = JsonSerializer.Serialize(new ClassWithNullablePerson
+            {
+                Person = new Person
+                {
+                    FirstName = "John",
+                    Age = 24
+                }
+            });
+            Assert.Contains(@"{""Person"":{", serialized);
+            Assert.Contains(@"""FirstName"":""John""", serialized);
+            Assert.Contains(@"""Age"":24", serialized);
+            Assert.Contains(@"""Birthday"":null", serialized);
+            Assert.DoesNotContain(@"""Value"":{""", serialized);
+            Assert.DoesNotContain(@"""HasValue"":""", serialized);
+
+            var obj = JsonSerializer.Deserialize<ClassWithNullablePerson>(serialized);
+            Assert.Equal("John", obj.Person?.FirstName);
+            Assert.Equal(24, obj.Person?.Age);
+            Assert.Null(obj.Person?.Birthday);
+
+            serialized = JsonSerializer.Serialize(new ClassWithNullablePerson());
+            Assert.Equal(@"{""Person"":null}", serialized);
+
+            obj = JsonSerializer.Deserialize<ClassWithNullablePerson>(serialized);
+            Assert.Null(obj.Person);
+        }
+
+        public class ClassWithNullablePerson
+        {
+            public Person? Person { get; set; }
+        }
+
+        public struct Person
+        {
+            public string FirstName { get; set; }
+            public int? Age { get; set; }
+            public DateTime? Birthday { get; set; }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -1349,16 +1349,16 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class HashSetWithBackingClollection : ICollection<string>
+    public class HashSetWithBackingCollection : ICollection<string>
     {
         private readonly ICollection<string> _inner;
 
-        public HashSetWithBackingClollection()
+        public HashSetWithBackingCollection()
         {
             _inner = new HashSet<string>();
         }
 
-        public HashSetWithBackingClollection(IEnumerable<string> values)
+        public HashSetWithBackingCollection(IEnumerable<string> values)
         {
             _inner = new HashSet<string>(values);
         }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -1349,17 +1349,57 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class StringToGenericSortedDictionary<T> : SortedDictionary<string, T>
+    public class HashSetWithBackingClollection : ICollection<string>
     {
-        public StringToGenericSortedDictionary() { }
+        private readonly ICollection<string> _inner;
 
-        // For populating test data only. We cannot assume actual input will have this method.
-        public StringToGenericSortedDictionary(IList<KeyValuePair<string, T>> items)
+        public HashSetWithBackingClollection()
         {
-            foreach (KeyValuePair<string, T> item in items)
-            {
-                Add(item.Key, item.Value);
-            }
+            _inner = new HashSet<string>();
+        }
+
+        public HashSetWithBackingClollection(IEnumerable<string> values)
+        {
+            _inner = new HashSet<string>(values);
+        }
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => _inner.IsReadOnly;
+
+        public void Add(string item)
+        {
+            _inner.Add(item);
+        }
+
+        public void Clear()
+        {
+            _inner.Clear();
+        }
+
+        public bool Contains(string item)
+        {
+            return _inner.Contains(item);
+        }
+
+        public void CopyTo(string[] array, int arrayIndex)
+        {
+            _inner.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        public bool Remove(string item)
+        {
+            return _inner.Remove(item);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _inner.GetEnumerator();
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1267,17 +1267,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(json, serialized);
         }
 
-        public class Client
+        private class Client
         {
-            private ICollection<string> _allowedGrantTypes = new HashSetWithBackingClollection();
+            private ICollection<string> _allowedGrantTypes = new HashSetWithBackingCollection();
 
             public ICollection<string> AllowedGrantTypes
             {
                 get { return _allowedGrantTypes; }
-                set
-                {
-                    _allowedGrantTypes = new HashSetWithBackingClollection(value);
-                }
+                set { _allowedGrantTypes = new HashSetWithBackingCollection(value); }
             }
         }
     }

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
-using System;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -1253,7 +1251,7 @@ namespace System.Text.Json.Serialization.Tests
             public IEnumerable<string> NetworkList
             {
                 get => Networks.Split(',');
-                set => Networks = value != null ? string.Join(',', value) : "";
+                set => Networks = value != null ? string.Join(",", value) : "";
             }
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1220,5 +1220,67 @@ namespace System.Text.Json.Serialization.Tests
             NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize(json, type));
             Assert.Contains(type.ToString(), ex.Message);
         }
+
+        [Fact]
+        public static void DoesNotCall_CollectionPropertyGetter_EveryTimeElementIsAdded()
+        {
+            var networkList = new List<string> { "Network1", "Network2" };
+
+            string serialized = JsonSerializer.Serialize(new NetworkWrapper { NetworkList = networkList });
+            Assert.Equal(@"{""NetworkList"":[""Network1"",""Network2""]}", serialized);
+
+            NetworkWrapper obj = JsonSerializer.Deserialize<NetworkWrapper>(serialized);
+
+            int i = 0;
+            foreach (string network in obj.NetworkList)
+            {
+                Assert.Equal(networkList[i], network);
+                i++;
+            }
+        }
+
+        public class NetworkWrapper
+        {
+            private string _Networks = string.Empty;
+
+            [JsonIgnore]
+            public string Networks
+            {
+                get => _Networks;
+                set => _Networks = value ?? string.Empty;
+            }
+
+            public IEnumerable<string> NetworkList
+            {
+                get => Networks.Split(',');
+                set => Networks = value != null ? string.Join(',', value) : "";
+            }
+        }
+
+        [Fact]
+        public static void CollectionWith_BackingField_CanRoundtrip()
+        {
+            string json = "{\"AllowedGrantTypes\":[\"client_credentials\"]}";
+
+            Client obj = JsonSerializer.Deserialize<Client>(json);
+            Assert.Equal("client_credentials", obj.AllowedGrantTypes.First());
+
+            string serialized = JsonSerializer.Serialize(obj);
+            Assert.Equal(json, serialized);
+        }
+
+        public class Client
+        {
+            private ICollection<string> _allowedGrantTypes = new HashSetWithBackingClollection();
+
+            public ICollection<string> AllowedGrantTypes
+            {
+                get { return _allowedGrantTypes; }
+                set
+                {
+                    _allowedGrantTypes = new HashSetWithBackingClollection(value);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes issues fixed by https://github.com/dotnet/runtime/pull/2259.

- Fixes https://github.com/dotnet/runtime/issues/30843. Nullable structs were serialized with the "HasValue" and "Value" properties. This is fixed by the use of a converter for nullable structs and by unwrapping the value from the nullable before serializing it.

- Fixes https://github.com/dotnet/runtime/issues/31089; fixes https://github.com/dotnet/runtime/issues/31553. Deserializing collection properties that performed logic in their getters could throw exceptions. We no longer call the getter on deserializing, so this issue is fixed.