### PR TITLE
Disable component governance

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -12,6 +12,15 @@ jobs:
 - template: ${{ coalesce(parameters.helixQueuesTemplate, parameters.jobTemplate) }}
   parameters:
     variables:
+      # Disable component governance in our CI builds. These builds are not shipping nor
+      # are they a service. Also the component governance jobs issue lots of inconsequential
+      # warnings and errors into our build timelines that make it hard to track down 
+      # real errors in the build
+      - name: skipComponentGovernanceDetection
+        value: true
+      - name: runCodesignValidationInjection
+        value: false
+
       # Workaround for azure devops flakiness when dowloading artifacts
       # https://github.com/dotnet/runtime/issues/32805
       - name: System.DisableZipDownload


### PR DESCRIPTION
Disable component governance in our CI builds. These builds are not
shipping nor are they services hence they don't need governance.

Also these injected tasks emit lots of warning and error noise into our
build timelines. This makes it hard to filter out real issues in the
build.

Example output that these jobs currently add. Note none of these fail
the build but do show up as errors that we have to filter out
```
        error General (NETCORE_ENGINEERING_TELEMETRY=Build) Build failed (exit code '1').
        error General Bash exited with code '1'.
        error General Unable to locate dotnetcore on build agent.
        error General Unable to locate dotnetcore on build agent.
```