### PR TITLE
Remove duplicates and fix namespaces in S.T.RegularExpressions.Tests

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/MonoRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/MonoRegexTests.cs
@@ -413,7 +413,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?<!c)b", RegexOptions.None, "ab", "Pass. Group[0]=(1,1)" };
             yield return new object[] { @"(?<!c)b", RegexOptions.None, "cb", "Fail." };
             yield return new object[] { @"(?<!c)b", RegexOptions.None, "b", "Pass. Group[0]=(0,1)" };
-            yield return new object[] { @"(?<!c)b", RegexOptions.None, "b", "Pass. Group[0]=(0,1)" };
             yield return new object[] { @"(?<%)b", RegexOptions.None, "-", "Error." };
             yield return new object[] { @"(?:..)*a", RegexOptions.None, "aba", "Pass. Group[0]=(0,3)" };
             yield return new object[] { @"(?:..)*?a", RegexOptions.None, "aba", "Pass. Group[0]=(0,1)" };
@@ -438,12 +437,10 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"((?i:a))b", RegexOptions.None, "aB", "Fail." };
             yield return new object[] { @"(?:(?-i)a)b", RegexOptions.IgnoreCase, "ab", "Pass. Group[0]=(0,2)" };
             yield return new object[] { @"((?-i)a)b", RegexOptions.IgnoreCase, "ab", "Pass. Group[0]=(0,2) Group[1]=(0,1)" };
-            yield return new object[] { @"(?:(?-i)a)b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2)" };
             yield return new object[] { @"((?-i)a)b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2) Group[1]=(0,1)" };
             yield return new object[] { @"(?:(?-i)a)b", RegexOptions.IgnoreCase, "Ab", "Fail." };
             yield return new object[] { @"((?-i)a)b", RegexOptions.IgnoreCase, "Ab", "Fail." };
             yield return new object[] { @"(?:(?-i)a)b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2)" };
-            yield return new object[] { @"((?-i)a)b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2) Group[1]=(0,1)" };
             yield return new object[] { @"(?:(?-i)a)b", RegexOptions.IgnoreCase, "AB", "Fail." };
             yield return new object[] { @"((?-i)a)b", RegexOptions.IgnoreCase, "AB", "Fail." };
             yield return new object[] { @"(?-i:a)b", RegexOptions.IgnoreCase, "ab", "Pass. Group[0]=(0,2)" };
@@ -452,8 +449,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"((?-i:a))b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2) Group[1]=(0,1)" };
             yield return new object[] { @"(?-i:a)b", RegexOptions.IgnoreCase, "Ab", "Fail." };
             yield return new object[] { @"((?-i:a))b", RegexOptions.IgnoreCase, "Ab", "Fail." };
-            yield return new object[] { @"(?-i:a)b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2)" };
-            yield return new object[] { @"((?-i:a))b", RegexOptions.IgnoreCase, "aB", "Pass. Group[0]=(0,2) Group[1]=(0,1)" };
             yield return new object[] { @"(?-i:a)b", RegexOptions.IgnoreCase, "AB", "Fail." };
             yield return new object[] { @"((?-i:a))b", RegexOptions.IgnoreCase, "AB", "Fail." };
             yield return new object[] { @"((?-i:a.))b", RegexOptions.IgnoreCase, "a\nB", "Fail." };
@@ -479,8 +474,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"((?m)^b)", RegexOptions.None, "a\nb\n", "Pass. Group[0]=(2,1) Group[1]=(2,1)" };
             yield return new object[] { @"\n((?m)^b)", RegexOptions.None, "a\nb\n", "Pass. Group[0]=(1,2) Group[1]=(2,1)" };
             yield return new object[] { @"((?s).)c(?!.)", RegexOptions.None, "a\nb\nc\n", "Pass. Group[0]=(3,2) Group[1]=(3,1)" };
-            yield return new object[] { @"((?s).)c(?!.)", RegexOptions.None, "a\nb\nc\n", "Pass. Group[0]=(3,2) Group[1]=(3,1)" };
-            yield return new object[] { @"((?s)b.)c(?!.)", RegexOptions.None, "a\nb\nc\n", "Pass. Group[0]=(2,3) Group[1]=(2,2)" };
             yield return new object[] { @"((?s)b.)c(?!.)", RegexOptions.None, "a\nb\nc\n", "Pass. Group[0]=(2,3) Group[1]=(2,2)" };
             yield return new object[] { @"^b", RegexOptions.None, "a\nb\nc\n", "Fail." };
             yield return new object[] { @"()^b", RegexOptions.None, "a\nb\nc\n", "Fail." };
@@ -507,23 +500,16 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"^(?=(a+?))\1ab", RegexOptions.None, "aaab", "Fail." };
             yield return new object[] { @"(\w+:)+", RegexOptions.None, "one:", "Pass. Group[0]=(0,4) Group[1]=(0,4)" };
             yield return new object[] { @"$(?<=^(a))", RegexOptions.None, "a", "Pass. Group[0]=(1,0) Group[1]=(0,1)" };
-            yield return new object[] { @"(?=(a+?))(\1ab)", RegexOptions.None, "aaab", "Pass. Group[0]=(1,3) Group[1]=(1,1) Group[2]=(1,3)" };
-            yield return new object[] { @"^(?=(a+?))\1ab", RegexOptions.None, "aaab", "Fail." };
             yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "abcd:", "Fail." };
             yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "abcd", "Pass. Group[0]=(0,4) Group[1]= Group[2]=(0,4)" };
             yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "xy:z:::abcd", "Pass. Group[0]=(0,11) Group[1]=(0,7) Group[2]=(7,4)" };
             yield return new object[] { @"^[^bcd]*(c+)", RegexOptions.None, "aexycd", "Pass. Group[0]=(0,5) Group[1]=(4,1)" };
             yield return new object[] { @"(a*)b+", RegexOptions.None, "caab", "Pass. Group[0]=(1,3) Group[1]=(1,2)" };
-            yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "abcd:", "Fail." };
-            yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "abcd", "Pass. Group[0]=(0,4) Group[1]= Group[2]=(0,4)" };
-            yield return new object[] { @"([\w:]+::)?(\w+)$", RegexOptions.None, "xy:z:::abcd", "Pass. Group[0]=(0,11) Group[1]=(0,7) Group[2]=(7,4)" };
-            yield return new object[] { @"^[^bcd]*(c+)", RegexOptions.None, "aexycd", "Pass. Group[0]=(0,5) Group[1]=(4,1)" };
             yield return new object[] { @"(>a+)ab", RegexOptions.None, "aaab", "Fail." };
             yield return new object[] { @"(?>a+)b", RegexOptions.None, "aaab", "Pass. Group[0]=(0,4)" };
             yield return new object[] { @"([[:]+)", RegexOptions.None, "a:[b]:", "Pass. Group[0]=(1,2) Group[1]=(1,2)" };
             yield return new object[] { @"([[=]+)", RegexOptions.None, "a=[b]=", "Pass. Group[0]=(1,2) Group[1]=(1,2)" };
             yield return new object[] { @"([[.]+)", RegexOptions.None, "a.[b].", "Pass. Group[0]=(1,2) Group[1]=(1,2)" };
-            yield return new object[] { @"[a[:]b[:c]", RegexOptions.None, "abc", "Pass. Group[0]=(0,3)" };
             yield return new object[] { @"[a[:]b[:c]", RegexOptions.None, "abc", "Pass. Group[0]=(0,3)" };
             yield return new object[] { @"((?>a+)b)", RegexOptions.None, "aaab", "Pass. Group[0]=(0,4) Group[1]=(0,4)" };
             yield return new object[] { @"(?>(a+))b", RegexOptions.None, "aaab", "Pass. Group[0]=(0,4) Group[1]=(0,3)" };
@@ -842,7 +828,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?<!c)b", RegexOptions.RightToLeft, "ab", "Pass. Group[0]=(1,1)" };
             yield return new object[] { @"(?<!c)b", RegexOptions.RightToLeft, "cb", "Fail." };
             yield return new object[] { @"(?<!c)b", RegexOptions.RightToLeft, "b", "Pass. Group[0]=(0,1)" };
-            yield return new object[] { @"(?<!c)b", RegexOptions.RightToLeft, "b", "Pass. Group[0]=(0,1)" };
             yield return new object[] { @"a(?=d).", RegexOptions.RightToLeft, "adabad", "Pass. Group[0]=(4,2)" };
             yield return new object[] { @"a(?=c|d).", RegexOptions.RightToLeft, "adabad", "Pass. Group[0]=(4,2)" };
             yield return new object[] { @"ab*c", RegexOptions.RightToLeft, "abc", "Pass. Group[0]=(0,3)" };
@@ -1030,7 +1015,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"^(((?<foo>\()[^()]*)+((?<bar-foo>\))[^()]*)+)+(?(foo)(?!))$", RegexOptions.None, "((a(b))c))","Fail." };
             yield return new object[] { @"^(((?<foo>\()[^()]*)+((?<bar-foo>\))[^()]*)+)+(?(foo)(?!))$", RegexOptions.None, ")(","Fail." };
             yield return new object[] { @"^(((?<foo>\()[^()]*)+((?<bar-foo>\))[^()]*)+)+(?(foo)(?!))$", RegexOptions.None, "((a((b))c)","Fail." };
-            yield return new object[] { @"b", RegexOptions.RightToLeft, "babaaa", "Pass. Group[0]=(2,1)" };
             yield return new object[] { @"^((\[(?<NAME>[^\]]+)\])|(?<NAME>[^\.\[\]]+))$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture, "[n]", "Pass. Group[0]=(0,3) Group[1]=(1,1)" };
             yield return new object[] { @"^((\[(?<NAME>[^\]]+)\])|(?<NAME>[^\.\[\]]+))$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture, "n", "Pass. Group[0]=(0,1) Group[1]=(0,1)" };
             yield return new object[] { @"^((\[(?<NAME>[^\]]+)\])|(?<NAME>[^\.\[\]]+))$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture, "n[i]e", "Fail." };
@@ -1087,7 +1071,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?<=a+?)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(1,3)" };
             yield return new object[] { @"(?<=a*?)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(0,4)" };
             yield return new object[] { @"(?<=a{1,5}?)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(1,3)" };
-            yield return new object[] { @"(?<=a{1}?)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(1,3)" };
             yield return new object[] { @"(?<=a{1}?)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(1,3)" };
             yield return new object[] { @"(?<!a+)(?:a)*bc", RegexOptions.None, "aabc", "Pass. Group[0]=(0,4)" };
             yield return new object[] { @"(?<!a*)(?:a)*bc", RegexOptions.None, "aabc", "Fail." };

--- a/src/libraries/System.Text.RegularExpressions/tests/PrecompiledRegexScenarioTest.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/PrecompiledRegexScenarioTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 // NOTE: Be very thoughtful when editing this test file.  It's decompiled from an assembly generated
 // by CompileToAssembly on .NET Framework, and is used to help validate compatibility with such assemblies.
 
-namespace System.Text.RegularExpressionsTests
+namespace System.Text.RegularExpressions.Tests
 {
     public class PrecompiledRegexScenarioTest
     {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -29,11 +29,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.ECMAScript, new string[] { "02468" } };
             yield return new object[] { null, @"[\d-[13579]]+", "\x066102468\x0660", RegexOptions.None, new string[] { "\x066102468\x0660" } };
 
-            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
-
-            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
-            yield return new object[] { null, @"[\w-[b-y]]+", "bbbaaaABCD09zzzyyy", RegexOptions.None, new string[] { "aaaABCD09zzz" } };
-
             yield return new object[] { null, @"[\p{Ll}-[ae-z]]+", "aaabbbcccdddeee", RegexOptions.None, new string[] { "bbbcccddd" } };
             yield return new object[] { null, @"[\p{Nd}-[2468]]+", "20135798", RegexOptions.None, new string[] { "013579" } };
 
@@ -164,7 +159,6 @@ namespace System.Text.RegularExpressions.Tests
 
             // Character Class Substraction
             yield return new object[] { null, @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
-            yield return new object[] { null, @"[abcd\-d-[bc]]+", "bbbaaa---dddccc", RegexOptions.None, new string[] { "aaa---ddd" } };
             yield return new object[] { null, @"[^a-f-[\x00-\x60\u007B-\uFFFF]]+", "aaafffgggzzz{{{", RegexOptions.None, new string[] { "gggzzz" } };
             yield return new object[] { null, @"[\[\]a-f-[[]]+", "gggaaafff]]][[[", RegexOptions.None, new string[] { "aaafff]]]" } };
             yield return new object[] { null, @"[\[\]a-f-[]]]+", "gggaaafff[[[]]]", RegexOptions.None, new string[] { "aaafff[[[" } };
@@ -189,7 +183,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"[\0- [bc]+", "!!!\0\0\t\t  [[[[bbbcccaaa", RegexOptions.None, new string[] { "\0\0\t\t  [[[[bbbccc" } };
             yield return new object[] { null, "[[abcd]-[bc]]+", "a-b]", RegexOptions.None, new string[] { "a-b]" } };
             yield return new object[] { null, "[-[e-g]+", "ddd[[[---eeefffggghhh", RegexOptions.None, new string[] { "[[[---eeefffggg" } };
-            yield return new object[] { null, "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
             yield return new object[] { null, "[-e-g]+", "ddd---eeefffggghhh", RegexOptions.None, new string[] { "---eeefffggg" } };
             yield return new object[] { null, "[a-e - m-p]+", "---a b c d e m n o p---", RegexOptions.None, new string[] { "a b c d e m n o p" } };
             yield return new object[] { null, "[^-[bc]]", "b] c] -] aaaddd]", RegexOptions.None, new string[] { "d]" } };
@@ -345,7 +338,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(cat)(\77)", "hellocat?dogworld", RegexOptions.None, new string[] { "cat?", "cat", "?" } };
             yield return new object[] { null, @"(cat)(\176)", "hellocat~dogworld", RegexOptions.None, new string[] { "cat~", "cat", "~" } };
             yield return new object[] { null, @"(cat)(\400)", "hellocat\0dogworld", RegexOptions.None, new string[] { "cat\0", "cat", "\0" } };
-            yield return new object[] { null, @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
             yield return new object[] { null, @"(cat)(\300)", "hellocat\u00C0dogworld", RegexOptions.None, new string[] { "cat\u00C0", "cat", "\u00C0" } };
             yield return new object[] { null, @"(cat)(\477)", "hellocat\u003Fdogworld", RegexOptions.None, new string[] { "cat\u003F", "cat", "\u003F" } };
             yield return new object[] { null, @"(cat)(\777)", "hellocat\u00FFdogworld", RegexOptions.None, new string[] { "cat\u00FF", "cat", "\u00FF" } };
@@ -646,7 +638,6 @@ namespace System.Text.RegularExpressions.Tests
 
             // Atomic subexpressions
             // Implicitly upgrading (or not) oneloop to be atomic
-            yield return new object[] { null, @"a*", "aaa", RegexOptions.None, new string[] { "aaa" } };
             yield return new object[] { null, @"a*b", "aaab", RegexOptions.None, new string[] { "aaab" } };
             yield return new object[] { null, @"a*b+", "aaab", RegexOptions.None, new string[] { "aaab" } };
             yield return new object[] { null, @"a*b+?", "aaab", RegexOptions.None, new string[] { "aaab" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -28,9 +28,6 @@ namespace System.Text.RegularExpressions.Tests
             // Testing control character escapes???: "2", "(\u0032)"
             yield return new object[] { "(\u0034)", "4", RegexOptions.None, 0, 1, true, "4", };
 
-            // Using *, +, ?, {}: Actual - "a+\\.?b*\\.?c{2}"
-            yield return new object[] { @"a+\.?b*\.+c{2}", "ab.cc", RegexOptions.None, 0, 5, true, "ab.cc" };
-
             // Using long loop prefix
             yield return new object[] { @"a{10}", new string('a', 10), RegexOptions.None, 0, 10, true, new string('a', 10) };
             yield return new object[] { @"a{100}", new string('a', 100), RegexOptions.None, 0, 100, true, new string('a', 100) };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 
-namespace System.Text.RegularExpressions
+namespace System.Text.RegularExpressions.Tests
 {
     public class RegexUnicodeCharTests
     {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexGroupNameTests.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 using System.Collections;
 using System.Diagnostics;
 
-namespace System.Text.RegularExpressionsTests
+namespace System.Text.RegularExpressions.Tests
 {
     /// <summary>
     /// Tests the Name property on the Group class.


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/pull/33915 (VSTest runner logs duplicate test rows)