### PR TITLE
JIT: block throw helper merges for first block of a try

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -25869,6 +25869,14 @@ void Compiler::fgTailMergeThrows()
     // and there is less jumbled flow to sort out later.
     for (BasicBlock* block = fgLastBB; block != nullptr; block = block->bbPrev)
     {
+        // Workaround: don't consider try entry blocks as candidates
+        // for merging; if the canonical throw is later in the same try,
+        // we'll create invalid flow.
+        if ((block->bbFlags & BBF_TRY_BEG) != 0)
+        {
+            continue;
+        }
+
         // For throw helpers the block should have exactly one statement....
         // (this isn't guaranteed, but seems likely)
         Statement* stmt = block->firstStmt();

--- a/src/coreclr/tests/src/JIT/opt/ThrowHelper/ThrowHelperAtTryEntry.cs
+++ b/src/coreclr/tests/src/JIT/opt/ThrowHelper/ThrowHelperAtTryEntry.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+// Test case where throw helper is in the try entry block.
+//
+// Throw helper merging is run lexically backwards,
+// so the optimization may introduce a jump into the middle of the try.
+
+class ThrowHelperAtTryEntry
+{
+    static void ThrowHelper()
+    {
+        throw new Exception();
+    }
+
+    public static int Main()
+    {
+        int x = 0;
+        bool p = true;
+        try
+        {
+            ThrowHelper();
+            x = -1;
+            if (p) ThrowHelper();
+        }
+        catch (Exception)
+        {
+            x = 100;
+        }
+
+        return x;
+    }
+}

--- a/src/coreclr/tests/src/JIT/opt/ThrowHelper/ThrowHelperAtTryEntry.csproj
+++ b/src/coreclr/tests/src/JIT/opt/ThrowHelper/ThrowHelperAtTryEntry.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ThrowHelperAtTryEntry.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Otherwise we may create a branch into the middle of a try. We could fix the
transform, but if the first block of a try has a throw helper call, the rest
of the try will subsequently be removed, so merging is not all that
interesting.

Addresses an issue that came up in #33924.