### PR TITLE
Fixing opts.setSupportedISAs to use the computed instructionSetFlags value

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -2352,7 +2352,7 @@ void Compiler::compSetProcessor()
 #endif
 
     instructionSetFlags = EnsureInstructionSetFlagsAreValid(instructionSetFlags);
-    opts.setSupportedISAs(jitFlags.GetInstructionSetFlags());
+    opts.setSupportedISAs(instructionSetFlags);
 
 #ifdef TARGET_XARCH
     if (!compIsForInlining())


### PR DESCRIPTION
This should resolve https://github.com/dotnet/runtime/issues/34135