### PR TITLE
Fix EnumerableViewOfDispatch.GetEnumerator ref counting

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
@@ -40,13 +40,25 @@ namespace System.Runtime.InteropServices.CustomMarshalers
                     IntPtr.Zero);
             }
 
-            object? resultAsObject = result.ToObject();
-            if (!(resultAsObject is IEnumVARIANT enumVariant))
+            IntPtr enumVariantPtr = IntPtr.Zero;
+            try
             {
-                throw new InvalidOperationException(SR.InvalidOp_InvalidNewEnumVariant);
-            }
+                object? resultAsObject = result.ToObject();
+                if (!(resultAsObject is IEnumVARIANT enumVariant))
+                {
+                    throw new InvalidOperationException(SR.InvalidOp_InvalidNewEnumVariant);
+                }
 
-            return (IEnumerator)EnumeratorToEnumVariantMarshaler.GetInstance(null).MarshalNativeToManaged(Marshal.GetIUnknownForObject(enumVariant));
+                enumVariantPtr = Marshal.GetIUnknownForObject(enumVariant);
+                return (IEnumerator)EnumeratorToEnumVariantMarshaler.GetInstance(null).MarshalNativeToManaged(enumVariantPtr);
+            }
+            finally
+            {
+                result.Clear();
+
+                if (enumVariantPtr != IntPtr.Zero)
+                    Marshal.Release(enumVariantPtr);
+            }
         }
 
         public object GetUnderlyingObject()


### PR DESCRIPTION
This function would end up increasing the ref count via `Variant.ToObject` and `Marshal.GetIUnknownForObject`, but not decreasing it, thus leaking the object.

Fixes #32747