### PR TITLE
Fix incorrect comment.

### DIFF
--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -182,7 +182,7 @@ namespace System.Collections
         }
 
         // Removes the object at the head of the queue and returns it. If the queue
-        // is empty, this method simply returns null.
+        // is empty, this method throws an InvalidOperationException.
         public virtual object? Dequeue()
         {
             if (Count == 0)


### PR DESCRIPTION
The comment in front of System.Collections.Queue.Dequeue() changed to
match actual routine behavior.