### PR TITLE
Move assert checking the size of structs with GC pointers.

### DIFF
--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -373,12 +373,6 @@ void ClassLayout::InitializeGCPtrs(Compiler* compiler)
         // so it should be safe to fit this into a 30 bits bit field.
         assert(gcPtrCount < (1 << 30));
 
-        // We assume that we cannot have a struct with GC pointers that is not a multiple
-        // of the register size.
-        // The EE currently does not allow this, but it could change.
-        // Let's assert it just to be safe.
-        noway_assert((gcPtrCount == 0) || (roundUp(m_size, REGSIZE_BYTES) == m_size));
-
         m_gcPtrCount = gcPtrCount;
     }
 


### PR DESCRIPTION
Codegen for CpObj assumes that we cannot have a struct with GC pointers
whose size is not a multiple of the register size. We had an assert that
 verified that in `ClassLayout::InitializeGCPtrs`.

The assert fired in the new pipeline that tests off-by-default features
in the leg that turns on object stack allocation. Stack-allocated
objects are never copied so the assert shouldn't apply to them.
I moved the assert to `Compiler::gtNewCpObjNode`. I clarified the
comment for the assert and changed it from `noway_assert` to a
regular `assert` since recompilation with minopts will not help if we
hit the assert.

I also added a repro case to ObjectStackAllocationTests that run with
COMPlus_JitObjectStackAllocation=1 in regular test runs.