### PR TITLE
Add service name to System.ServiceProcess.TimeoutException message

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/Resources/Strings.resx
@@ -94,7 +94,7 @@
     <value>Cannot stop '{0}' service on computer '{1}'.</value>
   </data>
   <data name="Timeout" xml:space="preserve">
-    <value>Time out has expired and the operation has not been completed.</value>
+    <value>The operation requested for service '{0}' has not been completed within the specified time interval.</value>
   </data>
   <data name="PlatformNotSupported_ServiceController" xml:space="preserve">
     <value>ServiceController enables manipulating and accessing Windows services and it is not applicable for other operating systems.</value>

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -900,7 +900,7 @@ namespace System.ServiceProcess
             while (Status != desiredStatus)
             {
                 if (DateTime.UtcNow - start > timeout)
-                    throw new System.ServiceProcess.TimeoutException(SR.Timeout);
+                    throw new System.ServiceProcess.TimeoutException(SR.Format(SR.Timeout, ServiceName));
 
                 _waitForStatusSignal.WaitOne(250);
                 Refresh();


### PR DESCRIPTION
This small PR adds the service name to the message of the `TimeoutException` raised by method `WaitForStatus`.  
This is very useful in the following scenario where a service depends on other services:
  - the user calls `Stop` on the service, which tries to stops all the dependent services first
  - one of the dependent services cannot be stopped in time and therefore raises a `TimeoutException`, but the user does not know which service caused it

Related to issue #765.