### PR TITLE
[loader] Initial work to support ALC collectability

### DIFF
--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -15,13 +15,15 @@
 GENERATE_GET_CLASS_WITH_CACHE (assembly_load_context, "System.Runtime.Loader", "AssemblyLoadContext");
 
 void
-mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain)
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collectible)
 {
 	MonoLoadedImages *li = g_new0 (MonoLoadedImages, 1);
 	mono_loaded_images_init (li, alc);
 	alc->domain = domain;
 	alc->loaded_images = li;
 	alc->loaded_assemblies = NULL;
+	alc->unloading = FALSE;
+	alc->collectible = collectible;
 	alc->pinvoke_scopes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 	mono_coop_mutex_init (&alc->assemblies_lock);
 	mono_coop_mutex_init (&alc->pinvoke_lock);
@@ -31,37 +33,80 @@ void
 mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 {
 	/*
-	 * As it stands, ALC and domain cleanup is probably broken on netcore. Without ALC collectability, this should not
-	 * be hit. I've documented roughly the things that still need to be accomplish, but the implementation is TODO and
-	 * the ideal order and locking unclear.
+	 * This is still very much WIP. It needs to be split up into various other functions and adjusted to work with the 
+	 * managed LoaderAllocator design. For now, I've put it all in this function, but don't look at it too closely.
 	 * 
-	 * For now, this makes two important assumptions:
-	 *   1. The minimum refcount on assemblies is 2: one for the domain and one for the ALC. The domain refcount might 
-	 *        be less than optimal on netcore, but its removal is too likely to cause issues for now.
-	 *   2. An ALC will have been removed from the domain before cleanup.
+	 * Of particular note: the minimum refcount on assemblies is 2: one for the domain and one for the ALC. 
+	 * The domain refcount might be less than optimal on netcore, but its removal is too likely to cause issues for now.
 	 */
-	//GSList *tmp;
-	//MonoDomain *domain = alc->domain;
+	GSList *tmp;
+	MonoDomain *domain = alc->domain;
 
-	/*
-	 * Missing steps:
-	 * 
-	 * + Release GC roots for all assemblies in the ALC
-	 * + Iterate over the domain_assemblies and remove ones that belong to the ALC, which will probably require
-	 *     converting domain_assemblies to a doubly-linked list, ideally GQueue
-	 * + Close dynamic and then remaining assemblies, potentially nulling the data field depending on refcount
-	 * + Second pass to call mono_assembly_close_finish on remaining assemblies
-	 * + Free the loaded_assemblies list itself
-	 */
+	g_assert (alc != mono_domain_default_alc (domain));
+	g_assert (alc->collectible == TRUE);
 
+	// FIXME: alc unloading profiler event
+
+	// Remove the assemblies from domain_assemblies
+	mono_domain_assemblies_lock (domain);
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
+		g_slist_remove (domain->domain_assemblies, assembly);
+		mono_atomic_dec_i32 (&assembly->ref_count);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Unloading ALC [%p], removing assembly %s[%p] from domain_assemblies, ref_count=%d\n", assembly->aname.name, assembly->ref_count);
+	}
+	mono_domain_assemblies_unlock (domain);
+
+	// Some equivalent to mono_gc_clear_domain? I guess in our case we just have to assert that we have no lingering references?
+
+	// Release the GC roots
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
+		mono_assembly_release_gc_roots (assembly);
+	}
+
+	// Close dynamic assemblies
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
+		if (!assembly->image || !image_is_dynamic (assembly->image))
+			continue;
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Unloading ALC [%p], dynamic assembly %s[%p], ref_count=%d", domain, assembly->aname.name, assembly, assembly->ref_count);
+		if (!mono_assembly_close_except_image_pools (assembly))
+			tmp->data = NULL;
+	}
+
+	// Close the remaining assemblies
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
+		if (!assembly)
+			continue;
+		if (!assembly->image || image_is_dynamic (assembly->image))
+			continue;
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Unloading ALC [%p], non-dynamic assembly %s[%p], ref_count=%d", domain, assembly->aname.name, assembly, assembly->ref_count);
+		if (!mono_assembly_close_except_image_pools (assembly))
+			tmp->data = NULL;
+	}
+
+	// Complete the second closing pass on lingering assemblies
+	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
+		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
+		if (assembly)
+			mono_assembly_close_finish (assembly);
+	}
+
+	// Free the loaded_assemblies
+	g_slist_free (alc->loaded_assemblies);
 	alc->loaded_assemblies = NULL;
+
+	// FIXME: alc unloaded profiler event
+
 	g_hash_table_destroy (alc->pinvoke_scopes);
 	mono_coop_mutex_destroy (&alc->assemblies_lock);
 	mono_coop_mutex_destroy (&alc->pinvoke_lock);
 
 	mono_loaded_images_free (alc->loaded_images);
 
-	g_assert_not_reached ();
+	// TODO: free mempool stuff/jit info tables, see domain freeing for an example
 }
 
 void
@@ -80,11 +125,7 @@ gpointer
 ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC (gpointer this_gchandle_ptr, MonoBoolean is_default_alc, MonoBoolean collectible, MonoError *error)
 {
 	/* If the ALC is collectible, this_gchandle is weak, otherwise it's strong. */
-	uint32_t this_gchandle = (uint32_t)GPOINTER_TO_UINT (this_gchandle_ptr);
-	if (collectible) {
-		mono_error_set_execution_engine (error, "Collectible AssemblyLoadContexts are not yet supported by MonoVM");
-		return NULL;
-	}
+	MonoGCHandle this_gchandle = (MonoGCHandle)this_gchandle_ptr;
 
 	MonoDomain *domain = mono_domain_get ();
 	MonoAssemblyLoadContext *alc = NULL;
@@ -101,13 +142,28 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC 
 	return alc;
 }
 
+void
+ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContextRelease (gpointer alc_pointer, gpointer strong_gchandle_ptr, MonoError *error)
+{
+	MonoGCHandle strong_gchandle = (MonoGCHandle)strong_gchandle_ptr;
+	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
+
+	g_assert (alc->collectible == TRUE);
+	g_assert (alc->unloading == FALSE);
+	alc->unloading = TRUE;
+
+	MonoGCHandle weak_gchandle = alc->gchandle;
+	alc->gchandle = strong_gchandle;
+	mono_gchandle_free_internal (weak_gchandle);
+}
+
 gpointer
 ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (MonoReflectionAssemblyHandle assm_obj, MonoError *error)
 {
 	MonoAssembly *assm = MONO_HANDLE_GETVAL (assm_obj, assembly);
 	MonoAssemblyLoadContext *alc = mono_assembly_get_alc (assm);
 
-	return GUINT_TO_POINTER (alc->gchandle);
+	return (gpointer)alc->gchandle;
 }
 
 gboolean
@@ -134,7 +190,7 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 
 	MonoReflectionAssemblyHandle assm;
 	gpointer gchandle;
-	gchandle = GUINT_TO_POINTER (alc->gchandle);
+	gchandle = (gpointer)alc->gchandle;
 	gpointer args [2];
 	args [0] = &gchandle;
 	args [1] = MONO_HANDLE_RAW (aname_obj);

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -700,7 +700,7 @@ mono_domain_default_alc (MonoDomain *domain);
 
 #ifdef ENABLE_NETCORE
 MonoAssemblyLoadContext *
-mono_domain_create_individual_alc (MonoDomain *domain, uint32_t this_gchandle, gboolean collectible, MonoError *error);
+mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error);
 #endif
 
 static inline

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -128,9 +128,6 @@ get_runtimes_from_exe (const char *exe_file, MonoImage **exe_image);
 static const MonoRuntimeInfo*
 get_runtime_by_version (const char *version);
 
-static void
-mono_domain_alcs_destroy (MonoDomain *domain);
-
 #ifdef ENABLE_NETCORE
 static void
 mono_domain_alcs_lock (MonoDomain *domain);
@@ -1118,6 +1115,7 @@ unregister_vtable_reflection_type (MonoVTable *vtable)
 void
 mono_domain_free (MonoDomain *domain, gboolean force)
 {
+#ifndef ENABLE_NETCORE
 	int code_size, code_alloc;
 	GSList *tmp;
 	gpointer *p;
@@ -1294,12 +1292,6 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 		domain->method_to_dyn_method = NULL;
 	}
 
-	mono_domain_alcs_destroy (domain);
-
-#ifdef ENABLE_NETCORE
-	mono_coop_mutex_destroy (&domain->alcs_lock);
-#endif
-
 	mono_os_mutex_destroy (&domain->finalizable_objects_hash_lock);
 	mono_coop_mutex_destroy (&domain->assemblies_lock);
 	mono_os_mutex_destroy (&domain->jit_code_hash_lock);
@@ -1323,6 +1315,9 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 
 	if (domain == mono_root_domain)
 		mono_root_domain = NULL;
+#else
+	g_assert_not_reached ();
+#endif
 }
 
 /**
@@ -2088,12 +2083,9 @@ mono_domain_alcs_unlock (MonoDomain *domain)
 {
 	mono_coop_mutex_unlock (&domain->alcs_lock);
 }
-#endif
 
-
-#ifdef ENABLE_NETCORE
 static MonoAssemblyLoadContext *
-create_alc (MonoDomain *domain, gboolean is_default)
+create_alc (MonoDomain *domain, gboolean is_default, gboolean collectible)
 {
 	MonoAssemblyLoadContext *alc = NULL;
 
@@ -2102,7 +2094,7 @@ create_alc (MonoDomain *domain, gboolean is_default)
 		goto leave;
 
 	alc = g_new0 (MonoAssemblyLoadContext, 1);
-	mono_alc_init (alc, domain);
+	mono_alc_init (alc, domain, collectible);
 
 	domain->alcs = g_slist_prepend (domain->alcs, alc);
 	if (is_default)
@@ -2111,22 +2103,19 @@ leave:
 	mono_domain_alcs_unlock (domain);
 	return alc;
 }
-#endif
 
-#ifdef ENABLE_NETCORE
 void
 mono_domain_create_default_alc (MonoDomain *domain)
 {
 	if (domain->default_alc)
 		return;
-	create_alc (domain, TRUE);
+	create_alc (domain, TRUE, FALSE);
 }
 
 MonoAssemblyLoadContext *
-mono_domain_create_individual_alc (MonoDomain *domain, uint32_t this_gchandle, gboolean collectible, MonoError *error)
+mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error)
 {
-	g_assert (!collectible); /* TODO: implement collectible ALCs */
-	MonoAssemblyLoadContext *alc = create_alc (domain, FALSE);
+	MonoAssemblyLoadContext *alc = create_alc (domain, FALSE, collectible);
 	alc->gchandle = this_gchandle;
 	return alc;
 }
@@ -2138,19 +2127,3 @@ mono_alc_free (MonoAssemblyLoadContext *alc)
 	g_free (alc);
 }
 #endif
-
-void
-mono_domain_alcs_destroy (MonoDomain *domain)
-{
-#ifdef ENABLE_NETCORE
-	mono_domain_alcs_lock (domain);
-	GSList *alcs = domain->alcs;
-	domain->alcs = NULL;
-	domain->default_alc = NULL;
-	mono_domain_alcs_unlock (domain);
-
-	for (GSList *iter = alcs; iter; iter = g_slist_next (iter)) {
-		mono_alc_free ((MonoAssemblyLoadContext*)iter->data);
-	}
-#endif
-}

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -381,6 +381,7 @@ HANDLES(ALC_4, "InternalGetLoadedAssemblies", ves_icall_System_Runtime_Loader_As
 HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 3, (gpointer, MonoBoolean, MonoBoolean))
 HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile, MonoReflectionAssembly, 3, (gpointer, MonoString, MonoStackCrawlMark_ptr))
 HANDLES(ALC_3, "InternalLoadFromStream", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFromStream, MonoReflectionAssembly, 5, (gpointer, gpointer, gint32, gpointer, gint32))
+HANDLES(ALC_6, "PrepareForAssemblyLoadContextRelease", ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContextRelease, void, 2, (gpointer, gpointer))
 
 ICALL_TYPE(RFH, "System.RuntimeFieldHandle", RFH_1)
 HANDLES(RFH_1, "GetValueDirect", ves_icall_System_RuntimeFieldHandle_GetValueDirect, MonoObject, 4, (MonoReflectionField, MonoReflectionType, MonoTypedRef_ptr, MonoReflectionType))

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -38,8 +38,13 @@ struct _MonoAssemblyLoadContext {
 	/* Handle of the corresponding managed object.  If the ALC is
 	 * collectible, the handle is weak, otherwise it's strong.
 	 */
-	uint32_t gchandle;
-
+	MonoGCHandle gchandle;
+	// Whether the ALC can be unloaded; should only be set at creation
+	gboolean collectible;
+	// Set to TRUE when the unloading process has begun, ensures nothing else will use that ALC
+	// Maybe remove this? for now, should be helpful for debugging
+	// Alternatively, check for it in the various ALC functions and error if it's true when calling them
+	gboolean unloading;
 	// Used in native-library.c for the hash table below; do not access anywhere else
 	MonoCoopMutex pinvoke_lock;
 	// Maps malloc-ed char* pinvoke scope -> MonoDl*
@@ -75,7 +80,7 @@ void
 mono_set_pinvoke_search_directories (int dir_count, char **dirs);
 
 void
-mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain);
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collectible);
 
 void
 mono_alc_cleanup (MonoAssemblyLoadContext *alc);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -117,8 +117,8 @@ namespace System.Reflection
             }
         }
 
-        // TODO:
-        public override bool IsCollectible => false;
+        // TODO: consider a dedicated icall instead
+        public override bool IsCollectible => AssemblyLoadContext.GetLoadContext((Assembly)this).IsCollectible;
 
         internal static AssemblyName CreateAssemblyName(string assemblyString, out RuntimeAssembly assemblyFromResolveEvent)
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
@@ -25,9 +25,8 @@ namespace System.Runtime.Loader
             return InternalInitializeNativeALC(thisHandlePtr, representsTPALoadContext, isCollectible);
         }
 
-        private static void PrepareForAssemblyLoadContextRelease(IntPtr nativeAssemblyLoadContext, IntPtr assemblyLoadContextStrong)
-        {
-        }
+        [MethodImplAttribute (MethodImplOptions.InternalCall)]
+        private static extern void PrepareForAssemblyLoadContextRelease (IntPtr nativeAssemblyLoadContext, IntPtr assemblyLoadContextStrong);
 
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         private Assembly InternalLoadFromPath(string assemblyPath, string nativeImagePath)


### PR DESCRIPTION
This should enable creation of a collectible ALC from managed, though it will not actually unload properly when Unload is called. This should be enough to unblock Xamarin porting work.

If you think the `mono_alc_cleanup` work is just noise I can remove that, but I thought it helpful to check in to make future diffs clearer as I split it up with the LoaderAllocator work.