### PR TITLE
Add System.Type converter for JsonSerializer

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -506,4 +506,7 @@
   <data name="BufferMaximumSizeExceeded" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
+  <data name="DeserializeTypeInstanceNotSupported" xml:space="preserve">
+    <value>Deserialization of 'System.Type' instances is not supported and should be avoided since it can lead to security issues. A workaround is to use a custom converter.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -506,7 +506,7 @@
   <data name="BufferMaximumSizeExceeded" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
-  <data name="DeserializeTypeInstanceNotSupported" xml:space="preserve">
-    <value>Deserialization of 'System.Type' instances is not supported and should be avoided since it can lead to security issues. A workaround is to use a custom converter.</value>
+  <data name="SerializeTypeInstanceNotSupported" xml:space="preserve">
+    <value>Serialization and deserialization of 'System.Type' instances are not supported and should be avoided since they can lead to security issues.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -109,6 +109,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SByteConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SingleConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\StringConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Value\TypeConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt16Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt32Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt64Converter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
@@ -8,12 +8,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            throw ThrowHelper.GetNotSupportedException_DeserializeTypeInstanceNotSupported();
+            throw ThrowHelper.GetNotSupportedException_SerializeTypeInstanceNotSupported();
         }
 
         public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.AssemblyQualifiedName);
+            throw ThrowHelper.GetNotSupportedException_SerializeTypeInstanceNotSupported();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
@@ -8,12 +8,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            throw ThrowHelper.GetNotSupportedException_SerializeTypeInstanceNotSupported();
+            throw new NotSupportedException(SR.SerializeTypeInstanceNotSupported);
         }
 
         public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
         {
-            throw ThrowHelper.GetNotSupportedException_SerializeTypeInstanceNotSupported();
+            throw new NotSupportedException(SR.SerializeTypeInstanceNotSupported);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TypeConverter.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class TypeConverter : JsonConverter<Type>
+    {
+        public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw ThrowHelper.GetNotSupportedException_DeserializeTypeInstanceNotSupported();
+        }
+
+        public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.AssemblyQualifiedName);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
         {
-            const int NumberOfSimpleConverters = 21;
+            const int NumberOfSimpleConverters = 22;
             var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
 
             // Use a dictionary for simple converters.
@@ -59,6 +59,7 @@ namespace System.Text.Json
             Add(new SByteConverter());
             Add(new SingleConverter());
             Add(new StringConverter());
+            Add(new TypeConverter());
             Add(new UInt16Converter());
             Add(new UInt32Converter());
             Add(new UInt64Converter());

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -28,9 +28,15 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static NotSupportedException ThrowNotSupportedException_ConstructorMaxOf64Parameters(ConstructorInfo constructorInfo, Type type)
+        public static void ThrowNotSupportedException_ConstructorMaxOf64Parameters(ConstructorInfo constructorInfo, Type type)
         {
             throw new NotSupportedException(SR.Format(SR.ConstructorMaxOf64Parameters, constructorInfo, type));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static NotSupportedException GetNotSupportedException_DeserializeTypeInstanceNotSupported()
+        {
+            return new NotSupportedException(SR.DeserializeTypeInstanceNotSupported);
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -34,9 +34,9 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static NotSupportedException GetNotSupportedException_DeserializeTypeInstanceNotSupported()
+        public static NotSupportedException GetNotSupportedException_SerializeTypeInstanceNotSupported()
         {
-            return new NotSupportedException(SR.DeserializeTypeInstanceNotSupported);
+            return new NotSupportedException(SR.SerializeTypeInstanceNotSupported);
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -33,12 +33,6 @@ namespace System.Text.Json
             throw new NotSupportedException(SR.Format(SR.ConstructorMaxOf64Parameters, constructorInfo, type));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static NotSupportedException GetNotSupportedException_SerializeTypeInstanceNotSupported()
-        {
-            return new NotSupportedException(SR.SerializeTypeInstanceNotSupported);
-        }
-
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)

--- a/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -526,5 +526,23 @@ namespace System.Text.Json.Serialization.Tests
             // Root-level Types (not from a property) do not include the Path.
             Assert.DoesNotContain("Path: $", ex.Message);
         }
+
+        [Fact]
+        public static void DeserializeTypeInstance()
+        {
+            string json = JsonSerializer.Serialize(typeof(int));
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Type>(json));
+            string exAsStr = ex.ToString();
+            Assert.Contains("System.Type", exAsStr);
+            Assert.Contains("$", exAsStr);
+
+            json = $@"{{""Type"":{json}}}";
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithType>(json));
+            exAsStr = ex.ToString();
+            Assert.Contains("System.Type", exAsStr);
+            Assert.Contains("$.Type", exAsStr);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -530,7 +530,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void DeserializeTypeInstance()
         {
-            string json = JsonSerializer.Serialize(typeof(int));
+            string json = @"""System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e""";
 
             NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Type>(json));
             string exAsStr = ex.ToString();
@@ -543,6 +543,41 @@ namespace System.Text.Json.Serialization.Tests
             exAsStr = ex.ToString();
             Assert.Contains("System.Type", exAsStr);
             Assert.Contains("$.Type", exAsStr);
+
+            // NSE is not thrown because the serializer handles null.
+            Assert.Null(JsonSerializer.Deserialize<Type>("null"));
+
+            ClassWithType obj = JsonSerializer.Deserialize<ClassWithType>(@"{""Type"":null}");
+            Assert.Null(obj.Type);
+        }
+
+        [Fact]
+        public static void SerializeTypeInstance()
+        {
+            Type type = typeof(int);
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(type));
+            string exAsStr = ex.ToString();
+            Assert.Contains("System.Type", exAsStr);
+            Assert.Contains("$", exAsStr);
+
+            type = null;
+            string serialized = JsonSerializer.Serialize(type);
+            Assert.Equal("null", serialized);
+
+            ClassWithType obj = new ClassWithType { Type = typeof(int) };
+
+            ex = Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj));
+            exAsStr = ex.ToString();
+            Assert.Contains("System.Type", exAsStr);
+            Assert.Contains("$.Type", exAsStr);
+
+            obj.Type = null;
+            serialized = JsonSerializer.Serialize(obj);
+            Assert.Equal(@"{""Type"":null}", serialized);
+
+            serialized = JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal(@"{}", serialized);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -1853,4 +1853,9 @@ namespace System.Text.Json.Serialization.Tests
             MyData.Verify();
         }
     }
+
+    public class ClassWithType
+    {
+        public Type Type { get; set; }
+    }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -394,47 +394,5 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<OutOfMemoryException>(() => JsonSerializer.Serialize(temp, typeof(CustomClassToExceedMaxBufferSize)));
         }
-
-        [Fact]
-        public static void SerializeTypeInstance()
-        {
-            Type type = typeof(int);
-
-            string serialized = JsonSerializer.Serialize(type);
-            Assert.Contains("System.Int32", serialized);
-            Assert.Contains("Version=", serialized);
-            Assert.Contains("Culture=", serialized);
-            Assert.Contains("PublicKeyToken=", serialized);
-
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Type>(serialized));
-
-            type = null;
-            serialized = JsonSerializer.Serialize(type);
-            Assert.Equal("null", serialized);
-
-            ClassWithType obj = new ClassWithType { Type = typeof(int) };
-
-            serialized = JsonSerializer.Serialize(obj);
-            Assert.Contains(@"{""Type"":", serialized);
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithType>(serialized));
-
-            serialized = JsonSerializer.Serialize(obj.Type);
-            Assert.Contains("System.Int32", serialized);
-            Assert.Contains("Version=", serialized);
-            Assert.Contains("Culture=", serialized);
-            Assert.Contains("PublicKeyToken=", serialized);
-
-            obj.Type = null;
-
-            serialized = JsonSerializer.Serialize(obj);
-            Assert.Equal(@"{""Type"":null}", serialized);
-
-            obj = JsonSerializer.Deserialize<ClassWithType>(serialized);
-            // NSE is not thrown because the serializer handles null and sets the property to null.
-            Assert.Null(obj.Type);
-
-            serialized = JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
-            Assert.Equal(@"{}", serialized);
-        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -394,5 +394,47 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<OutOfMemoryException>(() => JsonSerializer.Serialize(temp, typeof(CustomClassToExceedMaxBufferSize)));
         }
+
+        [Fact]
+        public static void SerializeTypeInstance()
+        {
+            Type type = typeof(int);
+
+            string serialized = JsonSerializer.Serialize(type);
+            Assert.Contains("System.Int32", serialized);
+            Assert.Contains("Version=", serialized);
+            Assert.Contains("Culture=", serialized);
+            Assert.Contains("PublicKeyToken=", serialized);
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Type>(serialized));
+
+            type = null;
+            serialized = JsonSerializer.Serialize(type);
+            Assert.Equal("null", serialized);
+
+            ClassWithType obj = new ClassWithType { Type = typeof(int) };
+
+            serialized = JsonSerializer.Serialize(obj);
+            Assert.Contains(@"{""Type"":", serialized);
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithType>(serialized));
+
+            serialized = JsonSerializer.Serialize(obj.Type);
+            Assert.Contains("System.Int32", serialized);
+            Assert.Contains("Version=", serialized);
+            Assert.Contains("Culture=", serialized);
+            Assert.Contains("PublicKeyToken=", serialized);
+
+            obj.Type = null;
+
+            serialized = JsonSerializer.Serialize(obj);
+            Assert.Equal(@"{""Type"":null}", serialized);
+
+            obj = JsonSerializer.Deserialize<ClassWithType>(serialized);
+            // NSE is not thrown because the serializer handles null and sets the property to null.
+            Assert.Null(obj.Type);
+
+            serialized = JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal(@"{}", serialized);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31567. Per the conversation in this issue & following triage, this PR adds a new converter for `System.Type` with the following behavior:

- serialization: writes the [`AssemblyQualifiedName`](https://docs.microsoft.com/dotnet/api/system.type.assemblyqualifiedname?view=netcore-3.1) of the `Type` instance. This is compatible with Newtonsoft.Json.

- deserialization: throws `NotSupportedException`, as deserializing `Type` instances from arbitrary user input is a security vulnerability. Relevant path and reader position information is added to the exception message, as applicable.

The behavior before this PR was a `JsonException` (max depth exceeded) on serialization, and `JsonException` on deserialization (most commonly due to the current token being `JsonTokenType.String` rather than `JsonTokenType.StartObject` as the serializer expects when parsing object types).

---

EDIT: the converter will throw a `NotSupportedException` for both serialization and deserialization.