### PR TITLE
Remove -stripsymbols option from build scripts

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -151,10 +151,6 @@ while [[ $# > 0 ]]; do
       arguments="$arguments /p:Coverage=true"
       shift 1
       ;;
-     -stripsymbols)
-      arguments="$arguments /p:BuildNativeStripSymbols=true"
-      shift 1
-      ;;
      -runtimeconfiguration)
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
       arguments="$arguments /p:RuntimeConfiguration=$val"

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -187,7 +187,6 @@ usage()
     echo "-portablebuild: pass -portablebuild=false to force a non-portable build."
     echo "-skipconfigure: skip build configuration."
     echo "-skipgenerateversion: disable version generation even if MSBuild is supported."
-    echo "-stripsymbols: skip native image generation."
     echo "-verbose: optional argument to enable verbose build output."
     echo ""
     echo "Additional Options:"
@@ -334,9 +333,6 @@ while :; do
 
         skipgenerateversion|-skipgenerateversion)
             __SkipGenerateVersion=1
-            ;;
-
-        stripsymbols|-stripsymbols)
             ;;
 
         verbose|-verbose)

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -123,7 +123,6 @@ jobs:
       value: >-
         $(Build.SourcesDirectory)/installer.sh --restore --build --ci --test
         -configuration $(_BuildConfig)
-        /p:StripSymbols=true
         $(LiveOverridePathArgs)
         $(CommonMSBuildArgs)
         $(OfficialBuildArg)
@@ -192,7 +191,6 @@ jobs:
         $(LiveOverridePathArgs)
         $(CommonMSBuildArgs)
         $(OutputRidArg)
-        /p:StripSymbols=true
 
     - name: PublishArguments
       value: >-

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -11,7 +11,6 @@
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
       <_CoreClrBuildArg Condition="'$(CrossBuild)' == 'true'" Include="-cross" />
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'x64') and '$(Configuration)' == 'Release'" Include="-enforcepgo" />
-      <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows)) and '$(Configuration)' == 'Release'" Include="-stripsymbols" />
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CrossDac)' != ''" Include="-$(CrossDac)dac" />
       <_CoreClrBuildArg Condition="'$(OfficialBuildId)' != ''" Include="/p:OfficialBuildId=$(OfficialBuildId)" />
     </ItemGroup>

--- a/src/installer/corehost/build.proj
+++ b/src/installer/corehost/build.proj
@@ -32,7 +32,6 @@
       <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) -cross</BuildArgs>
       <BuildArgs Condition="'$(Compiler)' != ''">$(BuildArgs) $(Compiler)</BuildArgs>
       <BuildArgs Condition="'$(CMakeArgs)' != ''">$(BuildArgs) $(CMakeArgs)</BuildArgs>
-      <BuildArgs Condition="'$(StripSymbols)' == 'true'">$(BuildArgs) -stripsymbols</BuildArgs>
     </PropertyGroup>
 
     <!--

--- a/src/libraries/Native/build-native.proj
+++ b/src/libraries/Native/build-native.proj
@@ -20,7 +20,6 @@
         then we should consider calling Environment.ProcessorCount
       -->
       <_ProcessorCountArg> -numproc $(MSBuildNodeCount)</_ProcessorCountArg>
-      <_StripSymbolsArg Condition="'$(BuildNativeStripSymbols)' == 'true' and '$(TargetOS)' != 'WebAssembly' and '$(TargetOS)' != 'iOS'"> -stripsymbols</_StripSymbolsArg>
       <_PortableBuildArg Condition="'$(PortableBuild)' != 'true'"> -portablebuild=false</_PortableBuildArg>
       <_CrossBuildArg Condition="'$(CrossBuild)' == 'true'"> -cross</_CrossBuildArg>
       <_CMakeArgs Condition="'$(CMakeArgs)' != ''"> $(CMakeArgs)</_CMakeArgs>
@@ -30,7 +29,7 @@
         used to force a specific compiler toolset.
       -->
       <_BuildNativeCompilerArg Condition="'$(BuildNativeCompiler)' != ''"> $(BuildNativeCompiler)</_BuildNativeCompilerArg>
-      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_CrossBuildArg)$(_BuildNativeCompilerArg)$(_CMakeArgs) $(Compiler)</_BuildNativeUnixArgs>
+      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_PortableBuildArg)$(_CrossBuildArg)$(_BuildNativeCompilerArg)$(_CMakeArgs) $(Compiler)</_BuildNativeUnixArgs>
     </PropertyGroup>
 
     <Message Text="$(MSBuildProjectDirectory)/build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>

--- a/tools-local/scripts/dev/master-build-deb-rpm-docker.sh
+++ b/tools-local/scripts/dev/master-build-deb-rpm-docker.sh
@@ -96,7 +96,6 @@ package() {
     ./build.sh \
     -c Release \
     /p:PortableBuild=true \
-    /p:StripSymbols=true \
     /p:TargetArchitecture=x64 \
     /bl:artifacts/msbuild.portable.binlog
 


### PR DESCRIPTION
Symbol stripping is on by default in cmake scripts. This cleans up the remaining places where the no-op `-stripsymbols` option is passed from shell scripts via `.proj` files.

Fixes #32957

cc @janvorli