### PR TITLE
API Proposal: Add BindConfiguration extension method for OptionsBuilder

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> Bind<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, Microsoft.Extensions.Configuration.IConfiguration config) where TOptions : class { throw null; }
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> Bind<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, Microsoft.Extensions.Configuration.IConfiguration config, System.Action<Microsoft.Extensions.Configuration.BinderOptions> configureBinder) where TOptions : class { throw null; }
+        public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> BindConfiguration<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, string sectionName = null, System.Action<Microsoft.Extensions.Configuration.BinderOptions> configureBinder = null) where TOptions : class { throw null; }
     }
     public static partial class OptionsConfigurationServiceCollectionExtensions
     {


### PR DESCRIPTION

*This PR has been copied from https://github.com/dotnet/extensions/pull/3020*

# Summary
* Add `BindConfiguration` extension method for `OptionsBuilder<TOptions>`.

# Description

There are situations in which the `IConfiguration` instance from which to configure options has not yet been materialized when a method like `ConfigureServices` is being executed. For example, the .NET Core Generic Host Builder offers the `ConfigureServices` method which does not offer access to the Application Configuration instance that will materialize when the Host is built. *(Note: A fully materialized host configuration instance can be obtained from the `HostBuilderContext` instance that is passed to the callback, however, this host configuration can differ from the Application configuration and may not offer the desired behaviour.)*

In such situations, the `Bind` extension methods on the `OptionsBuilder<TOptions>` cannot be called, since they all require a fully materialized `IConfiguration` instance. Instead, you need to call the `Configure` extension method, specifying `IConfiguration` as a DI dependency for configuration and then call the `IConfiguration.Bind` extension method in the specifying configuration callback action.

Since binding from a DI-provided `IConfiguration` is a fairly usual scenario when using the .NET Generic Host (i.e. without using a Startup class), it would be advantageous to simplify this scenario by providing 1<sup>st</sup> class support in form of an extension method that performs the necessary steps.

# Proposal

* Add `BindConfiguration` extension method for `OptionsBuilder<TOptions>`.
``` csharp
namespace Microsoft.Extensions.DependencyInjection
{
// Existing extensions holder type
public static class OptionsBuilderConfigurationExtensions
{
   // New API
   public static OptionsBuilder<TOptions> BindConfiguration<TOptions>(
            this OptionsBuilder<TOptions> optionsBuilder,
            string sectionName = null,
            Action<BinderOptions> configureBinder = null)
            where TOptions : class => null;
}
}
```

# Usage
``` csharp
partial class Startup
{
       public static void ConfigureServices(IServiceCollection services)
        {
            services.AddOptions<MyOptions>()
                .BindConfiguration();
        }
}
```

# Previous implementation
The proposed API is a convenience wrapper around existing APIs. The code above could previously be implemented as follows:
``` csharp
partial class Startup
{
       public static void ConfigureServices(IServiceCollection services)
        {
            services.AddOptions<MyOptions>()
                .Configure<IConfiguration>((opts, config) => config.Bind(opts));
        }
}
```

# Comments

The name `BindConfiguration` was chosen, since the arguments of the extension method do not directly conway how binding is performed. The existing `Bind` extension methods all take an `IConfiguration` instance as argument, and in these cases the binding is implied from the argument type. Conceptually, the proposed API can be thought of as an overload to the existing `Bind` extension methods.