### PR TITLE
Fix wrong assert in cgroups code

### DIFF
--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -189,7 +189,7 @@ private:
             common_path_prefix_len = 0;
         }
 
-        assert(cgroup_path_relative_to_mount[common_path_prefix_len] == '/');
+        assert((cgroup_path_relative_to_mount[common_path_prefix_len] == '/') || (cgroup_path_relative_to_mount[common_path_prefix_len] == '\0'));
 
         strcat(cgroup_path, cgroup_path_relative_to_mount + common_path_prefix_len);
 

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -179,7 +179,7 @@ private:
             common_path_prefix_len = 0;
         }
 
-        _ASSERTE(cgroup_path_relative_to_mount[common_path_prefix_len] == '/');
+        _ASSERTE((cgroup_path_relative_to_mount[common_path_prefix_len] == '/') || (cgroup_path_relative_to_mount[common_path_prefix_len] == '\0'));
 
         strcat_s(cgroup_path, len+1, cgroup_path_relative_to_mount + common_path_prefix_len);
 


### PR DESCRIPTION
There is an assert in FindCgroupPath that fires when hierarchy_root
and cgroup_path_relative_to_mount are equal, which is the case for
cgroups that are not named. This assert checks that the common
path in those two variables ends with / which is only the case
with named groups.

We have never seen this assert to fire because cgroups initialization
happens before the debugger support initialization in PAL and so
asserts are disabled at that point. I am going to fix that in a
separate PR.

This problem was discovered with the standalone GC where the assert
actually fires as it uses a plain C assert function.

This change fixes the assert to account for the case when both the
paths are the same.

Close #34287