### PR TITLE
Remove a couple unnecessary ToStrings in System.DirectoryServices

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -630,7 +630,7 @@ namespace System.DirectoryServices.AccountManagement
 
                     innerLdapFilter.Append(')');
 
-                    ldapFilter.Append(innerLdapFilter.ToString());
+                    ldapFilter.Append(innerLdapFilter);
                 }
 
                 // Wrap off the filter

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
@@ -153,7 +153,7 @@ namespace System.DirectoryServices.Interop
                         strb.Append("B:");
                         strb.Append(binaryPart.Length);
                         strb.Append(':');
-                        strb.Append(binaryPart.ToString());
+                        strb.Append(binaryPart);
                         strb.Append(':');
                         strb.Append(Marshal.PtrToStringUni(dnb.pszDNString));
 


### PR DESCRIPTION
These are calling ToString on a StringBuilder, but StringBuilder.Append has a StringBuilder-based overload in netcoreapp.  On other builds this will just fall back to the object-based overload, which will call ToString.

Related to https://github.com/dotnet/roslyn-analyzers/pull/3443
We'd previously fixed most of these in dotnet/runtime, but missed these.

cc: @bartonjs