### PR TITLE
Use RtlUnwind instead of RtlUnwindEx.

### DIFF
--- a/src/coreclr/src/inc/clrnt.h
+++ b/src/coreclr/src/inc/clrnt.h
@@ -935,18 +935,6 @@ typedef struct _UNWIND_INFO {
 } UNWIND_INFO, *PUNWIND_INFO;
 
 #if defined(TARGET_UNIX) || defined(HOST_X86)
-EXTERN_C
-NTSYSAPI
-VOID
-NTAPI
-RtlUnwindEx (
-    __in_opt PVOID TargetFrame,
-    __in_opt PVOID TargetIp,
-    __in_opt PEXCEPTION_RECORD ExceptionRecord,
-    __in PVOID ReturnValue,
-    __in PT_CONTEXT ContextRecord,
-    __in_opt PVOID HistoryTable
-    );
 
 EXTERN_C
 NTSYSAPI

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -1138,7 +1138,7 @@ ProcessCLRException(IN     PEXCEPTION_RECORD   pExceptionRecord
             // Once we reach the target frame in the second pass unwind, we call
             // the catch funclet that caused us to resume execution and it
             // tells us where we are resuming to.  At that point, we patch
-            // the context record with the resume IP and RtlUnwind2 finishes
+            // the context record with the resume IP and RtlUnwind finishes
             // by restoring our context at the right spot.
             //
             // If we are unable to set the resume PC for some reason, then
@@ -5367,15 +5367,10 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
 #ifndef TARGET_UNIX
 void ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord, UINT_PTR ReturnValue, UINT_PTR TargetIP, UINT_PTR TargetFrameSp)
 {
-    PVOID TargetFrame = (PVOID)TargetFrameSp;
-
-    CONTEXT ctx;
-    RtlUnwindEx(TargetFrame,
-                (PVOID)TargetIP,
-                pExceptionRecord,
-                (PVOID)ReturnValue, // ReturnValue
-                &ctx,
-                NULL);      // HistoryTable
+    RtlUnwind((PVOID)TargetFrameSp, // TargetFrame
+              (PVOID)TargetIP,
+              pExceptionRecord,
+              (PVOID)ReturnValue);
 
     // doesn't return
     UNREACHABLE();


### PR DESCRIPTION
Because the formerly uninitialized scratch context is now an input.