### PR TITLE
fix TLS13 procesing on windows

### DIFF
--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -230,9 +230,15 @@ namespace System
                 // assume no if key is missing or on error.
                 return false;
             }
+            else if (IsOSX)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/1979")]
+                return false;
+            }
             else
             {
-                return !IsOSX && (OpenSslVersion.CompareTo(new Version(1,1,1)) >= 0);
+                // Covers Linux and FreeBSD
+                return OpenSslVersion >= new Version(1,1,1);
             }
         }
 

--- a/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -114,7 +114,7 @@ namespace System
         public static bool SupportsClientAlpn => SupportsAlpn || (IsOSX && PlatformDetection.OSXVersion > new Version(10, 12));
 
         // OpenSSL 1.1.1 and above.
-        public static bool SupportsTls13 => !IsWindows && !IsOSX && (OpenSslVersion.CompareTo(new Version(1,1,1)) >= 0);
+        public static bool SupportsTls13 => GetTls13Support();
 
         private static Lazy<bool> s_largeArrayIsNotSupported = new Lazy<bool>(IsLargeArrayNotSupported);
 
@@ -202,6 +202,38 @@ namespace System
             }
 
             return (IsOSX || (IsLinux && OpenSslVersion < new Version(1, 0, 2) && !IsDebian));
+        }
+
+        private static bool GetTls13Support()
+        {
+            if (IsWindows)
+            {
+                if (!IsWindows10Version2004OrGreater)
+                {
+                    return false;
+                }
+
+                string clientKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Client";
+                string serverKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.3\Server";
+
+                object client, server;
+                try
+                {
+                    client = Registry.GetValue(clientKey, "Enabled", null);
+                    server = Registry.GetValue(serverKey, "Enabled", null);
+                    if (client is int c && server is int s)
+                    {
+                        return c == 1 && s == 1;
+                    }
+                }
+                catch { };
+                // assume no if key is missing or on error.
+                return false;
+            }
+            else
+            {
+                return !IsOSX && (OpenSslVersion.CompareTo(new Version(1,1,1)) >= 0);
+            }
         }
 
         private static bool GetIsRunningOnMonoInterpreter()

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -60,7 +60,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
-                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocols.Tls | SslProtocols.Tls11 |  SslProtocols.Tls12, false);
 
                     _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
                         serverNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
@@ -719,7 +719,7 @@ namespace System.Net.Security.Tests
                     Task serverTask = server.WriteAsync(data, 0, data.Length);
                     for (int i = 0; i < data.Length; i++)
                     {
-                        Assert.True(client.ReadAsync(data, 0, 1).Wait(TestConfiguration.PassingTestTimeoutMilliseconds),
+                        Assert.True(client.ReadAsync(receivedData, 0, 1).Wait(TestConfiguration.PassingTestTimeoutMilliseconds),
                                                                         $"Read task failed to finish in {TestConfiguration.PassingTestTimeoutMilliseconds}ms.");
                         Assert.Equal(data[i], receivedData[0]);
                     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
@@ -715,13 +715,17 @@ namespace System.Net.Security.Tests
                 {
                     // send some bytes, make sure they can talk
                     byte[] data = new byte[] { 1, 2, 3 };
-                    server.WriteAsync(data, 0, data.Length);
-
+                    byte[] receivedData = new byte[1];
+                    Task serverTask = server.WriteAsync(data, 0, data.Length);
                     for (int i = 0; i < data.Length; i++)
                     {
-                        Assert.Equal(data[i], client.ReadByte());
+                        Assert.True(client.ReadAsync(data, 0, 1).Wait(TestConfiguration.PassingTestTimeoutMilliseconds),
+                                                                        $"Read task failed to finish in {TestConfiguration.PassingTestTimeoutMilliseconds}ms.");
+                        Assert.Equal(data[i], receivedData[0]);
                     }
 
+                    Assert.True(serverTask.Wait(TestConfiguration.PassingTestTimeoutMilliseconds),
+                                $"WriteTask failed to finish in {TestConfiguration.PassingTestTimeoutMilliseconds}ms.");
                     return new NegotiatedParams(server, client);
                 }
                 else


### PR DESCRIPTION
This is follow-up on #32925. While that PR made it generally safe e.g. avoided concurrent decrypt/encrypt beyond OpenSSL it did not  address few remaining issues.

With TLS1.3 "renegotiation" can happen without any read. That left framing  `unknown` and caused exception visible in #1720. That also left some test hanging because of incorrect logic in `ForceAuthenticationAsync`.

We do not have CI to cover this but all tests are passing on my insider preview build. 
TLS13 test should light-up when we have newer Windows versions in CI and when registry is set.  (right now TLS13 is opt-in feature) 

fixes #1720

 