### PR TITLE
Flow TargetArchitecture always in Unix build script

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -112,7 +112,6 @@ while [[ $# > 0 ]]; do
       ;;
      -arch)
       arch=$2
-      arguments="$arguments /p:TargetArchitecture=$2"
       shift 2
       ;;
      -configuration|-c)
@@ -213,5 +212,6 @@ initDistroRid $os $arch $crossBuild
 # URL-encode space (%20) to avoid quoting issues until the msbuild call in /eng/common/tools.sh.
 # In *proj files (XML docs), URL-encoded string are rendered in their decoded form.
 cmakeargs="${cmakeargs// /%20}"
+arguments="$arguments /p:TargetArchitecture=$arch"
 arguments="$arguments /p:CMakeArgs=\"$cmakeargs\" $extraargs"
 "$scriptroot/common/build.sh" $arguments


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/34254

In: https://github.com/dotnet/runtime/commit/59be94b69845ecfbd5a694483c2a4853e99cc64b build properties were cleaned up and we removed the default we had for S.P.CoreLib that if no arch was passed, x64 was used. However, I noticed that in Windows and Unix we have automatic arch detection based on the build machine, so if no `-arch` parameter build script is passed down we use that one. However in Unix we are not using the detected value, only the parameter value if passed. 

This changes that to match what we do in Windows:
https://github.com/dotnet/runtime/blob/335ffb05fbe97187452046bc6791405ea33f210c/eng/build.ps1#L14

https://github.com/dotnet/runtime/blob/335ffb05fbe97187452046bc6791405ea33f210c/eng/build.ps1#L164

Currently after we removed the default in `dir.common.props` when building S.P.CoreLib using `build.sh -subsetCategory coreclr -subset corelib` S.P.Corelib is binplaced in the wrong path, since `TargetArchitecture` remains empty:
https://github.com/dotnet/runtime/blob/335ffb05fbe97187452046bc6791405ea33f210c/src/coreclr/dir.common.props#L14

> System.Private.CoreLib -> /home/santifdezm/repos/runtime/artifacts/bin/coreclr/Linux..Release/IL/System.Private.CoreLib.dll

cc: @jkotas @dotnet/runtime-infrastructure 