### PR TITLE
Add string ctor to MemberNotNull

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -127,36 +127,52 @@ namespace System.Diagnostics.CodeAnalysis
     }
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 #if INTERNAL_NULLABLE_ATTRIBUTES
     internal
 #else
-    [CLSCompliant(false)]
     public
 #endif
         sealed class MemberNotNullAttribute : Attribute
     {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
         /// <summary>Initializes the attribute with the list of field and property members.</summary>
         /// <param name="members">
         /// The list of field and property members that are promised to be not-null.
         /// </param>
-        public MemberNotNullAttribute(params string[] members)
-            => Members = members;
+        public MemberNotNullAttribute(params string[] members) => Members = members;
 
         /// <summary>Gets field or property member names.</summary>
         public string[] Members { get; }
     }
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 #if INTERNAL_NULLABLE_ATTRIBUTES
     internal
 #else
-    [CLSCompliant(false)]
     public
 #endif
         sealed class MemberNotNullWhenAttribute : Attribute
     {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
         /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
         /// <param name="returnValue">
         /// The return value condition. If the method returns this value, the associated parameter will not be null.

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5618,17 +5618,17 @@ namespace System.Diagnostics.CodeAnalysis
         public NotNullWhenAttribute(bool returnValue) { }
         public bool ReturnValue { get { throw null; } }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited = false)]
-    [System.CLSCompliant(false)]
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     public sealed class MemberNotNullAttribute : System.Attribute
     {
+        public MemberNotNullAttribute(string member) { }
         public MemberNotNullAttribute(params string[] members) { }
         public string[] Members { get { throw null; } }
     }
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited = false)]
-    [System.CLSCompliant(false)]
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     public sealed class MemberNotNullWhenAttribute : System.Attribute
     {
+        public MemberNotNullWhenAttribute(bool returnValue, string member) { }
         public MemberNotNullWhenAttribute(bool returnValue, params string[] members) { }
         public bool ReturnValue { get { throw null; } }
         public string[] Members { get { throw null; } }


### PR DESCRIPTION
With only the params string[] ctor, every usage of MemberNotNull in a CLSCompliant(true) assembly needs to have its warning suppressed.

cc: @jcouv, @terrajobst 

Relates to https://github.com/dotnet/roslyn/issues/41438