### PR TITLE
Add System*Native libraries from .NET Core 3.1 release, to Platform Manifest

### DIFF
--- a/src/coreclr/src/vm/gdbjit.cpp
+++ b/src/coreclr/src/vm/gdbjit.cpp
@@ -1133,7 +1133,7 @@ ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMem
             break;
         case ELEMENT_TYPE_ARRAY:
         case ELEMENT_TYPE_SZARRAY:
-            m_type_size = pMT->GetClass()->GetSize();
+            m_type_size = typeHandle.AsMethodTable()->GetBaseSize();
             break;
         default:
             m_type_size = 0;

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -71,8 +71,8 @@
   </Target>
 
   <!-- Platform manifest needs to include all System*Native items from 3.1 release. This target adds them explicitly,
-      to work around the issue introduced with a fix for https://github.com/dotnet/runtime/issues/33118,
-      Android libraries need to conform to a specific naming convention which necessitated renames of these libraries.
+      to fill the gap that appeared when the
+      names of these libraries were changed in 5.0 to conform to a specific Android naming convention. The library name change was a fix for https://github.com/dotnet/runtime/issues/33118.
       For more details of the issue and fix see https://github.com/dotnet/runtime/issues/33450 -->
 
   <Target Name="AddSharedFrameworkNativeFilesWithoutLibPrefixToPlatformManifest"

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -70,41 +70,35 @@
     </ItemGroup>
   </Target>
 
-  <!-- Platform manifest needs to include all System*Native items from 3.1 release. This target adds them explicitly,
-      to work around the issue introduced with a fix for https://github.com/dotnet/runtime/issues/33118,
-      Android libraries need to conform to a specific naming convention which necessitated renames of these libraries.
-      For more details of the issue and fix see https://github.com/dotnet/runtime/issues/33450 -->
-
-  <Target Name="AddSharedFrameworkNativeFilesWithoutLibPrefixToPlatformManifest"
-          BeforeTargets="GenerateFileVersionProps">
-    <ItemGroup>
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Globalization.Native.so" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.Apple.a" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.Apple.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
-      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Globalization.Native.dylib" />
-    </ItemGroup>
-
-    <!-- SharedFrameworkRuntimeFiles are passed into GenerateFileVersionProps task for PlatformManifest generation. -->
-    <ItemGroup>
-      <SharedFrameworkRuntimeFiles Include="@(_sharedFrameworkNativeFilesWithoutLibPrefix)"
-                                   TargetPath="runtimes/" />
-    </ItemGroup>
-  </Target>
+  <!--
+    Platform manifest needs to include all System*Native items from 3.1 release. This target adds
+    them explicitly, to fill the gap that appeared when the names of these libraries were changed
+    in 5.0 to conform to a specific Android naming convention. The library name change was a fix
+    for https://github.com/dotnet/runtime/issues/33118. For more details of the issue and fix see
+    https://github.com/dotnet/runtime/issues/33450.
+  -->
+  <ItemGroup>
+    <_pastShimFiles Include="System.Globalization.Native.dylib" />
+    <_pastShimFiles Include="System.Globalization.Native.so" />
+    <_pastShimFiles Include="System.IO.Compression.Native.a" />
+    <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
+    <_pastShimFiles Include="System.IO.Compression.Native.so" />
+    <_pastShimFiles Include="System.Native.a" />
+    <_pastShimFiles Include="System.Native.dylib" />
+    <_pastShimFiles Include="System.Native.so" />
+    <_pastShimFiles Include="System.Net.Http.Native.a" />
+    <_pastShimFiles Include="System.Net.Http.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Http.Native.so" />
+    <_pastShimFiles Include="System.Net.Security.Native.a" />
+    <_pastShimFiles Include="System.Net.Security.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Security.Native.so" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
+    <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />
+  </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="localnetcoreapp.override.targets" />

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -70,6 +70,42 @@
     </ItemGroup>
   </Target>
 
+  <!-- Platform manifest needs to include all System*Native items from 3.1 release. This target adds them explicitly,
+      to work around the issue introduced with a fix for https://github.com/dotnet/runtime/issues/33118,
+      Android libraries need to conform to a specific naming convention which necessitated renames of these libraries.
+      For more details of the issue and fix see https://github.com/dotnet/runtime/issues/33450 -->
+
+  <Target Name="AddSharedFrameworkNativeFilesWithoutLibPrefixToPlatformManifest"
+          BeforeTargets="GenerateFileVersionProps">
+    <ItemGroup>
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Globalization.Native.so" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.IO.Compression.Native.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Native.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Http.Native.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Net.Security.Native.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.Apple.a" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.Apple.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+      <_sharedFrameworkNativeFilesWithoutLibPrefix Include="System.Globalization.Native.dylib" />
+    </ItemGroup>
+
+    <!-- SharedFrameworkRuntimeFiles are passed into GenerateFileVersionProps task for PlatformManifest generation. -->
+    <ItemGroup>
+      <SharedFrameworkRuntimeFiles Include="@(_sharedFrameworkNativeFilesWithoutLibPrefix)"
+                                   TargetPath="runtimes/" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="localnetcoreapp.override.targets" />
 </Project>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
@@ -89,7 +89,7 @@ namespace System.Drawing
         /// table or bitmasks, as appropriate.
         /// </summary>
         /// <returns>True if successful, false otherwise.</returns>
-        private bool FillBitmapInfo(IntPtr hdc, IntPtr hpal, ref NativeMethods.BITMAPINFO_FLAT pbmi)
+        private unsafe bool FillBitmapInfo(IntPtr hdc, IntPtr hpal, ref NativeMethods.BITMAPINFO_FLAT pbmi)
         {
             IntPtr hbm = IntPtr.Zero;
             bool bRet = false;
@@ -104,8 +104,7 @@ namespace System.Drawing
                     throw new OutOfMemoryException(SR.GraphicsBufferQueryFail);
                 }
 
-                pbmi.bmiHeader_biSize = Marshal.SizeOf(typeof(NativeMethods.BITMAPINFOHEADER));
-                pbmi.bmiColors = new byte[NativeMethods.BITMAPINFO_MAX_COLORSIZE * 4];
+                pbmi.bmiHeader_biSize = sizeof(NativeMethods.BITMAPINFOHEADER);
 
                 // Call first time to fill in BITMAPINFO header.
                 SafeNativeMethods.GetDIBits(new HandleRef(null, hdc),

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -562,22 +562,6 @@ namespace System.Drawing
             public IntPtr bmBits;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class BITMAPINFOHEADER
-        {
-            public int biSize = 40;
-            public int biWidth;
-            public int biHeight;
-            public short biPlanes;
-            public short biBitCount;
-            public int biCompression;
-            public int biSizeImage;
-            public int biXPelsPerMeter;
-            public int biYPelsPerMeter;
-            public int biClrUsed;
-            public int biClrImportant;
-        }
-
         // https://devblogs.microsoft.com/oldnewthing/20101018-00/?p=12513
         // https://devblogs.microsoft.com/oldnewthing/20120720-00/?p=7083
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Unix.cs
@@ -449,7 +449,7 @@ namespace System.Drawing
             SaveIconImage(writer, (IconImage)imageData![best]);
         }
 
-        private void SaveBitmapAsIcon(BinaryWriter writer)
+        private unsafe void SaveBitmapAsIcon(BinaryWriter writer)
         {
             writer.Write((ushort)0);    // idReserved must be 0
             writer.Write((ushort)1);    // idType must be 1
@@ -466,7 +466,7 @@ namespace System.Drawing
             ide.imageOffset = 22;   // 22 is the first icon position (for single icon files)
 
             BitmapInfoHeader bih = default;
-            bih.biSize = (uint)Marshal.SizeOf(typeof(BitmapInfoHeader));
+            bih.biSize = (uint)sizeof(BitmapInfoHeader);
             bih.biWidth = bitmap.Width;
             bih.biHeight = 2 * bitmap.Height; // include both XOR and AND images
             bih.biPlanes = 1;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -738,7 +738,7 @@ namespace System.Drawing
                         uint* pixelPtr = (uint*)bmpdata.Scan0.ToPointer();
 
                         // jumping the image header
-                        int newOffset = (int)(_bestImageOffset + Marshal.SizeOf(typeof(SafeNativeMethods.BITMAPINFOHEADER)));
+                        int newOffset = (int)(_bestImageOffset + sizeof(NativeMethods.BITMAPINFOHEADER));
                         // there is no color table that we need to skip since we're 32bpp
 
                         int lineLength = Size.Width * 4;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
@@ -9,7 +9,7 @@ namespace System.Drawing
 {
     internal class NativeMethods
     {
-        internal static HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
+        internal static HandleRef NullHandleRef => new HandleRef(null, IntPtr.Zero);
 
         public const int MAX_PATH = 260;
         internal const int SM_REMOTESESSION = 0x1000;
@@ -20,9 +20,9 @@ namespace System.Drawing
         internal const int BITMAPINFO_MAX_COLORSIZE = 256;
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct BITMAPINFO_FLAT
+        internal unsafe struct BITMAPINFO_FLAT
         {
-            public int bmiHeader_biSize; // = Marshal.SizeOf(typeof(BITMAPINFOHEADER));
+            public int bmiHeader_biSize; // = sizeof(BITMAPINFOHEADER)
             public int bmiHeader_biWidth;
             public int bmiHeader_biHeight;
             public short bmiHeader_biPlanes;
@@ -34,14 +34,13 @@ namespace System.Drawing
             public int bmiHeader_biClrUsed;
             public int bmiHeader_biClrImportant;
 
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = BITMAPINFO_MAX_COLORSIZE * 4)]
-            public byte[] bmiColors; // RGBQUAD structs... Blue-Green-Red-Reserved, repeat...
+            public fixed byte bmiColors[BITMAPINFO_MAX_COLORSIZE * 4]; // RGBQUAD structs... Blue-Green-Red-Reserved, repeat...
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal class BITMAPINFOHEADER
+        internal struct BITMAPINFOHEADER
         {
-            public int biSize = 40;
+            public int biSize;
             public int biWidth;
             public int biHeight;
             public short biPlanes;

--- a/src/mono/mono/metadata/Makefile.am
+++ b/src/mono/mono/metadata/Makefile.am
@@ -455,6 +455,7 @@ libmonoruntimeinclude_HEADERS = \
 	mono-config.h		\
 	mono-debug.h		\
 	mono-gc.h		\
+	mono-private-unstable.h	\
 	object.h		\
 	object-forward.h	\
 	opcodes.h		\

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/mini/Makefile.am.in
+++ b/src/mono/mono/mini/Makefile.am.in
@@ -783,7 +783,9 @@ libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
 # These are public headers.
 # They should not use glib.h, G_BEGIN_DECLS, guint, etc.
 # They should be wrapped in MONO_BEGIN_DECLS / MONO_END_DECLS.
-libmonoinclude_HEADERS = jit.h
+libmonoinclude_HEADERS = \
+	jit.h		\
+	mono-private-unstable.h
 
 CSFLAGS = -unsafe -nowarn:0219,0169,0414,0649,0618
 

--- a/src/mono/mono/mini/mono-private-unstable.h
+++ b/src/mono/mono/mini/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_JIT_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_JIT_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_JIT_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/utils/Makefile.am
+++ b/src/mono/mono/utils/Makefile.am
@@ -343,6 +343,7 @@ libmonoutilsinclude_HEADERS = 	\
 	mono-publib.h		\
 	mono-jemalloc.h		\
 	mono-dl-fallback.h	\
+	mono-private-unstable.h	\
 	mono-counters.h
 
 EXTRA_DIST = mono-errno.h mono-embed.h mono-embed.c ../../support/libm/complex.c mono-experiments.def

--- a/src/mono/mono/utils/mono-private-unstable.h
+++ b/src/mono/mono/utils/mono-private-unstable.h
@@ -1,0 +1,19 @@
+/**
+ * \file
+ * 
+ * Private unstable APIs.
+ *
+ * WARNING: The declarations and behavior of functions in this header are NOT STABLE and can be modified or removed at
+ * any time.
+ *
+ */
+
+
+#ifndef __MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__
+#define __MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__
+
+#include <mono/utils/mono-publib.h>
+
+
+
+#endif /*__MONO_UTILS_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/msvc/libmono.bat
+++ b/src/mono/msvc/libmono.bat
@@ -69,6 +69,7 @@ metadata.h ^
 mono-config.h ^
 mono-debug.h ^
 mono-gc.h ^
+mono-private-unstable.h ^
 object.h ^
 object-forward.h ^
 opcodes.h ^
@@ -88,15 +89,22 @@ mono-error.h ^
 mono-forward.h ^
 mono-jemalloc.h ^
 mono-logger.h ^
+mono-private-unstable.h ^
 mono-publib.h
+
+SET JIT_FILES=^
+jit.h ^
+mono-private-unstable.h
 
 ECHO Copying mono include files from %SOURCE_ROOT% to %TARGET_ROOT% ...
 
 SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\cil\opcode.def" "%TARGET_ROOT%\cil\" %OPTIONS%
 call :runCommand "%RUN%" %ARGUMENTS%
 
-SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\mini\jit.h" "%TARGET_ROOT%\jit\" %OPTIONS%
-call :runCommand "%RUN%" %ARGUMENTS%
+FOR %%a IN (%JIT_FILES%) DO (
+	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\mini\%%a" "%TARGET_ROOT%\jit\" %OPTIONS%
+	call :runCommand "!RUN!" %ARGUMENTS%
+)
 
 FOR %%a IN (%META_DATA_FILES%) DO (
 	SET RUN=%XCOPY_COMMAND% "%SOURCE_ROOT%\metadata\%%a" "%TARGET_ROOT%\metadata\" %OPTIONS%

--- a/src/mono/msvc/libmonoruntime-common.targets
+++ b/src/mono/msvc/libmonoruntime-common.targets
@@ -244,6 +244,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-config.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-debug.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-gc.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-private-unstable.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-bridge.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\opcodes.h" />

--- a/src/mono/msvc/libmonoruntime-common.targets.filters
+++ b/src/mono/msvc/libmonoruntime-common.targets.filters
@@ -675,6 +675,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-gc.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-private-unstable.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-bridge.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>

--- a/src/mono/msvc/libmonoutils-common.targets
+++ b/src/mono/msvc/libmonoutils-common.targets
@@ -207,6 +207,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-error.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-publib.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-private-unstable.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-dl-fallback.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-counters.h" />
   </ItemGroup>

--- a/src/mono/msvc/libmonoutils-common.targets.filters
+++ b/src/mono/msvc/libmonoutils-common.targets.filters
@@ -492,6 +492,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-logger.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-private-unstable.h">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-error.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common\public</Filter>
     </ClInclude>


### PR DESCRIPTION
Platform manifest needs to include all System*Native items from 3.1 release. We need to add them explicitly, to work around the issue introduced with a fix for https://github.com/dotnet/runtime/issues/33118 - Android libraries need to conform to a specific naming convention which necessitated renames of these libraries.

List of libraries being added:
```
System.IO.Compression.Native.a
System.IO.Compression.Native.so
System.Native.a
System.Native.so
System.Net.Http.Native.a
System.Net.Http.Native.so
System.Net.Security.Native.a
System.Net.Security.Native.so
System.Security.Cryptography.Native.OpenSsl.a
System.Security.Cryptography.Native.OpenSsl.so
System.Globalization.Native.so
System.IO.Compression.Native.dylib
System.Native.dylib
System.Net.Http.Native.dylib
System.Net.Security.Native.dylib
System.Security.Cryptography.Native.Apple.a
System.Security.Cryptography.Native.Apple.dylib
System.Security.Cryptography.Native.OpenSsl.dylib
System.Globalization.Native.dylib
```

Fixes the issue: https://github.com/dotnet/runtime/issues/33450
