### PR TITLE
Add build configuration to generate runtime packs for iOS

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -225,22 +225,8 @@
     <ProjectToBuild Include="@(DepprojProjectToBuild)" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-')) and '$(TargetOS)' != 'iOS'">
+  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-'))">
     <PkgprojProjectToBuild Include="$(InstallerProjectRoot)pkg\projects\**\*.pkgproj" SignPhase="MsiFiles" BuildInParallel="false" />
-    <ProjectToBuild Include="@(PkgprojProjectToBuild)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-')) and '$(TargetOS)' == 'iOS'">    
-    <!-- For iOS we only need to construct runtime packs-->
-    <PkgprojProjectToBuild  
-        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj" 
-        SignPhase="MsiFiles" BuildInParallel="false" />
-    <PkgprojProjectToBuild  
-        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\legacy\**\*.pkgproj" 
-        SignPhase="MsiFiles" BuildInParallel="false" />
-    <PkgprojProjectToBuild  
-        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\workaround\**\*.pkgproj" 
-        SignPhase="MsiFiles" BuildInParallel="false" />
     <ProjectToBuild Include="@(PkgprojProjectToBuild)" />
   </ItemGroup>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -61,7 +61,7 @@
     <DefaultSubsetCategories Condition="'$(TargetOS)' == 'iOS'">libraries-installer-mono</DefaultSubsetCategories>
     <DefaultSubsetCategories Condition="'$(TargetOS)' == 'Android'">libraries-mono</DefaultSubsetCategories>
     <DefaultInstallerSubsets>corehost-managed-depproj-pkgproj-bundle-installers-test</DefaultInstallerSubsets>
-    <DefaultInstallerSubsets Condition="'$(TargetOS)' == 'iOS'">managed-depproj-pkgproj-bundle-test</DefaultInstallerSubsets>
+    <DefaultInstallerSubsets Condition="'$(TargetOS)' == 'iOS'">depproj-pkgproj</DefaultInstallerSubsets>
     <!-- TODO: Split into multiple sets. -->
     <DefaultLibrariesSubsets>all</DefaultLibrariesSubsets>
     <DefaultCoreClrSubsets>runtime-linuxdac-corelib-nativecorelib-tools-packages</DefaultCoreClrSubsets>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -58,8 +58,10 @@
 
   <PropertyGroup>
     <DefaultSubsetCategories>libraries-installer-coreclr-mono</DefaultSubsetCategories>
-    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'">libraries-mono</DefaultSubsetCategories>
+    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'iOS'">libraries-installer-mono</DefaultSubsetCategories>
+    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'Android'">libraries-mono</DefaultSubsetCategories>
     <DefaultInstallerSubsets>corehost-managed-depproj-pkgproj-bundle-installers-test</DefaultInstallerSubsets>
+    <DefaultInstallerSubsets Condition="'$(TargetOS)' == 'iOS'">managed-depproj-pkgproj-bundle-test</DefaultInstallerSubsets>
     <!-- TODO: Split into multiple sets. -->
     <DefaultLibrariesSubsets>all</DefaultLibrariesSubsets>
     <DefaultCoreClrSubsets>runtime-linuxdac-corelib-nativecorelib-tools-packages</DefaultCoreClrSubsets>
@@ -218,12 +220,27 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-depproj-'))">
-    <DepprojProjectToBuild Include="$(InstallerProjectRoot)pkg\projects\**\*.depproj" SignPhase="R2RBinaries" BuildInParallel="false" />
+    <DepprojProjectToBuild Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(InstallerProjectRoot)pkg\projects\**\*.depproj" SignPhase="R2RBinaries" BuildInParallel="false" />
+    <DepprojProjectToBuild Condition="'$(RuntimeFlavor)' == 'Mono'" Include="$(InstallerProjectRoot)pkg\projects\**\*.depproj" SignPhase="Binaries" BuildInParallel="false" />
     <ProjectToBuild Include="@(DepprojProjectToBuild)" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-'))">
+  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-')) and '$(TargetOS)' != 'iOS'">
     <PkgprojProjectToBuild Include="$(InstallerProjectRoot)pkg\projects\**\*.pkgproj" SignPhase="MsiFiles" BuildInParallel="false" />
+    <ProjectToBuild Include="@(PkgprojProjectToBuild)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subsetCategory.Contains('installer')) and $(_subset.Contains('-pkgproj-')) and '$(TargetOS)' == 'iOS'">    
+    <!-- For iOS we only need to construct runtime packs-->
+    <PkgprojProjectToBuild  
+        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj" 
+        SignPhase="MsiFiles" BuildInParallel="false" />
+    <PkgprojProjectToBuild  
+        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\legacy\**\*.pkgproj" 
+        SignPhase="MsiFiles" BuildInParallel="false" />
+    <PkgprojProjectToBuild  
+        Include="$(InstallerProjectRoot)pkg\projects\netcoreapp\pkg\workaround\**\*.pkgproj" 
+        SignPhase="MsiFiles" BuildInParallel="false" />
     <ProjectToBuild Include="@(PkgprojProjectToBuild)" />
   </ItemGroup>
 

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -78,7 +78,7 @@
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
   </PropertyGroup>
 
-  <Target Name="ResolveVMFilesFromLocalBuild">
+  <Target Name="ResolveRuntimeFilesFromLocalBuild">
     <Error Condition="!Exists('$(CoreCLRArtifactsPath)') and '$(RuntimeFlavor)' == 'CoreCLR'" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The CoreCLR subset category must be built before building this project." />
     <Error Condition="!Exists('$(MonoArtifactsPath)') and '$(RuntimeFlavor)' == 'Mono'" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The Mono subset category must be built before building this project." />
 
@@ -97,25 +97,25 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
-      <VMFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
+      <RuntimeFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''" Include="$(CoreCLRCrossTargetComponentDir)*.*" IsNative="true" />
-      <VMFiles Include="$(CoreCLRArtifactsPath)Redist/**/*.dll" />
-      <VMFiles>
+      <RuntimeFiles Include="$(CoreCLRArtifactsPath)Redist/**/*.dll" />
+      <RuntimeFiles>
         <IsNative>true</IsNative>
-      </VMFiles>
+      </RuntimeFiles>
       <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll"
                              Condition="Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')" />
       <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll"
                              Condition="Exists('$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll') and '@(_systemPrivateCoreLib)' == ''" />
-      <VMFiles Include="@(_systemPrivateCoreLib)" />
-      <VMFiles
+      <RuntimeFiles Include="@(_systemPrivateCoreLib)" />
+      <RuntimeFiles
         Include="
           $(CoreCLRSharedFrameworkDir)PDB/*.pdb;
           $(CoreCLRSharedFrameworkDir)PDB/*.dbg;
           $(CoreCLRSharedFrameworkDir)PDB/*.dwarf" />
-      <VMFiles
+      <RuntimeFiles
         Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.pdb;" />
-      <VMFiles Condition="Exists('$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb')"
+      <RuntimeFiles Condition="Exists('$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb')"
         Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''"
         Include="
@@ -128,13 +128,18 @@
       </CoreCLRCrossTargetFiles>
     </ItemGroup>
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
-      <VMFiles Include="$(MonoArtifactsPath)\*.*" />
-      <VMFiles>
+      <RuntimeFiles Include="$(MonoArtifactsPath)\*.*" />
+      <RuntimeFiles>
         <IsNative>true</IsNative>
-      </VMFiles>
+      </RuntimeFiles>
+
+      <MonoCrossFiles Condition="'$(TargetOS)' == 'iOS'"
+        Include="$(MonoArtifactsPath)\cross\*.*" />
+      <MonoIncludeFiles Condition="'$(TargetOS)' == 'iOS'"
+        Include="$(MonoArtifactsPath)\include\**\*.*" />
     </ItemGroup>
 
-    <Error Condition="'@(VMFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
+    <Error Condition="'@(RuntimeFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
   </Target>
 
   <Target Name="EnsureLocalArtifactsExist">

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -78,10 +78,11 @@
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
   </PropertyGroup>
 
-  <Target Name="ResolveCoreCLRFilesFromLocalBuild">
-    <Error Condition="!Exists('$(CoreCLRArtifactsPath)')" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The CoreCLR subset category must be built before building this project." />
+  <Target Name="ResolveRuntimeFilesFromLocalBuild">
+    <Error Condition="!Exists('$(CoreCLRArtifactsPath)') and '$(RuntimeFlavor)' == 'CoreCLR'" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The CoreCLR subset category must be built before building this project." />
+    <Error Condition="!Exists('$(MonoArtifactsPath)') and '$(RuntimeFlavor)' == 'Mono'" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The Mono subset category must be built before building this project." />
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
       <CoreCLRArtifactsPath>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)'))</CoreCLRArtifactsPath>
       <!--
         Even though CoreCLRSharedFrameworkDir is statically initialized, set it again in case the
@@ -91,7 +92,11 @@
       <CoreCLRCrossTargetComponentDir
         Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','$(CoreCLRCrossTargetComponentDirName)','sharedFramework'))</CoreCLRCrossTargetComponentDir>
     </PropertyGroup>
-    <ItemGroup>
+    <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
+      <MonoArtifactsPath>$([MSBuild]::NormalizeDirectory('$(MonoArtifactsPath)'))</MonoArtifactsPath>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
       <CoreCLRFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''" Include="$(CoreCLRCrossTargetComponentDir)*.*" IsNative="true" />
       <CoreCLRFiles Include="$(CoreCLRArtifactsPath)Redist/**/*.dll" />
@@ -122,8 +127,14 @@
         <TargetPath>runtime/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
       </CoreCLRCrossTargetFiles>
     </ItemGroup>
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
+      <CoreCLRFiles Include="$(MonoArtifactsPath)\*.*" />
+      <CoreCLRFiles>
+        <IsNative>true</IsNative>
+      </CoreCLRFiles>
+    </ItemGroup>
 
-    <Error Condition="'@(CoreCLRFiles)' == ''" Text="The CoreCLR subset category must be built before building this project." />
+    <Error Condition="'@(CoreCLRFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
   </Target>
 
   <Target Name="ResolveMonoFilesFromLocalBuild">

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -78,7 +78,7 @@
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
   </PropertyGroup>
 
-  <Target Name="ResolveRuntimeFilesFromLocalBuild">
+  <Target Name="ResolveVMFilesFromLocalBuild">
     <Error Condition="!Exists('$(CoreCLRArtifactsPath)') and '$(RuntimeFlavor)' == 'CoreCLR'" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The CoreCLR subset category must be built before building this project." />
     <Error Condition="!Exists('$(MonoArtifactsPath)') and '$(RuntimeFlavor)' == 'Mono'" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The Mono subset category must be built before building this project." />
 
@@ -97,25 +97,25 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
-      <CoreCLRFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
+      <VMFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''" Include="$(CoreCLRCrossTargetComponentDir)*.*" IsNative="true" />
-      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)Redist/**/*.dll" />
-      <CoreCLRFiles>
+      <VMFiles Include="$(CoreCLRArtifactsPath)Redist/**/*.dll" />
+      <VMFiles>
         <IsNative>true</IsNative>
-      </CoreCLRFiles>
+      </VMFiles>
       <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll"
                              Condition="Exists('$(CoreCLRArtifactsPath)System.Private.CoreLib.dll')" />
       <_systemPrivateCoreLib Include="$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll"
                              Condition="Exists('$(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll') and '@(_systemPrivateCoreLib)' == ''" />
-      <CoreCLRFiles Include="@(_systemPrivateCoreLib)" />
-      <CoreCLRFiles
+      <VMFiles Include="@(_systemPrivateCoreLib)" />
+      <VMFiles
         Include="
           $(CoreCLRSharedFrameworkDir)PDB/*.pdb;
           $(CoreCLRSharedFrameworkDir)PDB/*.dbg;
           $(CoreCLRSharedFrameworkDir)PDB/*.dwarf" />
-      <CoreCLRFiles
+      <VMFiles
         Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.pdb;" />
-      <CoreCLRFiles Condition="Exists('$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb')"
+      <VMFiles Condition="Exists('$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb')"
         Include="$(CoreCLRArtifactsPath)PDB/System.Private.CoreLib.ni.pdb" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''"
         Include="
@@ -128,23 +128,13 @@
       </CoreCLRCrossTargetFiles>
     </ItemGroup>
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
-      <CoreCLRFiles Include="$(MonoArtifactsPath)\*.*" />
-      <CoreCLRFiles>
+      <VMFiles Include="$(MonoArtifactsPath)\*.*" />
+      <VMFiles>
         <IsNative>true</IsNative>
-      </CoreCLRFiles>
+      </VMFiles>
     </ItemGroup>
 
-    <Error Condition="'@(CoreCLRFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
-  </Target>
-
-  <Target Name="ResolveMonoFilesFromLocalBuild">
-    <Error Condition="!Exists('$(MonoArtifactsPath)')" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The Mono subset category must be built before building this project." />
-
-    <ItemGroup>
-      <MonoFiles Include="$(MonoArtifactsPath)\*.*" />
-    </ItemGroup>
-
-    <Error Condition="'@(MonoFiles)' == ''" Text="The Mono subset category must be built before building this project." />
+    <Error Condition="'@(VMFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
   </Target>
 
   <Target Name="EnsureLocalArtifactsExist">

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -227,7 +227,7 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       osGroup: iOS
       archType: arm
-      platform: iOS_x64
+      platform: iOS_arm
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}
@@ -247,7 +247,7 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       osGroup: iOS
       archType: arm64
-      platform: iOS_x64
+      platform: iOS_arm64
       jobParameters:
         runtimeFlavor: mono
         stagedBuild: ${{ parameters.stagedBuild }}

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -127,7 +127,7 @@ jobs:
         $(CommonMSBuildArgs)
         $(OfficialBuildArg)
 
- - ${{ if eq(parameters.osGroup, 'iOS') }}:
+  - ${{ if eq(parameters.osGroup, 'iOS') }}:
 
     - name: CommonMSBuildArgs
       value: >-

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -138,8 +138,8 @@ jobs:
       value: >-
         $(Build.SourcesDirectory)/installer.sh --restore --build --ci --test
         -configuration $(_BuildConfig)
-        -os $(parameters.osGroup)
-        -arch $(parameters.archType)
+        -os ${{ parameters.osGroup }}
+        -arch ${{ parameters.archType }}
         /p:StripSymbols=true
         $(LiveOverridePathArgs)
         $(CommonMSBuildArgs)

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -112,7 +112,7 @@ jobs:
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
 
-  - ${{ if eq(parameters.osGroup, 'OSX') }}:
+  - ${{ if or(eq(parameters.osGroup, 'OSX'), eq(parameters.osGroup, 'iOS')) }}:
 
     - name: CommonMSBuildArgs
       value: >-

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -112,7 +112,7 @@ jobs:
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
 
-  - ${{ if or(eq(parameters.osGroup, 'OSX'), eq(parameters.osGroup, 'iOS')) }}:
+  - ${{ if eq(parameters.osGroup, 'OSX') }}:
 
     - name: CommonMSBuildArgs
       value: >-
@@ -123,6 +123,24 @@ jobs:
       value: >-
         $(Build.SourcesDirectory)/installer.sh --restore --build --ci --test
         -configuration $(_BuildConfig)
+        $(LiveOverridePathArgs)
+        $(CommonMSBuildArgs)
+        $(OfficialBuildArg)
+
+ - ${{ if eq(parameters.osGroup, 'iOS') }}:
+
+    - name: CommonMSBuildArgs
+      value: >-
+        /p:PortableBuild=true
+        /p:SkipTests=$(SkipTests)
+
+    - name: BaseJobBuildCommand
+      value: >-
+        $(Build.SourcesDirectory)/installer.sh --restore --build --ci --test
+        -configuration $(_BuildConfig)
+        -os $(parameters.osGroup)
+        -arch $(parameters.archType)
+        /p:StripSymbols=true
         $(LiveOverridePathArgs)
         $(CommonMSBuildArgs)
         $(OfficialBuildArg)

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -185,7 +185,6 @@ jobs:
       value: >-
         --restore --build --ci --test
         /p:CrossBuild=${{ ne(parameters.crossrootfsDir, '') }}
-        /p:DisableCrossgen=$(_DisableCrossgen)
         /p:PortableBuild=$(_PortableBuild)
         /p:SkipTests=$(SkipTests)
         $(LiveOverridePathArgs)

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -170,9 +170,6 @@ jobs:
     - name: _PortableBuild
       value: ${{ eq(parameters.osSubgroup, '') }}
 
-    - name: _DisableCrossgen
-      value: false
-
     - ${{ if and(eq(parameters.osSubgroup, '_musl'), eq(parameters.osGroup, 'Linux')) }}:
       # Set output RID manually: musl isn't properly detected. Make sure to also convert linux to
       # lowercase for RID format. (Detection normally converts, but we're preventing it.)

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -164,19 +164,19 @@ stages:
     #
     # Installer Build for platforms using Mono
     #
-    - template: /eng/pipelines/installer/installer-matrix.yml
-      parameters:
-        jobParameters:
-          liveRuntimeBuildConfig: release
-          liveLibrariesBuildConfig: Release
-          isOfficialBuild: ${{ variables.isOfficialBuild }}
-          useOfficialAllConfigurations: true
-          buildFullPlatformManifest: true
-        runtimeFlavor: mono
-        platforms:
-        - iOS_arm
-        - iOS_arm64
-        - iOS_x64
+  - template: /eng/pipelines/installer/installer-matrix.yml
+    parameters:
+      jobParameters:
+        liveRuntimeBuildConfig: release
+        liveLibrariesBuildConfig: Release
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
+        useOfficialAllConfigurations: true
+        buildFullPlatformManifest: true
+      runtimeFlavor: mono
+      platforms:
+      - iOS_arm
+      - iOS_arm64
+      - iOS_x64
 
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -170,8 +170,8 @@ stages:
         liveRuntimeBuildConfig: release
         liveLibrariesBuildConfig: Release
         isOfficialBuild: ${{ variables.isOfficialBuild }}
-        useOfficialAllConfigurations: true
-        buildFullPlatformManifest: true
+        useOfficialAllConfigurations: false
+        buildFullPlatformManifest: false
       runtimeFlavor: mono
       platforms:
       - iOS_arm

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -161,6 +161,23 @@ stages:
       - Windows_NT_arm
       - Windows_NT_arm64
 
+    #
+    # Installer Build for platforms using Mono
+    #
+    - template: /eng/pipelines/installer/installer-matrix.yml
+      parameters:
+        jobParameters:
+          liveRuntimeBuildConfig: release
+          liveLibrariesBuildConfig: Release
+          isOfficialBuild: ${{ variables.isOfficialBuild }}
+          useOfficialAllConfigurations: true
+          buildFullPlatformManifest: true
+        runtimeFlavor: mono
+        platforms:
+        - iOS_arm
+        - iOS_arm64
+        - iOS_x64
+
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml
     parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -481,16 +481,6 @@ jobs:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
-- template: /eng/pipelines/installer/installer-matrix.yml
-  parameters:
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-    runtimeFlavor: mono
-    platforms:
-      - iOS_x64
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-
 #
 # Libraries Test Build
 # Only when CoreCLR, Mono or Libraries is changed

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -486,8 +486,6 @@ jobs:
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     runtimeFlavor: mono
     platforms:
-      - iOS_arm
-      - iOS_arm64
       - iOS_x64
     jobParameters:
       liveRuntimeBuildConfig: release

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -481,6 +481,18 @@ jobs:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
+- template: /eng/pipelines/installer/installer-matrix.yml
+  parameters:
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    runtimeFlavor: mono
+    platforms:
+      - iOS_arm
+      - iOS_arm64
+      - iOS_x64
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+
 #
 # Libraries Test Build
 # Only when CoreCLR, Mono or Libraries is changed

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -481,6 +481,18 @@ jobs:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
+- template: /eng/pipelines/installer/installer-matrix.yml
+  parameters:
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    runtimeFlavor: mono
+    platforms:
+      - iOS_x64
+      - iOS_arm
+      - iOS_arm64
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+
 #
 # Libraries Test Build
 # Only when CoreCLR, Mono or Libraries is changed

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -33,8 +33,7 @@
 
   <Target Name="GetFilesFromRuntime" Returns="@(RuntimeFiles)" DependsOnTargets="GetFilesFromCoreClr;GetFilesFromMono">
     <ItemGroup>
-      <RuntimeFiles Include="@(CoreCLRFiles)" Condition="'$(RuntimeFlavor)' != 'Mono'" />
-      <RuntimeFiles Include="@(MonoFiles)" Condition="'$(RuntimeFlavor)' == 'Mono'" />
+      <RuntimeFiles Include="@(VMFiles)" />
     </ItemGroup>
   </Target>
 
@@ -44,13 +43,13 @@
   -->
   <Target Name="GetFilesFromCoreCLR" 
           Condition="'$(RuntimeFlavor)' != 'Mono'"
-          Returns="@(CoreCLRFiles)"
-          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" />
+          Returns="@(VMFiles)"
+          DependsOnTargets="ResolveVMFilesFromLocalBuild" />
 
   <Target Name="GetFilesFromMono" 
           Condition="'$(RuntimeFlavor)' == 'Mono'"
-          Returns="@(MonoFiles)"
-          DependsOnTargets="ResolveMonoFilesFromLocalBuild" />
+          Returns="@(VMFiles)"
+          DependsOnTargets="ResolveVMFilesFromLocalBuild" />
 
   <Target Name="FilterReferenceFromRuntime"
           AfterTargets="ResolveProjectReferences"

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -45,7 +45,7 @@
   <Target Name="GetFilesFromCoreCLR" 
           Condition="'$(RuntimeFlavor)' != 'Mono'"
           Returns="@(CoreCLRFiles)"
-          DependsOnTargets="ResolveCoreCLRFilesFromLocalBuild" />
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" />
 
   <Target Name="GetFilesFromMono" 
           Condition="'$(RuntimeFlavor)' == 'Mono'"

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -33,7 +33,7 @@
 
   <Target Name="GetFilesFromRuntime" Returns="@(RuntimeFiles)" DependsOnTargets="GetFilesFromCoreClr;GetFilesFromMono">
     <ItemGroup>
-      <RuntimeFiles Include="@(VMFiles)" />
+      <RuntimeFiles Include="@(RuntimeFiles)" />
     </ItemGroup>
   </Target>
 
@@ -43,13 +43,13 @@
   -->
   <Target Name="GetFilesFromCoreCLR" 
           Condition="'$(RuntimeFlavor)' != 'Mono'"
-          Returns="@(VMFiles)"
-          DependsOnTargets="ResolveVMFilesFromLocalBuild" />
+          Returns="@(RuntimeFiles)"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" />
 
   <Target Name="GetFilesFromMono" 
           Condition="'$(RuntimeFlavor)' == 'Mono'"
-          Returns="@(VMFiles)"
-          DependsOnTargets="ResolveVMFilesFromLocalBuild" />
+          Returns="@(RuntimeFiles)"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" />
 
   <Target Name="FilterReferenceFromRuntime"
           AfterTargets="ResolveProjectReferences"

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -94,7 +94,7 @@
     <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'iOS'">iOS-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -130,7 +130,7 @@
     <DisableCrossgen>false</DisableCrossgen>
     <DisableCrossgen Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableCrossgen>
     <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
-    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD'">true</DisableCrossgen> 
+    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD'">true</DisableCrossgen>
     <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(Configuration)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
@@ -189,7 +189,7 @@
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
-    <When Condition="$(OutputRid.StartsWith('iOS'))">
+    <When Condition="$(OutputRid.StartsWith('ios'))">
       <PropertyGroup>
         <TargetsiOS>true</TargetsiOS>
         <TargetsUnix>true</TargetsUnix>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -128,8 +128,9 @@
 
   <PropertyGroup>
     <DisableCrossgen>false</DisableCrossgen>
+    <DisableCrossgen Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableCrossgen>
     <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
-    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD' or '$(RuntimeFlavor)' == 'Mono'">true</DisableCrossgen>
+    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD'">true</DisableCrossgen> 
     <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(Configuration)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
@@ -147,10 +148,10 @@
 
     <!-- OSX specific intermediate package suffix . OSX specific intermediate packages are suffixed with -internal to avoid name collision for bundle package (dotnet-runtime-*)
          and runtime ( earlier as dotnet-sharedframework-*)	-->
-    <InstallerStartSuffix Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">internal</InstallerStartSuffix>
-    <SharedHostInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
-    <HostFxrInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
-    <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
+    <InstallerStartSuffix Condition="'$(TargetOS)' == 'OSX'">internal</InstallerStartSuffix>
+    <SharedHostInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
+    <HostFxrInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
+    <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
 
   </PropertyGroup>
 
@@ -283,7 +284,7 @@
     <CompressedFileExtension Condition="'$(TargetOS)' == 'Windows_NT'">.zip</CompressedFileExtension>
     <CompressedFileExtension Condition="'$(TargetOS)' != 'Windows_NT'">.tar.gz</CompressedFileExtension>
     <InstallerExtension Condition="'$(TargetOS)' == 'Windows_NT'">.msi</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">.pkg</InstallerExtension>
+    <InstallerExtension Condition="'$(TargetOS)' == 'OSX'">.pkg</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsDebian)' == 'true' or '$(TargetsUbuntu)' == 'true' or '$(TargetsLinuxMint)' == 'true' or '$(HostMachineRidTargetsDebianPackages)' == 'true'">.deb</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true' or '$(TargetsOpensuse)' == 'true' or '$(TargetsFedora)' == 'true' or '$(TargetsOracle)' == 'true' or '$(TargetsSles)' == 'true' or '$(HostMachineRidTargetsRpmPackages)' == 'true'">.rpm</InstallerExtension>
     <CombinedInstallerExtension Condition="'$(TargetOS)' == 'Windows_NT'">.exe</CombinedInstallerExtension>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -94,6 +94,7 @@
     <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'iOS'">iOS-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -128,7 +129,7 @@
   <PropertyGroup>
     <DisableCrossgen>false</DisableCrossgen>
     <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
-    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD'">true</DisableCrossgen>
+    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD' or '$(RuntimeFlavor)' == 'Mono'">true</DisableCrossgen>
     <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(Configuration)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
@@ -146,10 +147,10 @@
 
     <!-- OSX specific intermediate package suffix . OSX specific intermediate packages are suffixed with -internal to avoid name collision for bundle package (dotnet-runtime-*)
          and runtime ( earlier as dotnet-sharedframework-*)	-->
-    <InstallerStartSuffix Condition="'$(TargetOS)' == 'OSX'">internal</InstallerStartSuffix>
-    <SharedHostInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
-    <HostFxrInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
-    <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
+    <InstallerStartSuffix Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">internal</InstallerStartSuffix>
+    <SharedHostInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
+    <HostFxrInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
+    <SharedFrameworkInstallerStart Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
 
   </PropertyGroup>
 
@@ -162,6 +163,7 @@
   <PropertyGroup>
     <TargetsWindows>false</TargetsWindows>
     <TargetsOSX>false</TargetsOSX>
+    <TargetsiOS>false</TargetsiOS>
     <TargetsLinux>false</TargetsLinux>
     <TargetsUnix>false</TargetsUnix>
     <TargetsUbuntu>false</TargetsUbuntu>
@@ -183,6 +185,12 @@
     <When Condition="$(OutputRid.StartsWith('osx'))">
       <PropertyGroup>
         <TargetsOSX>true</TargetsOSX>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(OutputRid.StartsWith('iOS'))">
+      <PropertyGroup>
+        <TargetsiOS>true</TargetsiOS>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
@@ -275,7 +283,7 @@
     <CompressedFileExtension Condition="'$(TargetOS)' == 'Windows_NT'">.zip</CompressedFileExtension>
     <CompressedFileExtension Condition="'$(TargetOS)' != 'Windows_NT'">.tar.gz</CompressedFileExtension>
     <InstallerExtension Condition="'$(TargetOS)' == 'Windows_NT'">.msi</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetOS)' == 'OSX'">.pkg</InstallerExtension>
+    <InstallerExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">.pkg</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsDebian)' == 'true' or '$(TargetsUbuntu)' == 'true' or '$(TargetsLinuxMint)' == 'true' or '$(HostMachineRidTargetsDebianPackages)' == 'true'">.deb</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true' or '$(TargetsOpensuse)' == 'true' or '$(TargetsFedora)' == 'true' or '$(TargetsOracle)' == 'true' or '$(TargetsSles)' == 'true' or '$(HostMachineRidTargetsRpmPackages)' == 'true'">.rpm</InstallerExtension>
     <CombinedInstallerExtension Condition="'$(TargetOS)' == 'Windows_NT'">.exe</CombinedInstallerExtension>
@@ -319,7 +327,7 @@
     <LibPrefix Condition="'$(TargetOS)' != 'Windows_NT'">lib</LibPrefix>
     <LibSuffix>.so</LibSuffix>
     <LibSuffix Condition="'$(TargetOS)' == 'Windows_NT'">.dll</LibSuffix>
-    <LibSuffix Condition="'$(TargetOS)' == 'OSX'">.dylib</LibSuffix>
+    <LibSuffix Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">.dylib</LibSuffix>
     <StaticLibPrefix>lib</StaticLibPrefix>
     <StaticLibSuffix>.a</StaticLibSuffix>
     <StaticLibSuffix Condition="'$(TargetOS)' == 'Windows_NT'">.lib</StaticLibSuffix>
@@ -329,7 +337,7 @@
     <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
     <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'Windows_NT'">.ni.pdb</CrossGenSymbolExtension>
     <!-- OSX doesn't have crossgen symbols, yet -->
-    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX'"></CrossGenSymbolExtension>
+    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'"></CrossGenSymbolExtension>
   </PropertyGroup>
 
 </Project>

--- a/src/installer/pkg/packaging/osx/package.targets
+++ b/src/installer/pkg/packaging/osx/package.targets
@@ -5,13 +5,13 @@
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
 
   <Target Name="InitPkg"
-          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS') == 'iOS'">
+          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">
     <MakeDir Condition="!Exists('$(PackagesIntermediateDir)')"
              Directories="$(PackagesIntermediateDir)" />
   </Target>
 
   <Target Name="GeneratePkgs"
-          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS') == 'iOS'"
+          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'"
           DependsOnTargets="GetInstallerBrandingNames;InitPkg">
     <ItemGroup>
         <OSXPackages Include="sharedframework">

--- a/src/installer/pkg/packaging/osx/package.targets
+++ b/src/installer/pkg/packaging/osx/package.targets
@@ -5,13 +5,13 @@
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
 
   <Target Name="InitPkg"
-          Condition="'$(TargetOS)' == 'OSX'">
+          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS') == 'iOS'">
     <MakeDir Condition="!Exists('$(PackagesIntermediateDir)')"
              Directories="$(PackagesIntermediateDir)" />
   </Target>
 
   <Target Name="GeneratePkgs"
-          Condition="'$(TargetOS)' == 'OSX'"
+          Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS') == 'iOS'"
           DependsOnTargets="GetInstallerBrandingNames;InitPkg">
     <ItemGroup>
         <OSXPackages Include="sharedframework">

--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <PackagePlatform>AnyCPU</PackagePlatform>
 
-    <SkipBuildOnRuntimePackOnlyOS>false</SkipBuildOnRuntimePackOnlyOS>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>

--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <PackagePlatform>AnyCPU</PackagePlatform>
 
+    <SkipBuildOnRuntimePackOnlyOS>false</SkipBuildOnRuntimePackOnlyOS>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -15,6 +15,17 @@
   </PropertyGroup>
 
   <!--
+    For mobile targets, we do not need the host, so allow depproj's to opt 
+    in in order to skip building. 
+  -->
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" 
+    Condition="'$(SkipBuildOnRuntimePackOnlyOS)' and '$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+      <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
+  <!--
     For any Dependency items with a VersionProp, set it to the property by that name given by the
     version generation target. For any with a VersionFromProject, query the ProductVersion from that
     project file and use it as the dependency's version.

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -18,8 +18,9 @@
     For mobile targets, we do not need the host, so allow depproj's to opt 
     in in order to skip building. 
   -->
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" 
-    Condition="'$(SkipBuildOnRuntimePackOnlyOS)' and '$(TargetOS)' == 'iOS'">
+  <Target Name="MobileSkipBuildProps" 
+          Condition="'$(SkipBuildOnRuntimePackOnlyOS)' and '$(TargetOS)' == 'iOS'"
+          BeforeTargets="GetSkipBuildProps">
     <PropertyGroup>
       <SkipBuild>true</SkipBuild>
     </PropertyGroup>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -16,10 +16,10 @@
 
   <!--
     For mobile targets, we do not need the host, so allow depproj's to opt 
-    in in order to skip building. 
+    out and skip building. 
   -->
   <Target Name="MobileSkipBuildProps" 
-          Condition="'$(SkipBuildOnRuntimePackOnlyOS)' and '$(TargetOS)' == 'iOS'"
+          Condition="'$(SkipBuildOnRuntimePackOnlyOS)' == 'true' and '$(TargetOS)' == 'iOS'"
           BeforeTargets="GetSkipBuildProps">
     <PropertyGroup>
       <SkipBuild>true</SkipBuild>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -4,5 +4,5 @@
     <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
+  <Import Project="$(MSBuildProjectName).props" />
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -1,14 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionProp>AppHostVersion</VersionProp>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
   <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
-
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -1,9 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <VersionProp>AppHostVersion</VersionProp>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectName).props" />
+  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
+
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import
-    Condition="'$(PackageTargetRuntime)' != ''"
+    Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' != 'iOS'"
     Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import
-    Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' != 'iOS'"
+    Condition="'$(PackageTargetRuntime)' != '' and Exists('$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)')"
     Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -47,6 +47,12 @@
     </ItemGroup>
   </Target>
 
-  <Import Condition="'$(PackageTargetRuntime)' != ''" Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props" />
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
+  <Import Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' != 'iOS'" Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -48,6 +48,8 @@
     </ItemGroup>
   </Target>
 
-  <Import Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' != 'iOS'" Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props" />
+  <Import 
+    Condition="'$(PackageTargetRuntime)' != '' and Exists('$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props')"
+    Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -5,6 +5,7 @@
 
     <InstallerName>dotnet-host</InstallerName>
     <GenerateSharedFrameworkPart>true</GenerateSharedFrameworkPart>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
   <Target Name="SetupHostSpecificWixBuild"
@@ -45,12 +46,6 @@
       <CandleVariables Include="ExtraPropertyRefIds" Value="ProductCPU;RTM_ProductVersion" />
       <CandleVariables Include="HostSrc" Value="$(PublishRootDir)" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
   </Target>
 
   <Import Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' != 'iOS'" Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildProjectName).props" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -9,5 +9,5 @@
     <Dependency Include="Microsoft.NETCore.DotNetHostResolver" VersionProp="HostResolverVersion" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
+  <Import Project="$(MSBuildProjectName).props" />
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <VersionProp>HostPolicyVersion</VersionProp>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,11 +10,4 @@
   </ItemGroup>
 
   <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
-
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -8,6 +8,12 @@
     <Dependency Include="Microsoft.NETCore.DotNetHostResolver" VersionProp="HostResolverVersion" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildProjectName).props" />
+  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
+
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import
-    Condition="'$(PackageTargetRuntime)' != ''"
+    Condition="'$(PackageTargetRuntime)' != '' and Exists('$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)')"
     Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -45,6 +45,12 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(MSBuildProjectName).props" />
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -46,6 +46,6 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />
+  <Import Project="$(MSBuildProjectName).props" />
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -5,6 +5,7 @@
 
     <InstallerName>dotnet-hostfxr</InstallerName>
     <GenerateSharedFrameworkPart>true</GenerateSharedFrameworkPart>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,12 +44,6 @@
         ComponentGroupName="InstallFiles"
         DirectoryRef="DOTNETHOME" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
   </Target>
 
   <Import Project="$(MSBuildProjectName).props" Condition="'$(TargetOS)' != 'iOS'" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import
-    Condition="'$(PackageTargetRuntime)' != ''"
+    Condition="'$(PackageTargetRuntime)' != '' and Exists('$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)')"
     Project="$(MSBuildThisFileDirectory)runtime.$(TargetOS).$(MSBuildThisFile)" />
 
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/Directory.Build.props
@@ -9,6 +9,7 @@
     <CoreCLRTargetOS Condition="'$(TargetsWindows)' == 'true'">Windows_NT</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsLinux)' == 'true'">Linux</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsOSX)' == 'true'">OSX</CoreCLRTargetOS>
+    <CoreCLRTargetOS Condition="'$(TargetsiOS)' == 'true'">iOS</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsFreeBSD)' == 'true'">FreeBSD</CoreCLRTargetOS>
     <LibrariesTargetOS>$(CoreCLRTargetOS)</LibrariesTargetOS>
   </PropertyGroup>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <FrameworkPackType>crossgen2</FrameworkPackType>
     <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
   </PropertyGroup>
 
   <!--
@@ -85,12 +86,6 @@
       </File>
     </ItemGroup>
 
-  </Target>
-
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -87,6 +87,12 @@
 
   </Target>
 
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
@@ -26,4 +26,9 @@
     <CrossArchSdkMsiInstallerArch Include="x64;x86" />
   </ItemGroup>
 
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
@@ -26,9 +26,7 @@
     <CrossArchSdkMsiInstallerArch Include="x64;x86" />
   </ItemGroup>
 
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
-  </Target>
+  <PropertyGroup>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
+  </PropertyGroup>
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Ref.pkgproj
@@ -5,10 +5,7 @@
     <File Include="PackageOverrides.txt" TargetPath="data/" />
   </ItemGroup>
 
-  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
-    <PropertyGroup>
-        <SkipBuild>true</SkipBuild>
-    </PropertyGroup>
-  </Target>
-
+  <PropertyGroup>
+    <SkipBuildOnRuntimePackOnlyOS>true</SkipBuildOnRuntimePackOnlyOS>
+  </PropertyGroup>
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Ref.pkgproj
@@ -5,4 +5,10 @@
     <File Include="PackageOverrides.txt" TargetPath="data/" />
   </ItemGroup>
 
+  <Target Name="MobileSkipBuildProps" BeforeTargets="GetSkipBuildProps" Condition="'$(TargetOS)' == 'iOS'">
+    <PropertyGroup>
+        <SkipBuild>true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
@@ -1,10 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
+  Don't include host resolver or host policy in iOS or Android runtime packs, because there is no
+  shared framework on those platforms.
+  -->
+  <PropertyGroup>
+    <ExcludeHostAssets Condition="'$(TargetOS)' == 'iOS'">true</ExcludeHostAssets>
+    <ExcludeHostAssets Condition="'$(TargetOS)' == 'Android'">true</ExcludeHostAssets>
+  </PropertyGroup>
+  <!--
     Include HostPolicy and HostResolver based on legacy packages. This can be collapsed once the
     legacy packages are no longer used.
   -->
-  <Import Condition="'$(TargetOS)' != 'iOS'" Project="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.props" />
-  <Import Condition="'$(TargetOS)' != 'iOS'" Project="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.props" />
+  <Import Condition="'$(ExcludeHostAssets)' != 'true'" Project="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.props" />
+  <Import Condition="'$(ExcludeHostAssets)' != 'true'" Project="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.props" />
 
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
@@ -4,7 +4,7 @@
     Include HostPolicy and HostResolver based on legacy packages. This can be collapsed once the
     legacy packages are no longer used.
   -->
-  <Import Project="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.props" />
-  <Import Project="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.props" />
+  <Import Condition="'$(TargetOS)' != 'iOS'" Project="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.props" />
+  <Import Condition="'$(TargetOS)' != 'iOS'" Project="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.props" />
 
 </Project>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Runtime.pkgproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-  Don't include host resolver or host policy in iOS or Android runtime packs, because there is no
-  shared framework on those platforms.
+    Don't include host resolver or host policy in iOS or Android runtime packs, because there is no
+    shared framework on those platforms.
   -->
   <PropertyGroup>
     <ExcludeHostAssets Condition="'$(TargetOS)' == 'iOS'">true</ExcludeHostAssets>

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -57,15 +57,15 @@
 
   <Target Name="GetDependencyVersionFiles" />
 
-  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
+  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveVMFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
     <ItemGroup>
-      <CoreCLRFiles>
+      <VMFiles>
         <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
-      </CoreCLRFiles>
+      </VMFiles>
 
-      <CoreCLRFiles Condition="'%(FileName)' == 'crossgen'">
+      <VMFiles Condition="'%(FileName)' == 'crossgen'">
         <TargetPath>tools</TargetPath>
-      </CoreCLRFiles>
+      </VMFiles>
 
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'clrjit' or '%(FileName)' == 'libclrjit'">
         <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
@@ -79,7 +79,7 @@
       <CoreCLRCrossTargetFiles Condition="'%(FileName)%(Extension)' == 'mscordbi.dll' and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
       </CoreCLRCrossTargetFiles>
-      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles);@(CoreCLRCrossTargetFiles)" />
+      <ReferenceCopyLocalPaths Include="@(VMFiles);@(CoreCLRCrossTargetFiles)" />
     </ItemGroup>
   </Target>
 

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -57,15 +57,24 @@
 
   <Target Name="GetDependencyVersionFiles" />
 
-  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveVMFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
+  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
     <ItemGroup>
-      <VMFiles>
+      <RuntimeFiles>
         <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
-      </VMFiles>
+      </RuntimeFiles>
 
-      <VMFiles Condition="'%(FileName)' == 'crossgen'">
+      <RuntimeFiles Condition="'%(FileName)' == 'crossgen'">
         <TargetPath>tools</TargetPath>
-      </VMFiles>
+      </RuntimeFiles>
+
+      <RuntimeFiles Condition="'$(TargetOS)' == 'iOS'"
+        Include="@(MonoCrossFiles)">
+        <TargetPath>runtimes/$(PackageRID)/native/cross</TargetPath>
+      </RuntimeFiles>
+      <RuntimeFiles Condition="'$(TargetOS)' == 'iOS'"
+        Include="@(MonoIncludeFiles)">
+        <TargetPath>runtimes/$(PackageRID)/native/include/%(RecursiveDir)</TargetPath>
+      </RuntimeFiles>
 
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'clrjit' or '%(FileName)' == 'libclrjit'">
         <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
@@ -79,7 +88,7 @@
       <CoreCLRCrossTargetFiles Condition="'%(FileName)%(Extension)' == 'mscordbi.dll' and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
       </CoreCLRCrossTargetFiles>
-      <ReferenceCopyLocalPaths Include="@(VMFiles);@(CoreCLRCrossTargetFiles)" />
+      <ReferenceCopyLocalPaths Include="@(RuntimeFiles);@(CoreCLRCrossTargetFiles);" />
     </ItemGroup>
   </Target>
 

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -57,7 +57,7 @@
 
   <Target Name="GetDependencyVersionFiles" />
 
-  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveCoreCLRFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
+  <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild" BeforeTargets="GetFilesFromPackageResolve">
     <ItemGroup>
       <CoreCLRFiles>
         <TargetPath>runtimes/$(PackageRID)/native</TargetPath>

--- a/src/installer/test/Directory.Build.props
+++ b/src/installer/test/Directory.Build.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <TargetOSTrait Condition="'$(TargetOS)' == 'Windows_NT'">nonwindowstests</TargetOSTrait>
     <TargetOSTrait Condition="'$(TargetOS)' == 'Linux'">nonlinuxtests</TargetOSTrait>
-    <TargetOSTrait Condition="'$(TargetOS)' == 'OSX'">nonosxtests</TargetOSTrait>
+    <TargetOSTrait Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'">nonosxtests</TargetOSTrait>
     <TargetOSTrait Condition="'$(TargetOS)' == 'FreeBSD'">nonfreebsdtests</TargetOSTrait>
     <TargetOSTrait Condition="'$(TargetOS)' == 'NetBSD'">nonnetbsdtests</TargetOSTrait>
 

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -74,7 +74,7 @@
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"
-          DependsOnTargets="ResolveCoreCLRFilesFromLocalBuild"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' != 'Mono'">
     <ItemGroup>
@@ -94,7 +94,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveCoreCLRFilesFromLocalBuild">
+  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup>
       <CoreCLRILFiles Include="$(CoreCLRArtifactsPath)/IL/*.*" />
     </ItemGroup>

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -74,27 +74,27 @@
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"
-          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
+          DependsOnTargets="ResolveVMFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' != 'Mono'">
     <ItemGroup>
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
-      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/corerun*" />
-      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/PDB/corerun*" />
-      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles)" />
+      <VMFiles Include="$(CoreCLRArtifactsPath)/corerun*" />
+      <VMFiles Include="$(CoreCLRArtifactsPath)/PDB/corerun*" />
+      <ReferenceCopyLocalPaths Include="@(VMFiles)" />
     </ItemGroup>
   </Target>
 
   <Target Name="OverrideRuntimeMono"
-          DependsOnTargets="ResolveMonoFilesFromLocalBuild"
+          DependsOnTargets="ResolveVMFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' == 'Mono'">
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(MonoFiles)" />
+      <ReferenceCopyLocalPaths Include="@(VMFiles)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
+  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveVMFilesFromLocalBuild">
     <ItemGroup>
       <CoreCLRILFiles Include="$(CoreCLRArtifactsPath)/IL/*.*" />
     </ItemGroup>

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -74,27 +74,27 @@
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"
-          DependsOnTargets="ResolveVMFilesFromLocalBuild"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' != 'Mono'">
     <ItemGroup>
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
-      <VMFiles Include="$(CoreCLRArtifactsPath)/corerun*" />
-      <VMFiles Include="$(CoreCLRArtifactsPath)/PDB/corerun*" />
-      <ReferenceCopyLocalPaths Include="@(VMFiles)" />
+      <RuntimeFiles Include="$(CoreCLRArtifactsPath)/corerun*" />
+      <RuntimeFiles Include="$(CoreCLRArtifactsPath)/PDB/corerun*" />
+      <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
     </ItemGroup>
   </Target>
 
   <Target Name="OverrideRuntimeMono"
-          DependsOnTargets="ResolveVMFilesFromLocalBuild"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' == 'Mono'">
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="@(VMFiles)" />
+      <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveVMFilesFromLocalBuild">
+  <Target Name="GetCoreCLRILFiles" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup>
       <CoreCLRILFiles Include="$(CoreCLRArtifactsPath)/IL/*.*" />
     </ItemGroup>


### PR DESCRIPTION
This adds support for generating iOS runtime packs, which is intended to be consumed by the Xamarin iOS SDK.