### PR TITLE
Remove erroneous curlies in Xml resource 

### DIFF
--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1720,7 +1720,7 @@
     <value>Cannot load the schema from the location '{0}' - {1}</value>
   </data>
   <data name="Sch_LengthGtBaseLength" xml:space="preserve">
-    <value>It is an error if 'length' is among the members of {facets} of {base type definition} and {value} is greater than the {value} of the parent 'length'.</value>
+    <value>It is an error if 'length' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'length'.</value>
   </data>
   <data name="Sch_MinLengthGtBaseMinLength" xml:space="preserve">
     <value>It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1501,7 +1501,7 @@
     <value>Duplicate ID attribute.</value>
   </data>
   <data name="Sch_InvalidAllElementMax" xml:space="preserve">
-    <value>The {max occurs} of all the particles in the {particles} of an all group must be 0 or 1.</value>
+    <value>The 'maxOccurs' attribute of all the particles of an 'all' group must be 0 or 1.</value>
   </data>
   <data name="Sch_InvalidAny" xml:space="preserve">
     <value>Invalid namespace in 'any'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1510,7 +1510,7 @@
     <value>The value of the namespace attribute of the element or attribute wildcard is invalid - {0}</value>
   </data>
   <data name="Sch_InvalidExamplar" xml:space="preserve">
-    <value>Cannot be nominated as the {substitution group affiliation} of any other declaration.</value>
+    <value>Element '{0}' cannot be nominated as the 'substitutionGroup' of any other declaration.</value>
   </data>
   <data name="Sch_NoExamplar" xml:space="preserve">
     <value>Reference to undeclared substitution group affiliation.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1396,7 +1396,7 @@
     <value>'all' must have 'minOccurs' value of 0 or 1.</value>
   </data>
   <data name="Sch_InvalidAllMax" xml:space="preserve">
-    <value>'all' must have {max occurs}=1.</value>
+    <value>'all' must have a 'maxOccurs' value of 1.</value>
   </data>
   <data name="Sch_InvalidFacet" xml:space="preserve">
     <value>The 'value' attribute must be present in facet.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1729,7 +1729,7 @@
     <value>It is an error if the derived 'maxLength' facet value is greater than the parent 'maxLength' facet value.</value>
   </data>
   <data name="Sch_MaxMinLengthBaseLength" xml:space="preserve">
-    <value>It is an error for both 'length' and either 'minLength' or 'maxLength' to be members of {facets}, unless they are specified in different derivation steps. In which case the following must be true: the {value} of 'minLength' &lt;= the {value} of 'length' &lt;= the {value} of 'maxLength'.</value>
+    <value>It is an error for both 'length' and either 'minLength' or 'maxLength' to be members of facets, unless they are specified in different derivation steps. In which case the following must be true: the value of 'minLength' &lt;= the value of 'length' &lt;= the value of 'maxLength'.</value>
   </data>
   <data name="Sch_MaxInclusiveMismatch" xml:space="preserve">
     <value>It is an error if the derived 'maxInclusive' facet value is greater than the parent 'maxInclusive' facet value.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1120,7 +1120,7 @@
     <value>It is an error for both length and minLength or maxLength to be present.</value>
   </data>
   <data name="Sch_MinLengthGtMaxLength" xml:space="preserve">
-    <value>MinLength is greater than MaxLength.</value>
+    <value>minLength is greater than maxLength.</value>
   </data>
   <data name="Sch_FractionDigitsGtTotalDigits" xml:space="preserve">
     <value>FractionDigits is greater than TotalDigits.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1654,7 +1654,7 @@
     <value>The group ref to 'all' is not the root particle, or it is being used as an extension.</value>
   </data>
   <data name="Sch_AllRefMinMax" xml:space="preserve">
-    <value>The group ref to 'all' must have {min occurs}= 0 or 1 and {max occurs}=1.</value>
+    <value>The group ref to 'all' must have 'minOccurs' = 0 or 1 and 'maxOccurs' = 1.</value>
   </data>
   <data name="Sch_NotAllAlone" xml:space="preserve">
     <value>'all' is not the only particle in a group, or is being used as an extension.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1723,7 +1723,7 @@
     <value>It is an error if 'length' is among the members of {facets} of {base type definition} and {value} is greater than the {value} of the parent 'length'.</value>
   </data>
   <data name="Sch_MinLengthGtBaseMinLength" xml:space="preserve">
-    <value>It is an error if 'minLength' is among the members of {facets} of {base type definition} and {value} is less than the {value} of the parent 'minLength'.</value>
+    <value>It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.</value>
   </data>
   <data name="Sch_MaxLengthGtBaseMaxLength" xml:space="preserve">
     <value>It is an error if 'maxLength' is among the members of {facets} of {base type definition} and {value} is greater than the {value} of the parent 'maxLength'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1723,7 +1723,7 @@
     <value>It is an error if 'length' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'length'.</value>
   </data>
   <data name="Sch_MinLengthGtBaseMinLength" xml:space="preserve">
-    <value>It is an error if 'minLength' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'minLength'.</value>
+    <value>It is an error if 'minLength' is among the members of the facets of the base type definition and its value is less than the value of the parent 'minLength'.</value>
   </data>
   <data name="Sch_MaxLengthGtBaseMaxLength" xml:space="preserve">
     <value>It is an error if 'maxLength' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'maxLength'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1768,7 +1768,7 @@
     <value>It is an error if the derived 'fractionDigits' facet value is greater than the parent 'fractionDigits' facet value.</value>
   </data>
   <data name="Sch_FacetBaseFixed" xml:space="preserve">
-    <value>Values that are declared as {fixed} in a base type can not be changed in a derived type.</value>
+    <value>Values that are declared with fixed='true' in a base type can not be changed in a derived type.</value>
   </data>
   <data name="Sch_WhiteSpaceRestriction1" xml:space="preserve">
     <value>It is an error if 'whiteSpace' is among the members of {facets} of {base type definition}, {value} is 'replace' or 'preserve', and the {value} of the parent 'whiteSpace' is 'collapse'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1726,7 +1726,7 @@
     <value>It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.</value>
   </data>
   <data name="Sch_MaxLengthGtBaseMaxLength" xml:space="preserve">
-    <value>It is an error if 'maxLength' is among the members of {facets} of {base type definition} and {value} is greater than the {value} of the parent 'maxLength'.</value>
+    <value>It is an error if the derived 'maxLength' facet value is greater than the parent 'maxLength' facet value.</value>
   </data>
   <data name="Sch_MaxMinLengthBaseLength" xml:space="preserve">
     <value>It is an error for both 'length' and either 'minLength' or 'maxLength' to be members of {facets}, unless they are specified in different derivation steps. In which case the following must be true: the {value} of 'minLength' &lt;= the {value} of 'length' &lt;= the {value} of 'maxLength'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1636,7 +1636,7 @@
     <value>The derived particle cannot have more members than the base particle - All:All,Sequence:Sequence -- Recurse Rule 2 / Choice:Choice -- RecurseLax.</value>
   </data>
   <data name="Sch_GroupBaseRestNotEmptiable" xml:space="preserve">
-    <value>All particles in the {particles} of the base particle which are not mapped to by any particle in the {particles} of the derived particle should be emptiable - All:All,Sequence:Sequence -- Recurse Rule 2 / Choice:Choice -- RecurseLax.</value>
+    <value>All particles in the particles of the base particle which are not mapped to by any particle in the particles of the derived particle should be emptiable - All:All,Sequence:Sequence -- Recurse Rule 2 / Choice:Choice -- RecurseLax.</value>
   </data>
   <data name="Sch_SeqFromAll" xml:space="preserve">
     <value>The derived sequence particle at ({0}, {1}) is not a valid restriction of the base all particle at ({2}, {3}) according to Sequence:All -- RecurseUnordered.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1723,10 +1723,10 @@
     <value>It is an error if 'length' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'length'.</value>
   </data>
   <data name="Sch_MinLengthGtBaseMinLength" xml:space="preserve">
-    <value>It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.</value>
+    <value>It is an error if 'minLength' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'minLength'.</value>
   </data>
   <data name="Sch_MaxLengthGtBaseMaxLength" xml:space="preserve">
-    <value>It is an error if the derived 'maxLength' facet value is greater than the parent 'maxLength' facet value.</value>
+    <value>It is an error if 'maxLength' is among the members of the facets of the base type definition and its value is greater than the value of the parent 'maxLength'.</value>
   </data>
   <data name="Sch_MaxMinLengthBaseLength" xml:space="preserve">
     <value>It is an error for both 'length' and either 'minLength' or 'maxLength' to be members of facets, unless they are specified in different derivation steps. In which case the following must be true: the value of 'minLength' &lt;= the value of 'length' &lt;= the value of 'maxLength'.</value>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -437,7 +437,7 @@ namespace System.Xml.Schema
             {
                 if (examplar.FinalResolved == XmlSchemaDerivationMethod.All)
                 {
-                    SendValidationEvent(SR.Sch_InvalidExamplar, examplar);
+                    SendValidationEvent(SR.Sch_InvalidExamplar, examplar.Name, examplar);
                 }
 
                 for (int i = 0; i < substitutionGroup.Members.Count; ++i)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -487,7 +487,7 @@ namespace System.Xml.Schema
             {
                 if (examplar.FinalResolved == XmlSchemaDerivationMethod.All)
                 {
-                    SendValidationEvent(SR.Sch_InvalidExamplar, examplar);
+                    SendValidationEvent(SR.Sch_InvalidExamplar, examplar.Name, examplar);
                 }
                 //Build transitive members
                 ArrayList newMembers = null;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -218,5 +218,47 @@ namespace System.Xml.Tests
             Assert.IsType<XmlSchemaException>(exception);
             Assert.Contains("minLength", exception.Message);
         }
+
+        /// <summary>
+        /// Test for issue #30218, resource Sch_MaxLengthGtBaseMaxLength
+        /// </summary>
+        [Fact]
+        public void MaxLengthGtBaseMaxLength_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:maxLength value='5'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxLength value='6'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+";
+
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception exception;
+
+            try
+            {
+                ss.Compile();
+                exception = null;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            Assert.NotNull(exception);
+            Assert.IsType<XmlSchemaException>(exception);
+            Assert.Contains("maxLength", exception.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -978,5 +978,33 @@ namespace System.Xml.Tests
             Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
             Assert.Empty(rx.Matches(ex.Message));
         }
+
+        [Fact]
+        public void InvalidAllElementMax_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:complexType name='person'>
+        <xs:all>
+            <xs:element name='firstname' maxOccurs='2'/>
+            <xs:element name='lastname'/>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>
+";
+            XmlReader xr;
+            xr = XmlReader.Create(new StringReader(schema));
+            XmlSchemaSet ss = new XmlSchemaSet();
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Add(null, xr));
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+
+            Assert.Contains("all", ex.Message);
+            Assert.Contains("maxOccurs", ex.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -183,7 +183,7 @@ namespace System.Xml.Tests
         /// Test for issue #30218, resource Sch_MinLengthGtBaseMinLength
         /// </summary>
         [Fact]
-        public void MinLengthGtBaseMinLength_Throws()
+        public void MinLengthLtBaseMinLength_Throws()
         {
             string schema = @"<?xml version='1.0' encoding='utf-8' ?>
 <xs:schema elementFormDefault='qualified'

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -216,7 +216,7 @@ namespace System.Xml.Tests
 
             Assert.NotNull(exception);
             Assert.IsType<XmlSchemaException>(exception);
-            Assert.Equal("Error:  'minLength' is among the facets of {0} and its value ({1}) is less than the value ({2}) of the parent 'minLength'.",
+            Assert.Equal("It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.",
                 exception.Message);
         }
     }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -7,7 +7,6 @@ using Xunit.Abstractions;
 using System.IO;
 using System.Xml.Schema;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace System.Xml.Tests
 {
@@ -375,13 +374,10 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+
             Assert.Contains("length", ex.Message);
             Assert.Contains("minLength", ex.Message);
             Assert.Contains("maxLength", ex.Message);
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
         }
 
         [Fact]
@@ -402,12 +398,9 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+
             Assert.Contains("minLength", ex.Message);
             Assert.Contains("maxLength", ex.Message);
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{[0-9]*[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
         }
 
         public static IEnumerable<object[]> MaxMinLengthBaseLength_TestData
@@ -638,11 +631,8 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-            Assert.Contains("length", ex.Message);
 
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
+            Assert.Contains("length", ex.Message);
         }
 
         #region FacetBaseFixed tests
@@ -943,11 +933,6 @@ namespace System.Xml.Tests
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
             Assert.Contains("fixed='true'", ex.Message);
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
-
         }
         #endregion
 
@@ -970,11 +955,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Add(null, xr));
-            Assert.Contains("all", ex.Message);
 
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
+            Assert.Contains("all", ex.Message);
         }
 
         [Fact]
@@ -996,10 +978,6 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Add(null, xr));
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
 
             Assert.Contains("all", ex.Message);
             Assert.Contains("maxOccurs", ex.Message);
@@ -1028,10 +1006,6 @@ namespace System.Xml.Tests
             ss.Add(null, xr);
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
-            Assert.Empty(rx.Matches(ex.Message));
 
             Assert.Contains("substitutionGroup", ex.Message);
             Assert.Contains("person", ex.Message);
@@ -1076,10 +1050,6 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
 
             Assert.Contains("particle", ex.Message);
         }
@@ -1141,10 +1111,6 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-
-            // Issue 30218: invalid formatters
-            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
 
             Assert.Contains("all", ex.Message);
             Assert.Contains("minOccurs", ex.Message);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -592,16 +592,9 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
-            Exception exception;
-            try
-            {
-                ss.Compile();
-                exception = null;
-            } catch (Exception ex)
-            {
-                exception = ex;
-            }
-            Assert.Null(exception);
+            ss.Compile();
+
+            Assert.True(true);
         }
         #endregion
 

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1038,5 +1038,52 @@ namespace System.Xml.Tests
             Assert.Contains("substitutionGroup", ex.Message);
             Assert.Contains("person", ex.Message);
         }
+
+        [Fact]
+        public void GroupBaseRestNotEmptiable_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8'?>
+<xs:schema elementFormDefault='qualified'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='component'>
+        <xs:restriction base='xs:integer'>
+            <xs:minInclusive value='0'/>
+            <xs:maxInclusive value='255'/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name='alienColor'>
+        <xs:sequence>
+            <xs:element name='red' type='component' minOccurs='1' maxOccurs='1'/>
+            <xs:element name='green' type='component' minOccurs='1' maxOccurs='1'/>
+            <xs:element name='blue' type='component' minOccurs='1' maxOccurs='1'/>
+            <xs:element name='ultraviolet' type='component' minOccurs='1' maxOccurs='1'/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name='humanColor'>
+        <xs:complexContent>
+            <xs:restriction base='alienColor'>
+                <xs:sequence>
+                    <xs:element name='red' type='component' minOccurs='1' maxOccurs='1'/>
+                    <xs:element name='green' type='component' minOccurs='1' maxOccurs='1'/>
+                    <xs:element name='blue' type='component' minOccurs='1' maxOccurs='1'/>
+                </xs:sequence>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>
+";
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+
+            Assert.Contains("particle", ex.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1006,5 +1006,37 @@ namespace System.Xml.Tests
             Assert.Contains("all", ex.Message);
             Assert.Contains("maxOccurs", ex.Message);
         }
+
+        [Fact]
+        public void InvalidExemplar_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8'?>
+<xs:schema elementFormDefault='qualified'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:complexType name = 'personType'>
+         <xs:all>
+             <xs:element name='firstname'/>
+             <xs:element name='lastname'/>
+         </xs:all>
+     </xs:complexType>
+     <xs:element name='person' type='personType' final='#all'/>
+     <xs:element name='human' type='personType' substitutionGroup='person'/>
+</xs:schema>
+";
+
+            XmlReader xr;
+            xr = XmlReader.Create(new StringReader(schema));
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, xr);
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+
+            Assert.Contains("substitutionGroup", ex.Message);
+            Assert.Contains("person", ex.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -202,21 +202,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
-            Exception exception;
-
-            try
-            {
-                ss.Compile();
-                exception = null;
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-            }
-
-            Assert.NotNull(exception);
-            Assert.IsType<XmlSchemaException>(exception);
-            Assert.Contains("minLength", exception.Message);
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+            Assert.Contains("minLength", ex.Message);
         }
 
         /// <summary>
@@ -244,21 +231,8 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
-            Exception exception;
-
-            try
-            {
-                ss.Compile();
-                exception = null;
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-            }
-
-            Assert.NotNull(exception);
-            Assert.IsType<XmlSchemaException>(exception);
-            Assert.Contains("maxLength", exception.Message);
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+            Assert.Contains("maxLength", ex.Message);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -176,5 +176,48 @@ namespace System.Xml.Tests
             Assert.Contains("fractionDigits", ex.Message);
             Assert.DoesNotContain("totalDigits", ex.Message);
         }
+
+        /// <summary>
+        /// Test for issue #30218, resource Sch_MinLengthGtBaseMinLength
+        /// </summary>
+        [Fact]
+        public void MinLengthGtBaseMinLength_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:minLength value='5'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minLength value='4'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+";
+
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception exception;
+
+            try
+            {
+                ss.Compile();
+                exception = null;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            Assert.NotNull(exception);
+            Assert.IsType<XmlSchemaException>(exception);
+            Assert.Equal("Error:  'minLength' is among the facets of {0} and its value ({1}) is less than the value ({2}) of the parent 'minLength'.",
+                exception.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -207,9 +207,6 @@ namespace System.Xml.Tests
             Assert.Contains("minLength", ex.Message);
         }
 
-        /// <summary>
-        /// Test for issue #30218, resource Sch_MaxLengthGtBaseMaxLength
-        /// </summary>
         [Fact]
         public void MaxLengthGtBaseMaxLength_Throws()
         {
@@ -598,9 +595,6 @@ namespace System.Xml.Tests
         }
         #endregion
 
-        /// <summary>
-        /// Test for issue #30218, resource Sch_LengthGtBaseLength
-        /// </summary>
         [Fact]
         public void LengthGtBaseLength_Throws()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -612,7 +612,39 @@ namespace System.Xml.Tests
             }
             Assert.Null(exception);
         }
-
         #endregion
+
+        /// <summary>
+        /// Test for issue #30218, resource Sch_LengthGtBaseLength
+        /// </summary>
+        [Fact]
+        public void LengthGtBaseLength_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:length value='5'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:length value='6'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+";
+
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+            Assert.Contains("length", ex.Message);
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -707,7 +707,7 @@ namespace System.Xml.Tests
 "
                     },
                     new object[]
-                    {  // maxLength, derived type has larger value.
+                    {  // maxLength, derived type has lower value.
                         @"<?xml version='1.0' encoding='utf-8' ?>
 <xs:schema elementFormDefault='qualified'
            xmlns:xs='http://www.w3.org/2001/XMLSchema'>

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -178,9 +178,6 @@ namespace System.Xml.Tests
             Assert.DoesNotContain("totalDigits", ex.Message);
         }
 
-        /// <summary>
-        /// Test for issue #30218, resource Sch_MinLengthGtBaseMinLength
-        /// </summary>
         [Fact]
         public void MinLengthLtBaseMinLength_Throws()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -952,5 +952,31 @@ namespace System.Xml.Tests
 
         }
         #endregion
+
+        [Fact]
+        public void InvalidAllMax_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:complexType name='person'>
+        <xs:all maxOccurs='2'>
+            <xs:element name='firstname'/>
+            <xs:element name='lastname'/>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>
+";
+            XmlReader xr;
+            xr = XmlReader.Create(new StringReader(schema));
+            XmlSchemaSet ss = new XmlSchemaSet();
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Add(null, xr));
+            Assert.Contains("all", ex.Message);
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -904,15 +904,6 @@ namespace System.Xml.Tests
 </xs:schema>
 "
                     }
-                    // NOTE: the cases of totalDigits, with larger and smaller
-                    // values are not tested here as Issue 34426 was found
-                    // and will be addressed separately.
-                    // NOTE: the case of fractionDigits with a larger
-                    //   value is not tested here as Issue 34413 was found,
-                    //   and will be addressed separately.
-                    // NOTE: the case of fractionDigits with a smaller
-                    //   value is not tested here as Issue 34418 was found,
-                    //   and will be addressed separately.
                 };
             }
         }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -646,5 +646,311 @@ namespace System.Xml.Tests
             Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
             Assert.Empty(rx.Matches(ex.Message));
         }
+
+        #region FacetBaseFixed tests
+        public static IEnumerable<object[]> FacetBaseFixed_Throws_TestData
+        {
+            get{
+                return new List<object[]>()
+                {
+                    new object[]
+                    {  // length, derived type has larger value.
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:length value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:length value='6'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // length, derived type has smaller value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:length value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:length value='4'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minLength, derived type has larger value.
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:minLength value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minLength value='6'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minLength, derived type has smaller value.
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:minLength value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minLength value='4'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxLength, derived type has larger value.
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:maxLength value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxLength value='6'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxLength, derived type has larger value.
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:maxLength value='5' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxLength value='4'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // whiteSpace
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:string'>
+            <xs:whiteSpace value='collapse' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:whiteSpace value='replace'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxInclusive, derived type with larger value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:maxInclusive value='18' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxInclusive value='19'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxInclusive, derived type with smaller value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:maxInclusive value='18' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxInclusive value='17'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxExclusive, derived type has larger value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:maxExclusive value='19' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxExclusive value='20'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // maxExclusive, derived type has smaller value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:maxExclusive value='19' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:maxExclusive value='18'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minExclusive, derived type has larger value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:minExclusive value='2' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minExclusive value='3'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minExclusive, derived type has smaller value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:minExclusive value='2' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minExclusive value='1'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minInclusive, derived type has larger value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:minInclusive value='3' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minInclusive value='4'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    },
+                    new object[]
+                    {  // minInclusive, derived type has smaller value
+                        @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:integer'>
+            <xs:minInclusive value='3' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:minInclusive value='2'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    }
+                    // NOTE: the cases of totalDigits, with larger and smaller
+                    // values are not tested here as Issue 34426 was found
+                    // and will be addressed separately.
+                    // NOTE: the case of fractionDigits with a larger
+                    //   value is not tested here as Issue 34413 was found,
+                    //   and will be addressed separately.
+                    // NOTE: the case of fractionDigits with a smaller
+                    //   value is not tested here as Issue 34418 was found,
+                    //   and will be addressed separately.
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FacetBaseFixed_Throws_TestData))]
+        public void FacetBaseFixed_Throws(string schema)
+        {
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+            Assert.Contains("fixed", ex.Message);
+
+            // Issue 30218: invalid formatters
+            Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+
+        }
+        #endregion
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -944,7 +944,7 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-            Assert.Contains("fixed", ex.Message);
+            Assert.Contains("fixed='true'", ex.Message);
 
             // Issue 30218: invalid formatters
             Regex rx = new Regex(@"\{.*[a-zA-Z ]+.*\}");

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -216,8 +216,7 @@ namespace System.Xml.Tests
 
             Assert.NotNull(exception);
             Assert.IsType<XmlSchemaException>(exception);
-            Assert.Equal("It is an error if the derived 'minLength' facet value is less than the parent 'minLength' facet value.",
-                exception.Message);
+            Assert.Contains("minLength", exception.Message);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -403,7 +403,7 @@ namespace System.Xml.Tests
             Assert.Contains("maxLength", ex.Message);
         }
 
-        public static IEnumerable<object[]> MaxMinLengthBaseLength_TestData
+        public static IEnumerable<object[]> MaxMinLengthBaseLength_Success_TestData
         {
             get
             {
@@ -586,7 +586,7 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxMinLengthBaseLength_TestData))]
+        [MemberData(nameof(MaxMinLengthBaseLength_Success_TestData))]
         public void MaxMinLengthBaseLength_Test(string schema)
         {
             XmlSchemaSet ss = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -402,10 +402,8 @@ namespace System.Xml.Tests
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-            // The thrown error message has an upper case 'M' in both
-            // minLength and maxLength.
-            Assert.Contains("minlength", ex.Message.ToLower());
-            Assert.Contains("maxlength", ex.Message.ToLower());
+            Assert.Contains("minLength", ex.Message);
+            Assert.Contains("maxLength", ex.Message);
 
             // Issue 30218: invalid formatters
             Regex rx = new Regex(@"\{[0-9]*[a-zA-Z ]+[^\}]*\}");


### PR DESCRIPTION
This is addressing one of the 13 strings in issue 30218 that have faulty formatters (Sch_MinLengthGtBaseMinLength).  I'd like some feedback on this approach before I tackle the other 12.  