### PR TITLE
JIT: allow CORINFO_HELP_READYTORUN_GENERIC_HANDLE to be optimized

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -7636,7 +7636,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                     // it may cause registered args to be spilled. Simply spill it.
 
                     unsigned lclNum = lvaGrabTemp(true DEBUGARG("VirtualCall with runtime lookup"));
-                    impAssignTempGen(lclNum, stubAddr, (unsigned)CHECK_SPILL_ALL);
+                    impAssignTempGen(lclNum, stubAddr, (unsigned)CHECK_SPILL_NONE);
                     stubAddr = gtNewLclvNode(lclNum, TYP_I_IMPL);
 
                     // Create the actual call node

--- a/src/coreclr/src/jit/utils.cpp
+++ b/src/coreclr/src/jit/utils.cpp
@@ -1312,6 +1312,7 @@ void HelperCallProperties::init()
             case CORINFO_HELP_RUNTIMEHANDLE_CLASS:
             case CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG:
             case CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG:
+            case CORINFO_HELP_READYTORUN_GENERIC_HANDLE:
                 // logging helpers are not technically pure but can be optimized away
                 isPure        = true;
                 noThrow       = true;

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -8825,6 +8825,7 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
         case VNF_ReadyToRunGenericStaticBase:
         case VNF_ReadyToRunIsInstanceOf:
         case VNF_ReadyToRunCastClass:
+        case VNF_ReadyToRunGenericHandle:
         {
             useEntryPointAddrAsArg0 = true;
         }
@@ -9218,6 +9219,10 @@ VNFunc Compiler::fgValueNumberJitHelperMethodVNFunc(CorInfoHelpFunc helpFunc)
         case CORINFO_HELP_RUNTIMEHANDLE_METHOD:
         case CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG:
             vnf = VNF_RuntimeHandleMethod;
+            break;
+
+        case CORINFO_HELP_READYTORUN_GENERIC_HANDLE:
+            vnf = VNF_ReadyToRunGenericHandle;
             break;
 
         case CORINFO_HELP_RUNTIMEHANDLE_CLASS:

--- a/src/coreclr/src/jit/valuenumfuncs.h
+++ b/src/coreclr/src/jit/valuenumfuncs.h
@@ -128,6 +128,7 @@ ValueNumFuncDef(GetsharedNongcthreadstaticBaseDynamicclass, 2, false, true, true
 ValueNumFuncDef(ClassinitSharedDynamicclass, 2, false, false, false)
 ValueNumFuncDef(RuntimeHandleMethod, 2, false, true, false)
 ValueNumFuncDef(RuntimeHandleClass, 2, false, true, false)
+ValueNumFuncDef(ReadyToRunGenericHandle, 2, false, true, false)
 
 ValueNumFuncDef(GetStaticAddrContext, 1, false, true, false)
 ValueNumFuncDef(GetStaticAddrTLS, 1, false, true, false)


### PR DESCRIPTION
This helper is idempotent and exception free, so enable it for value numbering.
Also, no need to spill the entire eval stack for a virtual stub calls.

Addresses part of #7723.