### PR TITLE
[debugger] Fix suspend_policy that will be send to debugger-libs

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -298,7 +298,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 54
+#define MINOR_VERSION 55
 
 typedef enum {
 	CMD_SET_VM = 1,
@@ -3921,7 +3921,10 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 				return;
 		}
 	}
-
+	
+	if (event == EVENT_KIND_VM_START) 
+		suspend_policy = agent_config.suspend ? SUSPEND_POLICY_ALL : SUSPEND_POLICY_NONE;	
+	
 	nevents = g_slist_length (events);
 	buffer_init (&buf, 128);
 	buffer_add_byte (&buf, suspend_policy);
@@ -4032,7 +4035,6 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 	}
 
 	if (event == EVENT_KIND_VM_START) {
-		suspend_policy = agent_config.suspend ? SUSPEND_POLICY_ALL : SUSPEND_POLICY_NONE;
 		if (!agent_config.defer) {
 			ERROR_DECL (error);
 			start_debugger_thread (error);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19317,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>- Fix suspend_policy that will be send to debugger-libs, because on debugger-libs we want to resume the VM only when it's suspended, but we were sending the wrong suspend_policy in the case of EVENT_KIND_VM_START and mono is started with suspend=y.
With this fix we can do this PR again: https://github.com/mono/debugger-libs/pull/264/

- Bumping protocol for this https://github.com/mono/mono/pull/19248 fix as suggested by @vargaz.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/999375/

