### PR TITLE
Fixed build with GDBJIT enabled and PREJIT disabled

### DIFF
--- a/src/coreclr/src/vm/gdbjit.cpp
+++ b/src/coreclr/src/vm/gdbjit.cpp
@@ -1133,7 +1133,7 @@ ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMem
             break;
         case ELEMENT_TYPE_ARRAY:
         case ELEMENT_TYPE_SZARRAY:
-            m_type_size = pMT->GetClass()->GetSize();
+            m_type_size = typeHandle.AsMethodTable()->GetBaseSize();
             break;
         default:
             m_type_size = 0;


### PR DESCRIPTION
This commit fixes build for case, when FEATURE_GDBJIT
is enabled, but FEATURE_PREJIT is disabled.

This solves issue #33956.