### PR TITLE
Generate memory barrier with inner shareable domain for ARM64

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1906,7 +1906,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     if (emitBarrier)
     {
 #ifdef TARGET_ARM64
-        instGen_MemoryBarrier(INS_BARRIER_OSHLD);
+        instGen_MemoryBarrier(INS_BARRIER_ISHLD);
 #else
         instGen_MemoryBarrier();
 #endif


### PR DESCRIPTION
Today, for volatile variable access, JIT generates "dmb oshld" which is a memory barrier with outer shareable domain.

Coreclr uses [atomics and interlocked APIs](https://github.com/dotnet/runtime/blob/fcd862e06413a000f9cafa9d2f359226c60b9b42/src/coreclr/src/inc/volatile.h#L153) for memory safety and msvc / clang both generate inner shareable domain
for them. Hence it is sensible for JIT that is compiled with [msvs](https://godbolt.org/z/8XEWYr) / [clang](https://godbolt.org/z/DMZi26) to generate inner shareable domain for volatile access.

[gcc](https://godbolt.org/z/zSf4fS) too emits inner shareable domain for API that takes full system memory barrier.
