### PR TITLE
Refactor System.IO.BinaryWriter

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -574,9 +574,9 @@ namespace System
             return true;
         }
 
-        internal static void GetBytes(in decimal d, byte[] buffer)
+        internal static void GetBytes(in decimal d, Span<byte> buffer)
         {
-            Debug.Assert(buffer != null && buffer.Length >= 16, "[GetBytes]buffer != null && buffer.Length >= 16");
+            Debug.Assert(buffer.Length >= 16, "[GetBytes]buffer.Length >= 16");
             buffer[0] = (byte)d.lo;
             buffer[1] = (byte)(d.lo >> 8);
             buffer[2] = (byte)(d.lo >> 16);
@@ -596,6 +596,12 @@ namespace System
             buffer[13] = (byte)(d.flags >> 8);
             buffer[14] = (byte)(d.flags >> 16);
             buffer[15] = (byte)(d.flags >> 24);
+        }
+
+        internal static void GetBytes(in decimal d, byte[] buffer)
+        {
+            Debug.Assert(buffer != null, "[GetBytes]buffer != null");
+            GetBytes(in d, buffer.AsSpan());
         }
 
         internal static decimal ToDecimal(ReadOnlySpan<byte> span)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -245,11 +245,11 @@ namespace System.IO
         // Writes a two-byte signed integer to this stream. The current position of
         // the stream is advanced by two.
         //
-        public virtual void Write(short value)
+        public virtual unsafe void Write(short value)
         {
-            Span<byte> span = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16LittleEndian(span, value);
-            OutStream.Write(span);
+            if (!BitConverter.IsLittleEndian)
+                value = BinaryPrimitives.ReverseEndianness(value);
+            OutStream.Write(new ReadOnlySpan<byte>(&value, sizeof(short)));
         }
 
         // Writes a two-byte unsigned integer to this stream. The current position
@@ -266,9 +266,9 @@ namespace System.IO
         //
         public virtual unsafe void Write(int value)
         {
-            Span<byte> span = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32LittleEndian(span, value);
-            OutStream.Write(span);
+            if (!BitConverter.IsLittleEndian)
+                value = BinaryPrimitives.ReverseEndianness(value);
+            OutStream.Write(new ReadOnlySpan<byte>(&value, sizeof(int)));
         }
 
         // Writes a four-byte unsigned integer to this stream. The current position
@@ -285,9 +285,9 @@ namespace System.IO
         //
         public virtual unsafe void Write(long value)
         {
-            Span<byte> span = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64LittleEndian(span, value);
-            OutStream.Write(span);
+            if (!BitConverter.IsLittleEndian)
+                value = BinaryPrimitives.ReverseEndianness(value);
+            OutStream.Write(new ReadOnlySpan<byte>(&value, sizeof(long)));
         }
 
         // Writes an eight-byte unsigned integer to this stream. The current


### PR DESCRIPTION
As the title says, this PR refactors the `System.IO.BinaryWriter` class.

Binary writers no longer use a 16-byte buffer array when they write simple types; instead they ~~allocate from the stack~~ reverse endianness on big-endian platforms, and directly write the values to the base stream using spans.

I also reduced code duplication by redirecting functions like `BinaryWriter.Write(uint)` to `BinaryWriter.Write(int)`. Previously, their code was identical and spanned many lines; the latter was fixed using the `BinaryPrimitives` methods.