### PR TITLE
Add System*Native libraries from .NET Core 3.1 release, to Platform Manifest

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -19,6 +19,36 @@
     <DependenciesToPackage Include="NETStandard.Library" />
   </ItemGroup>
 
+  <!--
+    Platform manifest needs to include all System*Native items from 3.1 release. This itemgroup adds
+    them explicitly, to fill the gap that appeared when the names of these libraries were changed
+    in 5.0 to conform to a specific Android naming convention. The library name change was a fix
+    for https://github.com/dotnet/runtime/issues/33118. For more details of the issue and fix see
+    https://github.com/dotnet/runtime/issues/33450.
+  -->
+  <ItemGroup>
+    <_pastShimFiles Include="System.Globalization.Native.dylib" />
+    <_pastShimFiles Include="System.Globalization.Native.so" />
+    <_pastShimFiles Include="System.IO.Compression.Native.a" />
+    <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
+    <_pastShimFiles Include="System.IO.Compression.Native.so" />
+    <_pastShimFiles Include="System.Native.a" />
+    <_pastShimFiles Include="System.Native.dylib" />
+    <_pastShimFiles Include="System.Native.so" />
+    <_pastShimFiles Include="System.Net.Http.Native.a" />
+    <_pastShimFiles Include="System.Net.Http.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Http.Native.so" />
+    <_pastShimFiles Include="System.Net.Security.Native.a" />
+    <_pastShimFiles Include="System.Net.Security.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Security.Native.so" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
+    <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />
+  </ItemGroup>
+
   <!-- get paths from packages that are needed for cross-gen and other includes,
        only relevant for runtime-specific builds -->
   <Target Name="GetPackagePaths"
@@ -69,36 +99,6 @@
       <_docFilesToPackage Include="$(ArtifactsBinDir)/docs/%(LibrariesRefAssemblies.FileName).xml" Condition="Exists('$(ArtifactsBinDir)/docs/%(LibrariesRefAssemblies.FileName).xml')"/>
     </ItemGroup>
   </Target>
-
-  <!--
-    Platform manifest needs to include all System*Native items from 3.1 release. This target adds
-    them explicitly, to fill the gap that appeared when the names of these libraries were changed
-    in 5.0 to conform to a specific Android naming convention. The library name change was a fix
-    for https://github.com/dotnet/runtime/issues/33118. For more details of the issue and fix see
-    https://github.com/dotnet/runtime/issues/33450.
-  -->
-  <ItemGroup>
-    <_pastShimFiles Include="System.Globalization.Native.dylib" />
-    <_pastShimFiles Include="System.Globalization.Native.so" />
-    <_pastShimFiles Include="System.IO.Compression.Native.a" />
-    <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
-    <_pastShimFiles Include="System.IO.Compression.Native.so" />
-    <_pastShimFiles Include="System.Native.a" />
-    <_pastShimFiles Include="System.Native.dylib" />
-    <_pastShimFiles Include="System.Native.so" />
-    <_pastShimFiles Include="System.Net.Http.Native.a" />
-    <_pastShimFiles Include="System.Net.Http.Native.dylib" />
-    <_pastShimFiles Include="System.Net.Http.Native.so" />
-    <_pastShimFiles Include="System.Net.Security.Native.a" />
-    <_pastShimFiles Include="System.Net.Security.Native.dylib" />
-    <_pastShimFiles Include="System.Net.Security.Native.so" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
-    <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />
-  </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="localnetcoreapp.override.targets" />

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -70,6 +70,36 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Platform manifest needs to include all System*Native items from 3.1 release. This target adds
+    them explicitly, to fill the gap that appeared when the names of these libraries were changed
+    in 5.0 to conform to a specific Android naming convention. The library name change was a fix
+    for https://github.com/dotnet/runtime/issues/33118. For more details of the issue and fix see
+    https://github.com/dotnet/runtime/issues/33450.
+  -->
+  <ItemGroup>
+    <_pastShimFiles Include="System.Globalization.Native.dylib" />
+    <_pastShimFiles Include="System.Globalization.Native.so" />
+    <_pastShimFiles Include="System.IO.Compression.Native.a" />
+    <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
+    <_pastShimFiles Include="System.IO.Compression.Native.so" />
+    <_pastShimFiles Include="System.Native.a" />
+    <_pastShimFiles Include="System.Native.dylib" />
+    <_pastShimFiles Include="System.Native.so" />
+    <_pastShimFiles Include="System.Net.Http.Native.a" />
+    <_pastShimFiles Include="System.Net.Http.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Http.Native.so" />
+    <_pastShimFiles Include="System.Net.Security.Native.a" />
+    <_pastShimFiles Include="System.Net.Security.Native.dylib" />
+    <_pastShimFiles Include="System.Net.Security.Native.so" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
+    <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />
+  </ItemGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="localnetcoreapp.override.targets" />
 </Project>


### PR DESCRIPTION
Platform manifest needs to include all System*Native items from 3.1 release. We need to add them explicitly, to work around the issue introduced with a fix for https://github.com/dotnet/runtime/issues/33118 - Android libraries need to conform to a specific naming convention which necessitated renames of these libraries.

List of libraries being added:
```
System.IO.Compression.Native.a
System.IO.Compression.Native.so
System.Native.a
System.Native.so
System.Net.Http.Native.a
System.Net.Http.Native.so
System.Net.Security.Native.a
System.Net.Security.Native.so
System.Security.Cryptography.Native.OpenSsl.a
System.Security.Cryptography.Native.OpenSsl.so
System.Globalization.Native.so
System.IO.Compression.Native.dylib
System.Native.dylib
System.Net.Http.Native.dylib
System.Net.Security.Native.dylib
System.Security.Cryptography.Native.Apple.a
System.Security.Cryptography.Native.Apple.dylib
System.Security.Cryptography.Native.OpenSsl.dylib
System.Globalization.Native.dylib
```

Fixes the issue: https://github.com/dotnet/runtime/issues/33450
