### PR TITLE
Move __allocator under PAL_STDCPP_COMPAT

### DIFF
--- a/src/coreclr/src/pal/inc/rt/specstrings.h
+++ b/src/coreclr/src/pal/inc/rt/specstrings.h
@@ -310,8 +310,8 @@ __ANNOTATION(SAL_failureDefault(enum __SAL_failureKind));
 				            __byte_readableTo((expr) ? (size) : (size) * 2)
 #define __post_invalid                      _Post_ __notvalid
 /* integer related macros */
-#define __allocator                         __inner_allocator
 #ifndef PAL_STDCPP_COMPAT
+#define __allocator                         __inner_allocator
 #define __deallocate(kind)                  _Pre_ __notnull __post_invalid
 #define __deallocate_opt(kind)              _Pre_ __maybenull __post_invalid
 #endif


### PR DESCRIPTION
Fixes CoreCLR build on Android device with Clang 9.0.1.

```sh
make[2]: Entering directory '/data/data/com.termux/files/home/runtime/artifacts/obj/coreclr/Linux.x64.Debug'
make[2]: Leaving directory '/data/data/com.termux/files/home/runtime/artifacts/obj/coreclr/Linux.x64.Debug'
In file included from /data/data/com.termux/files/home/runtime/src/coreclr/src/debug/dbgutil/elfreader.cpp:11:
In file included from /data/data/com.termux/files/home/runtime/src/coreclr/src/debug/dbgutil/elfreader.h:9:
In file included from /data/data/com.termux/files/usr/bin/../include/c++/v1/string:505:
In file included from /data/data/com.termux/files/usr/bin/../include/c++/v1/string_view:176:
In file included from /data/data/com.termux/files/usr/bin/../include/c++/v1/__string:57:
In file included from /data/data/com.termux/files/usr/bin/../include/c++/v1/algorithm:645:
/data/data/com.termux/files/usr/bin/../include/c++/v1/functional:1493:31: error: expected member name or ';' after declaration specifiers
    const _Alloc& __allocator() const { return __f_.second(); }
    ~~~~~~~~~~~~              ^
/data/data/com.termux/files/usr/bin/../include/c++/v1/functional:1615:29: error: expected unqualified-id
    _Ap __a(__f_.__allocator());
                            ^
/data/data/com.termux/files/usr/bin/../include/c++/v1/functional:1626:57: error: expected unqualified-id
    ::new (__p) __func(__f_.__target(), __f_.__allocator());
                                                        ^
/data/data/com.termux/files/usr/bin/../include/c++/v1/functional:1642:29: error: expected unqualified-id
    _Ap __a(__f_.__allocator());
                            ^
/data/data/com.termux/files/usr/bin/../include/c++/v1/functional:1928:39: error: expected unqualified-id
        _FunAlloc __a(__f->__allocator());
                                      ^
make[2]: Entering directory '/data/data/com.termux/files/home/runtime/artifacts/obj/coreclr/Linux.x64.Debug'
make[2]: Entering directory '/data/data/com.termux/files/home/runtime/artifacts/obj/coreclr/Linux.x64.Debug'
```

This was also fixed in LLVM repo: https://reviews.llvm.org/D57355.