### PR TITLE
Add RuntimeInformation.RuntimeIdentifier

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -28,7 +28,7 @@ namespace System
             // Initialize tracing before any user code can be called.
             System.Diagnostics.Tracing.RuntimeEventSource.Initialize();
 
-            string? startupHooksVariable = (string?)AppContext.GetData("STARTUP_HOOKS");
+            string? startupHooksVariable = AppContext.GetData("STARTUP_HOOKS") as string;
             if (startupHooksVariable == null)
             {
                 return;

--- a/src/installer/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.cpp
@@ -203,7 +203,8 @@ namespace
         _X("JIT_PATH"),
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
-        _X("APP_NI_PATHS")
+        _X("APP_NI_PATHS"),
+        _X("RUNTIME_IDENTIFIER")
     };
 
     static_assert((sizeof(PropertyNameMapping) / sizeof(*PropertyNameMapping)) == static_cast<size_t>(common_property::Last), "Invalid property count");

--- a/src/installer/corehost/cli/hostpolicy/coreclr.h
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.h
@@ -67,6 +67,7 @@ enum class common_property
     StartUpHooks,
     AppPaths,
     AppNIPaths,
+    RuntimeIdentifier,
 
     // Sentinel value - new values should be defined above
     Last

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -145,6 +145,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());
     coreclr_properties.add(common_property::FxProductVersion, clr_library_version.c_str());
+    coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id(true /*use_fallback*/).c_str());
 
     if (!clrjit_path.empty())
         coreclr_properties.add(common_property::JitPath, clrjit_path.c_str());

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -22,7 +22,7 @@ namespace System
         public static string BaseDirectory =>
             // The value of APP_CONTEXT_BASE_DIRECTORY key has to be a string and it is not allowed to be any other type.
             // Otherwise the caller will get invalid cast exception
-            (string?)GetData("APP_CONTEXT_BASE_DIRECTORY") ??
+            GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
             (s_defaultBaseDirectory ??= GetBaseDirectoryCore());
 
         public static string? TargetFrameworkName =>

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -144,7 +144,7 @@ namespace System
             {
                 // FX_PRODUCT_VERSION is expected to be set by the host
                 // Use AssemblyInformationalVersionAttribute as fallback if the exact product version is not specified by the host
-                string? versionString = (string?)AppContext.GetData("FX_PRODUCT_VERSION") ??
+                string? versionString = AppContext.GetData("FX_PRODUCT_VERSION") as string ??
                     typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
                 ReadOnlySpan<char> versionSpan = versionString.AsSpan();

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.Uap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.Uap.cs
@@ -88,7 +88,7 @@ namespace System.Resources
                 return false;
 
             // Check to see if the assembly is under PLATFORM_RESOURCE_ROOTS. If it is, then we should use satellite assembly lookup for it.
-            string? platformResourceRoots = (string?)AppContext.GetData("PLATFORM_RESOURCE_ROOTS");
+            string? platformResourceRoots = AppContext.GetData("PLATFORM_RESOURCE_ROOTS") as string;
             if (!string.IsNullOrEmpty(platformResourceRoots))
             {
                 string resourceAssemblyPath = resourcesAssembly.Location;

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -32,6 +32,7 @@ namespace System.Runtime.InteropServices
     }
     public static partial class RuntimeInformation
     {
+        public static string RuntimeIdentifier { get { throw null; } }
         public static string FrameworkDescription { get { throw null; } }
         public static System.Runtime.InteropServices.Architecture OSArchitecture { get { throw null; } }
         public static string OSDescription { get { throw null; } }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -43,6 +43,14 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        /// <summary>
+        /// Returns an opaque string that identifies the platform on which an app is running.
+        /// </summary>
+        /// <remarks>
+        /// The property returns a string that identifies the operating system, typically including version,
+        /// and processor architecture of the currently executing process.
+        /// Since this string is opaque, it is not recommended to parse the string into its constituent parts.
+        /// </remarks>
         public static string RuntimeIdentifier
         {
             get

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -10,6 +10,7 @@ namespace System.Runtime.InteropServices
     {
         private const string FrameworkName = ".NET Core";
         private static string? s_frameworkDescription;
+        private static string? s_runtimeIdentifier;
 
         public static string FrameworkDescription
         {
@@ -39,6 +40,19 @@ namespace System.Runtime.InteropServices
                 }
 
                 return s_frameworkDescription;
+            }
+        }
+
+        public static string RuntimeIdentifier
+        {
+            get
+            {
+                if (s_runtimeIdentifier == null)
+                {
+                    s_runtimeIdentifier = (string?)AppContext.GetData("RUNTIME_IDENTIFIER") ?? "unknown";
+                }
+
+                return s_runtimeIdentifier;
             }
         }
     }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -18,7 +18,7 @@ namespace System.Runtime.InteropServices
             {
                 if (s_frameworkDescription == null)
                 {
-                    string? versionString = (string?)AppContext.GetData("FX_PRODUCT_VERSION");
+                    string? versionString = AppContext.GetData("FX_PRODUCT_VERSION") as string;
 
                     if (versionString == null)
                     {
@@ -50,18 +50,10 @@ namespace System.Runtime.InteropServices
         /// The property returns a string that identifies the operating system, typically including version,
         /// and processor architecture of the currently executing process.
         /// Since this string is opaque, it is not recommended to parse the string into its constituent parts.
+        ///
+        /// For more information, see https://docs.microsoft.com/dotnet/core/rid-catalog.
         /// </remarks>
-        public static string RuntimeIdentifier
-        {
-            get
-            {
-                if (s_runtimeIdentifier == null)
-                {
-                    s_runtimeIdentifier = (string?)AppContext.GetData("RUNTIME_IDENTIFIER") ?? "unknown";
-                }
-
-                return s_runtimeIdentifier;
-            }
-        }
+        public static string RuntimeIdentifier =>
+            s_runtimeIdentifier ??= AppContext.GetData("RUNTIME_IDENTIFIER") as string ?? "unknown";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -22,7 +22,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             string osd = RuntimeInformation.OSDescription.Trim();
             string osv = Environment.OSVersion.ToString();
             string osa = RuntimeInformation.OSArchitecture.ToString();
-            Console.WriteLine($"### OS: Distro={dvs} Description={osd} Version={osv} Arch={osa}");
+            string rid = RuntimeInformation.RuntimeIdentifier;
+            Console.WriteLine($"### OS: Distro={dvs} Description={osd} Version={osv} Arch={osa} Rid={rid}");
 
             string lcr = PlatformDetection.LibcRelease;
             string lcv = PlatformDetection.LibcVersion;

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Runtime.InteropServices.RuntimeInformationTests
+{
+    public class RuntimeIdentifierTests
+    {
+        [Fact(Skip = "#26780 Need new testhost")]
+        public void VerifyOSRid()
+        {
+            Assert.NotNull(RuntimeInformation.RuntimeIdentifier);
+            Assert.Same(RuntimeInformation.RuntimeIdentifier, RuntimeInformation.RuntimeIdentifier);
+            Assert.EndsWith(RuntimeInformation.ProcessArchitecture.ToString(), RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact(Skip = "#26780 Need new testhost")]
+        public void VerifyEnvironmentVariable()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables.Add("DOTNET_RUNTIME_ID", "overridenFromEnv-rid");
+
+            RemoteExecutor.Invoke(() =>
+            {
+                Assert.Equal("overridenFromEnv-rid", RuntimeInformation.RuntimeIdentifier);
+            }, options).Dispose();
+        }
+
+        [Fact]
+        public void VerifyAppContextVariable()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetData("RUNTIME_IDENTIFIER", "overriden-rid");
+
+                Assert.Equal("overriden-rid", RuntimeInformation.RuntimeIdentifier);
+            }).Dispose();
+        }
+
+        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.Windows)]
+        public void VerifyWindowsRid()
+        {
+            Assert.StartsWith("win", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.Linux)]
+        public void VerifyLinuxRid()
+        {
+            string expectedOSName = File.ReadAllLines("/etc/os-release")
+                .First(line => line.StartsWith("ID=", StringComparison.OrdinalIgnoreCase))
+                .Substring("ID=".Length)
+                .Trim();
+
+            Assert.StartsWith(expectedOSName, RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.FreeBSD)]
+        public void VerifyFreeBSDRid()
+        {
+            Assert.StartsWith("freebsd", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.OSX)]
+        public void VerifyOSXRid()
+        {
+            Assert.StartsWith("osx", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -11,7 +11,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 {
     public class RuntimeIdentifierTests
     {
-        [Fact(Skip = "#26780 Need new testhost")]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyOSRid()
         {
             Assert.NotNull(RuntimeInformation.RuntimeIdentifier);
@@ -19,7 +20,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.EndsWith(RuntimeInformation.ProcessArchitecture.ToString(), RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
-        [Fact(Skip = "#26780 Need new testhost")]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyEnvironmentVariable()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -42,13 +44,33 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             }).Dispose();
         }
 
-        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.Windows)]
+        [Fact]
+        public void VerifyAppContextVariableUnknown()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetData("RUNTIME_IDENTIFIER", null);
+
+                Assert.Equal("unknown", RuntimeInformation.RuntimeIdentifier);
+            }).Dispose();
+
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetData("RUNTIME_IDENTIFIER", new object());
+
+                Assert.Equal("unknown", RuntimeInformation.RuntimeIdentifier);
+            }).Dispose();
+        }
+
+        [Fact, PlatformSpecific(TestPlatforms.Windows)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyWindowsRid()
         {
             Assert.StartsWith("win", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
-        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.Linux)]
+        [Fact, PlatformSpecific(TestPlatforms.Linux)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyLinuxRid()
         {
             string expectedOSName = File.ReadAllLines("/etc/os-release")
@@ -59,13 +81,15 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.StartsWith(expectedOSName, RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
-        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.FreeBSD)]
+        [Fact, PlatformSpecific(TestPlatforms.FreeBSD)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyFreeBSDRid()
         {
             Assert.StartsWith("freebsd", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
-        [Fact(Skip = "#26780 Need new testhost"), PlatformSpecific(TestPlatforms.OSX)]
+        [Fact, PlatformSpecific(TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyOSXRid()
         {
             Assert.StartsWith("osx", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CheckArchitectureTests.cs" />
     <Compile Include="CheckPlatformTests.cs" />
+    <Compile Include="RuntimeIdentifierTests.cs" />
     <Compile Include="DescriptionNameTests.cs" />
     <Compile Include="$(CommonPath)Interop\Linux\cgroups\Interop.cgroups.cs">
       <Link>Common\Interop\Linux\Interop.cgroups.cs</Link>


### PR DESCRIPTION
This value returns the Runtime Identifier (RID) of the current machine.

Contributes to #26780

Most of the tests are disabled because we use an old host to run our tests. When we update to a host with the new code, the tests can be enabled. I'll keep #26780 open until the tests are enabled.