### PR TITLE
Clean up warnings building CLR tests

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -295,9 +295,8 @@ set __MsbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging='!__MsbuildLog!' '!__MsbuildWrn!' '!__MsbuildErr!'
 
-REM Disable warnAsError - coreclr issue 19922
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__RepoRootDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
-  %__ProjectDir%\tests\build.proj -warnAsError:0 /t:BatchRestorePackages /nodeReuse:false^
+  %__ProjectDir%\tests\build.proj -warnAsError:1 /t:BatchRestorePackages /nodeReuse:false^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   %__SkipFXRestoreArg%^
@@ -355,9 +354,8 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
     set __TestGroupToBuild=%%G
 
     if not "%__CopyNativeTestBinaries%" == "1" (
-        REM Disable warnAsError - coreclr issue 19922
         set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj
-        set __MSBuildBuildArgs=!__MSBuildBuildArgs! -warnAsError:0
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! -warnAsError:1
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! /nodeReuse:false
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__Logging!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !TargetsWindowsMsbuildArg!
@@ -381,8 +379,7 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
             goto     :Exit_Failure
         )
     ) else (
-        REM Disable warnAsError - coreclr issue 19922
-        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:0 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
+        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:1 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
         echo Running: msbuild !__MSBuildBuildArgs!
         !__CommonMSBuildCmdPrefix! !__MSBuildBuildArgs!
 

--- a/src/coreclr/tests/Directory.Build.targets
+++ b/src/coreclr/tests/Directory.Build.targets
@@ -6,6 +6,6 @@
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
 
-  <Import Project="disableversioncheck.targets" />
+  <Import Project="disableversioncheck.targets" Condition="'$(DisableVersionCheckImported)' != 'true'" />
 
 </Project>

--- a/src/coreclr/tests/disableversioncheck.targets
+++ b/src/coreclr/tests/disableversioncheck.targets
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup>
+    <DisableVersionCheckImported>true</DisableVersionCheckImported>
+  </PropertyGroup>
+
   <Target Name="DisableNETCoreVersionCheck"
           BeforeTargets="_CheckForUnsupportedNETCoreVersion">
     <!-- Force the CLI to allow us to target higher netcoreapp than it may know about -->

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -5,7 +5,8 @@
     If they ever need to take part, we can conditionally include them as documented
     here https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets
   -->
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('disableversioncheck.targets', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('disableversioncheck.targets', '$(MSBuildThisFileDirectory)../'))"
+          Condition="'$(DisableVersionCheckImported)' != 'true'" />
 
   <ItemGroup>
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
@@ -47,7 +47,7 @@ namespace ComWrappersTests
                 return entryRaw;
             }
 
-            protected override object? CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
+            protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
             {
                 var iid = typeof(ITrackerObject).GUID;
                 IntPtr iTrackerComObject;
@@ -202,7 +202,7 @@ namespace ComWrappersTests
                 }
             }
 
-            protected override object? CreateObject(IntPtr externalComObject, CreateObjectFlags flags)
+            protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flags)
             {
                 switch (CreateObjectMode)
                 {

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/Program.cs
@@ -150,7 +150,7 @@ namespace ComWrappersTests.GlobalInstance
                 return null;
             }
 
-            protected override object? CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
+            protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
             {
                 if (ReturnInvalid)
                     return null;


### PR DESCRIPTION
The CLR test build was producing two different warnings:
1. Invalid use of C# nullable reference types
1. Double import of disableversioncheck.targets

Unwinding the double import was tricky due to the way several of the
projects in this tree were double built with different variables which
changed the directories that code was imported from. Eventually settled
on an old C++ trick of using a set variable to avoid the future double
import.

Not particularly happy with this trick but also not a clear way to
unwind the double imports here.

Overall these warnings snuck into the build because warn as error was
disabled for all the MSBuild invocations. That was apparently due to
coreclr#19922 which has long since been closed. Hence I flipped back on
warn as error here.