### PR TITLE
Remove mode bits from open O_RDONLY

### DIFF
--- a/src/installer/corehost/cli/hostmisc/pal.unix.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.unix.cpp
@@ -60,7 +60,7 @@ bool pal::touch_file(const pal::string_t& path)
 
 void* pal::map_file_readonly(const pal::string_t& path, size_t& length)
 {
-    int fd = open(path.c_str(), O_RDONLY, (S_IRUSR | S_IRGRP | S_IROTH));
+    int fd = open(path.c_str(), O_RDONLY);
     if (fd == -1)
     {
         trace::error(_X("Failed to map file. open(%s) failed with error %d"), path.c_str(), errno);


### PR DESCRIPTION
A suppression was missed from deletion of `src/installer/settings.cmake` in the previous PR. However, the only warning seems straightforward to fix:

```
  [ 10%] Building CXX object cli/hostcommon/CMakeFiles/libhostcommon.dir/__/json_parser.cpp.o
  /runtime/src/installer/corehost/cli/hostmisc/pal.unix.cpp:63:72: error: 'open' has superfluous mode bits; missing O_CREAT? [-Werror,-Wuser-defined-warnings]
      int fd = open(path.c_str(), O_RDONLY, (S_IRUSR | S_IRGRP | S_IROTH));
                                                                         ^
  /runtime/.tools/android-rootfs/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/fcntl.h:76:9: note: from 'diagnose_if' attribute on 'open':
          __clang_warning_if(!__open_modes_useful(flags) && modes,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /runtime/.tools/android-rootfs/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/sys/cdefs.h:135:54: note: expanded from macro '__clang_warning_if'
  #define __clang_warning_if(cond, msg) __attribute__((diagnose_if(cond, msg, "warning")))
                                                       ^           ~~~~
  1 error generated.

```

mode bits are only ever used with `O_CREAT` going by POSIX and FORTIFY sources.

cc @janvorli