### PR TITLE
Add build configuration to generate runtime packs for Android

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -49,8 +49,7 @@
 
   <PropertyGroup>
     <DefaultSubsetCategories>libraries-installer-coreclr-mono</DefaultSubsetCategories>
-    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'iOS'">libraries-installer-mono</DefaultSubsetCategories>
-    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'Android'">libraries-mono</DefaultSubsetCategories>
+    <DefaultSubsetCategories Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'">libraries-installer-mono</DefaultSubsetCategories>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -63,7 +62,7 @@
     <DefaultLibrariesSubsets Condition="'$(IncludeLibrariesTestSubset)' == 'true'">$(DefaultLibrariesSubsets)-libtests</DefaultLibrariesSubsets>
 
     <DefaultInstallerSubsets>corehost-managed-depproj-pkgproj-bundle-installers-test</DefaultInstallerSubsets>
-    <DefaultInstallerSubsets Condition="'$(TargetOS)' == 'iOS'">depproj-pkgproj</DefaultInstallerSubsets>
+    <DefaultInstallerSubsets Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'">depproj-pkgproj</DefaultInstallerSubsets>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -133,9 +133,9 @@
         <IsNative>true</IsNative>
       </RuntimeFiles>
 
-      <MonoCrossFiles Condition="'$(TargetOS)' == 'iOS'"
+      <MonoCrossFiles Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'"
         Include="$(MonoArtifactsPath)\cross\*.*" />
-      <MonoIncludeFiles Condition="'$(TargetOS)' == 'iOS'"
+      <MonoIncludeFiles Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'"
         Include="$(MonoArtifactsPath)\include\**\*.*" />
     </ItemGroup>
 

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -127,7 +127,7 @@ jobs:
         $(CommonMSBuildArgs)
         $(OfficialBuildArg)
 
-  - ${{ if eq(parameters.osGroup, 'iOS') }}:
+  - ${{ if in(parameters.osGroup, 'iOS', 'Android') }}:
 
     - name: CommonMSBuildArgs
       value: >-

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -206,6 +206,10 @@ stages:
       # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
       - iOS_arm64
       - iOS_x64
+      - Android_arm
+      - Android_arm64
+      - Android_x64
+      - Android_x86
 
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -526,6 +526,10 @@ jobs:
       - iOS_x64
       # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
       - iOS_arm64
+      - Android_x64
+      - Android_x86
+      - Android_arm
+      - Android_arm64
     jobParameters:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -92,10 +92,10 @@
   <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
     <OutputRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
-    <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -92,6 +92,7 @@
   <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
     <OutputRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</OutputRid>
@@ -165,6 +166,7 @@
     <TargetsWindows>false</TargetsWindows>
     <TargetsOSX>false</TargetsOSX>
     <TargetsiOS>false</TargetsiOS>
+    <TargetsAndroid>false</TargetsAndroid>
     <TargetsLinux>false</TargetsLinux>
     <TargetsUnix>false</TargetsUnix>
     <TargetsUbuntu>false</TargetsUbuntu>
@@ -192,6 +194,13 @@
     <When Condition="$(OutputRid.StartsWith('ios'))">
       <PropertyGroup>
         <TargetsiOS>true</TargetsiOS>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(OutputRid.StartsWith('android'))">
+      <PropertyGroup>
+        <TargetsAndroid>true</TargetsAndroid>
+        <TargetsLinux>true</TargetsLinux>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
@@ -338,7 +347,7 @@
     <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
     <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'Windows_NT'">.ni.pdb</CrossGenSymbolExtension>
     <!-- OSX doesn't have crossgen symbols, yet -->
-    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS'"></CrossGenSymbolExtension>
+    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'"></CrossGenSymbolExtension>
   </PropertyGroup>
 
 </Project>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -19,7 +19,7 @@
     out and skip building. 
   -->
   <Target Name="MobileSkipBuildProps" 
-          Condition="'$(SkipBuildOnRuntimePackOnlyOS)' == 'true' and '$(TargetOS)' == 'iOS'"
+          Condition="'$(SkipBuildOnRuntimePackOnlyOS)' == 'true' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android')"
           BeforeTargets="GetSkipBuildProps">
     <PropertyGroup>
       <SkipBuild>true</SkipBuild>

--- a/src/installer/pkg/projects/netcoreapp/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/Directory.Build.props
@@ -10,6 +10,7 @@
     <CoreCLRTargetOS Condition="'$(TargetsLinux)' == 'true'">Linux</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsOSX)' == 'true'">OSX</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsiOS)' == 'true'">iOS</CoreCLRTargetOS>
+    <CoreCLRTargetOS Condition="'$(TargetsAndroid)' == 'true'">Android</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsFreeBSD)' == 'true'">FreeBSD</CoreCLRTargetOS>
     <LibrariesTargetOS>$(CoreCLRTargetOS)</LibrariesTargetOS>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds support for generating Android runtime packs, which is intended to be consumed by the Xamarin Android SDK. It takes after #34050 and when that is merged, this PR will rebase off it.