### PR TITLE
Speed up SuperPMI mcs remove dup process

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MCS_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(../superpmi-shared)
 set(MCS_SOURCES
     commandline.cpp
     mcs.cpp
+    removedup.cpp
     verbasmdump.cpp
     verbconcat.cpp
     verbdump.cpp

--- a/src/coreclr/src/ToolBox/superpmi/mcs/commandline.h
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/commandline.h
@@ -32,6 +32,7 @@ public:
             , actionTOC(false)
             , legacyCompare(false)
             , recursive(false)
+            , dedup(false)
             , stripCR(false)
             , nameOfFile1(nullptr)
             , nameOfFile2(nullptr)
@@ -57,6 +58,7 @@ public:
         bool  actionTOC;
         bool  legacyCompare;
         bool  recursive;
+        bool  dedup;
         bool  stripCR;
         char* nameOfFile1;
         char* nameOfFile2;

--- a/src/coreclr/src/ToolBox/superpmi/mcs/mcs.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/mcs.cpp
@@ -51,7 +51,7 @@ int __cdecl main(int argc, char* argv[])
     }
     if (o.actionMerge)
     {
-        exitCode = verbMerge::DoWork(o.nameOfFile1, o.nameOfFile2, o.recursive);
+        exitCode = verbMerge::DoWork(o.nameOfFile1, o.nameOfFile2, o.recursive, o.dedup, o.stripCR);
     }
     if (o.actionCopy)
     {

--- a/src/coreclr/src/ToolBox/superpmi/mcs/removedup.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/removedup.cpp
@@ -1,0 +1,169 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "standardpch.h"
+#include "verbremovedup.h"
+#include "simpletimer.h"
+#include "lightweightmap.h"
+#include "methodcontext.h"
+#include "methodcontextiterator.h"
+#include "removedup.h"
+
+RemoveDup::~RemoveDup()
+{
+    if (m_cleanup)
+    {
+        if (m_inFile != nullptr)
+        {
+            for (int i = 0; i < (int)m_inFile->GetCount(); i++)
+            {
+                DenseLightWeightMap<char*>* md5HashMap = m_inFile->GetItem(i);
+                if (md5HashMap != nullptr)
+                {
+                    // go through and delete items
+                    for (int j = 0; j < (int)md5HashMap->GetCount(); j++)
+                    {
+                        char* p = md5HashMap->GetItem(j);
+                        delete[] p;
+                    }
+                    delete md5HashMap;
+                }
+            }
+            delete m_inFile;
+            m_inFile = nullptr;
+        }
+        if (m_inFileLegacy != nullptr)
+        {
+            for (int i = 0; i < (int)m_inFileLegacy->GetCount(); i++)
+            {
+                DenseLightWeightMap<MethodContext*>* md5HashMap = m_inFileLegacy->GetItem(i);
+                if (md5HashMap != nullptr)
+                {
+                    // go through and delete items
+                    for (int j = 0; j < (int)md5HashMap->GetCount(); j++)
+                    {
+                        MethodContext* p = md5HashMap->GetItem(j);
+                        delete p;
+                    }
+                    delete md5HashMap;
+                }
+            }
+            delete m_inFileLegacy;
+            m_inFileLegacy = nullptr;
+        }
+    }
+}
+
+bool RemoveDup::unique(MethodContext* mc)
+{
+    if (m_inFile == nullptr)
+        m_inFile = new LightWeightMap<int, DenseLightWeightMap<char*>*>();
+
+    CORINFO_METHOD_INFO newInfo;
+    unsigned            newFlags = 0;
+    mc->repCompileMethod(&newInfo, &newFlags);
+
+    // Assume that there are lots of duplicates, so don't allocate a new buffer for the MD5 hash data
+    // until we know we're going to add it to the map.
+    char md5Buff[MD5_HASH_BUFFER_SIZE];
+    mc->dumpMethodMD5HashToBuffer(md5Buff, MD5_HASH_BUFFER_SIZE, /* ignoreMethodName */ true, &newInfo, newFlags);
+
+    if (m_inFile->GetIndex(newInfo.ILCodeSize) == -1)
+        m_inFile->Add(newInfo.ILCodeSize, new DenseLightWeightMap<char*>());
+
+    DenseLightWeightMap<char*>* ourRank = m_inFile->Get(newInfo.ILCodeSize);
+
+    for (unsigned i = 0; i < ourRank->GetCount(); i++)
+    {
+        char* md5Buff2 = ourRank->Get(i);
+        if (strncmp(md5Buff, md5Buff2, MD5_HASH_BUFFER_SIZE) == 0)
+        {
+            return false;
+        }
+    }
+
+    char* newmd5Buff = new char[MD5_HASH_BUFFER_SIZE];
+    memcpy(newmd5Buff, md5Buff, MD5_HASH_BUFFER_SIZE);
+    ourRank->Append(newmd5Buff);
+    return true;
+}
+
+bool RemoveDup::uniqueLegacy(MethodContext* mc)
+{
+    if (m_inFileLegacy == nullptr)
+        m_inFileLegacy = new LightWeightMap<int, DenseLightWeightMap<MethodContext*>*>();
+
+    CORINFO_METHOD_INFO newInfo;
+    unsigned            newFlags = 0;
+    mc->repCompileMethod(&newInfo, &newFlags);
+
+    if (m_inFileLegacy->GetIndex(newInfo.ILCodeSize) == -1)
+        m_inFileLegacy->Add(newInfo.ILCodeSize, new DenseLightWeightMap<MethodContext*>());
+
+    DenseLightWeightMap<MethodContext*>* ourRank = m_inFileLegacy->Get(newInfo.ILCodeSize);
+
+    for (unsigned i = 0; i < ourRank->GetCount(); i++)
+    {
+        MethodContext* scratch = ourRank->Get(i);
+        if (mc->Equal(scratch))
+        {
+            return false;
+        }
+    }
+
+    // We store the MethodContext in our map.
+    ourRank->Append(mc);
+    return true;
+}
+
+bool RemoveDup::CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut, bool stripCR, bool legacyCompare)
+{
+    MethodContextIterator mci(/* progressReport */ true);
+    if (!mci.Initialize(nameOfInput))
+        return false;
+
+    int savedCount = 0;
+
+    while (mci.MoveNext())
+    {
+        MethodContext* mc = mci.CurrentTakeOwnership();
+        if (stripCR)
+        {
+            delete mc->cr;
+            mc->cr = new CompileResult();
+        }
+        if (legacyCompare)
+        {
+            if (uniqueLegacy(mc))
+            {
+                mc->saveToFile(hFileOut);
+                savedCount++;
+
+                // In this case, for the legacy comparer, it has placed the 'mc' in the 'm_inFileLegacy' table, so we
+                // can't delete it.
+            }
+            else
+            {
+                delete mc; // we no longer need this
+            }
+        }
+        else
+        {
+            if (unique(mc))
+            {
+                mc->saveToFile(hFileOut);
+                savedCount++;
+            }
+            delete mc; // we no longer need this
+        }
+    }
+
+    LogInfo("Loaded %d, Saved %d", mci.MethodContextNumber(), savedCount);
+
+    if (!mci.Destroy())
+        return false;
+
+    return true;
+}

--- a/src/coreclr/src/ToolBox/superpmi/mcs/removedup.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/removedup.cpp
@@ -118,7 +118,7 @@ bool RemoveDup::uniqueLegacy(MethodContext* mc)
     return true;
 }
 
-bool RemoveDup::CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut, bool stripCR, bool legacyCompare)
+bool RemoveDup::CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut)
 {
     MethodContextIterator mci(/* progressReport */ true);
     if (!mci.Initialize(nameOfInput))
@@ -129,12 +129,12 @@ bool RemoveDup::CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut, bool
     while (mci.MoveNext())
     {
         MethodContext* mc = mci.CurrentTakeOwnership();
-        if (stripCR)
+        if (m_stripCR)
         {
             delete mc->cr;
             mc->cr = new CompileResult();
         }
-        if (legacyCompare)
+        if (m_legacyCompare)
         {
             if (uniqueLegacy(mc))
             {

--- a/src/coreclr/src/ToolBox/superpmi/mcs/removedup.h
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/removedup.h
@@ -16,17 +16,38 @@ class RemoveDup
 {
 public:
 
-    RemoveDup(bool cleanup = true)
-        : m_inFile(nullptr)
+    RemoveDup()
+        : m_stripCR(false)
+        , m_legacyCompare(false)
+        , m_cleanup(false)
+        , m_inFile(nullptr)
         , m_inFileLegacy(nullptr)
-        , m_cleanup(cleanup)
     {}
+
+    bool Initialize(bool stripCR = false, bool legacyCompare = false, bool cleanup = true)
+    {
+        m_stripCR       = stripCR;
+        m_legacyCompare = legacyCompare;
+        m_cleanup       = cleanup;
+        m_inFile        = nullptr;
+        m_inFileLegacy  = nullptr;
+
+        return true;
+    }
 
     ~RemoveDup();
 
-    bool CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut, bool stripCR, bool legacyCompare);
+    bool CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut);
 
 private:
+
+    bool m_stripCR;       // 'true' if we remove CompileResults when removing duplicates.
+    bool m_legacyCompare; // 'true' to use the legacy comparer.
+
+    // If false, we don't spend time cleaning up the `m_inFile` and `m_inFileLegacy`
+    // data structures. Only set it to `false` if you're ok with memory leaks, e.g.,
+    // if the process will exit soon afterwards.
+    bool m_cleanup;
 
     // We use a hash to limit the number of comparisons we need to do.
     // The first level key to our hash map is ILCodeSize and the second
@@ -34,11 +55,6 @@ private:
 
     LightWeightMap<int, DenseLightWeightMap<char*>*>*          m_inFile;
     LightWeightMap<int, DenseLightWeightMap<MethodContext*>*>* m_inFileLegacy;
-
-    // If false, we don't spend time cleaning up the `m_inFile` and `m_inFileLegacy`
-    // data structures. Only set it to `false` if you're ok with memory leaks, e.g.,
-    // if the process will exit soon afterwards.
-    bool m_cleanup;
 
     bool unique(MethodContext* mc);
     bool uniqueLegacy(MethodContext* mc);

--- a/src/coreclr/src/ToolBox/superpmi/mcs/removedup.h
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/removedup.h
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// RemoveDup.h - Functions to remove dups from a method context hive (MCH)
+//----------------------------------------------------------
+#ifndef _RemoveDup
+#define _RemoveDup
+
+#include "methodcontext.h"
+#include "lightweightmap.h"
+
+class RemoveDup
+{
+public:
+
+    RemoveDup(bool cleanup = true)
+        : m_inFile(nullptr)
+        , m_inFileLegacy(nullptr)
+        , m_cleanup(cleanup)
+    {}
+
+    ~RemoveDup();
+
+    bool CopyAndRemoveDups(const char* nameOfInput, HANDLE hFileOut, bool stripCR, bool legacyCompare);
+
+private:
+
+    // We use a hash to limit the number of comparisons we need to do.
+    // The first level key to our hash map is ILCodeSize and the second
+    // level map key is just an index and the value is an existing MC Hash.
+
+    LightWeightMap<int, DenseLightWeightMap<char*>*>*          m_inFile;
+    LightWeightMap<int, DenseLightWeightMap<MethodContext*>*>* m_inFileLegacy;
+
+    // If false, we don't spend time cleaning up the `m_inFile` and `m_inFileLegacy`
+    // data structures. Only set it to `false` if you're ok with memory leaks, e.g.,
+    // if the process will exit soon afterwards.
+    bool m_cleanup;
+
+    bool unique(MethodContext* mc);
+    bool uniqueLegacy(MethodContext* mc);
+};
+
+#endif

--- a/src/coreclr/src/ToolBox/superpmi/mcs/verbmerge.h
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/verbmerge.h
@@ -10,10 +10,12 @@
 #ifndef _verbMerge
 #define _verbMerge
 
+#include "removedup.h"
+
 class verbMerge
 {
 public:
-    static int DoWork(const char* nameOfOutputFile, const char* pattern, bool recursive);
+    static int DoWork(const char* nameOfOutputFile, const char* pattern, bool recursive, bool dedup, bool stripCR);
 
 private:
     typedef bool (*DirectoryFilterFunction_t)(WIN32_FIND_DATAW*);
@@ -29,13 +31,17 @@ private:
 
     static char* ConvertWideCharToMultiByte(LPCWSTR wstr);
 
-    static int AppendFile(HANDLE hFileOut, LPCWSTR fileName, unsigned char* buffer, size_t bufferSize);
+    static int AppendFileRaw(HANDLE hFileOut, LPCWSTR fileFullPath, unsigned char* buffer, size_t bufferSize);
+    static int AppendFile(HANDLE hFileOut, LPCWSTR fileFullPath, bool dedup, unsigned char* buffer, size_t bufferSize);
     static int AppendAllInDir(HANDLE              hFileOut,
                               LPCWSTR             dir,
                               LPCWSTR             file,
                               unsigned char*      buffer,
                               size_t              bufferSize,
                               bool                recursive,
+                              bool                dedup,
                               /* out */ LONGLONG* size);
+
+    static RemoveDup m_removeDups;
 };
 #endif

--- a/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
@@ -5,90 +5,11 @@
 
 #include "standardpch.h"
 #include "verbremovedup.h"
-#include "simpletimer.h"
-#include "lightweightmap.h"
-#include "methodcontext.h"
-#include "methodcontextiterator.h"
-
-// We use a hash to limit the number of comparisons we need to do.
-// The first level key to our hash map is ILCodeSize and the second
-// level map key is just an index and the value is an existing MC Hash.
-
-LightWeightMap<int, DenseLightWeightMap<char*>*>* inFile = nullptr;
-
-bool unique(MethodContext* mc)
-{
-    if (inFile == nullptr)
-        inFile = new LightWeightMap<int, DenseLightWeightMap<char*>*>();
-
-    CORINFO_METHOD_INFO newInfo;
-    unsigned            newFlags = 0;
-    mc->repCompileMethod(&newInfo, &newFlags);
-
-    // Assume that there are lots of duplicates, so don't allocate a new buffer for the MD5 hash data
-    // until we know we're going to add it to the map.
-    char md5Buff[MD5_HASH_BUFFER_SIZE];
-    mc->dumpMethodMD5HashToBuffer(md5Buff, MD5_HASH_BUFFER_SIZE, /* ignoreMethodName */ true, &newInfo, newFlags);
-
-    if (inFile->GetIndex(newInfo.ILCodeSize) == -1)
-        inFile->Add(newInfo.ILCodeSize, new DenseLightWeightMap<char*>());
-
-    DenseLightWeightMap<char*>* ourRank = inFile->Get(newInfo.ILCodeSize);
-
-    for (int i = 0; i < (int)ourRank->GetCount(); i++)
-    {
-        char* md5Buff2 = ourRank->Get(i);
-        if (strncmp(md5Buff, md5Buff2, MD5_HASH_BUFFER_SIZE) == 0)
-        {
-            return false;
-        }
-    }
-
-    char* newmd5Buff = new char[MD5_HASH_BUFFER_SIZE];
-    memcpy(newmd5Buff, md5Buff, MD5_HASH_BUFFER_SIZE);
-    ourRank->Append(newmd5Buff);
-    return true;
-}
-
-LightWeightMap<int, DenseLightWeightMap<MethodContext*>*>* inFileLegacy = nullptr;
-
-bool uniqueLegacy(MethodContext* mc)
-{
-    if (inFileLegacy == nullptr)
-        inFileLegacy = new LightWeightMap<int, DenseLightWeightMap<MethodContext*>*>();
-
-    CORINFO_METHOD_INFO newInfo;
-    unsigned            newFlags = 0;
-    mc->repCompileMethod(&newInfo, &newFlags);
-
-    if (inFileLegacy->GetIndex(newInfo.ILCodeSize) == -1)
-        inFileLegacy->Add(newInfo.ILCodeSize, new DenseLightWeightMap<MethodContext*>());
-
-    DenseLightWeightMap<MethodContext*>* ourRank = inFileLegacy->Get(newInfo.ILCodeSize);
-
-    for (int i = 0; i < (int)ourRank->GetCount(); i++)
-    {
-        MethodContext* scratch = ourRank->Get(i);
-        if (mc->Equal(scratch))
-        {
-            return false;
-        }
-    }
-
-    // We store the MethodContext in our map.
-    ourRank->Append(mc);
-    return true;
-}
+#include "removedup.h"
 
 int verbRemoveDup::DoWork(const char* nameOfInput, const char* nameOfOutput, bool stripCR, bool legacyCompare)
 {
     LogVerbose("Removing duplicates from '%s', writing to '%s'", nameOfInput, nameOfOutput);
-
-    MethodContextIterator mci(true);
-    if (!mci.Initialize(nameOfInput))
-        return -1;
-
-    int savedCount = 0;
 
     HANDLE hFileOut = CreateFileA(nameOfOutput, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
                                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
@@ -98,52 +19,18 @@ int verbRemoveDup::DoWork(const char* nameOfInput, const char* nameOfOutput, boo
         return -1;
     }
 
-    while (mci.MoveNext())
+    RemoveDup removeDups(/* cleanup */ false);
+    if (!removeDups.CopyAndRemoveDups(nameOfInput, hFileOut, stripCR, legacyCompare))
     {
-        MethodContext* mc = mci.CurrentTakeOwnership();
-        if (stripCR)
-        {
-            delete mc->cr;
-            mc->cr = new CompileResult();
-        }
-        if (legacyCompare)
-        {
-            if (uniqueLegacy(mc))
-            {
-                mc->saveToFile(hFileOut);
-                savedCount++;
-
-                // In this case, for the legacy comparer, it has placed the 'mc' in the 'inFileLegacy' table, so we
-                // can't delete it.
-            }
-            else
-            {
-                delete mc; // we no longer need this
-            }
-        }
-        else
-        {
-            if (unique(mc))
-            {
-                mc->saveToFile(hFileOut);
-                savedCount++;
-            }
-            delete mc; // we no longer need this
-        }
+        LogError("Failed to remove dups");
+        return -1;
     }
-
-    LogInfo("Loaded %d, Saved %d", mci.MethodContextNumber(), savedCount);
-
-    // We're leaking 'inFile' or 'inFileLegacy', but the process is going away, so it shouldn't matter.
 
     if (CloseHandle(hFileOut) == 0)
     {
-        LogError("2nd CloseHandle failed. GetLastError()=%u", GetLastError());
+        LogError("CloseHandle failed. GetLastError()=%u", GetLastError());
         return -1;
     }
-
-    if (!mci.Destroy())
-        return -1;
 
     return 0;
 }

--- a/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/verbremovedup.cpp
@@ -19,8 +19,9 @@ int verbRemoveDup::DoWork(const char* nameOfInput, const char* nameOfOutput, boo
         return -1;
     }
 
-    RemoveDup removeDups(/* cleanup */ false);
-    if (!removeDups.CopyAndRemoveDups(nameOfInput, hFileOut, stripCR, legacyCompare))
+    RemoveDup removeDups;
+    if (!removeDups.Initialize(stripCR, legacyCompare, /* cleanup */ false)
+        || !removeDups.CopyAndRemoveDups(nameOfInput, hFileOut))
     {
         LogError("Failed to remove dups");
         return -1;

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
@@ -1,0 +1,197 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// hash.cpp - Class for hashing a text stream using MD5 hashing
+//
+// Note that on Windows, acquiring the Crypto hash provider is expensive, so
+// only do that once and cache it.
+//----------------------------------------------------------
+
+#include "standardpch.h"
+#include "runtimedetails.h"
+#include "errorhandling.h"
+#include "md5.h"
+#include "hash.h"
+
+Hash::Hash()
+#ifndef TARGET_UNIX
+    : m_Initialized(false)
+    , m_hCryptProv(NULL)
+#endif // !TARGET_UNIX
+{
+}
+
+Hash::~Hash()
+{
+    Destroy(); // Ignoring return code.
+}
+
+// static
+bool Hash::Initialize()
+{
+#ifdef TARGET_UNIX
+
+    // No initialization necessary.
+
+#else // !TARGET_UNIX
+
+    if (m_Initialized)
+    {
+        LogError("Hash class has already been initialized");
+        return false;
+    }
+
+    // Get handle to the crypto provider
+    if (!CryptAcquireContextA(&m_hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+        goto OnError;
+
+    m_Initialized = true;
+    return true;
+
+OnError:
+    LogError("Failed to create a hash using the Crypto API (Error 0x%X)", GetLastError());
+
+    if (m_hCryptProv != NULL)
+        CryptReleaseContext(m_hCryptProv, 0);
+
+    m_Initialized = false;
+    return false;
+
+#endif // !TARGET_UNIX
+}
+
+// static
+bool Hash::Destroy()
+{
+#ifdef TARGET_UNIX
+
+    // No destruction necessary.
+
+#else // !TARGET_UNIX
+
+    // Should probably check Crypt() function return codes.
+    if (m_hCryptProv != NULL)
+    {
+        CryptReleaseContext(m_hCryptProv, 0);
+        m_hCryptProv = NULL;
+    }
+
+    m_Initialized = false;
+    return true;
+
+#endif // !TARGET_UNIX
+}
+
+// Hash::WriteHashValueAsText - Take a binary hash value in the array of bytes pointed to by
+// 'pHash' (size in bytes 'cbHash'), and write an ASCII hexadecimal representation of it in the buffer
+// 'hashTextBuffer' (size in bytes 'hashTextBufferLen').
+//
+// Returns true on success, false on failure (only if the arguments are bad).
+bool Hash::WriteHashValueAsText(const BYTE* pHash, size_t cbHash, char* hashTextBuffer, size_t hashTextBufferLen)
+{
+    // This could be:
+    //
+    // for (DWORD i = 0; i < MD5_HASH_BYTE_SIZE; i++)
+    // {
+    //    sprintf_s(hash + i * 2, hashLen - i * 2, "%02X", bHash[i]);
+    // }
+    //
+    // But this function is hot, and sprintf_s is too slow. This is a specialized function to speed it up.
+
+    if (hashTextBufferLen < 2 * cbHash + 1) // 2 characters for each byte, plus null terminator
+    {
+        LogError("WriteHashValueAsText doesn't have enough space to write the output");
+        return false;
+    }
+
+    static const char hexDigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+    char* pCur = hashTextBuffer;
+    for (size_t i = 0; i < cbHash; i++)
+    {
+        unsigned digit = pHash[i];
+        unsigned lowNibble = digit & 0xF;
+        unsigned highNibble = digit >> 4;
+        *pCur++ = hexDigits[highNibble];
+        *pCur++ = hexDigits[lowNibble];
+    }
+    *pCur++ = '\0';
+    return true;
+}
+
+// Hash::HashBuffer - Compute an MD5 hash of the data pointed to by 'pBuffer', of 'bufLen' bytes,
+// writing the hexadecimal ASCII text representation of the hash to the buffer pointed to by 'hash',
+// of 'hashLen' bytes in size, which must be at least MD5_HASH_BUFFER_SIZE bytes.
+//
+// Returns the number of bytes written, or -1 on error.
+int Hash::HashBuffer(BYTE* pBuffer, size_t bufLen, char* hash, size_t hashLen)
+{
+#ifdef TARGET_UNIX
+
+    MD5HASHDATA md5_hashdata;
+    MD5         md5_hasher;
+
+    if (hashLen < MD5_HASH_BUFFER_SIZE)
+        return -1;
+
+    md5_hasher.Hash(pBuffer, (ULONG)bufLen, &md5_hashdata);
+
+    DWORD md5_hashdata_size = sizeof(md5_hashdata.rgb) / sizeof(BYTE);
+    Assert(md5_hashdata_size == MD5_HASH_BYTE_SIZE);
+
+    if (!WriteHashValueAsText(md5_hashdata.rgb, md5_hashdata_size, hash, hashLen))
+        return -1;
+
+    return MD5_HASH_BUFFER_SIZE; // if we had success we wrote MD5_HASH_BUFFER_SIZE bytes to the buffer
+
+#else // !TARGET_UNIX
+
+    if (!m_Initialized)
+    {
+        LogError("Hash class not initialized");
+        return -1;
+    }
+
+    HCRYPTHASH hCryptHash;
+    BYTE       bHash[MD5_HASH_BYTE_SIZE];
+    DWORD      cbHash = MD5_HASH_BYTE_SIZE;
+
+    if (hashLen < MD5_HASH_BUFFER_SIZE)
+        return -1;
+
+    if (!CryptCreateHash(m_hCryptProv, CALG_MD5, 0, 0, &hCryptHash))
+        goto OnError;
+
+    if (!CryptHashData(hCryptHash, pBuffer, (DWORD)bufLen, 0))
+        goto OnError;
+
+    if (!CryptGetHashParam(hCryptHash, HP_HASHVAL, bHash, &cbHash, 0))
+        goto OnError;
+
+    if (cbHash != MD5_HASH_BYTE_SIZE)
+        goto OnError;
+
+    if (!WriteHashValueAsText(bHash, cbHash, hash, hashLen))
+        return -1;
+
+    // Clean up.
+    CryptDestroyHash(hCryptHash);
+    hCryptHash = NULL;
+
+    return MD5_HASH_BUFFER_SIZE; // if we had success we wrote MD5_HASH_BUFFER_SIZE bytes to the buffer
+
+OnError:
+    LogError("Failed to create a hash using the Crypto API (Error 0x%X)", GetLastError());
+
+    if (hCryptHash != NULL)
+    {
+        CryptDestroyHash(hCryptHash);
+        hCryptHash = NULL;
+    }
+
+    return -1;
+
+#endif // !TARGET_UNIX
+}

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.cpp
@@ -35,6 +35,7 @@ bool Hash::Initialize()
 #ifdef TARGET_UNIX
 
     // No initialization necessary.
+    return true;
 
 #else // !TARGET_UNIX
 
@@ -69,6 +70,7 @@ bool Hash::Destroy()
 #ifdef TARGET_UNIX
 
     // No destruction necessary.
+    return true;
 
 #else // !TARGET_UNIX
 

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/hash.h
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// hash.h - Class for hashing a text stream using MD5 hashing
+//----------------------------------------------------------
+#ifndef _hash
+#define _hash
+
+#define MD5_HASH_BYTE_SIZE 16   // MD5 is 128-bit, so we need 16 bytes to store it
+#define MD5_HASH_BUFFER_SIZE 33 // MD5 is 128-bit, so we need 32 chars + 1 char to store null-terminator
+
+class Hash
+{
+public:
+
+    Hash();
+    ~Hash();
+
+    bool Initialize();
+    bool Destroy();
+
+    bool IsInitialized()
+    {
+#ifdef TARGET_UNIX
+        return true; // No initialization necessary.
+#else // TARGET_UNIX 
+        return m_Initialized;
+#endif // !TARGET_UNIX 
+
+    }
+
+    int HashBuffer(BYTE* pBuffer, size_t bufLen, char* hash, size_t hashLen);
+
+private:
+
+    bool WriteHashValueAsText(const BYTE* pHash, size_t cbHash, char* hashTextBuffer, size_t hashTextBufferLen);
+
+#ifndef TARGET_UNIX
+    bool m_Initialized;
+    HCRYPTPROV m_hCryptProv;
+#endif // !TARGET_UNIX
+};
+
+#endif

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -14,11 +14,9 @@
 #include "compileresult.h"
 #include "lightweightmap.h"
 #include "errorhandling.h"
+#include "hash.h"
 
 #define METHOD_IDENTITY_INFO_SIZE 0x10000 // We assume that the METHOD_IDENTITY_INFO_SIZE will not exceed 64KB
-
-#define MD5_HASH_BYTE_SIZE 16   // MD5 is 128-bit, so we need 16 bytes to store it
-#define MD5_HASH_BUFFER_SIZE 33 // MD5 is 128-bit, so we need 32 chars + 1 char to store null-terminator
 
 class MethodContext
 {
@@ -583,8 +581,8 @@ public:
     static int dumpStatTitleToBuffer(char* buff, int len);
     int methodSize;
 
-    int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false);
-    int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false);
+    int dumpMethodIdentityInfoToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
+    int dumpMethodMD5HashToBuffer(char* buff, int len, bool ignoreMethodName = false, CORINFO_METHOD_INFO* optInfo = nullptr, unsigned optFlags = 0);
 
     void recGlobalContext(const MethodContext& other);
 
@@ -1315,6 +1313,9 @@ private:
 #define LWM(map, key, value) LightWeightMap<key, value>* map;
 #define DENSELWM(map, value) DenseLightWeightMap<value>* map;
 #include "lwmlist.h"
+
+    // MD5 hasher
+    static Hash m_hash;
 };
 
 // ********************* Please keep this up-to-date to ease adding more ***************

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontextiterator.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontextiterator.cpp
@@ -92,11 +92,11 @@ bool MethodContextIterator::MoveNext()
 
         if (m_progressReport)
         {
-            if (m_methodContextNumber % 500 == 0)
+            if ((m_methodContextNumber % m_progressRate) == 0)
             {
                 m_timer->Stop();
                 LogVerbose("Loaded %d at %d per second", m_methodContextNumber,
-                           (int)((double)500 / m_timer->GetSeconds()));
+                           (int)((double)m_progressRate / m_timer->GetSeconds()));
                 m_timer->Start();
             }
         }

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontextiterator.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontextiterator.h
@@ -19,6 +19,7 @@ public:
         , m_index(0)
         , m_indexes(nullptr)
         , m_progressReport(progressReport)
+        , m_progressRate(1000)
         , m_timer(nullptr)
     {
         if (m_progressReport)
@@ -36,6 +37,7 @@ public:
         , m_index(0)
         , m_indexes(indexes)
         , m_progressReport(progressReport)
+        , m_progressRate(1000)
         , m_timer(nullptr)
     {
         if (m_progressReport)
@@ -98,5 +100,6 @@ private:
     // Should we log a progress report as we are loading the method contexts?
     // The timer is only used when m_progressReport==true.
     bool         m_progressReport;
+    const int    m_progressRate;    // Report progress every `m_progressRate` method contexts.
     SimpleTimer* m_timer;
 };

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SUPERPMI_SHIM_COLLECTOR_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SUPERPMI_SHIM_COUNTER_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SUPERPMI_SHIM_SIMPLE_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp

--- a/src/coreclr/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SUPERPMI_SOURCES
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp
     ../superpmi-shared/errorhandling.cpp
+    ../superpmi-shared/hash.cpp
     ../superpmi-shared/logging.cpp
     ../superpmi-shared/mclist.cpp
     ../superpmi-shared/methodcontext.cpp


### PR DESCRIPTION
To speed up the "remove dup" code, create a "Hash" class that encapsulates the MD5 hashing
that is used to determine if two MCs are equivalent. Primarily, this allows caching the
Windows Crypto provider, which it is very slow to acquire.

In addition, make some changes to avoid unnecessary memory allocations
and other unnecessary work.

The result is that mcs -removeDup is about 4x faster.

Much of the remaining cost is that we read, deserialize the MC,
then reserialize the MC (if unique), and finally destroy the in-memory MC.
There is a lot of memory allocation/deallocation in this process that
could possibly be avoided or improved for this scenario.

In addition, add support to `mcs -merge` to also remove duplicates at the same time.
This removes the need to create merged file with duplicates, and thus significantly reduces the
disk space required to do a collection, as well as speeds up the collection processing.

Update the superpmi.py drive script, superpmicollect unit test, and documentation to match.
