### PR TITLE
Add passing dotnet version in public

### DIFF
--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -55,7 +55,7 @@ $SetupArguments = "--repository https://github.com/$Repository --branch $Branch 
 
 if (!$Internal)
 {
-    $temp = Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/dotnet/runtime/master/global.json | ConvertFrom-Json
+    $temp = Get-Content global.json | ConvertFrom-Json
     $DotNetVersion = $temp.tools.dotnet
     $SetupArguments = "--dotnet-versions $DotNetVersion $SetupArguments"
 }

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -53,6 +53,13 @@ if ($Internal) {
 $CommonSetupArguments="--channel master --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 
+if (!$Internal)
+{
+    $temp = Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/dotnet/runtime/master/global.json | ConvertFrom-Json
+    $DotNetVersion = $temp.tools.dotnet
+    $SetupArguments = "--dotnet-versions $DotNetVersion $SetupArguments"
+}
+
 if ($RunFromPerformanceRepo) {
     $SetupArguments = "--perf-hash $CommitSha $CommonSetupArguments"
     

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -169,7 +169,7 @@ setup_arguments="--repository https://github.com/$repository --branch $branch --
 
 if [[ "$interal" != true ]]; then
     # Get the tools section from the global.json.
-    dotnet_version=`curl https://raw.githubusercontent.com/dotnet/runtime/master/global.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["tools"]["dotnet"])'`
+    dotnet_version=`cat global.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["tools"]["dotnet"])'`
     setup_arguments="--dotnet-versions $dotnet_version $setup_arguments"
 fi
 

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -167,6 +167,12 @@ fi
 common_setup_arguments="--channel master --queue $queue --build-number $build_number --build-configs $configurations --architecture $architecture"
 setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
 
+if [[ "$interal" != true ]]; then
+    # Get the tools section from the global.json.
+    dotnet_version=`curl https://raw.githubusercontent.com/dotnet/runtime/master/global.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["tools"]["dotnet"])'`
+    setup_arguments="--dotnet-versions $dotnet_version $setup_arguments"
+fi
+
 if [[ "$run_from_perf_repo" = true ]]; then
     payload_directory=
     workitem_directory=$source_directory


### PR DESCRIPTION
This will get the dotnet version that the runtime repo uses and use that version
to install the dotnet. This ensures that we will always be on the same version
and stop getting failures from bad builds being pushed.