### PR TITLE
Speed up SuperPMI `mcs -removeDup`

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MCS_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
@@ -1,0 +1,197 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// hash.cpp - Class for hashing a text stream using MD5 hashing
+//
+// Note that on Windows, acquiring the Crypto hash provider is expensive, so
+// only do that once and cache it.
+//----------------------------------------------------------
+
+#include "standardpch.h"
+#include "runtimedetails.h"
+#include "errorhandling.h"
+#include "md5.h"
+#include "hash.h"
+
+Hash::Hash()
+#ifndef TARGET_UNIX
+    : m_Initialized(false)
+    , m_hCryptProv(NULL)
+#endif // !TARGET_UNIX
+{
+}
+
+Hash::~Hash()
+{
+    Destroy(); // Ignoring return code.
+}
+
+// static
+bool Hash::Initialize()
+{
+#ifdef TARGET_UNIX
+
+    // No initialization necessary.
+
+#else // !TARGET_UNIX
+
+    if (m_Initialized)
+    {
+        LogError("Hash class has already been initialized");
+        return false;
+    }
+
+    // Get handle to the crypto provider
+    if (!CryptAcquireContextA(&m_hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+        goto OnError;
+
+    m_Initialized = true;
+    return true;
+
+OnError:
+    LogError("Failed to create a hash using the Crypto API (Error 0x%X)", GetLastError());
+
+    if (m_hCryptProv != NULL)
+        CryptReleaseContext(m_hCryptProv, 0);
+
+    m_Initialized = false;
+    return false;
+
+#endif // !TARGET_UNIX
+}
+
+// static
+bool Hash::Destroy()
+{
+#ifdef TARGET_UNIX
+
+    // No destruction necessary.
+
+#else // !TARGET_UNIX
+
+    // Should probably check Crypt() function return codes.
+    if (m_hCryptProv != NULL)
+    {
+        CryptReleaseContext(m_hCryptProv, 0);
+        m_hCryptProv = NULL;
+    }
+
+    m_Initialized = false;
+    return true;
+
+#endif // !TARGET_UNIX
+}
+
+// Hash::WriteHashValueAsText - Take a binary hash value in the array of bytes pointed to by
+// 'pHash' (size in bytes 'cbHash'), and write an ASCII hexadecimal representation of it in the buffer
+// 'hashTextBuffer' (size in bytes 'hashTextBufferLen').
+//
+// Returns true on success, false on failure (only if the arguments are bad).
+bool Hash::WriteHashValueAsText(const BYTE* pHash, size_t cbHash, char* hashTextBuffer, size_t hashTextBufferLen)
+{
+    // This could be:
+    //
+    // for (DWORD i = 0; i < MD5_HASH_BYTE_SIZE; i++)
+    // {
+    //    sprintf_s(hash + i * 2, hashLen - i * 2, "%02X", bHash[i]);
+    // }
+    //
+    // But this function is hot, and sprintf_s is too slow. This is a specialized function to speed it up.
+
+    if (hashTextBufferLen < 2 * cbHash + 1) // 2 characters for each byte, plus null terminator
+    {
+        LogError("WriteHashValueAsText doesn't have enough space to write the output");
+        return false;
+    }
+
+    static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+    char* pCur = hashTextBuffer;
+    for (size_t i = 0; i < cbHash; i++)
+    {
+        unsigned digit = pHash[i];
+        unsigned lowNibble = digit & 0xF;
+        unsigned highNibble = digit >> 4;
+        *pCur++ = hexDigits[highNibble];
+        *pCur++ = hexDigits[lowNibble];
+    }
+    *pCur++ = '\0';
+    return true;
+}
+
+// Hash::HashBuffer - Compute an MD5 hash of the data pointed to by 'pBuffer', of 'bufLen' bytes,
+// writing the hexadecimal ASCII text representation of the hash to the buffer pointed to by 'hash',
+// of 'hashLen' bytes in size, which must be at least MD5_HASH_BUFFER_SIZE bytes.
+//
+// Returns the number of bytes written, or -1 on error.
+int Hash::HashBuffer(BYTE* pBuffer, size_t bufLen, char* hash, size_t hashLen)
+{
+#ifdef TARGET_UNIX
+
+    MD5HASHDATA md5_hashdata;
+    MD5         md5_hasher;
+
+    if (hashLen < MD5_HASH_BUFFER_SIZE)
+        return -1;
+
+    md5_hasher.Hash(pBuffer, (ULONG)bufLen, &md5_hashdata);
+
+    DWORD md5_hashdata_size = sizeof(md5_hashdata.rgb) / sizeof(BYTE);
+    Assert(md5_hashdata_size == MD5_HASH_BYTE_SIZE);
+
+    if (!WriteHashValueAsText(md5_hashdata.rgb, md5_hashdata_size, hash, hashLen))
+        return -1;
+
+    return MD5_HASH_BUFFER_SIZE; // if we had success we wrote MD5_HASH_BUFFER_SIZE bytes to the buffer
+
+#else // !TARGET_UNIX
+
+    if (!m_Initialized)
+    {
+        LogError("Hash class not initialized");
+        return -1;
+    }
+
+    HCRYPTHASH hCryptHash;
+    BYTE       bHash[MD5_HASH_BYTE_SIZE];
+    DWORD      cbHash = MD5_HASH_BYTE_SIZE;
+
+    if (hashLen < MD5_HASH_BUFFER_SIZE)
+        return -1;
+
+    if (!CryptCreateHash(m_hCryptProv, CALG_MD5, 0, 0, &hCryptHash))
+        goto OnError;
+
+    if (!CryptHashData(hCryptHash, pBuffer, (DWORD)bufLen, 0))
+        goto OnError;
+
+    if (!CryptGetHashParam(hCryptHash, HP_HASHVAL, bHash, &cbHash, 0))
+        goto OnError;
+
+    if (cbHash != MD5_HASH_BYTE_SIZE)
+        goto OnError;
+
+    if (!WriteHashValueAsText(bHash, cbHash, hash, hashLen))
+        return -1;
+
+    // Clean up.
+    CryptDestroyHash(hCryptHash);
+    hCryptHash = NULL;
+
+    return MD5_HASH_BUFFER_SIZE; // if we had success we wrote MD5_HASH_BUFFER_SIZE bytes to the buffer
+
+OnError:
+    LogError("Failed to create a hash using the Crypto API (Error 0x%X)", GetLastError());
+
+    if (hCryptHash != NULL)
+    {
+        CryptDestroyHash(hCryptHash);
+        hCryptHash = NULL;
+    }
+
+    return -1;
+
+#endif // !TARGET_UNIX
+}

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.h
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// hash.h - Class for hashing a text stream using MD5 hashing
+//----------------------------------------------------------
+#ifndef _hash
+#define _hash
+
+#define MD5_HASH_BYTE_SIZE 16   // MD5 is 128-bit, so we need 16 bytes to store it
+#define MD5_HASH_BUFFER_SIZE 33 // MD5 is 128-bit, so we need 32 chars + 1 char to store null-terminator
+
+class Hash
+{
+public:
+
+    Hash();
+    ~Hash();
+
+    bool Initialize();
+    bool Destroy();
+
+    bool IsInitialized()
+    {
+#ifdef TARGET_UNIX
+        return true; // No initialization necessary.
+#else // TARGET_UNIX 
+        return m_Initialized;
+#endif // !TARGET_UNIX 
+
+    }
+
+    int HashBuffer(BYTE* pBuffer, size_t bufLen, char* hash, size_t hashLen);
+
+private:
+
+    bool WriteHashValueAsText(const BYTE* pHash, size_t cbHash, char* hashTextBuffer, size_t hashTextBufferLen);
+
+#ifndef TARGET_UNIX
+    bool m_Initialized;
+    HCRYPTPROV m_hCryptProv;
+#endif // !TARGET_UNIX
+};
+
+#endif

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -14,11 +14,9 @@
 #include "compileresult.h"
 #include "lightweightmap.h"
 #include "errorhandling.h"
+#include "hash.h"
 
 #define METHOD_IDENTITY_INFO_SIZE 0x10000 // We assume that the METHOD_IDENTITY_INFO_SIZE will not exceed 64KB
-
-#define MD5_HASH_BYTE_SIZE 16   // MD5 is 128-bit, so we need 16 bytes to store it
-#define MD5_HASH_BUFFER_SIZE 33 // MD5 is 128-bit, so we need 32 chars + 1 char to store null-terminator
 
 class MethodContext
 {
@@ -583,8 +581,8 @@ public:
     static int dumpStatTitleToBuffer(char* buff, int len);
     int methodSize;
 
-    int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false);
-    int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false);
+    int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
+    int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
 
     void recGlobalContext(const MethodContext& other);
 
@@ -1315,6 +1313,9 @@ private:
 #define LWM(map, key, value) LightWeightMap<key, value>* map;
 #define DENSELWM(map, value) DenseLightWeightMap<value>* map;
 #include "lwmlist.h"
+
+    // MD5 hasher
+    static Hash m_hash;
 };
 
 // ********************* Please keep this up-to-date to ease adding more ***************

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SUPERPMI_SHIM_COLLECTOR_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SUPERPMI_SHIM_COUNTER_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SUPERPMI_SHIM_SIMPLE_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SUPERPMI_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp


### PR DESCRIPTION
Create a "Hash" class that encapsulates the MD5 hashing that is
used to determine if two MCs are equivalent. Primarily, this
allows caching the Windows Crypto provider, which it is very slow
to acquire.

In addition, make some changes to avoid unnecessary memory allocations
and other unnecessary work.

The result is that `mcs -removeDup` is about 4x faster.

Much of the remaining cost is that we read, deserialize the MC,
then reserialize the MC (if unique), and finally destroy the in-memory MC.
There is a lot of memory allocation/deallocation in this process that
could possibly be avoided or improved for this scenario.