### PR TITLE
UseClientCertOnHttp2_OSSupportsIt_Success requires Win10 build number 19753 at least

### DIFF
--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
@@ -63,6 +63,8 @@ namespace System
         // Per https://docs.microsoft.com/en-us/windows-insider/flight-hub/ the first 20H1 build is 18836.
         public static bool IsWindows10Version2004OrGreater => IsWindows &&
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 18836;
+        
+        public static bool IsWindows10Version2004Build19573OrGreater => IsWindows10Version2004OrGreater && GetWindowsBuildNumber() >= 19573;
 
         public static bool IsWindowsIoTCore
         {

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ClientCertificateTest.cs
@@ -55,8 +55,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
 
 // Disabling it for full .Net Framework due to a missing ALPN API which leads to a protocol downgrade
 #if !NETFRAMEWORK
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34010")]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004OrGreater))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version2004Build19573OrGreater))]
         public async Task UseClientCertOnHttp2_OSSupportsIt_Success()
         {
             using X509Certificate2 clientCert = Test.Common.Configuration.Certificates.GetClientCertificate();


### PR DESCRIPTION
Fixes #34010