### PR TITLE
Fix OverflowException in JsonSerializer.Serialize - Part 2

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PooledByteBufferWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PooledByteBufferWriter.cs
@@ -146,7 +146,7 @@ namespace System.Text.Json
                     newSize = currentLength + sizeHint;
                     if ((uint)newSize > int.MaxValue)
                     {
-                        newSize = int.MaxValue;
+                        ThrowHelper.ThrowOutOfMemoryException_BufferMaximumSizeExceeded((uint)newSize);
                     }
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -14,6 +14,13 @@ namespace System.Text.Json
     {
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowOutOfMemoryException_BufferMaximumSizeExceeded(uint capacity)
+        {
+            throw new OutOfMemoryException(SR.Format(SR.BufferMaximumSizeExceeded, capacity));
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_DeserializeWrongType(Type type, object value)
         {
             throw new ArgumentException(SR.Format(SR.DeserializeWrongType, type, value.GetType()));


### PR DESCRIPTION
Explicitly throw the OutOfMemoryException instead of relying on Shared.Rent/Array constructor. Because it can behave differently in OSX, where it supports int.MaxValue array size.

Fix #609