### PR TITLE
Hoist volatile variable's access outside the loop

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -636,9 +636,8 @@ namespace System.Collections.Concurrent
                 AcquireAllLocks(ref locksAcquired);
 
                 int count = 0;
-                int noOfLocks = _tables._locks.Length;
                 int[] countPerLock = _tables._countPerLock;
-                for (int i = 0; i < noOfLocks && count >= 0; i++)
+                for (int i = 0; i < countPerLock.Length && count >= 0; i++)
                 {
                     count += countPerLock[i];
                 }
@@ -671,9 +670,8 @@ namespace System.Collections.Concurrent
                 int count = 0;
                 checked
                 {
-                    int numOfLocks = _tables._locks.Length;
                     int[] countPerLock = _tables._countPerLock;
-                    for (int i = 0; i < numOfLocks; i++)
+                    for (int i = 0; i < countPerLock.Length; i++)
                     {
                         count += countPerLock[i];
                     }
@@ -1673,8 +1671,7 @@ namespace System.Collections.Concurrent
 
                 int count = 0;
                 int[] countPerLock = tables._countPerLock;
-                int numOfLocks = tables._locks.Length;
-                for (int i = 0; i < numOfLocks && count >= 0; i++)
+                for (int i = 0; i < countPerLock.Length && count >= 0; i++)
                 {
                     count += countPerLock[i];
                 }

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -636,10 +636,11 @@ namespace System.Collections.Concurrent
                 AcquireAllLocks(ref locksAcquired);
 
                 int count = 0;
-
-                for (int i = 0; i < _tables._locks.Length && count >= 0; i++)
+                int noOfLocks = _tables._locks.Length;
+                int[] countPerLock = _tables._countPerLock;
+                for (int i = 0; i < noOfLocks && count >= 0; i++)
                 {
-                    count += _tables._countPerLock[i];
+                    count += countPerLock[i];
                 }
 
                 if (array.Length - count < index || count < 0) //"count" itself or "count + index" can overflow
@@ -670,9 +671,11 @@ namespace System.Collections.Concurrent
                 int count = 0;
                 checked
                 {
-                    for (int i = 0; i < _tables._locks.Length; i++)
+                    int numOfLocks = _tables._locks.Length;
+                    int[] countPerLock = _tables._countPerLock;
+                    for (int i = 0; i < numOfLocks; i++)
                     {
-                        count += _tables._countPerLock[i];
+                        count += countPerLock[i];
                     }
                 }
 
@@ -998,11 +1001,12 @@ namespace System.Collections.Concurrent
         private int GetCountInternal()
         {
             int count = 0;
+            int[] countPerLocks = _tables._countPerLock;
 
             // Compute the count, we allow overflow
-            for (int i = 0; i < _tables._countPerLock.Length; i++)
+            for (int i = 0; i < countPerLocks.Length; i++)
             {
-                count += _tables._countPerLock[i];
+                count += countPerLocks[i];
             }
 
             return count;
@@ -1668,10 +1672,11 @@ namespace System.Collections.Concurrent
                 Tables tables = _tables;
 
                 int count = 0;
-
-                for (int i = 0; i < tables._locks.Length && count >= 0; i++)
+                int[] countPerLock = tables._countPerLock;
+                int numOfLocks = tables._locks.Length;
+                for (int i = 0; i < numOfLocks && count >= 0; i++)
                 {
-                    count += tables._countPerLock[i];
+                    count += countPerLock[i];
                 }
 
                 if (array.Length - count < index || count < 0) //"count" itself or "count + index" can overflow
@@ -1985,9 +1990,10 @@ namespace System.Collections.Concurrent
                 if (count < 0) throw new OutOfMemoryException();
 
                 List<TKey> keys = new List<TKey>(count);
-                for (int i = 0; i < _tables._buckets.Length; i++)
+                Node[] buckets = _tables._buckets;
+                for (int i = 0; i < buckets.Length; i++)
                 {
-                    Node current = _tables._buckets[i];
+                    Node current = buckets[i];
                     while (current != null)
                     {
                         keys.Add(current._key);
@@ -2017,9 +2023,10 @@ namespace System.Collections.Concurrent
                 if (count < 0) throw new OutOfMemoryException();
 
                 List<TValue> values = new List<TValue>(count);
-                for (int i = 0; i < _tables._buckets.Length; i++)
+                Node[] buckets = _tables._buckets;
+                for (int i = 0; i < buckets.Length; i++)
                 {
-                    Node current = _tables._buckets[i];
+                    Node current = buckets[i];
                     while (current != null)
                     {
                         values.Add(current._value);


### PR DESCRIPTION
`_tables` is a volatile object and it has `_countPerLock` volatile field. On ARM64, JIT generates memory barrier instruction "dmb" for every volatile variable access which could be expensive. This PR caches the volatile variables outside the loop and use cached local variables instead. All the places where I have hoisted the variable access are guarded by `AcquireAllLocks()` method.


Fixes: https://github.com/dotnet/runtime/issues/34198