### PR TITLE
[mono] Don't throw inheritance error on interfaces in GetCustomAttrs

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.Get.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.Get.cs
@@ -91,6 +91,12 @@ namespace System.Tests
         {
             Assert.Throws<AmbiguousMatchException>(() => typeof(ClassWithMixedCaseInterfaces).GetInterface("mixedinterface", ignoreCase: true));
         }
+
+        [Fact]
+        public void GetCustomAttributes_Interface()
+        {
+            Assert.True(typeof(ExampleWithAttribute).GetCustomAttributes(typeof(INameable), inherit: false)[0] is NameableAttribute);
+        }
     }
 
     public class ClassWithNoInterfaces { }
@@ -116,6 +122,20 @@ namespace System.Tests
         public interface Interface2 { }
         public interface Interface3 { }
     }
+
+    public interface INameable
+    {
+        string Name { get; }
+    }
+
+    [AttributeUsage (AttributeTargets.All, AllowMultiple=true)]
+    public class NameableAttribute : Attribute, INameable
+    {
+        string INameable.Name => "Nameable";
+    }
+
+    [Nameable]
+    public class ExampleWithAttribute { }
 }
 
 public interface Interface1 { }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -140,7 +140,8 @@ namespace System.Reflection
                 throw new ArgumentNullException(nameof(obj));
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
-            if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute) && attributeType != typeof(CustomAttribute) && attributeType != typeof(object))
+            if (!attributeType.IsSubclassOf(typeof(Attribute)) && !attributeType.IsInterface
+                && attributeType != typeof(Attribute) && attributeType != typeof(CustomAttribute) && attributeType != typeof(object))
                 throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
             if (attributeType == typeof(CustomAttribute))


### PR DESCRIPTION
Fixes #33639

Looking at https://github.com/dotnet/runtime/issues/7190, the .NET Core behavior here is strange and my changes in https://github.com/dotnet/runtime/commit/0844cb7a6152 with the type checking may have been a mistake. I think this should be fine with the interface special-casing, but if deemed too great a concern I can revert that subset of my old changes. Additionally, if people come up with other scenarios where this might fail, I'll just revert until we can migrate to use a shared CustomAttribute implementation rather than try to play whack-a-mole.