### PR TITLE
Cache parameterized ctor delegates in class info rather than converter

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (success)
             {
-                ((object[])state.Current.CtorArgumentState!.Arguments!)[jsonParameterInfo.Position] = arg0!;
+                ((object[])state.Current.CtorArgumentState!.Arguments)[jsonParameterInfo.Position] = arg0!;
             }
 
             return success;
@@ -26,17 +26,17 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override object CreateObject(ref ReadStackFrame frame)
         {
-            object[] arguments = (object[])frame.CtorArgumentState!.Arguments!;
+            object[] arguments = (object[])frame.CtorArgumentState!.Arguments;
 
-            var createObject = (JsonClassInfo.ParameterizedConstructorDelegate<T>)frame.JsonClassInfo.CreateObjectWithParameterizedCtor!;
+            var createObject = (JsonClassInfo.ParameterizedConstructorDelegate<T>?)frame.JsonClassInfo.CreateObjectWithParameterizedCtor;
 
             if (createObject == null)
             {
                 // This means this constructor has more than 64 parameters.
-                ThrowHelper.ThrowNotSupportedException_ConstructorMaxOf64Parameters(ConstructorInfo, TypeToConvert);
+                ThrowHelper.ThrowNotSupportedException_ConstructorMaxOf64Parameters(ConstructorInfo!, TypeToConvert);
             }
 
-            object obj = createObject(arguments)!;
+            object obj = createObject(arguments);
 
             ArrayPool<object>.Shared.Return(arguments, clearArray: true);
             return obj;
@@ -48,7 +48,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (classInfo.CreateObjectWithParameterizedCtor == null)
             {
-                classInfo.CreateObjectWithParameterizedCtor = options.MemberAccessorStrategy.CreateParameterizedConstructor<T>(ConstructorInfo)!;
+                classInfo.CreateObjectWithParameterizedCtor = options.MemberAccessorStrategy.CreateParameterizedConstructor<T>(ConstructorInfo!);
             }
 
             object[] arguments = ArrayPool<object>.Shared.Rent(classInfo.ParameterCount);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -12,11 +12,6 @@ namespace System.Text.Json.Serialization.Converters
     /// </summary>
     internal sealed class SmallObjectWithParameterizedConstructorConverter<T, TArg0, TArg1, TArg2, TArg3> : ObjectWithParameterizedConstructorConverter<T> where T : notnull
     {
-        internal override void CreateConstructorDelegate(JsonClassInfo classInfo, JsonSerializerOptions options)
-        {
-            classInfo.CreateObjectWithParameterizedCtor = options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo)!;
-        }
-
         protected override object CreateObject(ref ReadStackFrame frame)
         {
             var createObject = (JsonClassInfo.ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>)
@@ -72,9 +67,17 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override void InitializeConstructorArgumentCaches(ref ReadStack state, JsonSerializerOptions options)
         {
+            JsonClassInfo classInfo = state.Current.JsonClassInfo;
+
+            if (classInfo.CreateObjectWithParameterizedCtor == null)
+            {
+                classInfo.CreateObjectWithParameterizedCtor =
+                    options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo)!;
+            }
+
             var arguments = new Arguments<TArg0, TArg1, TArg2, TArg3>();
 
-            foreach (JsonParameterInfo parameterInfo in state.Current.JsonClassInfo.ParameterCache!.Values)
+            foreach (JsonParameterInfo parameterInfo in classInfo.ParameterCache!.Values)
             {
                 if (parameterInfo.ShouldDeserialize)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -12,17 +12,17 @@ namespace System.Text.Json.Serialization.Converters
     /// </summary>
     internal sealed class SmallObjectWithParameterizedConstructorConverter<T, TArg0, TArg1, TArg2, TArg3> : ObjectWithParameterizedConstructorConverter<T> where T : notnull
     {
-        private JsonClassInfo.ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>? _createObject;
-
-        internal override void CreateConstructorDelegate(JsonSerializerOptions options)
+        internal override void CreateConstructorDelegate(JsonClassInfo classInfo, JsonSerializerOptions options)
         {
-            _createObject = options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo)!;
+            classInfo.CreateObjectWithParameterizedCtor = options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo)!;
         }
 
         protected override object CreateObject(ref ReadStackFrame frame)
         {
+            var createObject = (JsonClassInfo.ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>)
+                frame.JsonClassInfo.CreateObjectWithParameterizedCtor!;
             var arguments = (Arguments<TArg0, TArg1, TArg2, TArg3>)frame.CtorArgumentState!.Arguments!;
-            return _createObject!(arguments.Arg0, arguments.Arg1, arguments.Arg2, arguments.Arg3)!;
+            return createObject!(arguments.Arg0, arguments.Arg1, arguments.Arg2, arguments.Arg3)!;
         }
 
         protected override bool ReadAndCacheConstructorArgument(ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -16,8 +16,8 @@ namespace System.Text.Json.Serialization.Converters
         {
             var createObject = (JsonClassInfo.ParameterizedConstructorDelegate<T, TArg0, TArg1, TArg2, TArg3>)
                 frame.JsonClassInfo.CreateObjectWithParameterizedCtor!;
-            var arguments = (Arguments<TArg0, TArg1, TArg2, TArg3>)frame.CtorArgumentState!.Arguments!;
-            return createObject!(arguments.Arg0, arguments.Arg1, arguments.Arg2, arguments.Arg3)!;
+            var arguments = (Arguments<TArg0, TArg1, TArg2, TArg3>)frame.CtorArgumentState!.Arguments;
+            return createObject!(arguments.Arg0, arguments.Arg1, arguments.Arg2, arguments.Arg3);
         }
 
         protected override bool ReadAndCacheConstructorArgument(ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Converters
             if (classInfo.CreateObjectWithParameterizedCtor == null)
             {
                 classInfo.CreateObjectWithParameterizedCtor =
-                    options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo)!;
+                    options.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo!);
             }
 
             var arguments = new Arguments<TArg0, TArg1, TArg2, TArg3>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -429,7 +429,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (state.Current.JsonClassInfo.ParameterCount != state.Current.JsonClassInfo.ParameterCache!.Count)
             {
-                ThrowHelper.ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(ConstructorInfo, TypeToConvert);
+                ThrowHelper.ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(ConstructorInfo!, TypeToConvert);
             }
 
             // Set current JsonPropertyInfo to null to avoid conflicts on push.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -161,13 +161,6 @@ namespace System.Text.Json
 
                         if (converter.ConstructorIsParameterized)
                         {
-                            // Create and cache the constructor delegate for this type.
-                            // We depend on the first converter created for this type to perform the initialization.
-                            // Subsequent instances of the converter will not perform this initialization since we will
-                            // not go down this code path (as the type will already be in the JsonClassInfo cache).
-                            // The converter is used because it has generic type support.
-                            converter.CreateConstructorDelegate(this, options);
-
                             InitializeConstructorParameters(converter.ConstructorInfo);
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -161,7 +161,7 @@ namespace System.Text.Json
 
                         if (converter.ConstructorIsParameterized)
                         {
-                            InitializeConstructorParameters(converter.ConstructorInfo);
+                            InitializeConstructorParameters(converter.ConstructorInfo!);
                         }
                     }
                     break;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json
 
         public ConstructorDelegate? CreateObject { get; private set; }
 
+        public object? CreateObjectWithParameterizedCtor { get; set; }
+
         public ClassType ClassType { get; private set; }
 
         public JsonPropertyInfo? DataExtensionProperty { get; private set; }
@@ -159,7 +161,13 @@ namespace System.Text.Json
 
                         if (converter.ConstructorIsParameterized)
                         {
-                            converter.CreateConstructorDelegate(options);
+                            // Create and cache the constructor delegate for this type.
+                            // We depend on the first converter created for this type to perform the initialization.
+                            // Subsequent instances of the converter will not perform this initialization since we will
+                            // not go down this code path (as the type will already be in the JsonClassInfo cache).
+                            // The converter is used because it has generic type support.
+                            converter.CreateConstructorDelegate(this, options);
+
                             InitializeConstructorParameters(converter.ConstructorInfo);
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -80,6 +80,6 @@ namespace System.Text.Json.Serialization
 
         internal ConstructorInfo ConstructorInfo { get; set; } = null!;
 
-        internal virtual void CreateConstructorDelegate(JsonSerializerOptions options) { }
+        internal virtual void CreateConstructorDelegate(JsonClassInfo classInfo, JsonSerializerOptions options) { }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -78,6 +78,6 @@ namespace System.Text.Json.Serialization
         // Whether a type (ClassType.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized => false;
 
-        internal ConstructorInfo ConstructorInfo { get; set; } = null!;
+        internal ConstructorInfo? ConstructorInfo { get; set; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -79,7 +79,5 @@ namespace System.Text.Json.Serialization
         internal virtual bool ConstructorIsParameterized => false;
 
         internal ConstructorInfo ConstructorInfo { get; set; } = null!;
-
-        internal virtual void CreateConstructorDelegate(JsonClassInfo classInfo, JsonSerializerOptions options) { }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests.ParameterMatching.cs
@@ -8,14 +8,14 @@ using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
-    public class ConstructorTests_StringTValue : ConstructorTests
+    public class ConstructorTests_String : ConstructorTests
     {
-        public ConstructorTests_StringTValue() : base(DeserializationWrapper.StringTValueSerializer) { }
+        public ConstructorTests_String() : base(DeserializationWrapper.StringDeserializer) { }
     }
 
-    public class ConstructorTests_StreamTValue : ConstructorTests
+    public class ConstructorTests_Stream : ConstructorTests
     {
-        public ConstructorTests_StreamTValue() : base(DeserializationWrapper.StreamTValueSerializer) { }
+        public ConstructorTests_Stream() : base(DeserializationWrapper.StreamDeserializer) { }
     }
 
     public abstract partial class ConstructorTests
@@ -301,7 +301,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => Serializer.Deserialize<ClassWrapper_For_Int_Point_3D_String>(@"{""MyPoint3DStruct"":null,""MyString"":""1""}"));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33928")]
         [Fact]
         public void OtherPropertiesAreSet()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33928. 

Caching parameterized ctor delegates in converters is not thread-safe. The delegates should be stored on the `JsonClassInfo` instance for the type, which is shared across all instances of the converter.