### PR TITLE
Fix the coreclr outerloop build

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -296,7 +296,7 @@ set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging='!__MsbuildLog!' '!__MsbuildWrn!' '!__MsbuildErr!'
 
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__RepoRootDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
-  %__ProjectDir%\tests\build.proj -warnAsError:1 /t:BatchRestorePackages /nodeReuse:false^
+  %__ProjectDir%\tests\build.proj -warnAsError:0 /t:BatchRestorePackages /nodeReuse:false^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   %__SkipFXRestoreArg%^
@@ -355,7 +355,7 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
 
     if not "%__CopyNativeTestBinaries%" == "1" (
         set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj
-        set __MSBuildBuildArgs=!__MSBuildBuildArgs! -warnAsError:1
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! -warnAsError:0
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! /nodeReuse:false
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__Logging!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !TargetsWindowsMsbuildArg!
@@ -379,7 +379,7 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
             goto     :Exit_Failure
         )
     ) else (
-        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:1 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
+        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:0 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
         echo Running: msbuild !__MSBuildBuildArgs!
         !__CommonMSBuildCmdPrefix! !__MSBuildBuildArgs!
 


### PR DESCRIPTION
Revert the warn as error as it's causing the coreclr outerloop build to
break. Investigated fixing the warnings but there are a mix of C# and IL
warnings. The latter I'm less sure of the fix. Reverting to unblock and
will investigate the warnings in parallel.

closes #34220