### PR TITLE
Unwrap the TargetInvocationException when a IDispatch invoke throws.

### DIFF
--- a/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
@@ -122,9 +122,8 @@ namespace NetClient
                 dispatchTesting.TriggerException(IDispatchTesting_Exception.Disp, errorCode);
                 Assert.Fail("DISP exception not thrown properly");
             }
-            catch (TargetInvocationException tie)
+            catch (COMException e)
             {
-                var e = (COMException)tie.InnerException;
                 Assert.AreEqual(GetErrorCodeFromHResult(e.HResult), errorCode);
                 Assert.AreEqual(e.Message, resultString);
             }
@@ -135,9 +134,8 @@ namespace NetClient
                 dispatchTesting.TriggerException(IDispatchTesting_Exception.HResult, errorCode);
                 Assert.Fail("HRESULT exception not thrown properly");
             }
-            catch (TargetInvocationException tie)
+            catch (COMException e)
             {
-                var e = (COMException)tie.InnerException;
                 Assert.AreEqual(GetErrorCodeFromHResult(e.HResult), errorCode);
                 // Failing HRESULT exceptions contain CLR generated messages
             }


### PR DESCRIPTION
Unwrap the `TargetInvocationException` thrown during an `IDispatch` invoke. This matches the behavior of .NET Framework.

Fixes #33050 

The decision to not add support for `BindingFlags.DoNotWrapExceptions` in the native side of this code path is due to the desire to avoid altering the `IDispatch` code paths that largely mimics .NET Framework. Keeping them as close as possible helps investigate bugs and since no new investment is being made in this area the code is largely frozen in place anyways.

/cc @jkoritzinsky @elinor-fung 