### PR TITLE
Fix cancellation-related deadlock in BoundedChannel

### DIFF
--- a/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -24,6 +24,12 @@ namespace System.Threading.Channels.Tests
         protected virtual bool RequiresSingleWriter => false;
         protected virtual bool BuffersItems => true;
 
+        public static IEnumerable<object[]> ThreeBools =>
+            from b1 in new[] { false, true }
+            from b2 in new[] { false, true }
+            from b3 in new[] { false, true }
+            select new object[] { b1, b2, b3 };
+
         [Fact]
         public void ValidateDebuggerAttributes()
         {


### PR DESCRIPTION
If:
- a BoundedChannel is opted-in to synchronous continuations via someone setting AllowSynchronousContinuations on its options when constructed, and
- if a read operation is performed when there's no data available and with a cancelable cancellation token, and
- if cancellation is requested concurrently with a write being performed that will satisfy that read...

then there's the potential for a deadlock.  While holding a lock, the writer needs to unregister the cancellation for the reader's operation prior to trying to complete it, and needs to know that all cancellation-related work has quiesced before it proceeds to try to complete that reader.  If the cancellation is currently in progress then, it waits for the cancellation callback to complete.  However, if a synchronous continuation was used, then it's possible the user's synchronous continuation might call back into the bounded channel and perform an operation that might require taking that same lock.  Deadlock.

The fix is to simply not try to use synchronous continuations with bounded channel when a cancelable token is employed.

Fixes https://github.com/dotnet/runtime/issues/33858
cc: @tarekgh 