### PR TITLE
Disable failing WinHttpHandler HTTP/2 test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -331,6 +331,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(CookieNamesValuesAndUseCookies))]
         public async Task GetAsync_ReceiveSetCookieHeader_CookieAdded(string cookieName, string cookieValue, bool useCookies)
         {
+            if (UseVersion.Major == 2)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/33930")]
+                return;
+            }
+
             await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/33930
This has been failing in the majority of PRs.
cc: @ManickaP, @CourtneyThurston 