### PR TITLE
[CBOR] Implement indefinite length writer and reader support

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                         break;
                     case string[] expectedChunks:
                         Assert.Equal(CborReaderState.StartTextString, reader.Peek());
-                        reader.ReadStartTextString();
+                        reader.ReadStartTextStringIndefiniteLength();
                         foreach(string expectedChunk in expectedChunks)
                         {
                             Assert.Equal(CborReaderState.TextString, reader.Peek());
@@ -52,11 +52,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                             Assert.Equal(expectedChunk, chunk);
                         }
                         Assert.Equal(CborReaderState.EndTextString, reader.Peek());
-                        reader.ReadEndTextString();
+                        reader.ReadEndTextStringIndefiniteLength();
                         break;
                     case byte[][] expectedChunks:
                         Assert.Equal(CborReaderState.StartByteString, reader.Peek());
-                        reader.ReadStartByteString();
+                        reader.ReadStartByteStringIndefiniteLength();
                         foreach (byte[] expectedChunk in expectedChunks)
                         {
                             Assert.Equal(CborReaderState.ByteString, reader.Peek());
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                             Assert.Equal(expectedChunk.ByteArrayToHex(), chunk.ByteArrayToHex());
                         }
                         Assert.Equal(CborReaderState.EndByteString, reader.Peek());
-                        reader.ReadEndByteString();
+                        reader.ReadEndByteStringIndefiniteLength();
                         break;
 
                     case object[] nested when CborWriterTests.Helpers.IsCborMapRepresentation(nested):

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 using System.Linq;
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
@@ -12,7 +13,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         internal static class Helpers
         {
-            public static void VerifyValue(CborReader reader, object expectedValue)
+            public static void VerifyValue(CborReader reader, object expectedValue, bool expectDefiniteLengthCollections = true)
             {
                 switch (expectedValue)
                 {
@@ -39,13 +40,38 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     case byte[] expected:
                         Assert.Equal(CborReaderState.ByteString, reader.Peek());
                         byte[] b = reader.ReadByteString();
-                        Assert.Equal(expected, b);
+                        Assert.Equal(expected.ByteArrayToHex(), b.ByteArrayToHex());
                         break;
+                    case string[] expectedChunks:
+                        Assert.Equal(CborReaderState.StartTextString, reader.Peek());
+                        reader.ReadStartTextString();
+                        foreach(string expectedChunk in expectedChunks)
+                        {
+                            Assert.Equal(CborReaderState.TextString, reader.Peek());
+                            string chunk = reader.ReadTextString();
+                            Assert.Equal(expectedChunk, chunk);
+                        }
+                        Assert.Equal(CborReaderState.EndTextString, reader.Peek());
+                        reader.ReadEndTextString();
+                        break;
+                    case byte[][] expectedChunks:
+                        Assert.Equal(CborReaderState.StartByteString, reader.Peek());
+                        reader.ReadStartByteString();
+                        foreach (byte[] expectedChunk in expectedChunks)
+                        {
+                            Assert.Equal(CborReaderState.ByteString, reader.Peek());
+                            byte[] chunk = reader.ReadByteString();
+                            Assert.Equal(expectedChunk.ByteArrayToHex(), chunk.ByteArrayToHex());
+                        }
+                        Assert.Equal(CborReaderState.EndByteString, reader.Peek());
+                        reader.ReadEndByteString();
+                        break;
+
                     case object[] nested when CborWriterTests.Helpers.IsCborMapRepresentation(nested):
-                        VerifyMap(reader, nested);
+                        VerifyMap(reader, nested, expectDefiniteLengthCollections);
                         break;
                     case object[] nested:
-                        VerifyArray(reader, nested);
+                        VerifyArray(reader, nested, expectDefiniteLengthCollections);
                         break;
                     default:
                         throw new ArgumentException($"Unrecognized argument type {expectedValue.GetType()}");
@@ -58,14 +84,21 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
             }
 
-            public static void VerifyArray(CborReader reader, params object[] expectedValues)
+            public static void VerifyArray(CborReader reader, object[] expectedValues, bool expectDefiniteLengthCollections = true)
             {
                 Assert.Equal(CborReaderState.StartArray, reader.Peek());
 
                 ulong? length = reader.ReadStartArray();
 
-                Assert.NotNull(length);
-                Assert.Equal(expectedValues.Length, (int)length!.Value);
+                if (expectDefiniteLengthCollections)
+                {
+                    Assert.NotNull(length);
+                    Assert.Equal(expectedValues.Length, (int)length!.Value);
+                }
+                else
+                {
+                    Assert.Null(length);
+                }
 
                 foreach (object value in expectedValues)
                 {
@@ -76,7 +109,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 reader.ReadEndArray();
             }
 
-            public static void VerifyMap(CborReader reader, params object[] expectedValues)
+            public static void VerifyMap(CborReader reader, object[] expectedValues, bool expectDefiniteLengthCollections = true)
             {
                 if (!CborWriterTests.Helpers.IsCborMapRepresentation(expectedValues))
                 {
@@ -84,10 +117,18 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
 
                 Assert.Equal(CborReaderState.StartMap, reader.Peek());
+
                 ulong? length = reader.ReadStartMap();
 
-                Assert.NotNull(length);
-                Assert.Equal((expectedValues.Length - 1) / 2, (int)length!.Value);
+                if (expectDefiniteLengthCollections)
+                {
+                    Assert.NotNull(length);
+                    Assert.Equal((expectedValues.Length - 1) / 2, (int)length!.Value);
+                }
+                else
+                {
+                    Assert.Null(length);
+                }
 
                 foreach (object value in expectedValues.Skip(1))
                 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
@@ -256,12 +256,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Theory]
         [InlineData("1f")]
         [InlineData("3f")]
-        public static void ReadInt64_IndefiniteLengthIntegers_ShouldThrowNotImplementedException(string hexEncoding)
+        public static void ReadInt64_IndefiniteLengthIntegers_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
 
-            Assert.Throws<NotImplementedException>(() => reader.ReadInt64());
+            Assert.Throws<FormatException>(() => reader.ReadInt64());
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -255,7 +255,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 reader.ReadInt64();
             }
 
-            Assert.Equal(CborReaderState.EndMap, reader.Peek()); // don't want this to fail
+            Assert.Equal(CborReaderState.FormatError, reader.Peek()); // don't want this to fail
             Assert.Throws<FormatException>(() => reader.ReadEndMap());
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -54,6 +54,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(CborReaderState.Finished, reader.Peek());
         }
 
+        [Theory]
+        [InlineData(new object[] { Map }, "bfff")]
+        [InlineData(new object[] { Map, 1, 2, 3, 4 }, "bf01020304ff")]
+        [InlineData(new object[] { Map, "a", "A", "b", "B", "c", "C", "d", "D", "e", "E" }, "bf6161614161626142616361436164614461656145ff")]
+        [InlineData(new object[] { Map, "a", "A", -1, 2, new byte[] { }, new byte[] { 1 } }, "bf616161412002404101ff")]
+        public static void ReadMap_IndefiniteLength_SimpleValues_HappyPath(object[] exoectedValues, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+            Helpers.VerifyMap(reader, exoectedValues, expectDefiniteLengthCollections: false);
+            Assert.Equal(CborReaderState.Finished, reader.Peek());
+        }
+
 
         [Theory]
         [InlineData(new object[] { Map, "a", 1, "a", 2 }, "a2616101616102")]
@@ -191,6 +204,59 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             Assert.Throws<FormatException>(() => reader.ReadInt64());
+        }
+
+        [Theory]
+        [InlineData("bf")]
+        [InlineData("bf0102")]
+        [InlineData("bf01020304")]
+        public static void ReadMap_IndefiniteLength_MissingBreakByte_ShouldReportEndOfData(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+            reader.ReadStartMap();
+            while (reader.Peek() == CborReaderState.UnsignedInteger)
+            {
+                reader.ReadInt64();
+            }
+
+            Assert.Equal(CborReaderState.EndOfData, reader.Peek());
+        }
+
+        [Theory]
+        [InlineData("bf0102ff", 1)]
+        [InlineData("bf01020304ff", 2)]
+        [InlineData("bf010203040506ff", 3)]
+        public static void ReadMap_IndefiniteLength_PrematureEndArrayCall_ShouldThrowInvalidOperationException(string hexEncoding, int length)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+            reader.ReadStartMap();
+            for (int i = 1; i < length; i++)
+            {
+                reader.ReadInt64();
+            }
+
+            Assert.Equal(CborReaderState.UnsignedInteger, reader.Peek());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadEndMap());
+        }
+
+        [Theory]
+        [InlineData("bf01ff", 1)]
+        [InlineData("bf010203ff", 3)]
+        [InlineData("bf0102030405ff", 5)]
+        public static void ReadMap_IndefiniteLength_OddKeyValuePairs_ShouldThrowFormatException(string hexEncoding, int length)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+            reader.ReadStartMap();
+            for (int i = 0; i < length; i++)
+            {
+                reader.ReadInt64();
+            }
+
+            Assert.Equal(CborReaderState.EndMap, reader.Peek()); // don't want this to fail
+            Assert.Throws<FormatException>(() => reader.ReadEndMap());
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -479,7 +479,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             string hexEncoding = "5f4001ff";
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
-            reader.ReadStartByteString();
+            reader.ReadStartByteStringIndefiniteLength();
             reader.ReadByteString();
 
             Assert.Equal(CborReaderState.FormatError, reader.Peek());
@@ -493,12 +493,56 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             string hexEncoding = "7f6001ff";
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
-            reader.ReadStartTextString();
+            reader.ReadStartTextStringIndefiniteLength();
             reader.ReadTextString();
 
             Assert.Equal(CborReaderState.FormatError, reader.Peek());
             // throws FormatException even if it's the right major type we're trying to read
             Assert.Throws<FormatException>(() => reader.ReadInt64());
+        }
+
+        [Fact]
+        public static void ReadByteString_IndefiniteLength_ContainingNestedIndefiniteLengthStrings_ShouldThrowFormatException()
+        {
+            string hexEncoding = "5f5fffff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+
+            reader.ReadStartByteStringIndefiniteLength();
+
+            Assert.Throws<FormatException>(() => reader.ReadStartByteStringIndefiniteLength());
+        }
+
+        [Fact]
+        public static void ReadByteString_IndefiniteLengthConcatenated_ContainingNestedIndefiniteLengthStrings_ShouldThrowFormatException()
+        {
+            string hexEncoding = "5f5fffff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+
+            Assert.Throws<FormatException>(() => reader.ReadByteString());
+        }
+
+        [Fact]
+        public static void ReadTextString_IndefiniteLength_ContainingNestedIndefiniteLengthStrings_ShouldThrowFormatException()
+        {
+            string hexEncoding = "7f7fffff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+
+            reader.ReadStartTextStringIndefiniteLength();
+
+            Assert.Throws<FormatException>(() => reader.ReadStartTextStringIndefiniteLength());
+        }
+
+        [Fact]
+        public static void ReadTextString_IndefiniteLengthConcatenated_ContainingNestedIndefiniteLengthStrings_ShouldThrowFormatException()
+        {
+            string hexEncoding = "7f7fffff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -133,6 +133,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(CborReaderState.Finished, reader.Peek());
         }
 
+        [Fact]
+        public static void ReadByteString_IndefiniteLengthConcatenated_NestedValues_HappyPath()
+        {
+            string hexEncoding = "825f41ab40ff5f41ab40ff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+            reader.ReadStartArray();
+            Assert.Equal("AB", reader.ReadByteString().ByteArrayToHex());
+            Assert.Equal("AB", reader.ReadByteString().ByteArrayToHex());
+            reader.ReadEndArray();
+            Assert.Equal(CborReaderState.Finished, reader.Peek());
+        }
+
         [Theory]
         [InlineData(new string[] { }, "7fff")]
         [InlineData(new string[] { "" }, "7f60ff")]
@@ -157,6 +170,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(CborReaderState.StartTextString, reader.Peek());
             string actualValue = reader.ReadTextString();
             Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(CborReaderState.Finished, reader.Peek());
+        }
+
+        [Fact]
+        public static void ReadTextString_IndefiniteLengthConcatenated_NestedValues_HappyPath()
+        {
+            string hexEncoding = "827f62616260ff7f62616260ff";
+            byte[] data = hexEncoding.HexToByteArray();
+            var reader = new CborReader(data);
+            reader.ReadStartArray();
+            Assert.Equal("ab", reader.ReadTextString());
+            Assert.Equal("ab", reader.ReadTextString());
+            reader.ReadEndArray();
             Assert.Equal(CborReaderState.Finished, reader.Peek());
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -44,6 +44,39 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(new object[] { }, "9fff")]
+        [InlineData(new object[] { 42 }, "9f182aff")]
+        [InlineData(new object[] { 1, 2, 3 }, "9f010203ff")]
+        [InlineData(new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }, "9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff")]
+        [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "9f0120604107ff")]
+        [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "9f656c6f72656d65697073756d65646f6c6f72ff")]
+        public static void WriteArray_IndefiniteLength_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+
+            using var writer = new CborWriter();
+            Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
+
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(new object[] { new object[] { } }, "9f9fffff")]
+        [InlineData(new object[] { 1, new object[] { 2, 3 }, new object[] { 4, 5 } }, "9f019f0203ff9f0405ffff")]
+        [InlineData(new object[] { "", new object[] { new object[] { }, new object[] { 1, new byte[] { 10 } } } }, "9f609f9fff9f01410affffff")]
+        public static void WriteArray_IndefiniteLength_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+
+            using var writer = new CborWriter();
+            Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
+
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
                 else
                 {
-                    writer.WriteStartArray();
+                    writer.WriteStartArrayIndefiniteLength();
                 }
 
                 foreach (object value in values)
@@ -71,7 +71,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
                 else
                 {
-                    writer.WriteStartMap();
+                    writer.WriteStartMapIndefiniteLength();
                 }
 
                 foreach (object value in keyValuePairs.Skip(1))
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public static void WriteChunkedByteString(CborWriter writer, byte[][] chunks)
             {
-                writer.WriteStartByteString();
+                writer.WriteStartByteStringIndefiniteLength();
                 foreach (byte[] chunk in chunks)
                 {
                     writer.WriteByteString(chunk);
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public static void WriteChunkedTextString(CborWriter writer, string[] chunks)
             {
-                writer.WriteStartTextString();
+                writer.WriteStartTextStringIndefiniteLength();
                 foreach (string chunk in chunks)
                 {
                     writer.WriteTextString(chunk);
@@ -109,10 +109,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     case nameof(writer.WriteInt64): writer.WriteInt64(42); break;
                     case nameof(writer.WriteByteString): writer.WriteByteString(Array.Empty<byte>()); break;
                     case nameof(writer.WriteTextString): writer.WriteTextString(""); break;
-                    case nameof(writer.WriteStartTextString): writer.WriteStartTextString(); break;
-                    case nameof(writer.WriteStartByteString): writer.WriteStartByteString(); break;
-                    case nameof(writer.WriteStartArray): writer.WriteStartArray(); break;
-                    case nameof(writer.WriteStartMap): writer.WriteStartMap(); break;
+                    case nameof(writer.WriteStartTextStringIndefiniteLength): writer.WriteStartTextStringIndefiniteLength(); break;
+                    case nameof(writer.WriteStartByteStringIndefiniteLength): writer.WriteStartByteStringIndefiniteLength(); break;
+                    case nameof(writer.WriteStartArray): writer.WriteStartArrayIndefiniteLength(); break;
+                    case nameof(writer.WriteStartMap): writer.WriteStartMapIndefiniteLength(); break;
                     case nameof(writer.WriteEndByteString): writer.WriteEndByteString(); break;
                     case nameof(writer.WriteEndTextString): writer.WriteEndTextString(); break;
                     case nameof(writer.WriteEndArray): writer.WriteEndArray(); break;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 return values.Length % 2 == 1 && values[0] is string s && s == MapPrefixIdentifier;
             }
 
-            public static void WriteValue(CborWriter writer, object value)
+            public static void WriteValue(CborWriter writer, object value, bool useDefiniteLengthCollections = true)
             {
                 switch (value)
                 {
@@ -31,37 +31,94 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     case ulong i: writer.WriteUInt64(i); break;
                     case string s: writer.WriteTextString(s); break;
                     case byte[] b: writer.WriteByteString(b); break;
-                    case object[] nested when IsCborMapRepresentation(nested): WriteMap(writer, nested); break;
-                    case object[] nested: WriteArray(writer, nested); break;
+                    case byte[][] chunks: WriteChunkedByteString(writer, chunks); break;
+                    case string[] chunks: WriteChunkedTextString(writer, chunks); break;
+                    case object[] nested when IsCborMapRepresentation(nested): WriteMap(writer, nested, useDefiniteLengthCollections); break;
+                    case object[] nested: WriteArray(writer, nested, useDefiniteLengthCollections); break;
                     default: throw new ArgumentException($"Unrecognized argument type {value.GetType()}");
                 };
             }
 
-            public static void WriteArray(CborWriter writer, params object[] values)
+            public static void WriteArray(CborWriter writer, object[] values, bool useDefiniteLengthCollections = true)
             {
-                writer.WriteStartArray(values.Length);
+                if (useDefiniteLengthCollections)
+                {
+                    writer.WriteStartArray(values.Length);
+                }
+                else
+                {
+                    writer.WriteStartArray();
+                }
+
                 foreach (object value in values)
                 {
-                    WriteValue(writer, value);
+                    WriteValue(writer, value, useDefiniteLengthCollections);
                 }
+
                 writer.WriteEndArray();
             }
 
-            public static void WriteMap(CborWriter writer, params object[] keyValuePairs)
+            public static void WriteMap(CborWriter writer, object[] keyValuePairs, bool useDefiniteLengthCollections = true)
             {
                 if (!IsCborMapRepresentation(keyValuePairs))
                 {
                     throw new ArgumentException($"CBOR map representation must contain odd number of elements prepended with a '{MapPrefixIdentifier}' constant.");
                 }
 
-                writer.WriteStartMap(keyValuePairs.Length / 2);
+                if (useDefiniteLengthCollections)
+                {
+                    writer.WriteStartMap(keyValuePairs.Length / 2);
+                }
+                else
+                {
+                    writer.WriteStartMap();
+                }
 
                 foreach (object value in keyValuePairs.Skip(1))
                 {
-                    WriteValue(writer, value);
+                    WriteValue(writer, value, useDefiniteLengthCollections);
                 }
 
                 writer.WriteEndMap();
+            }
+
+            public static void WriteChunkedByteString(CborWriter writer, byte[][] chunks)
+            {
+                writer.WriteStartByteString();
+                foreach (byte[] chunk in chunks)
+                {
+                    writer.WriteByteString(chunk);
+                }
+                writer.WriteEndByteString();
+            }
+
+            public static void WriteChunkedTextString(CborWriter writer, string[] chunks)
+            {
+                writer.WriteStartTextString();
+                foreach (string chunk in chunks)
+                {
+                    writer.WriteTextString(chunk);
+                }
+                writer.WriteEndTextString();
+            }
+
+            public static void ExecOperation(CborWriter writer, string op)
+            {
+                switch (op)
+                {
+                    case nameof(writer.WriteInt64): writer.WriteInt64(42); break;
+                    case nameof(writer.WriteByteString): writer.WriteByteString(Array.Empty<byte>()); break;
+                    case nameof(writer.WriteTextString): writer.WriteTextString(""); break;
+                    case nameof(writer.WriteStartTextString): writer.WriteStartTextString(); break;
+                    case nameof(writer.WriteStartByteString): writer.WriteStartByteString(); break;
+                    case nameof(writer.WriteStartArray): writer.WriteStartArray(); break;
+                    case nameof(writer.WriteStartMap): writer.WriteStartMap(); break;
+                    case nameof(writer.WriteEndByteString): writer.WriteEndByteString(); break;
+                    case nameof(writer.WriteEndTextString): writer.WriteEndTextString(); break;
+                    case nameof(writer.WriteEndArray): writer.WriteEndArray(); break;
+                    case nameof(writer.WriteEndMap): writer.WriteEndMap(); break;
+                    default: throw new Exception($"Unrecognized CborWriter operation name {op}");
+                }
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 {
                     writer.WriteByteString(chunk);
                 }
-                writer.WriteEndByteString();
+                writer.WriteEndByteStringIndefiniteLength();
             }
 
             public static void WriteChunkedTextString(CborWriter writer, string[] chunks)
@@ -99,7 +99,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 {
                     writer.WriteTextString(chunk);
                 }
-                writer.WriteEndTextString();
+                writer.WriteEndTextStringIndefiniteLength();
             }
 
             public static void ExecOperation(CborWriter writer, string op)
@@ -113,8 +113,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     case nameof(writer.WriteStartByteStringIndefiniteLength): writer.WriteStartByteStringIndefiniteLength(); break;
                     case nameof(writer.WriteStartArray): writer.WriteStartArrayIndefiniteLength(); break;
                     case nameof(writer.WriteStartMap): writer.WriteStartMapIndefiniteLength(); break;
-                    case nameof(writer.WriteEndByteString): writer.WriteEndByteString(); break;
-                    case nameof(writer.WriteEndTextString): writer.WriteEndTextString(); break;
+                    case nameof(writer.WriteEndByteStringIndefiniteLength): writer.WriteEndByteStringIndefiniteLength(); break;
+                    case nameof(writer.WriteEndTextStringIndefiniteLength): writer.WriteEndTextStringIndefiniteLength(); break;
                     case nameof(writer.WriteEndArray): writer.WriteEndArray(); break;
                     case nameof(writer.WriteEndMap): writer.WriteEndMap(); break;
                     default: throw new Exception($"Unrecognized CborWriter operation name {op}");

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void EndWriteMap_IndefiniteLength_EvenItems_ShouldThrowInvalidOperationException(int length)
         {
             using var writer = new CborWriter();
-            writer.WriteStartMap();
+            writer.WriteStartMapIndefiniteLength();
 
             for (int i = 1; i < length; i++)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -45,6 +45,33 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(new object[] { Map }, "bfff")]
+        [InlineData(new object[] { Map, 1, 2, 3, 4 }, "bf01020304ff")]
+        [InlineData(new object[] { Map, "a", "A", "b", "B", "c", "C", "d", "D", "e", "E" }, "bf6161614161626142616361436164614461656145ff")]
+        [InlineData(new object[] { Map, "a", "A", -1, 2, new byte[] { }, new byte[] { 1 } }, "bf616161412002404101ff")]
+        public static void WriteMap_IndefiniteLength_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter();
+            Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(new object[] { Map, "a", 1, "b", new object[] { Map, 2, 3 } }, "bf6161016162bf0203ffff")]
+        [InlineData(new object[] { Map, "a", new object[] { Map, 2, 3 }, "b", new object[] { Map, "x", -1, "y", new object[] { Map, "z", 0 } } }, "bf6161bf0203ff6162bf6178206179bf617a00ffffff")]
+        [InlineData(new object[] { Map, new object[] { Map, "x", 2 }, 42 }, "bfbf617802ff182aff")] // using maps as keys
+        public static void WriteMap_IndefiniteLength_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter();
+            Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
         [InlineData(new object[] { Map, "a", 1, "b", new object[] { 2, 3 } }, "a26161016162820203")]
         [InlineData(new object[] { Map, "a", new object[] { 2, 3, "b", new object[] { Map, "x", -1, "y", new object[] { "z", 0 } } } }, "a161618402036162a2617820617982617a00")]
         [InlineData(new object[] { "a", new object[] { Map, "b", "c" } }, "826161a161626163")]
@@ -141,6 +168,26 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 writer.WriteInt64(i);
                 writer.WriteEndMap();
             }
+
+            Assert.Throws<InvalidOperationException>(() => writer.WriteEndMap());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(3)]
+        [InlineData(10)]
+        public static void EndWriteMap_IndefiniteLength_EvenItems_ShouldThrowInvalidOperationException(int length)
+        {
+            using var writer = new CborWriter();
+            writer.WriteStartMap();
+
+            for (int i = 1; i < length; i++)
+            {
+                writer.WriteTextString($"key_{i}");
+                writer.WriteInt64(i);
+            }
+
+            writer.WriteInt64(0);
 
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndMap());
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -83,14 +83,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Theory]
         [InlineData(nameof(CborWriter.WriteInt64))]
         [InlineData(nameof(CborWriter.WriteByteString))]
-        [InlineData(nameof(CborWriter.WriteStartTextString))]
-        [InlineData(nameof(CborWriter.WriteStartByteString))]
+        [InlineData(nameof(CborWriter.WriteStartTextStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteStartByteStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
         public static void WriteTextString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartTextString();
+            writer.WriteStartTextStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
@@ -101,15 +101,15 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void WriteTextString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartTextString();
+            writer.WriteStartTextStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
         [Theory]
         [InlineData(nameof(CborWriter.WriteInt64))]
         [InlineData(nameof(CborWriter.WriteTextString))]
-        [InlineData(nameof(CborWriter.WriteStartTextString))]
-        [InlineData(nameof(CborWriter.WriteStartByteString))]
+        [InlineData(nameof(CborWriter.WriteStartTextStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteStartByteStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
         [InlineData(nameof(CborWriter.WriteEndTextString))]
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void WriteByteString_IndefiteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartByteString();
+            writer.WriteStartByteStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
@@ -129,7 +129,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void WriteByteString_IndefiteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartByteString();
+            writer.WriteStartByteStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new string[] { "" }, "7f60ff")]
         [InlineData(new string[] { "ab", "" }, "7f62616260ff")]
         [InlineData(new string[] { "ab", "bc", "" }, "7f62616262626360ff")]
-        public static void WriteTextString_IndefiteLength_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
+        public static void WriteTextString_IndefiniteLength_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(nameof(CborWriter.WriteStartByteString))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
-        public static void WriteTextString_IndefiteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
+        public static void WriteTextString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
             writer.WriteStartTextString();
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(nameof(CborWriter.WriteEndByteString))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
-        public static void WriteTextString_IndefiteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
+        public static void WriteTextString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
             writer.WriteStartTextString();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(nameof(CborWriter.WriteEndByteString))]
+        [InlineData(nameof(CborWriter.WriteEndByteStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteTextString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(nameof(CborWriter.WriteStartByteStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
-        [InlineData(nameof(CborWriter.WriteEndTextString))]
+        [InlineData(nameof(CborWriter.WriteEndTextStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
@@ -123,7 +123,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(nameof(CborWriter.WriteEndTextString))]
+        [InlineData(nameof(CborWriter.WriteEndTextStringIndefiniteLength))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 using System;
+using System.Linq;
 using Test.Cryptography;
 using Xunit;
 
@@ -27,6 +28,21 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(new string[] { }, "5fff")]
+        [InlineData(new string[] { "" }, "5f40ff")]
+        [InlineData(new string[] { "ab", "" }, "5f41ab40ff")]
+        [InlineData(new string[] { "ab", "bc", "" }, "5f41ab41bc40ff")]
+        public static void WriteByteString_IndefiteLength_SingleValue_HappyPath(string[] hexChunkInputs, string hexExpectedEncoding)
+        {
+            byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+
+            using var writer = new CborWriter();
+            Helpers.WriteChunkedByteString(writer, chunkInputs);
+            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+        }
+
+        [Theory]
         [InlineData("", "60")]
         [InlineData("a", "6161")]
         [InlineData("IETF", "6449455446")]
@@ -42,6 +58,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
         }
 
+        [Theory]
+        [InlineData(new string[] { }, "7fff")]
+        [InlineData(new string[] { "" }, "7f60ff")]
+        [InlineData(new string[] { "ab", "" }, "7f62616260ff")]
+        [InlineData(new string[] { "ab", "bc", "" }, "7f62616262626360ff")]
+        public static void WriteTextString_IndefiteLength_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
+        {
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            using var writer = new CborWriter();
+            Helpers.WriteChunkedTextString(writer, chunkInputs);
+            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+        }
+
         [Fact]
         public static void WriteTextString_InvalidUnicodeString_ShouldThrowEncoderFallbackException()
         {
@@ -49,6 +78,59 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             string invalidUnicodeString = "\ud800";
             using var writer = new CborWriter();
             Assert.Throws<System.Text.EncoderFallbackException>(() => writer.WriteTextString(invalidUnicodeString));
+        }
+
+        [Theory]
+        [InlineData(nameof(CborWriter.WriteInt64))]
+        [InlineData(nameof(CborWriter.WriteByteString))]
+        [InlineData(nameof(CborWriter.WriteStartTextString))]
+        [InlineData(nameof(CborWriter.WriteStartByteString))]
+        [InlineData(nameof(CborWriter.WriteStartArray))]
+        [InlineData(nameof(CborWriter.WriteStartMap))]
+        public static void WriteTextString_IndefiteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
+        {
+            using var writer = new CborWriter();
+            writer.WriteStartTextString();
+            Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
+        }
+
+        [Theory]
+        [InlineData(nameof(CborWriter.WriteEndByteString))]
+        [InlineData(nameof(CborWriter.WriteEndArray))]
+        [InlineData(nameof(CborWriter.WriteEndMap))]
+        public static void WriteTextString_IndefiteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
+        {
+            using var writer = new CborWriter();
+            writer.WriteStartTextString();
+            Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
+        }
+
+        [Theory]
+        [InlineData(nameof(CborWriter.WriteInt64))]
+        [InlineData(nameof(CborWriter.WriteTextString))]
+        [InlineData(nameof(CborWriter.WriteStartTextString))]
+        [InlineData(nameof(CborWriter.WriteStartByteString))]
+        [InlineData(nameof(CborWriter.WriteStartArray))]
+        [InlineData(nameof(CborWriter.WriteStartMap))]
+        [InlineData(nameof(CborWriter.WriteEndTextString))]
+        [InlineData(nameof(CborWriter.WriteEndArray))]
+        [InlineData(nameof(CborWriter.WriteEndMap))]
+        public static void WriteByteString_IndefiteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
+        {
+            using var writer = new CborWriter();
+            writer.WriteStartByteString();
+            Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
+        }
+
+        [Theory]
+        [InlineData(nameof(CborWriter.WriteEndTextString))]
+        [InlineData(nameof(CborWriter.WriteEndArray))]
+        [InlineData(nameof(CborWriter.WriteEndMap))]
+        public static void WriteByteString_IndefiteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
+        {
+            using var writer = new CborWriter();
+            writer.WriteStartByteString();
+            Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
@@ -30,7 +30,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     /// Represents the Cbor Data item initial byte structure
     internal readonly struct CborInitialByte
     {
+        public const byte IndefiniteLengthBreakByte = 0xff;
         private const byte AdditionalInformationMask = 0b000_11111;
+
         public byte InitialByte { get; }
 
         internal CborInitialByte(CborMajorType majorType, CborAdditionalInfo additionalInfo)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -12,17 +12,42 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public ulong? ReadStartArray()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Array);
-            ulong arrayLength = checked((ulong)ReadUnsignedInteger(header, out int additionalBytes));
-            AdvanceBuffer(1 + additionalBytes);
-            _remainingDataItems--;
 
-            PushDataItem(CborMajorType.Array, arrayLength);
-            return arrayLength;
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
+            {
+                AdvanceBuffer(1);
+                DecrementRemainingItemCount();
+                PushDataItem(CborMajorType.Array, null);
+                return null;
+            }
+            else
+            {
+                ulong arrayLength = ReadUnsignedInteger(header, out int additionalBytes);
+                AdvanceBuffer(1 + additionalBytes);
+                DecrementRemainingItemCount();
+                PushDataItem(CborMajorType.Array, arrayLength);
+                return arrayLength;
+            }
         }
 
         public void ReadEndArray()
         {
-            PopDataItem(expectedType: CborMajorType.Array);
+            if (_remainingDataItems == null)
+            {
+                CborInitialByte value = PeekInitialByte();
+
+                if (value.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
+                {
+                    throw new InvalidOperationException("Not at end of indefinite-length array.");
+                }
+
+                PopDataItem(expectedType: CborMajorType.Array);
+                AdvanceBuffer(1);
+            }
+            else
+            {
+                PopDataItem(expectedType: CborMajorType.Array);
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             else
             {
-                ulong arrayLength = ReadUnsignedInteger(header, out int additionalBytes);
+                ulong arrayLength = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
                 AdvanceBuffer(1 + additionalBytes);
                 DecrementRemainingItemCount();
                 PushDataItem(CborMajorType.Array, arrayLength);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -18,7 +18,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 case CborMajorType.UnsignedInteger:
                     ulong value = ReadUnsignedInteger(header, out int additionalBytes);
                     AdvanceBuffer(1 + additionalBytes);
-                    _remainingDataItems--;
+                    DecrementRemainingItemCount();
                     return value;
 
                 case CborMajorType.NegativeInteger:
@@ -42,13 +42,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 case CborMajorType.UnsignedInteger:
                     value = checked((long)ReadUnsignedInteger(header, out additionalBytes));
                     AdvanceBuffer(1 + additionalBytes);
-                    _remainingDataItems--;
+                    DecrementRemainingItemCount();
                     return value;
 
                 case CborMajorType.NegativeInteger:
                     value = checked(-1 - (long)ReadUnsignedInteger(header, out additionalBytes));
                     AdvanceBuffer(1 + additionalBytes);
-                    _remainingDataItems--;
+                    DecrementRemainingItemCount();
                     return value;
 
                 default:
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.NegativeInteger);
             ulong value = ReadUnsignedInteger(header, out int additionalBytes);
             AdvanceBuffer(1 + additionalBytes);
-            _remainingDataItems--;
+            DecrementRemainingItemCount();
             return value;
         }
 
@@ -97,9 +97,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     EnsureBuffer(9);
                     additionalBytes = 8;
                     return BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(1));
-
-                case CborAdditionalInfo.IndefiniteLength:
-                    throw new NotImplementedException("indefinite length support");
 
                 default:
                     throw new FormatException("initial byte contains invalid integer encoding data");

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             switch (header.MajorType)
             {
                 case CborMajorType.UnsignedInteger:
-                    ulong value = ReadUnsignedInteger(header, out int additionalBytes);
+                    ulong value = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
                     AdvanceBuffer(1 + additionalBytes);
                     DecrementRemainingItemCount();
                     return value;
@@ -40,13 +40,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             switch (header.MajorType)
             {
                 case CborMajorType.UnsignedInteger:
-                    value = checked((long)ReadUnsignedInteger(header, out additionalBytes));
+                    value = checked((long)ReadUnsignedInteger(_buffer.Span, header, out additionalBytes));
                     AdvanceBuffer(1 + additionalBytes);
                     DecrementRemainingItemCount();
                     return value;
 
                 case CborMajorType.NegativeInteger:
-                    value = checked(-1 - (long)ReadUnsignedInteger(header, out additionalBytes));
+                    value = checked(-1 - (long)ReadUnsignedInteger(_buffer.Span, header, out additionalBytes));
                     AdvanceBuffer(1 + additionalBytes);
                     DecrementRemainingItemCount();
                     return value;
@@ -61,17 +61,15 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public ulong ReadCborNegativeIntegerEncoding()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.NegativeInteger);
-            ulong value = ReadUnsignedInteger(header, out int additionalBytes);
+            ulong value = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
             AdvanceBuffer(1 + additionalBytes);
             DecrementRemainingItemCount();
             return value;
         }
 
         // Unsigned integer decoding https://tools.ietf.org/html/rfc7049#section-2.1
-        private ulong ReadUnsignedInteger(CborInitialByte header, out int additionalBytes)
+        private static ulong ReadUnsignedInteger(ReadOnlySpan<byte> buffer, CborInitialByte header, out int additionalBytes)
         {
-            ReadOnlySpan<byte> buffer = _buffer.Span;
-
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo x when (x < CborAdditionalInfo.Unsigned8BitIntegerEncoding):
@@ -79,22 +77,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     return (ulong)x;
 
                 case CborAdditionalInfo.Unsigned8BitIntegerEncoding:
-                    EnsureBuffer(2);
+                    EnsureBuffer(buffer, 2);
                     additionalBytes = 1;
                     return buffer[1];
 
                 case CborAdditionalInfo.Unsigned16BitIntegerEncoding:
-                    EnsureBuffer(3);
+                    EnsureBuffer(buffer, 3);
                     additionalBytes = 2;
                     return BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(1));
 
                 case CborAdditionalInfo.Unsigned32BitIntegerEncoding:
-                    EnsureBuffer(5);
+                    EnsureBuffer(buffer, 5);
                     additionalBytes = 4;
                     return BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(1));
 
                 case CborAdditionalInfo.Unsigned64BitIntegerEncoding:
-                    EnsureBuffer(9);
+                    EnsureBuffer(buffer, 9);
                     additionalBytes = 8;
                     return BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(1));
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             else
             {
-                ulong mapSize = ReadUnsignedInteger(header, out int additionalBytes);
+                ulong mapSize = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
 
                 if (mapSize > long.MaxValue)
                 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     throw new InvalidOperationException("Not at end of indefinite-length map.");
                 }
 
-                if (!_isEvenNumberOfDataItemsWritten)
+                if (!_isEvenNumberOfDataItemsRead)
                 {
                     throw new FormatException("CBOR Map types require an even number of key/value combinations");
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -12,22 +12,53 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public ulong? ReadStartMap()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Map);
-            ulong arrayLength = checked((ulong)ReadUnsignedInteger(header, out int additionalBytes));
-            AdvanceBuffer(1 + additionalBytes);
-            _remainingDataItems--;
 
-            if (arrayLength > long.MaxValue)
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                throw new OverflowException("Read CBOR map field count exceeds supported size.");
+                AdvanceBuffer(1);
+                DecrementRemainingItemCount();
+                PushDataItem(CborMajorType.Map, null);
+                return null;
             }
+            else
+            {
+                ulong mapSize = ReadUnsignedInteger(header, out int additionalBytes);
 
-            PushDataItem(CborMajorType.Map, 2 * arrayLength);
-            return arrayLength;
+                if (mapSize > long.MaxValue)
+                {
+                    throw new OverflowException("Read CBOR map field count exceeds supported size.");
+                }
+
+                AdvanceBuffer(1 + additionalBytes);
+                DecrementRemainingItemCount();
+                PushDataItem(CborMajorType.Map, 2 * mapSize);
+                return mapSize;
+            }
         }
 
         public void ReadEndMap()
         {
-            PopDataItem(expectedType: CborMajorType.Map);
+            if (_remainingDataItems == null)
+            {
+                CborInitialByte value = PeekInitialByte();
+
+                if (value.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
+                {
+                    throw new InvalidOperationException("Not at end of indefinite-length map.");
+                }
+
+                if (!_isEvenNumberOfDataItemsWritten)
+                {
+                    throw new FormatException("CBOR Map types require an even number of key/value combinations");
+                }
+
+                PopDataItem(expectedType: CborMajorType.Map);
+                AdvanceBuffer(1);
+            }
+            else
+            {
+                PopDataItem(expectedType: CborMajorType.Map);
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -105,7 +105,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             return true;
         }
 
-        public void ReadStartTextString()
+        public void ReadStartTextStringIndefiniteLength()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
 
@@ -120,14 +120,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
 
-        public void ReadEndTextString()
+        public void ReadEndTextStringIndefiniteLength()
         {
             ReadNextIndefiniteLengthBreakByte();
             PopDataItem(CborMajorType.TextString);
             AdvanceBuffer(1);
         }
 
-        public void ReadStartByteString()
+        public void ReadStartByteStringIndefiniteLength()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
 
@@ -142,7 +142,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
         }
 
-        public void ReadEndByteString()
+        public void ReadEndByteStringIndefiniteLength()
         {
             ReadNextIndefiniteLengthBreakByte();
             PopDataItem(CborMajorType.ByteString);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private bool TryReadChunkedByteStringConcatenated(Span<byte> destination, out int bytesWritten)
         {
-            List<(int offset, int length)> offsets = ReadChunkedStringRanges(CborMajorType.ByteString, out int offset, out int concatenatedBufferSize);
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
 
             if (concatenatedBufferSize > destination.Length)
             {
@@ -161,21 +161,21 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             ReadOnlySpan<byte> source = _buffer.Span;
 
-            foreach ((int o, int l) in offsets)
+            foreach ((int o, int l) in ranges)
             {
                 source.Slice(o, l).CopyTo(destination);
                 destination = destination.Slice(l);
             }
 
             bytesWritten = concatenatedBufferSize;
-            AdvanceBuffer(offset);
+            AdvanceBuffer(encodingLength);
             DecrementRemainingItemCount();
             return true;
         }
 
         private bool TryReadChunkedTextStringConcatenated(Span<char> destination, out int charsWritten)
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int offset, out int _);
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int _);
             ReadOnlySpan<byte> buffer = _buffer.Span;
 
             int concatenatedStringSize = 0;
@@ -197,14 +197,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             charsWritten = concatenatedStringSize;
-            AdvanceBuffer(offset);
+            AdvanceBuffer(encodingLength);
             DecrementRemainingItemCount();
             return true;
         }
 
         private byte[] ReadChunkedByteStringConcatenated()
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int offset, out int concatenatedBufferSize);
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
             var output = new byte[concatenatedBufferSize];
 
             ReadOnlySpan<byte> source = _buffer.Span;
@@ -217,14 +217,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             Debug.Assert(target.IsEmpty);
-            AdvanceBuffer(offset);
+            AdvanceBuffer(encodingLength);
             DecrementRemainingItemCount();
             return output;
         }
 
         private string ReadChunkedTextStringConcatenated()
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int offset, out int concatenatedBufferSize);
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int concatenatedBufferSize);
             ReadOnlySpan<byte> buffer = _buffer.Span;
             int concatenatedStringSize = 0;
 
@@ -243,7 +243,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             Debug.Assert(target.IsEmpty);
-            AdvanceBuffer(offset);
+            AdvanceBuffer(encodingLength);
             DecrementRemainingItemCount();
             return new string(output);
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
-using System.Threading;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -297,25 +294,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 return cib;
             }
-        }
-
-        private List<(int offset, int length)>? _rangeListAllocation = null;
-        private List<(int offset, int length)> AcquireRangeList()
-        {
-            List<(int offset, int length)>? ranges = Interlocked.Exchange(ref _rangeListAllocation, null);
-
-            if (ranges != null)
-            {
-                ranges.Clear();
-                return ranges;
-            }
-
-            return new List<(int, int)>();
-        }
-
-        private void ReturnRangeList(List<(int offset, int length)> ranges)
-        {
-            _rangeListAllocation = ranges;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -14,7 +18,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public byte[] ReadByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
-            int length = checked((int)ReadUnsignedInteger(header, out int additionalBytes));
+
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
+            {
+                return ReadChunkedByteStringConcatenated();
+            }
+
+            int length = checked((int)ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + length);
             byte[] result = new byte[length];
             _buffer.Slice(1 + additionalBytes, length).CopyTo(result);
@@ -26,7 +36,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public bool TryReadByteString(Span<byte> destination, out int bytesWritten)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
-            int length = checked((int)ReadUnsignedInteger(header, out int additionalBytes));
+
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
+            {
+                return TryReadChunkedByteStringConcatenated(destination, out bytesWritten);
+            }
+
+            int length = checked((int)ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + length);
 
             if (length > destination.Length)
@@ -47,7 +63,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public string ReadTextString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
-            int length = checked((int)ReadUnsignedInteger(header, out int additionalBytes));
+
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
+            {
+                return ReadChunkedTextStringConcatenated();
+            }
+
+            int length = checked((int)ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + length);
             ReadOnlySpan<byte> encodedString = _buffer.Span.Slice(1 + additionalBytes, length);
             string result = s_utf8Encoding.GetString(encodedString);
@@ -59,7 +81,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public bool TryReadTextString(Span<char> destination, out int charsWritten)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
-            int byteLength = checked((int)ReadUnsignedInteger(header, out int additionalBytes));
+
+            if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
+            {
+                return TryReadChunkedTextStringConcatenated(destination, out charsWritten);
+            }
+
+            int byteLength = checked((int)ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + byteLength);
 
             ReadOnlySpan<byte> encodedSlice = _buffer.Span.Slice(1 + additionalBytes, byteLength);
@@ -119,6 +147,146 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             ReadNextIndefiniteLengthBreakByte();
             PopDataItem(CborMajorType.ByteString);
             AdvanceBuffer(1);
+        }
+
+        private bool TryReadChunkedByteStringConcatenated(Span<byte> destination, out int bytesWritten)
+        {
+            List<(int offset, int length)> offsets = ReadChunkedStringRanges(CborMajorType.ByteString, out int offset, out int concatenatedBufferSize);
+
+            if (concatenatedBufferSize > destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            ReadOnlySpan<byte> source = _buffer.Span;
+
+            foreach ((int o, int l) in offsets)
+            {
+                source.Slice(o, l).CopyTo(destination);
+                destination = destination.Slice(l);
+            }
+
+            bytesWritten = concatenatedBufferSize;
+            AdvanceBuffer(offset);
+            DecrementRemainingItemCount();
+            return true;
+        }
+
+        private bool TryReadChunkedTextStringConcatenated(Span<char> destination, out int charsWritten)
+        {
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int offset, out int _);
+            ReadOnlySpan<byte> buffer = _buffer.Span;
+
+            int concatenatedStringSize = 0;
+            foreach ((int o, int l) in ranges)
+            {
+                concatenatedStringSize += s_utf8Encoding.GetCharCount(buffer.Slice(o, l));
+            }
+
+            if (concatenatedStringSize > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            foreach ((int o, int l) in ranges)
+            {
+                s_utf8Encoding.GetChars(buffer.Slice(o, l), destination);
+                destination = destination.Slice(l);
+            }
+
+            charsWritten = concatenatedStringSize;
+            AdvanceBuffer(offset);
+            DecrementRemainingItemCount();
+            return true;
+        }
+
+        private byte[] ReadChunkedByteStringConcatenated()
+        {
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int offset, out int concatenatedBufferSize);
+            var output = new byte[concatenatedBufferSize];
+
+            ReadOnlySpan<byte> source = _buffer.Span;
+            Span<byte> target = output;
+
+            foreach ((int o, int l) in ranges)
+            {
+                source.Slice(o, l).CopyTo(target);
+                target = target.Slice(l);
+            }
+
+            Debug.Assert(target.IsEmpty);
+            AdvanceBuffer(offset);
+            DecrementRemainingItemCount();
+            return output;
+        }
+
+        private string ReadChunkedTextStringConcatenated()
+        {
+            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int offset, out int concatenatedBufferSize);
+            ReadOnlySpan<byte> buffer = _buffer.Span;
+            int concatenatedStringSize = 0;
+
+            foreach ((int o, int l) in ranges)
+            {
+                concatenatedStringSize += s_utf8Encoding.GetCharCount(buffer.Slice(o, l));
+            }
+
+            var output = new char[concatenatedStringSize];
+            Span<char> target = output;
+
+            foreach ((int o, int l) in ranges)
+            {
+                s_utf8Encoding.GetChars(buffer.Slice(o, l), target);
+                target = target.Slice(l);
+            }
+
+            Debug.Assert(target.IsEmpty);
+            AdvanceBuffer(offset);
+            DecrementRemainingItemCount();
+            return new string(output);
+        }
+
+        // reads a buffer starting with an indefinite-length string,
+        // performing validation and returning a list of ranges containing the individual chunk payloads
+        private List<(int offset, int length)> ReadChunkedStringRanges(CborMajorType type, out int encodingLength, out int concatenatedBufferSize)
+        {
+            var ranges = new List<(int offset, int length)>();
+            ReadOnlySpan<byte> buffer = _buffer.Span;
+            concatenatedBufferSize = 0;
+
+            int i = 1; // skip the indefinite-length initial byte
+            CborInitialByte nextInitialByte = ReadNextInitialByte(buffer.Slice(i), type);
+
+            while (nextInitialByte.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
+            {
+                checked
+                {
+                    int chunkLength = (int)ReadUnsignedInteger(buffer.Slice(i), nextInitialByte, out int additionalBytes);
+                    ranges.Add((i + 1 + additionalBytes, chunkLength));
+                    i += 1 + additionalBytes + chunkLength;
+                    concatenatedBufferSize += chunkLength;
+                }
+
+                nextInitialByte = ReadNextInitialByte(buffer.Slice(i), type);
+            }
+
+            encodingLength = i + 1; // include the break byte
+            return ranges;
+
+            static CborInitialByte ReadNextInitialByte(ReadOnlySpan<byte> buffer, CborMajorType expectedType)
+            {
+                EnsureBuffer(buffer, 1);
+                var cib = new CborInitialByte(buffer[0]);
+
+                if (cib.InitialByte != CborInitialByte.IndefiniteLengthBreakByte && cib.MajorType != expectedType)
+                {
+                    throw new FormatException("Indefinite-length CBOR string containing invalid data item.");
+                }
+
+                return cib;
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -262,7 +262,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // performing validation and returning a list of ranges containing the individual chunk payloads
         private List<(int offset, int length)> ReadChunkedStringRanges(CborMajorType type, out int encodingLength, out int concatenatedBufferSize)
         {
-            var ranges = GetRangeList();
+            var ranges = AcquireRangeList();
             ReadOnlySpan<byte> buffer = _buffer.Span;
             concatenatedBufferSize = 0;
 
@@ -300,16 +300,21 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         private List<(int offset, int length)>? _rangeListAllocation = null;
-        private List<(int offset, int length)> GetRangeList()
+        private List<(int offset, int length)> AcquireRangeList()
         {
             List<(int offset, int length)>? ranges = Interlocked.Exchange(ref _rangeListAllocation, null);
-            ranges ??= new List<(int, int)>();
-            return ranges;
+
+            if (ranges != null)
+            {
+                ranges.Clear();
+                return ranges;
+            }
+
+            return new List<(int, int)>();
         }
 
         private void ReturnRangeList(List<(int offset, int length)> ranges)
         {
-            ranges.Clear();
             _rangeListAllocation = ranges;
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         Tag,
         Special,
         Finished,
+        FormatError,
         EndOfData,
     }
 
@@ -57,6 +58,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     return _nestedDataItemStack.Peek().type switch
                     {
                         CborMajorType.Array => CborReaderState.EndArray,
+                        CborMajorType.Map when !_isEvenNumberOfDataItemsWritten => CborReaderState.FormatError,
                         CborMajorType.Map => CborReaderState.EndMap,
                         _ => throw new Exception("CborReader internal error. Invalid CBOR major type pushed to stack."),
                     };
@@ -83,13 +85,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                         CborMajorType.ByteString => CborReaderState.EndByteString,
                         CborMajorType.TextString => CborReaderState.EndTextString,
                         CborMajorType.Array => CborReaderState.EndArray,
+                        CborMajorType.Map when !_isEvenNumberOfDataItemsWritten => CborReaderState.FormatError,
                         CborMajorType.Map => CborReaderState.EndMap,
                         _ => throw new Exception("CborReader internal error. Invalid CBOR major type pushed to stack."),
                     };
                 }
                 else
                 {
-                    throw new FormatException("Unexpected CBOR break byte.");
+                    return CborReaderState.FormatError;
                 }
             }
 
@@ -105,7 +108,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 CborMajorType.Map => CborReaderState.StartMap,
                 CborMajorType.Tag => CborReaderState.Tag,
                 CborMajorType.Special => CborReaderState.Special,
-                _ => throw new FormatException("Invalid CBOR major type"),
+                _ => CborReaderState.FormatError,
             };
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -253,6 +253,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new FormatException("Unexpected end of buffer.");
             }
         }
+
         private static void EnsureBuffer(ReadOnlySpan<byte> buffer, int requiredLength)
         {
             if (buffer.Length < requiredLength)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -23,7 +23,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteEndArray()
         {
+            if (!_remainingDataItems.HasValue)
+            {
+                // indefinite-length map, add break byte
+                EnsureWriteCapacity(1);
+                WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));
+            }
+
             PopDataItem(CborMajorType.Array);
+        }
+
+        public void WriteStartArray()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
+            DecrementRemainingItemCount();
+            PushDataItem(CborMajorType.Array, expectedNestedItems: null);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PopDataItem(CborMajorType.Array);
         }
 
-        public void WriteStartArray()
+        public void WriteStartArrayIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -31,43 +31,40 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Unsigned integer encoding https://tools.ietf.org/html/rfc7049#section-2.1
         private void WriteUnsignedInteger(CborMajorType type, ulong value)
         {
-            EnsureCanWriteNewDataItem();
-
             if (value < 24)
             {
                 EnsureWriteCapacity(1);
-                _buffer[_offset++] = new CborInitialByte(type, (CborAdditionalInfo)value).InitialByte;
+                WriteInitialByte(new CborInitialByte(type, (CborAdditionalInfo)value));
             }
             else if (value <= byte.MaxValue)
             {
                 EnsureWriteCapacity(2);
-                _buffer[_offset] = new CborInitialByte(type, CborAdditionalInfo.Unsigned8BitIntegerEncoding).InitialByte;
-                _buffer[_offset + 1] = (byte)value;
-                _offset += 2;
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Unsigned8BitIntegerEncoding));
+                _buffer[_offset++] = (byte)value;
             }
             else if (value <= ushort.MaxValue)
             {
                 EnsureWriteCapacity(3);
-                _buffer[_offset] = new CborInitialByte(type, CborAdditionalInfo.Unsigned16BitIntegerEncoding).InitialByte;
-                BinaryPrimitives.WriteUInt16BigEndian(_buffer.AsSpan(_offset + 1), (ushort)value);
-                _offset += 3;
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Unsigned16BitIntegerEncoding));
+                BinaryPrimitives.WriteUInt16BigEndian(_buffer.AsSpan(_offset), (ushort)value);
+                _offset += 2;
             }
             else if (value <= uint.MaxValue)
             {
                 EnsureWriteCapacity(5);
-                _buffer[_offset] = new CborInitialByte(type, CborAdditionalInfo.Unsigned32BitIntegerEncoding).InitialByte;
-                BinaryPrimitives.WriteUInt32BigEndian(_buffer.AsSpan(_offset + 1), (uint)value);
-                _offset += 5;
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Unsigned32BitIntegerEncoding));
+                BinaryPrimitives.WriteUInt32BigEndian(_buffer.AsSpan(_offset), (uint)value);
+                _offset += 4;
             }
             else
             {
                 EnsureWriteCapacity(9);
-                _buffer[_offset] = new CborInitialByte(type, CborAdditionalInfo.Unsigned64BitIntegerEncoding).InitialByte;
-                BinaryPrimitives.WriteUInt64BigEndian(_buffer.AsSpan(_offset + 1), value);
-                _offset += 9;
+                WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Unsigned64BitIntegerEncoding));
+                BinaryPrimitives.WriteUInt64BigEndian(_buffer.AsSpan(_offset), value);
+                _offset += 8;
             }
 
-            _remainingDataItems--;
+            DecrementRemainingItemCount();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -22,7 +22,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteEndMap()
         {
+            if (!_remainingDataItems.HasValue)
+            {
+                // indefinite-length map, add break byte
+                EnsureWriteCapacity(1);
+                WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));
+            }
+
             PopDataItem(CborMajorType.Map);
+        }
+
+        public void WriteStartMap()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
+            DecrementRemainingItemCount();
+            PushDataItem(CborMajorType.Map, expectedNestedItems: null);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PopDataItem(CborMajorType.Map);
         }
 
-        public void WriteStartMap()
+        public void WriteStartMapIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -22,6 +22,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteEndMap()
         {
+            if (!_isEvenNumberOfDataItemsWritten)
+            {
+                throw new InvalidOperationException("CBOR Map types require an even number of key/value combinations");
+            }
+
             if (!_remainingDataItems.HasValue)
             {
                 // indefinite-length map, add break byte

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             _offset += length;
         }
 
-        public void WriteStartByteString()
+        public void WriteStartByteStringIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.ByteString, CborAdditionalInfo.IndefiniteLength));
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PopDataItem(CborMajorType.ByteString);
         }
 
-        public void WriteStartTextString()
+        public void WriteStartTextStringIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.TextString, CborAdditionalInfo.IndefiniteLength));

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
         }
 
-        public void WriteEndByteString()
+        public void WriteEndByteStringIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
 
-        public void WriteEndTextString()
+        public void WriteEndTextStringIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -30,5 +30,35 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             s_utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset));
             _offset += length;
         }
+
+        public void WriteStartByteString()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborMajorType.ByteString, CborAdditionalInfo.IndefiniteLength));
+            DecrementRemainingItemCount();
+            PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
+        }
+
+        public void WriteEndByteString()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));
+            PopDataItem(CborMajorType.ByteString);
+        }
+
+        public void WriteStartTextString()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborMajorType.TextString, CborAdditionalInfo.IndefiniteLength));
+            DecrementRemainingItemCount();
+            PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
+        }
+
+        public void WriteEndTextString()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborInitialByte.IndefiniteLengthBreakByte));
+            PopDataItem(CborMajorType.TextString);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // The root context ony permits one data item to be written.
         private uint? _remainingDataItems = 1;
         private bool _isEvenNumberOfDataItemsWritten = true; // required for indefinite-length map writes
-        private Stack<(CborMajorType type, bool isEventNumberOfDataItemsWritten, uint? remainingDataItems)>? _nestedDataItemStack;
+        private Stack<(CborMajorType type, bool isEvenNumberOfDataItemsWritten, uint? remainingDataItems)>? _nestedDataItemStack;
 
         public CborWriter()
         {
@@ -79,11 +79,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             if (expectedType != actualType)
             {
                 throw new InvalidOperationException("Unexpected major type in nested CBOR data item.");
-            }
-
-            if (expectedType == CborMajorType.Map && !_isEvenNumberOfDataItemsWritten)
-            {
-                throw new InvalidOperationException("CBOR Map types require an even number of key/value combinations");
             }
 
             if (_remainingDataItems > 0)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -21,7 +21,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // with null representing indefinite length data items.
         // The root context ony permits one data item to be written.
         private uint? _remainingDataItems = 1;
-        private Stack<(CborMajorType type, uint? remainingDataItems)>? _nestedDataItemStack;
+        private bool _isEvenNumberOfDataItemsWritten = true; // required for indefinite-length map writes
+        private Stack<(CborMajorType type, bool isEventNumberOfDataItemsWritten, uint? remainingDataItems)>? _nestedDataItemStack;
 
         public CborWriter()
         {
@@ -58,26 +59,31 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
-        private void EnsureCanWriteNewDataItem()
-        {
-            if (_remainingDataItems == 0)
-            {
-                throw new InvalidOperationException("Adding a CBOR data item to the current context exceeds its definite length.");
-            }
-        }
-
         private void PushDataItem(CborMajorType type, uint? expectedNestedItems)
         {
-            _nestedDataItemStack ??= new Stack<(CborMajorType, uint?)>();
-            _nestedDataItemStack.Push((type, _remainingDataItems));
+            _nestedDataItemStack ??= new Stack<(CborMajorType, bool, uint?)>();
+            _nestedDataItemStack.Push((type, _isEvenNumberOfDataItemsWritten, _remainingDataItems));
             _remainingDataItems = expectedNestedItems;
+            _isEvenNumberOfDataItemsWritten = true;
         }
 
         private void PopDataItem(CborMajorType expectedType)
         {
-            if (_remainingDataItems == null)
+            if (_nestedDataItemStack is null || _nestedDataItemStack.Count == 0)
             {
-                throw new NotImplementedException("Indefinite-length data items");
+                throw new InvalidOperationException("No active CBOR nested data item to pop");
+            }
+
+            (CborMajorType actualType, bool isEvenNumberOfDataItemsWritten, uint? remainingItems) = _nestedDataItemStack.Peek();
+
+            if (expectedType != actualType)
+            {
+                throw new InvalidOperationException("Unexpected major type in nested CBOR data item.");
+            }
+
+            if (expectedType == CborMajorType.Map && !_isEvenNumberOfDataItemsWritten)
+            {
+                throw new InvalidOperationException("CBOR Map types require an even number of key/value combinations");
             }
 
             if (_remainingDataItems > 0)
@@ -85,20 +91,52 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("Definite-length nested CBOR data item is incomplete.");
             }
 
-            if (_nestedDataItemStack is null || _nestedDataItemStack.Count == 0)
-            {
-                throw new InvalidOperationException("No active CBOR nested data item to pop");
-            }
-
-            (CborMajorType actualType, uint? remainingItems) = _nestedDataItemStack.Peek();
-
-            if (expectedType != actualType)
-            {
-                throw new InvalidOperationException("Unexpected major type in nested CBOR data item.");
-            }
-
             _nestedDataItemStack.Pop();
             _remainingDataItems = remainingItems;
+            _isEvenNumberOfDataItemsWritten = isEvenNumberOfDataItemsWritten;
+        }
+
+        private void DecrementRemainingItemCount()
+        {
+            _remainingDataItems--;
+            _isEvenNumberOfDataItemsWritten = !_isEvenNumberOfDataItemsWritten;
+        }
+
+        private void WriteInitialByte(CborInitialByte initialByte)
+        {
+            if (_remainingDataItems == 0)
+            {
+                throw new InvalidOperationException("Adding a CBOR data item to the current context exceeds its definite length.");
+            }
+
+            if (_remainingDataItems.HasValue && initialByte.InitialByte == CborInitialByte.IndefiniteLengthBreakByte)
+            {
+                throw new InvalidOperationException("Cannot write CBOR break byte in definite-length contexts");
+            }
+
+            // TODO check for tag state
+
+            if (_nestedDataItemStack != null && _nestedDataItemStack.Count > 0)
+            {
+                CborMajorType parentType = _nestedDataItemStack.Peek().type;
+
+                switch (parentType)
+                {
+                    // indefinite-length string contexts do not permit nesting
+                    case CborMajorType.ByteString:
+                    case CborMajorType.TextString:
+                        if (initialByte.InitialByte == CborInitialByte.IndefiniteLengthBreakByte ||
+                            initialByte.MajorType == parentType &&
+                            initialByte.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
+                        {
+                            break;
+                        }
+
+                        throw new InvalidOperationException("Cannot nest data items in indefinite-length CBOR string contexts.");
+                }
+            }
+
+            _buffer[_offset++] = initialByte.InitialByte;
         }
 
         private void CheckDisposed()


### PR DESCRIPTION
Adds indefinite length writer and reader support for strings, maps and arrays:

- [x] Implement write support.
- [x] Implement read support.