### PR TITLE
Fixing net472 CI leg failure

### DIFF
--- a/src/libraries/Common/tests/Extensions/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/libraries/Common/tests/Extensions/TestingUtils/Microsoft.AspNetCore.Testing/src/xunit/FrameworkSkipConditionAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Testing
                 return true;
             }
 
-#if NET461 || NET46
+#if NETFRAMEWORK
             if (excludedFrameworks.HasFlag(RuntimeFrameworks.Mono) &&
                 TestPlatformHelper.IsMono)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/Microsoft.Extensions.Configuration.Xml.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/Microsoft.Extensions.Configuration.Xml.Tests.csproj
@@ -28,6 +28,12 @@
       <Link>Common\tests\Extensions\TestingUtils\Microsoft.AspNetCore.Testing\src\xunit\RuntimeFrameworks.cs</Link>
     </Compile>
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Compile Include="$(CommonTestPath)Extensions\TestingUtils\Microsoft.AspNetCore.Testing\src\TestPlatformHelper.cs">
+      <Link>Common\tests\Extensions\TestingUtils\Microsoft.AspNetCore.Testing\src\TestPlatformHelper.cs</Link>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <ReferenceFromRuntime Include="Microsoft.Extensions.Configuration.Xml" />


### PR DESCRIPTION
`FrameworkSkipConditionAttribute.cs` is used in Configuration.Xml tests: https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/Microsoft.Extensions.Configuration.Xml.Tests.csproj#L21-L23



 This PR fixes CI leg failure for netfx:

```
src\libraries\Common\tests\Extensions\TestingUtils\Microsoft.AspNetCore.Testing\src\xunit\FrameworkSkipConditionAttribute.cs(53,8): error CS1029: (NETCORE_ENGINEERING_TELEMETRY=Build) #error: 'Target frameworks need to be updated.'
```
https://github.com/dotnet/runtime/pull/34207/checks?check_run_id=540330536

Fixes: https://github.com/dotnet/runtime/issues/34216