### PR TITLE
Fix a few Process tests to avoid a FileStream assert

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -143,6 +143,7 @@ namespace System.Diagnostics.Tests
 
                     // Wait child process close to be sure that output buffer has been flushed
                     Assert.True(p.WaitForExit(WaitInMS), "Child process didn't close");
+                    p.WaitForExit(); // wait for event handlers to complete
 
                     Assert.Equal(1, dataReceived.Count);
                     Assert.Equal(1, dataReceived[0]);
@@ -239,6 +240,7 @@ namespace System.Diagnostics.Tests
 
                     // Wait child process close
                     Assert.True(p.WaitForExit(WaitInMS), "Child process didn't close");
+                    p.WaitForExit(); // wait for event handlers to complete
 
                     // Wait for value 7,8,9
                     using (CancellationTokenSource cts = new CancellationTokenSource(WaitInMS))
@@ -326,6 +328,7 @@ namespace System.Diagnostics.Tests
                 writer.WriteLine(expected);
             }
             Assert.True(p.WaitForExit(WaitInMS));
+            p.WaitForExit(); // wait for event handlers to complete
         }
 
         [Fact]
@@ -368,6 +371,7 @@ namespace System.Diagnostics.Tests
                 // The first child process should be unblocked and write out 'NULL', and then exit.
                 p1.StandardInput.Close();
                 Assert.True(p1.WaitForExit(WaitInMS));
+                p1.WaitForExit(); // wait for event handlers to complete
             }
             finally
             {
@@ -377,6 +381,7 @@ namespace System.Diagnostics.Tests
 
             // Cleanup
             Assert.True(p2.WaitForExit(WaitInMS));
+            p2.WaitForExit(); // wait for event handlers to complete
             p2.Dispose();
             p1.Dispose();
         }
@@ -451,6 +456,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [SkipOnCoreClr("Avoid asserts in FileStream.Read when concurrently disposed", ~RuntimeConfiguration.Release)]
         public void TestClosingStreamsAsyncDoesNotThrow()
         {
             Process p = CreateProcessPortable(RemotelyInvokable.WriteLinesAfterClose);
@@ -526,6 +532,7 @@ namespace System.Diagnostics.Tests
                 Assert.Throws<InvalidOperationException>(() => p.StandardOutput);
                 Assert.Throws<InvalidOperationException>(() => p.StandardError);
                 Assert.True(p.WaitForExit(WaitInMS));
+                p.WaitForExit(); // wait for event handlers to complete
             }
 
             {
@@ -543,6 +550,7 @@ namespace System.Diagnostics.Tests
                 Assert.Throws<InvalidOperationException>(() => p.BeginOutputReadLine());
                 Assert.Throws<InvalidOperationException>(() => p.BeginErrorReadLine());
                 Assert.True(p.WaitForExit(WaitInMS));
+                p.WaitForExit(); // wait for event handlers to complete
             }
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -33,6 +33,7 @@ namespace System.Diagnostics.Tests
                 {
                     p.Kill();
                     Assert.True(p.WaitForExit(WaitInMS));
+                    p.WaitForExit(); // wait for event handlers to complete
                 }
                 catch (InvalidOperationException) { } // in case it was never started
             }
@@ -104,6 +105,7 @@ namespace System.Diagnostics.Tests
             Thread.Sleep(200);
             p.Kill();
             Assert.True(p.WaitForExit(WaitInMS));
+            p.WaitForExit(); // wait for event handlers to complete
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -226,6 +226,7 @@ namespace System.Diagnostics.Tests
 
                         px.Kill();
                         Assert.True(px.WaitForExit(WaitInMS));
+                        px.WaitForExit(); // wait for event handlers to complete
                     }
                 }
             }
@@ -1407,6 +1408,9 @@ namespace System.Diagnostics.Tests
                 process.BeginOutputReadLine();
 
                 Assert.True(process.Start());
+
+                Assert.True(process.WaitForExit(WaitInMS));
+                process.WaitForExit(); // ensure event handlers have completed
             }
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -231,6 +231,7 @@ namespace System.Diagnostics.Tests
             Assert.True(await tcs.Task);
 
             Assert.True(p.WaitForExit(0));
+            p.WaitForExit(); // wait for event handlers to complete
         }
 
         [Theory]
@@ -441,6 +442,7 @@ namespace System.Diagnostics.Tests
             }
 
             Assert.True(p.WaitForExit(timeout), "Process has not exited");
+            p.WaitForExit(); // wait for event handlers to complete
             Assert.Equal(RemotelyInvokable.SuccessExitCode, p.ExitCode);
         }
 


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/runtime/issues/13295

We have a few tests that:
- Call BeginOutput/ErrorReadLine on a Process
- Don't call WaitForExit()
- Dispose the Process object

That sequence can result in us Dispose'ing of a FileStream while it's currently issuing a Read, and with the right interleaving, can result in FileStream asserting. I've added WaitForExit() calls anywhere we're using Begin*ReadLine.

Two asides:
1. There are a bunch of Process objects in the Process tests that are going undisposed.  We should fix that.
2. It's unsettling that we're Dispose'ing of a FileStream in general while it might still be in use.  This seems like something that should be revisited.