### PR TITLE
Forbid block morph in CSE.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2890,7 +2890,9 @@ public:
     void gtGetLclVarNameInfo(unsigned lclNum, const char** ilKindOut, const char** ilNameOut, unsigned* ilNumOut);
     int gtGetLclVarName(unsigned lclNum, char* buf, unsigned buf_remaining);
     char* gtGetLclVarName(unsigned lclNum);
-    void gtDispLclVar(unsigned varNum, bool padForBiggestDisp = true);
+    void gtDispLclVar(unsigned lclNum, bool padForBiggestDisp = true);
+    void gtDispLclVarStructType(unsigned lclNum);
+    void gtDispClassLayout(ClassLayout* layout, var_types type);
     void gtDispStmt(Statement* stmt, const char* msg = nullptr);
     void gtDispBlockStmts(BasicBlock* block);
     void gtGetArgMsg(GenTreeCall* call, GenTree* arg, unsigned argNum, int listCount, char* bufp, unsigned bufLength);

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -6847,7 +6847,7 @@ void Compiler::lvaDumpFrameLocation(unsigned lclNum)
 
 void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t refCntWtdWidth)
 {
-    LclVarDsc* varDsc = lvaTable + lclNum;
+    LclVarDsc* varDsc = lvaGetDesc(lclNum);
     var_types  type   = varDsc->TypeGet();
 
     if (curState == INITIAL_FRAME_LAYOUT)
@@ -6856,30 +6856,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         gtDispLclVar(lclNum);
 
         printf(" %7s ", varTypeName(type));
-        if (genTypeSize(type) == 0)
-        {
-#if FEATURE_FIXED_OUT_ARGS
-            if (lclNum == lvaOutgoingArgSpaceVar)
-            {
-                // Since lvaOutgoingArgSpaceSize is a PhasedVar we can't read it for Dumping until
-                // after we set it to something.
-                if (lvaOutgoingArgSpaceSize.HasFinalValue())
-                {
-                    // A PhasedVar<T> can't be directly used as an arg to a variadic function
-                    unsigned value = lvaOutgoingArgSpaceSize;
-                    printf("(%2d) ", value);
-                }
-                else
-                {
-                    printf("(na) "); // The value hasn't yet been determined
-                }
-            }
-            else
-#endif // FEATURE_FIXED_OUT_ARGS
-            {
-                printf("(%2d) ", lvaLclSize(lclNum));
-            }
-        }
+        gtDispLclVarStructType(lclNum);
     }
     else
     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13757,6 +13757,13 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
     switch (oper)
     {
         case GT_ASG:
+            // Make sure we're allowed to do this.
+            if (optValnumCSE_phase)
+            {
+                // It is not safe to reorder/delete CSE's
+                break;
+            }
+
             if (varTypeIsStruct(typ) && !tree->IsPhiDefn())
             {
                 if (tree->OperIsCopyBlkOp())
@@ -13771,14 +13778,6 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
 
             if (typ == TYP_LONG)
             {
-                break;
-            }
-
-            /* Make sure we're allowed to do this */
-
-            if (optValnumCSE_phase)
-            {
-                // It is not safe to reorder/delete CSE's
                 break;
             }
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/33845/commits/77f235c2c9c5ebef4ff10b491377cc6fd64bf292 forbids calling `fgMorphCopyBlock` or `fgMorphInitBlock` if we are in CSE phase. These functions could delete trees that are CSE candidates, which leads to asserts later. Exposed via struct changes, without retyping we have more structs and more CSE uses/defs.
There are no size diffs from that change, only a few text diffs, that look like changes in instruction order,
before:
```
IN0047: 0001AB lea      rsi, bword ptr [V02+0x20 rsp+A8H]
IN0048: 0001B3 mov      rbp, gword ptr [V02 rsp+88H]
IN0049: 0001BB lea      rdi, bword ptr [rbp+232]
```
after:
```
IN0047: 0001AB mov      rbp, gword ptr [V02 rsp+88H]
IN0048: 0001B3 lea      rdi, bword ptr [rbp+232]
IN0049: 0001BA lea      rsi, bword ptr [V02+0x20 rsp+A8H]
```
it happens because calls to `fgMorphBlockOperand` wraps everything in a `IND(ADDR(X))`, but if you call `fgMorphTree` on such a tree again it will fold them back to `X`.  So without the change we were adding useless `IND(ADDR())` nodes, now we don't (in CSE phase, others still do that, I tried to fix that behavior but it took me too far).
before:
```
N309 (  3,  4) [000212] ------------       t212 =    LCL_FLD_ADDR byref  V02 loc0         u:2[+32] Fseq[_currentToken] rsi REG rsi
                                                  /--*  t212   byref  
N311 (  6,  7) [000366] nc----------       t366 = *  IND       struct REG NA
```
after:
```
N311 (  3,  4) [000210] ------------       t210 =    LCL_FLD   ref    V02 loc0         u:2[+0] Fseq[_scanner] rbp REG rbp <l:$21c, c:$21d>
```


The second commit changes how we dump struct types in `; Initial local variable assignments` table:
before
```
;  V00 arg0              ref  class-hnd
;  V01 arg1           struct (16) 
;  V02 loc0             long 
;  V03 loc1            byref  pinned
;  V04 OutArgs        lclBlk (na)  "OutgoingArgSpace"
```
after
```
;  V00 arg0              ref  class-hnd
;  V01 arg1           struct <System.Span`1[Char], 16>
;  V02 loc0             long 
;  V03 loc1            byref  pinned
;  V04 OutArgs        lclBlk <na>  "OutgoingArgSpace"
```

I was planning to change it in the final local variable assignments printing too, but first: it generates too many asm diffs, second - right now it is nicely formatted as a table and adding long names there destroys this formatting.