### PR TITLE
Always set InstructionSet_ArmBase in PAL_GetJitCpuCapabilityFlags 

### DIFF
--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -32,6 +32,7 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 // From a single binary distribution perspective, compiling with latest kernel asm/hwcap.h should
 // include all published flags.  Given flags are merged to kernel and published before silicon is
 // available, using the latest kernel for release should be sufficient.
+    CPUCompileFlags.Set(InstructionSet_ArmBase);
 #ifdef HWCAP_AES
     if (hwCap & HWCAP_AES)
         CPUCompileFlags.Set(InstructionSet_Aes);


### PR DESCRIPTION
`PAL_GetJitCpuCapabilityFlags` should always set `InstructionSet_ArmBase`.
Otherwise based on an algorithm added in #33936 https://github.com/dotnet/runtime/blob/951bc705231bad09371339c321ae4c0e1283cb4d/src/coreclr/src/inc/corinfoinstructionset.h#L180-L195 we will end up with AdvSimd, Crc32 removed from the set of supported ISAs, but not their 64-bit counterparts AdvSimd_Arm64 and Crc32_Arm64.

This was a reason of failure as seen in https://github.com/dotnet/runtime/pull/33749#issuecomment-604000341 where code guarded with `AdvSimd.IsSupported` was just removed by JIT as dead but code guarded with `AdvSimd.Arm64.IsSupported` as in `System.Collections.BitArray..ctor(Boolean[] values)` was throwing `System.PlatformNotSupportedException` from JIT.

cc @davidwrighton @CarolEidt @tannergooding 