### PR TITLE
[llvmonly] Throw an ExecutionEngine exception with a helpful message when we try to execute a method which failed AOT compilation.

### DIFF
--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -139,7 +139,7 @@ MONO_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_iface_call) \
 MONO_JIT_ICALL (mini_llvmonly_resolve_iface_call_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
 MONO_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
-MONO_JIT_ICALL (mini_llvmonly_throw_missing_method_exception) \
+MONO_JIT_ICALL (mini_llvmonly_throw_aot_failed_exception) \
 MONO_JIT_ICALL (mono_amd64_resume_unwind)	\
 MONO_JIT_ICALL (mono_amd64_start_gsharedvt_call)	\
 MONO_JIT_ICALL (mono_amd64_throw_corlib_exception)	\

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -809,14 +809,11 @@ mini_llvmonly_throw_nullref_exception (void)
 	mono_llvm_throw_corlib_exception (ex_token_index);
 }
 
-static GENERATE_GET_CLASS_WITH_CACHE (missing_method, "System", "MissingMethodException")
-
 void
-mini_llvmonly_throw_missing_method_exception (void)
+mini_llvmonly_throw_aot_failed_exception (const char *name)
 {
-	MonoClass *klass = mono_class_get_missing_method_class ();
-
-	guint32 ex_token_index = m_class_get_type_token (klass) - MONO_TOKEN_TYPE_DEF;
-
-	mono_llvm_throw_corlib_exception (ex_token_index);
+	char *msg = g_strdup_printf ("AOT Compilation failed for method '%s'.", name);
+	MonoException *ex = mono_get_exception_execution_engine (msg);
+	g_free (msg);
+	mono_llvm_throw_exception ((MonoObject*)ex);
 }

--- a/src/mono/mono/mini/llvmonly-runtime.h
+++ b/src/mono/mono/mini/llvmonly-runtime.h
@@ -33,6 +33,6 @@ G_EXTERN_C void mini_llvm_init_method          (MonoAotFileInfo *info, gpointer 
 
 G_EXTERN_C void mini_llvmonly_throw_nullref_exception (void);
 
-G_EXTERN_C void mini_llvmonly_throw_missing_method_exception (void);
+G_EXTERN_C void mini_llvmonly_throw_aot_failed_exception (const char *name);
 
 #endif

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4672,7 +4672,7 @@ register_icalls (void)
 	register_icall (mini_llvmonly_init_delegate, mono_icall_sig_void_object, TRUE);
 	register_icall (mini_llvmonly_init_delegate_virtual, mono_icall_sig_void_object_object_ptr, TRUE);
 	register_icall (mini_llvmonly_throw_nullref_exception, mono_icall_sig_void, TRUE);
-	register_icall (mini_llvmonly_throw_missing_method_exception, mono_icall_sig_void, TRUE);
+	register_icall (mini_llvmonly_throw_aot_failed_exception, mono_icall_sig_void_ptr, TRUE);
 
 	register_icall (mono_get_assembly_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19302,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/><!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->