### PR TITLE
Add libicu66 dependency

### DIFF
--- a/src/installer/pkg/packaging/deb/package.targets
+++ b/src/installer/pkg/packaging/deb/package.targets
@@ -325,7 +325,7 @@
         Include="%SSL_DEPENDENCY_LIST%"
         ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
 
-      <KnownLibIcuVersion Include="65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue
         Include="%LIBICU_DEPENDENCY_LIST%"
         ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />


### PR DESCRIPTION
Ubuntu Focal updated libicu dependency to libicu66

Fixes the issue: https://github.com/dotnet/runtime/issues/32971
