### PR TITLE
[mono] Add headers for unstable APIs

### DIFF
--- a/src/mono/mono/metadata/Makefile.am
+++ b/src/mono/mono/metadata/Makefile.am
@@ -455,6 +455,7 @@ libmonoruntimeinclude_HEADERS = \
 	mono-config.h		\
 	mono-debug.h		\
 	mono-gc.h		\
+	mono-private-unstable.h	\
 	object.h		\
 	object-forward.h	\
 	opcodes.h		\

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/mini/Makefile.am.in
+++ b/src/mono/mono/mini/Makefile.am.in
@@ -783,7 +783,9 @@ libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
 # These are public headers.
 # They should not use glib.h, G_BEGIN_DECLS, guint, etc.
 # They should be wrapped in MONO_BEGIN_DECLS / MONO_END_DECLS.
-libmonoinclude_HEADERS = jit.h
+libmonoinclude_HEADERS = \
+	jit.h		\
+	mono-private-unstable.h
 
 CSFLAGS = -unsafe -nowarn:0219,0169,0414,0649,0618
 

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_JIT_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_JIT_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_JIT_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/utils/Makefile.am
+++ b/src/mono/mono/utils/Makefile.am
@@ -343,6 +343,7 @@ libmonoutilsinclude_HEADERS = 	\
 	mono-publib.h		\
 	mono-jemalloc.h		\
 	mono-dl-fallback.h	\
+	mono-private-unstable.h	\
 	mono-counters.h
 
 EXTRA_DIST = mono-errno.h mono-embed.h mono-embed.c ../../support/libm/complex.c mono-experiments.def

--- a/src/mono/mono/utils/mono-private-unstable.h
+++ b/src/mono/mono/utils/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/msvc/libmono.bat
+++ b/src/mono/msvc/libmono.bat
@@ -69,6 +69,7 @@ metadata.h ^
 mono-config.h ^
 mono-debug.h ^
 mono-gc.h ^
+mono-private-unstable.h ^
 object.h ^
 object-forward.h ^
 opcodes.h ^
@@ -88,15 +89,22 @@ mono-error.h ^
 mono-forward.h ^
 mono-jemalloc.h ^
 mono-logger.h ^
+mono-private-unstable.h ^
 mono-publib.h
+
+SET JIT_FILES=^
+jit.h ^
+mono-private-unstable.h
 
 ECHO Copying mono include files from %SOURCE_ROOT% to %TARGET_ROOT% ...
 
 SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\cil\opcode.def" "%TARGET_ROOT%\cil\" %OPTIONS%
 call :runCommand "%RUN%" %ARGUMENTS%
 
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\mini\jit.h" "%TARGET_ROOT%\jit\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
+FOR %%a IN (%JIT_FILES%) DO (
+	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\mini\%%a" "%TARGET_ROOT%\jit\" %OPTIONS%
+	call :runCommand "!RUN!" %ARGUMENTS%
+)
 
 FOR %%a IN (%META_DATA_FILES%) DO (
 	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\metadata\%%a" "%TARGET_ROOT%\metadata\" %OPTIONS%

--- a/src/mono/msvc/libmonoruntime-common.targets
+++ b/src/mono/msvc/libmonoruntime-common.targets
@@ -244,6 +244,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-config.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-debug.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-gc.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-private-unstable.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-bridge.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\opcodes.h" />

--- a/src/mono/msvc/libmonoruntime-common.targets.filters
+++ b/src/mono/msvc/libmonoruntime-common.targets.filters
@@ -675,6 +675,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-gc.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-private-unstable.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-bridge.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>

--- a/src/mono/msvc/libmonoutils-common.targets
+++ b/src/mono/msvc/libmonoutils-common.targets
@@ -207,6 +207,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-error.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-publib.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-private-unstable.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-dl-fallback.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-counters.h" />
   </ItemGroup>

--- a/src/mono/msvc/libmonoutils-common.targets.filters
+++ b/src/mono/msvc/libmonoutils-common.targets.filters
@@ -492,6 +492,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-private-unstable.h">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-error.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
     </ClInclude>


### PR DESCRIPTION
We have functions that are de-facto part of the Mono embedding API that are
used by Xamarin.iOS or Xamarin.Android that are not in a state where we want to
commit to supporting them forever in their current form.

Nonetheless, we would like to make sure that the symbols for these functions
are visible even if we otherwise compile the runtime with
`-fvisisibility=hidden`, and we would like to discourage declaring the
functions in the embedder's own headers.

The functions that go into the
`mono/{utils,metadata,jit}/mono-private-unstable.h` headers will all be marked
with `MONO_API MONO_RT_EXTERNAL_ONLY` but we will not guarantee that the
functions will be there from one release to the next or that they will not
change their signatures or their behaviors.