### PR TITLE
Execute chmod only on Unix environments for host

### DIFF
--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -70,7 +70,7 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 
-    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(TargetOS)' != 'Windows_NT'"/>
+    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(TargetOS)' != 'Windows_NT' and '$(OS)' != 'Windows_NT'"/>
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"


### PR DESCRIPTION
Fixes the following error when cross-targeting Unix on a Windows machine:

`C:\git\runtime3\src\libraries\restore\runtime\runtime.depproj(73,5): error MSB3073: The command "chmod +x C:\git\runtime3\artifacts\bin\testhost\netcoreapp5.0-Linux-Debug-x64\dotnet.exe" exited with code 9009.`