### PR TITLE
Use separate key instances for span/array/array+offset test classes

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
@@ -11,9 +11,6 @@ namespace System.Security.Cryptography.Dsa.Tests
 {
     public abstract class DSASignatureFormatTests : DsaFamilySignatureFormatTests
     {
-        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
-
-        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool SupportsSha2 => DSAFactory.SupportsFips186_3;
         protected override string HashParameterName => "rgbHash";
         protected override string SignatureParameterName => "rgbSignature";
@@ -50,7 +47,7 @@ namespace System.Security.Cryptography.Dsa.Tests
                 dsaParameters.Q.Length * 8);
         }
 
-        private static IEnumerable<KeyDescription> LocalGenerateTestKeys()
+        protected static IEnumerable<KeyDescription> LocalGenerateTestKeys()
         {
             if (DSAFactory.SupportsKeyGeneration)
             {
@@ -73,6 +70,9 @@ namespace System.Security.Cryptography.Dsa.Tests
 
     public sealed class DsaArraySignatureFormatTests : DSASignatureFormatTests
     {
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
+
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool IsArrayBased => true;
 
         protected override byte[] SignHash(
@@ -114,6 +114,9 @@ namespace System.Security.Cryptography.Dsa.Tests
 
     public sealed class DsaArrayOffsetSignatureFormatTests : DSASignatureFormatTests
     {
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
+
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool IsArrayBased => true;
 
         protected override byte[] SignHash(
@@ -232,6 +235,9 @@ namespace System.Security.Cryptography.Dsa.Tests
 
     public sealed class DsaSpanSignatureFormatTests : DSASignatureFormatTests
     {
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
+
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool IsArrayBased => false;
 
         protected override byte[] SignHash(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaSignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaSignatureFormatTests.cs
@@ -12,9 +12,6 @@ namespace System.Security.Cryptography.EcDsa.Tests
 {
     public abstract class ECDsaSignatureFormatTests : DsaFamilySignatureFormatTests
     {
-        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
-
-        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool SupportsSha2 => true;
 
         private static KeyDescription CreateKey(ECCurve curve)
@@ -38,7 +35,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
                 dsa.KeySize);
         }
 
-        private static IEnumerable<KeyDescription> LocalGenerateTestKeys()
+        protected static IEnumerable<KeyDescription> LocalGenerateTestKeys()
         {
             if (ECDsaFactory.IsCurveValid(EccTestData.BrainpoolP160r1Key1.Curve.Oid))
             {
@@ -58,8 +55,11 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
     public sealed class ECDsaArraySignatureFormatTests : ECDsaSignatureFormatTests
     {
-        protected override bool IsArrayBased => true;
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
 
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
+        protected override bool IsArrayBased => true;
+        
         protected override byte[] SignHash(
             KeyDescription key,
             byte[] hash,
@@ -99,6 +99,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
     public sealed class ECDsaArrayOffsetSignatureFormatTests : ECDsaSignatureFormatTests
     {
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
+
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool IsArrayBased => true;
 
         protected override byte[] SignHash(
@@ -217,6 +220,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
     public sealed class ECDsaSpanSignatureFormatTests : ECDsaSignatureFormatTests
     {
+        private static readonly KeyDescription[] s_keys = LocalGenerateTestKeys().ToArray();
+
+        protected override KeyDescription[] GenerateTestKeys() => s_keys;
         protected override bool IsArrayBased => false;
 
         protected override byte[] SignHash(


### PR DESCRIPTION
Because the key object generation was done in the algorithm-specific base class,
the triplet of interface types was using the key instances in parallel.

By moving the static variable (and initialization thereof) to each of the derived
classes, the key objects are unique per class, which matches the test parallelism.

Making the classes be part of the same test collection would also solve this problem,
which would save on a few random keygens, but would likely overall take more
time due to the number of tests that would be moved to sequential execution.

Fixes #34045.