### PR TITLE
Fix LangVersion for C# projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,9 +82,6 @@
 
   <!-- Language configuration -->
   <PropertyGroup>
-    <!-- default to allowing all language features -->
-    <LangVersion>latest</LangVersion>
-    <LangVersion Condition="'$(Language)' == 'C#'">preview</LangVersion>
     <Deterministic>true</Deterministic>
 
     <!-- Resource naming bug: https://github.com/microsoft/msbuild/issues/4740 -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,13 @@
     <GeneratedAssemblyInfoFile>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)'))</GeneratedAssemblyInfoFile>
   </PropertyGroup>
 
+  <!-- Language configuration -->
+  <PropertyGroup>
+    <!-- default to allowing all language features -->
+    <LangVersion>preview</LangVersion>
+    <LangVersion Condition="'$(Language)' == 'VB'">latest</LangVersion>
+  </PropertyGroup>
+
   <!--
     All source inputs to the compiler should be generated before BeforeCompile target. Sdk is not
     honoring this for GenerateAssemblyInfo target. https://github.com/dotnet/sdk/issues/10614 


### PR DESCRIPTION
For some reason I've not yet determined, the Language==C# condition is failing, resulting in us using latest rather than preview for building all of our C# projects.  Since all of our projects _are_ C# except for a single VB project, I've just defaulted to preview unconditionally and overrode it in that single .vbproj (since VB doesn't allow "preview").

cc: @ViktorHofer 