### PR TITLE
Expression.Field should validate field name for null

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -177,6 +177,7 @@ namespace System.Linq.Expressions
         public static MemberExpression Field(Expression? expression, Type type, string fieldName)
         {
             ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(fieldName, nameof(fieldName));
 
             // bind to public names first
             FieldInfo? fi = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy)

--- a/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -224,6 +224,7 @@ namespace System.Linq.Expressions.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("field", () => Expression.Field(null, (FieldInfo)null));
             AssertExtensions.Throws<ArgumentNullException>("fieldName", () => Expression.Field(Expression.Constant(new FC()), (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("fieldName", () => Expression.Field(Expression.Constant(new FC()), typeof(FC), (string)null));
         }
 
         [Fact]


### PR DESCRIPTION
Small change to correctly check for null in one of the overloads of Expression.Field.