### PR TITLE
Disable all PlatformHandlerTest_Cookies_Http2 for WinHttpHandler.

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -331,12 +331,6 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(CookieNamesValuesAndUseCookies))]
         public async Task GetAsync_ReceiveSetCookieHeader_CookieAdded(string cookieName, string cookieValue, bool useCookies)
         {
-            if (UseVersion.Major == 2)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/33930")]
-                return;
-            }
-
             await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 HttpClientHandler handler = CreateHttpClientHandler();

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -193,6 +193,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
 #if NETCOREAPP
+#if !WINHTTPHANDLER_TEST
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
@@ -200,6 +201,7 @@ namespace System.Net.Http.Functional.Tests
 
         public PlatformHandlerTest_Cookies_Http2(ITestOutputHelper output) : base(output) { }
     }
+#endif
 
     public sealed class PlatformHandler_HttpClientHandler_Asynchrony_Http2_Test : HttpClientHandler_Asynchrony_Test
     {

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -193,7 +193,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
 #if NETCOREAPP
-#if !WINHTTPHANDLER_TEST
+#if !WINHTTPHANDLER_TEST // [ActiveIssue("https://github.com/dotnet/runtime/issues/33930")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {


### PR DESCRIPTION
Disables all Cookie tests for HTTP/2 over WinHttpHandler.
Contributes to #12043

Disabled-test tracking issue: #33930
Supersedes PR #34011