### PR TITLE
Only run format job in master branch

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -202,7 +202,7 @@ jobs:
 
 #
 # Build CoreCLR Formatting Job
-# Only when CoreCLR is changed
+# Only when CoreCLR is changed, and only in the 'master' branch (no release branches).
 #
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -212,9 +212,11 @@ jobs:
     - Windows_NT_x64
     jobParameters:
       condition: >-
-        or(
-          eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
+        and(
+          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+          or(
+            eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
+            eq(variables['isFullMatrix'], true)))
 
 #
 # Build Mono debug

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -215,8 +215,8 @@ jobs:
       condition: >-
         and(
           or(
-            eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-            eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')),
+            eq(variables['Build.SourceBranchName'], 'master'),
+            eq(variables['System.PullRequest.TargetBranch'], 'master')),
           or(
             eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
             eq(variables['isFullMatrix'], true)))

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -202,7 +202,8 @@ jobs:
 
 #
 # Build CoreCLR Formatting Job
-# Only when CoreCLR is changed, and only in the 'master' branch (no release branches).
+# Only when CoreCLR is changed, and only in the 'master' branch (no release branches;
+# both CI and PR builds).
 #
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -213,7 +214,9 @@ jobs:
     jobParameters:
       condition: >-
         and(
-          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+          or(
+            eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+            eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')),
           or(
             eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
             eq(variables['isFullMatrix'], true)))


### PR DESCRIPTION
Don't run it in servicing branches, since it depends
on an unversioned `jitutils` repo.