### PR TITLE
Fix DAC minidump generation

### DIFF
--- a/src/coreclr/src/vm/codeman.cpp
+++ b/src/coreclr/src/vm/codeman.cpp
@@ -3617,9 +3617,15 @@ void CodeHeader::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, IJitManager* pJ
     this->pRealCodeHeader.EnumMem();
 #endif // USE_INDIRECT_CODEHEADER
 
+#ifdef FEATURE_ON_STACK_REPLACEMENT
+    BOOL hasFlagByte = TRUE;
+#else
+    BOOL hasFlagByte = FALSE;
+#endif
+
     if (this->GetDebugInfo() != NULL)
     {
-        CompressDebugInfo::EnumMemoryRegions(flags, this->GetDebugInfo());
+        CompressDebugInfo::EnumMemoryRegions(flags, this->GetDebugInfo(), hasFlagByte);
     }
 }
 
@@ -6771,7 +6777,7 @@ void ReadyToRunJitManager::EnumMemoryRegionsForMethodDebugInfo(CLRDataEnumMemory
     if (pDebugInfo == NULL)
         return;
 
-    CompressDebugInfo::EnumMemoryRegions(flags, pDebugInfo);
+    CompressDebugInfo::EnumMemoryRegions(flags, pDebugInfo, FALSE);
 }
 #endif
 

--- a/src/coreclr/src/vm/debuginfostore.cpp
+++ b/src/coreclr/src/vm/debuginfostore.cpp
@@ -702,7 +702,7 @@ PatchpointInfo * CompressDebugInfo::RestorePatchpointInfo(IN PTR_BYTE pDebugInfo
 #endif
 
 #ifdef DACCESS_COMPILE
-void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE pDebugInfo)
+void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE pDebugInfo, BOOL hasFlagByte)
 {
     CONTRACTL
     {
@@ -711,6 +711,27 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
         SUPPORTS_DAC;
     }
     CONTRACTL_END;
+
+#ifdef FEATURE_ON_STACK_REPLACEMENT
+    if (hasFlagByte)
+    {
+        // Check flag byte and skip over any patchpoint info
+        BYTE flagByte = *pDebugInfo;
+        pDebugInfo++;
+
+        if (flagByte == 1)
+        {
+            PTR_PatchpointInfo patchpointInfo = dac_cast<PTR_PatchpointInfo>(pDebugInfo);
+            pDebugInfo += patchpointInfo->PatchpointInfoSize();
+        }
+        else
+        {
+            _ASSERTE(flagByte == 0);
+        }
+    }
+#else
+    _ASSERTE(!hasFlagByte);
+#endif
 
     NibbleReader r(pDebugInfo, 12 /* maximum size of compressed 2 UINT32s */);
 

--- a/src/coreclr/src/vm/debuginfostore.h
+++ b/src/coreclr/src/vm/debuginfostore.h
@@ -107,7 +107,7 @@ public:
 #endif
 
 #ifdef DACCESS_COMPILE
-    static void EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE pDebugInfo);
+    static void EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE pDebugInfo, BOOL hasFlagByte);
 #endif
 };
 


### PR DESCRIPTION
CompressDebugInfo::EnumMemoryRegions did not add the correct debug info
memory when FEATURE_ON_STACK_REPLACEMENT is enabled. This caused the
diagnostics SOS tests to failure on Windows.