### PR TITLE
Add Nightly Build feed to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ We welcome contributions! Many people all over the world have helped make this p
 
 * [Contributing](CONTRIBUTING.md) explains what kinds of changes we welcome
 - [Workflow Instructions](docs/workflow/README.md) explains how to build and test
+* Try the latest versions of libraries from the [nightly build package feed](https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json) and test them in your projects.
 
 ## Reporting security issues and security bugs
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We welcome contributions! Many people all over the world have helped make this p
 
 * [Contributing](CONTRIBUTING.md) explains what kinds of changes we welcome
 - [Workflow Instructions](docs/workflow/README.md) explains how to build and test
-* Try the latest versions of libraries from the [nightly build package feed](https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json) and test them in your projects.
+* [Get Up and Running on .NET Core](docs/project/dogfooding.md) explains how to get nightly builds of the runtime and its libraries to test them in your own projects.
 
 ## Reporting security issues and security bugs
 

--- a/docs/project/dogfooding.md
+++ b/docs/project/dogfooding.md
@@ -68,7 +68,6 @@ To install additional .NET Core runtimes or SDKs:
 ```
 
 4. Our nightly builds are uploaded to dotnet-blob feeds, not NuGet - so ensure the .NET Core blob feed is in your nuget configuration in case you need other packages from .NET Core that aren't included in the download. For example, on Windows you could edit `%userprofile%\appdata\roaming\nuget\nuget.config` or on Linux edit `~/.nuget/NuGet/NuGet.Config` to add these lines:
-
 ```xml
 <packageSources>
     <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />

--- a/docs/project/dogfooding.md
+++ b/docs/project/dogfooding.md
@@ -8,18 +8,24 @@ this experience. Make sure to consult this document often.
 
 ## Obtaining nightly builds of NuGet packages
 
-If you are only looking to get fixes for an individual NuGet package, and don't need a preview version of the entire runtime, you can add the following package feed to `NuGet.config`:
+If you are only looking to get fixes for an individual NuGet package, and don't need a preview version of the entire runtime, you can add the nightly build package feed to your `NuGet.config` file.  The easiest way to do this is by using the dotnet CLI:
 
-**MSFT TODO:** Someone at Microsoft should confirm if any other feeds might be needed here
-
-```xml
-<packageSources>
-    <add key="dotnet-core" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
-    ...
-</packageSources>    
+**(Recommended)** Create a local NuGet.Config file for your solution, if don't already have one.  Using a local NuGet.Config file will enable the nightly feed as a package source for projects in the current directory only.
+```
+dotnet new nugetconfig
 ```
 
-(Documentation for configuring feeds is [here](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior).)
+Next, add the package source to NuGet.Config with the [dotnet nuget add source](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-add-source) command:
+```
+dotnet nuget add source -n dotnet5 https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json
+```
+
+Then, you will be able to add the latest prerelease version of the desired package to your project.
+
+**Example:** To add version 5.0.0-preview.1.20120.5 of the System.Data.OleDb package, use the [dotnet add package](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package) command:
+```
+dotnet add package System.Data.OleDb -v 5.0.0-preview.1.20120.5
+```
 
 To use nightly builds of the entire runtime, follow the steps given in the rest of this document instead.
 
@@ -63,15 +69,9 @@ To install additional .NET Core runtimes or SDKs:
 
 4. Our nightly builds are uploaded to dotnet-blob feeds, not NuGet - so ensure the .NET Core blob feed is in your nuget configuration in case you need other packages from .NET Core that aren't included in the download. For example, on Windows you could edit `%userprofile%\appdata\roaming\nuget\nuget.config` or on Linux edit `~/.nuget/NuGet/NuGet.Config` to add these lines:
 
-**MSFT TODO:** Someone at Microsoft should update these to make sure they are not outdated
 ```xml
 <packageSources>
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
-    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-    <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
-    <add key="aspnet-entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
-    <add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
+    <add key="dotnet5" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="gRPC repository" value="https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev" />
     ...
 </packageSources>    
@@ -246,4 +246,3 @@ windows (on Linux substitute ~/ for %HOMEPATH%) you could delete
      %HOMEPATH%\.nuget\packages\runtime.win-x64.microsoft.private.corefx.netcoreapp\4.6.0-dev.18626.1
 ```
 which should make `dotnet restore` now pick up the new copy.
-

--- a/docs/project/dogfooding.md
+++ b/docs/project/dogfooding.md
@@ -6,6 +6,23 @@ This document provides the steps necessary to consume a nightly build of
 Please note that these steps are likely to change as we're simplifying
 this experience. Make sure to consult this document often.
 
+## Obtaining nightly builds of NuGet packages
+
+If you are only looking to get fixes for an individual NuGet package, and don't need a preview version of the entire runtime, you can add the following package feed to `NuGet.config`:
+
+**MSFT TODO:** Someone at Microsoft should confirm if any other feeds might be needed here
+
+```xml
+<packageSources>
+    <add key="dotnet-core" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet5/nuget/v3/index.json" />
+    ...
+</packageSources>    
+```
+
+(Documentation for configuring feeds is [here](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior).)
+
+To use nightly builds of the entire runtime, follow the steps given in the rest of this document instead.
+
 ## Install prerequisites
 
 1. Acquire the latest nightly .NET Core SDK by downloading the zip or tarball listed in https://github.com/dotnet/core-sdk#installers-and-binaries (for example, https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.zip ) into a new folder, for instance `C:\dotnet`.
@@ -44,7 +61,9 @@ To install additional .NET Core runtimes or SDKs:
   https://aka.ms/dotnet-download
 ```
 
-4. Our nightly builds are uploaded to dotnet-blob feeds, not NuGet - so ensure the .NET Core blob feed is in your nuget configuration in case you need other packages from .NET Core that aren't included in the download. For example, on Windows you could edit `%userprofile%\appdata\roaming\nuget\nuget.config` or on Linux edit `~/.nuget/NuGet/NuGet.Config` to add these line:
+4. Our nightly builds are uploaded to dotnet-blob feeds, not NuGet - so ensure the .NET Core blob feed is in your nuget configuration in case you need other packages from .NET Core that aren't included in the download. For example, on Windows you could edit `%userprofile%\appdata\roaming\nuget\nuget.config` or on Linux edit `~/.nuget/NuGet/NuGet.Config` to add these lines:
+
+**MSFT TODO:** Someone at Microsoft should update these to make sure they are not outdated
 ```xml
 <packageSources>
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />


### PR DESCRIPTION
When a PR is merged that fixes an issue, the question is often raised as to how/when library consumers can use the fixed code.  The answer often states that we can download the latest version from the nightly NuGet package feed, but it is currently very difficult to locate the feed to use.  Furthermore, I don't think many Microsoft employees know the URL of the nightly feed, or at least they don't know what feed to tell the public.  This PR updates the home page for the repo with a link to the proper feed to make it easily discoverable for end users.

Some considerations:
1) Need to verify that this is actually the best feed URL to use.
2) Perhaps the full URL should be visible so that it can be copy/pasted without clicking the link, as that is what many people will do with it.  Hiding the full URL behind link text makes the home page look cleaner, but also means people have to click the link (or right click to copy the link).

This PR has been submitted at the request of @danmosemsft.