### PR TITLE
Fix Ref and impl dll locations in transport pack

### DIFF
--- a/src/libraries/pkg/Microsoft.Extensions.Internal.Transport/Microsoft.Extensions.Internal.Transport.pkgproj
+++ b/src/libraries/pkg/Microsoft.Extensions.Internal.Transport/Microsoft.Extensions.Internal.Transport.pkgproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <_libDocs Include="$(ASPNETCoreAppPackageRefPath)\*.xml" />
-    <File Include="$(ASPNETCoreAppPackageRefPath)\*.*" Exclude="@(_libDocs)" TargetPath="lib\$(NetCoreAppCurrent)" />
-    <File Include="$(ASPNETCoreAppPackageRuntimePath)\*.*;@(_libDocs)" TargetPath="ref\$(NetCoreAppCurrent)" />
+    <File Include="$(ASPNETCoreAppPackageRefPath)\*.*" Exclude="@(_libDocs)" TargetPath="ref\$(NetCoreAppCurrent)" />
+    <File Include="$(ASPNETCoreAppPackageRuntimePath)\*.*;@(_libDocs)" TargetPath="lib\$(NetCoreAppCurrent)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
Hey @ericstj, while I was trying to ingest the transport pack, I found that the location for ref and impl assemblies are backwards. 

FYI, other than that, I've got things building on my local box but I'm still working on getting all the tests fixed up. cc @maryamariyan 