### PR TITLE
Condition before/after import in IL.Sdk for pre5.0

### DIFF
--- a/src/coreclr/src/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.Common.targets
+++ b/src/coreclr/src/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.Common.targets
@@ -6,10 +6,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
+  <Import Condition="Exists('$(MSBuildToolsPath)\Microsoft.Managed.Before.targets')" Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
   
   <Import Condition="'$(IsCrossTargetingBuild)' != 'true'" Project="$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.IL.targets" />
   <Import Condition="'$(IsCrossTargetingBuild)' == 'true'" Project="$(MSBuildExtensionsPath)\Microsoft.Common.CrossTargeting.targets" />
   
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
+  <Import Condition="Exists('$(MSBuildToolsPath)\Microsoft.Managed.After.targets')" Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
 </Project> 


### PR DESCRIPTION
With this, the IL SDK will continue to work when it comes to either single or multitargeting without restoring the projects in multi-targeting mode. This helps to not introduce a breaking change for 3.x SDKs.