### PR TITLE
Fix reference in Microsoft.Ext.Options to P2P

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.csproj
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Reference Include="System.ComponentModel.Annotations" />
+    <ProjectReference Include="..\..\System.ComponentModel.Annotations\ref\System.ComponentModel.Annotations.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.Options.cs" />


### PR DESCRIPTION
When cross-targeting for Linux on Windows, reference issues to S.CM.Annotations are popping up for M.E.Options. Changing this from a named reference to P2P as it should be.

```
C:\git\runtime3\.dotnet\sdk\5.0.100-preview.3.20170.6\Microsoft.Common.CurrentVersion.targets(2081,5): error MSB3245: Could not resolve this reference. Could not locate the assembly "System.ComponentModel.Annotations". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\git\runtime3\src\libraries\Microsoft.Extensions.Options\ref\Microsoft.Extensions.Options.csproj]
C:\git\runtime3\.dotnet\sdk\5.0.100-preview.3.20170.6\Microsoft.Common.CurrentVersion.targets(2081,5): error MSB3245: Could not resolve this reference. Could not locate the assembly "System.ComponentModel.Annotations". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\git\runtime3\src\libraries\Microsoft.Extensions.Options\ref\Microsoft.Extensions.Options.csproj]
```