### PR TITLE
Set osOverride default value to empty on mono builds

### DIFF
--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -53,6 +53,8 @@ jobs:
       value: ${{ parameters.osSubgroup }}
     - name: officialBuildIdArg
       value: ''
+    - name: osOverride
+      value: ''
     # Strip symbols only on the release build
     - ${{ if eq(parameters.buildConfig, 'Release') }}:
       - name: stripSymbolsArg


### PR DESCRIPTION
I was looking at one mono build and noticed that for legs that don't set this value, a `$(osOverride)` literal is passed down to the scripts. Builds don't fail, but logs look weird and there is also a error in the script:
`mono.cmd -configuration debug -arch x64 $(osOverride) -ci /p:MonoEnableLLVM=false`

```
osOverride : The term 'osOverride' is not recognized as the name of a cmdlet, function, script file, or operable 
program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:92
+ ... bsetCategory mono -configuration debug -arch x64 $(osOverride) -ci /p ...
+                                                        ~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (osOverride:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```