### PR TITLE
Fix undetermined SPMI behavior.

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -1456,18 +1456,7 @@ void MethodContext::repGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
         (CORINFO_RUNTIME_LOOKUP_KIND)value.stubLookup.lookupKind.runtimeLookupKind;
     if (pResult->stubLookup.lookupKind.needsRuntimeLookup)
     {
-        pResult->stubLookup.runtimeLookup.signature =
-            (LPVOID)value.stubLookup.runtimeLookup.signature; // needs to be a more flexible copy based on
-                                                              // valuevalue.stubLookup.runtimeLookup.signature;
-        pResult->stubLookup.runtimeLookup.helper              = (CorInfoHelpFunc)value.stubLookup.runtimeLookup.helper;
-        pResult->stubLookup.runtimeLookup.indirections        = (WORD)value.stubLookup.runtimeLookup.indirections;
-        pResult->stubLookup.runtimeLookup.testForNull         = value.stubLookup.runtimeLookup.testForNull != 0;
-        pResult->stubLookup.runtimeLookup.testForFixup        = value.stubLookup.runtimeLookup.testForFixup != 0;
-        pResult->stubLookup.runtimeLookup.indirectFirstOffset = value.stubLookup.runtimeLookup.indirectFirstOffset != 0;
-        pResult->stubLookup.runtimeLookup.indirectSecondOffset =
-            value.stubLookup.runtimeLookup.indirectSecondOffset != 0;
-        for (int i                                       = 0; i < CORINFO_MAXINDIRECTIONS; i++)
-            pResult->stubLookup.runtimeLookup.offsets[i] = (SIZE_T)value.stubLookup.runtimeLookup.offsets[i];
+        pResult->stubLookup.runtimeLookup = SpmiRecordsHelper::RestoreCORINFO_RUNTIME_LOOKUP(value.stubLookup.runtimeLookup);
     }
     else
     {

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -233,6 +233,7 @@ public:
         DWORD     indirections;
         DWORD     testForNull;
         DWORD     testForFixup;
+        WORD      sizeOffset;
         DWORDLONG offsets[CORINFO_MAXINDIRECTIONS];
         DWORD     indirectFirstOffset;
         DWORD     indirectSecondOffset;

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -58,8 +58,8 @@ std::string SpmiDumpHelper::DumpAgnostic_CORINFO_RUNTIME_LOOKUP(
     const MethodContext::Agnostic_CORINFO_RUNTIME_LOOKUP& lookup)
 {
     char buffer[MAX_BUFFER_SIZE];
-    sprintf_s(buffer, MAX_BUFFER_SIZE, " sig-%016llX hlp-%u ind-%u tfn-%u tff-%u { ", lookup.signature, lookup.helper,
-              lookup.indirections, lookup.testForNull, lookup.testForFixup);
+    sprintf_s(buffer, MAX_BUFFER_SIZE, " sig-%016llX hlp-%u ind-%u tfn-%u tff-%u so-%u { ", lookup.signature, lookup.helper,
+              lookup.indirections, lookup.testForNull, lookup.testForFixup, lookup.sizeOffset);
     std::string resultDump(buffer);
     for (int i = 0; i < CORINFO_MAXINDIRECTIONS; i++)
     {

--- a/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
@@ -296,6 +296,7 @@ inline MethodContext::Agnostic_CORINFO_RUNTIME_LOOKUP SpmiRecordsHelper::StoreAg
     runtimeLookup.indirections         = (DWORD)pLookup->indirections;
     runtimeLookup.testForNull          = (DWORD)pLookup->testForNull;
     runtimeLookup.testForFixup         = (DWORD)pLookup->testForFixup;
+    runtimeLookup.sizeOffset           = pLookup->sizeOffset;
     runtimeLookup.indirectFirstOffset  = (DWORD)pLookup->indirectFirstOffset;
     runtimeLookup.indirectSecondOffset = (DWORD)pLookup->indirectSecondOffset;
     for (int i                   = 0; i < CORINFO_MAXINDIRECTIONS; i++)
@@ -312,6 +313,7 @@ inline CORINFO_RUNTIME_LOOKUP SpmiRecordsHelper::RestoreCORINFO_RUNTIME_LOOKUP(
     runtimeLookup.indirections         = (WORD)lookup.indirections;
     runtimeLookup.testForNull          = lookup.testForNull != 0;
     runtimeLookup.testForFixup         = lookup.testForFixup != 0;
+    runtimeLookup.sizeOffset           = lookup.sizeOffset;
     runtimeLookup.indirectFirstOffset  = lookup.indirectFirstOffset != 0;
     runtimeLookup.indirectSecondOffset = lookup.indirectSecondOffset != 0;
     for (int i                   = 0; i < CORINFO_MAXINDIRECTIONS; i++)


### PR DESCRIPTION
The observed behavior was very funny: I was getting hundreds of diffs with the same -b and -d jit, but when I turned JitDump on they were all disappearing, took me a while to catch the issue.

The new field was added in #32270, @fadimounir please notify jit-contrib if you add or delete fields from `struct CORINFO_*`, because we need to mirror that in SPMI.

It will require a new SPMI collection (the old will fail with buffer overread).