### PR TITLE
Unset repo tools manifest path in CI to fix restore errors

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <MSBuildTreatWarningsAsErrors>false</MSBuildTreatWarningsAsErrors>
     <EnableAnalyzers>true</EnableAnalyzers>
+    <!-- Unset the repo tool manifest property in CI as we don't use repo tools there anyway,
+    until https://github.com/dotnet/sdk/issues/10938 is fixed. -->
+    <_RepoToolManifest Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
   </PropertyGroup>
 
   <!-- We need to import this props file which contains PackageReferences to analyzers so that


### PR DESCRIPTION
An updated SDK with the net5.0 tfm change seems to break dotnet repo
tool restore, presumably because multiple compatible tfms are found.
Working around this by unsetting the repo tools manifest file path until the
issue is fixed.

Fixes https://github.com/dotnet/runtime/issues/33837

cc @stephentoub 