### PR TITLE
Add (internal) Task.WhenAny(task, task) overload

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -718,7 +718,7 @@ namespace System.Threading
                 // cancel, and we chain the caller's supplied token into it.
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
                 {
-                    if (asyncWaiter == await TaskFactory.CommonCWAnyLogic(new Task[] { asyncWaiter, Task.Delay(millisecondsTimeout, cts.Token) }).ConfigureAwait(false))
+                    if (asyncWaiter == await Task.WhenAny(asyncWaiter, Task.Delay(millisecondsTimeout, cts.Token)).ConfigureAwait(false))
                     {
                         cts.Cancel(); // ensure that the Task.Delay task is cleaned up
                         return true; // successfully acquired
@@ -731,7 +731,7 @@ namespace System.Threading
                 var cancellationTask = new Task(null, TaskCreationOptions.RunContinuationsAsynchronously, promiseStyle: true);
                 using (cancellationToken.UnsafeRegister(s => ((Task)s!).TrySetResult(), cancellationTask))
                 {
-                    if (asyncWaiter == await TaskFactory.CommonCWAnyLogic(new Task[] { asyncWaiter, cancellationTask }).ConfigureAwait(false))
+                    if (asyncWaiter == await Task.WhenAny(asyncWaiter, cancellationTask).ConfigureAwait(false))
                     {
                         return true; // successfully acquired
                     }


### PR DESCRIPTION
Currently internal and used as an implementation detail under Task.WhenAny(params Task[]) as well as from SemaphoreSlim.  Once API reviewed, it can be made public.

Contributes to https://github.com/dotnet/runtime/issues/23021

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.CompilerServices;
using System.Threading;
using System.Threading.Tasks;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private static readonly Task s_incompleteTask = new TaskCompletionSource<bool>().Task;
    private static readonly CancellationToken s_uncanceledToken = new CancellationTokenSource().Token;
    private static readonly SemaphoreSlim s_sem = new SemaphoreSlim(0);

    private const int Iterations = 1_000;

    [Benchmark(OperationsPerInvoke = Iterations)]
    public async Task SemaphoreWait()
    {
        for (int i = 0; i < Iterations; i++)
        {
            Task t = s_sem.WaitAsync(s_uncanceledToken);
            s_sem.Release();
            await t;
        }
    }

    [Benchmark(OperationsPerInvoke = Iterations)]
    public async Task WhenAny_Incomplete()
    {
        for (int i = 0; i < Iterations; i++)
        {
            AsyncTaskMethodBuilder atmb = default;
            Task t = Task.WhenAny(atmb.Task, s_incompleteTask);
            atmb.SetResult();
            await t;
        }
    }

    [Benchmark(OperationsPerInvoke = Iterations)]
    public async Task WhenAny_Complete()
    {
        for (int i = 0; i < Iterations; i++)
        {
            await Task.WhenAny(Task.CompletedTask, s_incompleteTask);
        }
    }
}
```

|             Method |           Toolchain |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |-------------------- |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|      SemaphoreWait | \master\corerun.exe | 978.00 ns | 13.790 ns | 12.900 ns |  1.00 |    0.00 | 0.0859 |     - |     - |     536 B |
|      SemaphoreWait |     \pr\corerun.exe | 951.92 ns |  9.384 ns |  8.778 ns |  0.97 |    0.02 | 0.0791 |     - |     - |     496 B |
|                    |                     |           |           |           |       |         |        |       |       |           |
| WhenAny_Incomplete | \master\corerun.exe | 198.69 ns |  0.487 ns |  0.407 ns |  1.00 |    0.00 | 0.0381 |     - |     - |     240 B |
| WhenAny_Incomplete |     \pr\corerun.exe | 170.02 ns |  1.293 ns |  1.209 ns |  0.85 |    0.01 | 0.0317 |     - |     - |     200 B |
|                    |                     |           |           |           |       |         |        |       |       |           |
|   WhenAny_Complete | \master\corerun.exe |  97.48 ns |  0.228 ns |  0.202 ns |  1.00 |    0.00 | 0.0319 |     - |     - |     200 B |
|   WhenAny_Complete |     \pr\corerun.exe |  25.88 ns |  0.378 ns |  0.354 ns |  0.27 |    0.00 | 0.0179 |     - |     - |     112 B |