### PR TITLE
Fix SemaphoreSlim handling of canceled continuation invocations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -728,7 +728,7 @@ namespace System.Threading
             else // millisecondsTimeout == Timeout.Infinite
             {
                 // Wait until either the task is completed or cancellation is requested.
-                var cancellationTask = new Task();
+                var cancellationTask = new Task(null, TaskCreationOptions.RunContinuationsAsynchronously, promiseStyle: true);
                 using (cancellationToken.UnsafeRegister(s => ((Task)s!).TrySetResult(), cancellationTask))
                 {
                     if (asyncWaiter == await TaskFactory.CommonCWAnyLogic(new Task[] { asyncWaiter, cancellationTask }).ConfigureAwait(false))


### PR DESCRIPTION
When a SemaphoreSlim.WaitAsync(CancellationToken) completes because the token has cancellation requested, we end up invoking any continuations off of the returned Task synchronously as part of the cancellation registration.  That in turn means that a thread is blocked waiting for that cancelation callback to complete, which can lead to deadlock in niche situations.  We need to force this continuation to be async.

cc: @tarekgh, @kouvel 