### PR TITLE
Improve platform detection for Android and SunOS

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -72,6 +72,9 @@ initNonPortableDistroRid()
     if [ "$targetOs" = "FreeBSD" ]; then
         __freebsd_major_version=$(freebsd-version | { read v; echo "${v%%.*}"; })
         nonPortableBuildID="freebsd.$__freebsd_major_version-${buildArch}"
+    elif getprop ro.product.system.model 2>&1 | grep -qi android; then
+        __android_sdk_version=$(getprop ro.build.version.sdk)
+        nonPortableBuildID="android.$__android_sdk_version-${buildArch}"
     fi
 
     if [ -n "${nonPortableBuildID}" ]; then

--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -2,18 +2,30 @@
 
 # Use uname to determine what the OS is.
 OSName=$(uname -s)
+
+if getprop ro.product.system.model 2>&1 | grep -qi android; then
+    OSName="Android"
+fi
+
 case "$OSName" in
-FreeBSD|Linux|NetBSD|OpenBSD|SunOS)
+FreeBSD|Linux|NetBSD|OpenBSD|SunOS|Android)
     os=$OSName ;;
 Darwin)
-	os=OSX ;;
+    os=OSX ;;
 *)
     echo "Unsupported OS $OSName detected, configuring as if for Linux"
     os=Linux ;;
 esac
 
-# Use uname to determine what the CPU is.
-CPUName=$(uname -m)
+# On Solaris, `uname -m` is discoragued, see https://docs.oracle.com/cd/E36784_01/html/E36870/uname-1.html
+# and `uname -p` returns processor type (e.g. i386 on amd64).
+# The appropriate tool to determine CPU is isainfo(1) https://docs.oracle.com/cd/E36784_01/html/E36870/isainfo-1.html.
+if [ "$OSName" = "SunOS" ]; then
+    CPUName=$(isainfo -n)
+else
+    # For rest of the operating systems, use uname(1) to determine what the CPU is.
+    CPUName=$(uname -m)
+fi
 
 case "$CPUName" in
     aarch64)


### PR DESCRIPTION
Note: Android part does not affect NDK/Xamarin builds. It is only for device and emulators, where Android is host OS, and we want to consistently recognize the OS as Android; mainly for correct output directory names under `artifacts/`.