### PR TITLE
Check for COM registration functions on base types of registered type

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -161,60 +161,68 @@ namespace Internal.Runtime.InteropServices
 
             Type classType = FindClassType(cxt.ClassId, cxt.AssemblyPath, cxt.AssemblyName, cxt.TypeName);
 
-            // Retrieve all the methods.
-            MethodInfo[] methods = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-
+            Type? currentType = classType;
             bool calledFunction = false;
 
-            // Go through all the methods and check for the custom attribute.
-            foreach (MethodInfo method in methods)
+            // Walk up the inheritance hierarchy. The first register/unregister function found is called; any additional functions on base types are ignored.
+            while (currentType != null && !calledFunction)
             {
-                // Check to see if the method has the custom attribute.
-                if (method.GetCustomAttributes(regFuncAttrType!, inherit: true).Length == 0)
+                // Retrieve all the methods.
+                MethodInfo[] methods = currentType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+                // Go through all the methods and check for the custom attribute.
+                foreach (MethodInfo method in methods)
                 {
-                    continue;
+                    // Check to see if the method has the custom attribute.
+                    if (method.GetCustomAttributes(regFuncAttrType!, inherit: true).Length == 0)
+                    {
+                        continue;
+                    }
+
+                    // Check to see if the method is static before we call it.
+                    if (!method.IsStatic)
+                    {
+                        string msg = register ? SR.InvalidOperation_NonStaticComRegFunction : SR.InvalidOperation_NonStaticComUnRegFunction;
+                        throw new InvalidOperationException(SR.Format(msg));
+                    }
+
+                    // Finally validate signature
+                    ParameterInfo[] methParams = method.GetParameters();
+                    if (method.ReturnType != typeof(void)
+                        || methParams == null
+                        || methParams.Length != 1
+                        || (methParams[0].ParameterType != typeof(string) && methParams[0].ParameterType != typeof(Type)))
+                    {
+                        string msg = register ? SR.InvalidOperation_InvalidComRegFunctionSig : SR.InvalidOperation_InvalidComUnRegFunctionSig;
+                        throw new InvalidOperationException(SR.Format(msg));
+                    }
+
+                    if (calledFunction)
+                    {
+                        string msg = register ? SR.InvalidOperation_MultipleComRegFunctions : SR.InvalidOperation_MultipleComUnRegFunctions;
+                        throw new InvalidOperationException(SR.Format(msg));
+                    }
+
+                    // The function is valid so set up the arguments to call it.
+                    var objs = new object[1];
+                    if (methParams[0].ParameterType == typeof(string))
+                    {
+                        // We are dealing with the string overload of the function - provide the registry key - see comhost.dll implementation
+                        objs[0] = $"HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID\\{cxt.ClassId.ToString("B")}";
+                    }
+                    else
+                    {
+                        // We are dealing with the type overload of the function.
+                        objs[0] = classType;
+                    }
+
+                    // Invoke the COM register function.
+                    method.Invoke(null, objs);
+                    calledFunction = true;
                 }
 
-                // Check to see if the method is static before we call it.
-                if (!method.IsStatic)
-                {
-                    string msg = register ? SR.InvalidOperation_NonStaticComRegFunction : SR.InvalidOperation_NonStaticComUnRegFunction;
-                    throw new InvalidOperationException(SR.Format(msg));
-                }
-
-                // Finally validate signature
-                ParameterInfo[] methParams = method.GetParameters();
-                if (method.ReturnType != typeof(void)
-                    || methParams == null
-                    || methParams.Length != 1
-                    || (methParams[0].ParameterType != typeof(string) && methParams[0].ParameterType != typeof(Type)))
-                {
-                    string msg = register ? SR.InvalidOperation_InvalidComRegFunctionSig : SR.InvalidOperation_InvalidComUnRegFunctionSig;
-                    throw new InvalidOperationException(SR.Format(msg));
-                }
-
-                if (calledFunction)
-                {
-                    string msg = register ? SR.InvalidOperation_MultipleComRegFunctions : SR.InvalidOperation_MultipleComUnRegFunctions;
-                    throw new InvalidOperationException(SR.Format(msg));
-                }
-
-                // The function is valid so set up the arguments to call it.
-                var objs = new object[1];
-                if (methParams[0].ParameterType == typeof(string))
-                {
-                    // We are dealing with the string overload of the function - provide the registry key - see comhost.dll implementation
-                    objs[0] = $"HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID\\{cxt.ClassId.ToString("B")}";
-                }
-                else
-                {
-                    // We are dealing with the type overload of the function.
-                    objs[0] = classType;
-                }
-
-                // Invoke the COM register function.
-                method.Invoke(null, objs);
-                calledFunction = true;
+                // Go through all the base types
+                currentType = currentType.BaseType;
             }
         }
 

--- a/src/coreclr/tests/src/Interop/COM/Activator/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Program.cs
@@ -157,9 +157,16 @@ namespace Activator
                 string.Empty,
                 string.Empty))
             {
-                foreach (string typename in new[] { "ValidRegistrationTypeCallbacks",  "ValidRegistrationStringCallbacks" })
+                string[] typeNamesToValidate = {
+                    "ValidRegistrationTypeCallbacks",
+                    "ValidRegistrationStringCallbacks",
+                    "InheritedRegistrationTypeCallbacks",
+                    "InheritedRegistrationStringCallbacks"
+                };
+
+                foreach (string typeName in typeNamesToValidate)
                 {
-                    Console.WriteLine($"Validating {typename}...");
+                    Console.WriteLine($"Validating {typeName}...");
 
                     var cxt = new ComActivationContext()
                     {
@@ -167,7 +174,7 @@ namespace Activator
                         InterfaceId = typeof(IClassFactory).GUID,
                         AssemblyPath = assemblyAPath,
                         AssemblyName = "AssemblyA",
-                        TypeName = typename
+                        TypeName = typeName
                     };
 
                     var factory = (IClassFactory)ComActivator.GetClassFactoryForType(cxt);
@@ -183,8 +190,8 @@ namespace Activator
                     ComActivator.ClassRegistrationScenarioForType(cxt, register: true);
                     ComActivator.ClassRegistrationScenarioForType(cxt, register: false);
 
-                    Assert.IsTrue(inst.DidRegister());
-                    Assert.IsTrue(inst.DidUnregister());
+                    Assert.IsTrue(inst.DidRegister(), $"User-defined register function should have been called.");
+                    Assert.IsTrue(inst.DidUnregister(), $"User-defined unregister function should have been called.");
                 }
             }
 

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.cs
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.cs
@@ -12,7 +12,7 @@ public class ClassFromA : IGetTypeFromC
     {
         this._fromC = new ClassFromC();
     }
-    
+
     public object GetTypeFromC()
     {
         return this._fromC.GetType();
@@ -62,6 +62,12 @@ public class ValidRegistrationStringCallbacks : IValidateRegistrationCallbacks
         s_didUnregister = false;
     }
 }
+
+public class InheritedRegistrationTypeCallbacks : RegistrationTypeCallbacksFromB
+{ }
+
+public class InheritedRegistrationStringCallbacks : RegistrationStringCallbacksFromB
+{ }
 
 public class NoRegistrationCallbacks : IValidateRegistrationCallbacks
 {

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.csproj
@@ -7,6 +7,7 @@
     <Compile Include="AssemblyA.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="AssemblyB.csproj" />
     <ProjectReference Include="AssemblyC.csproj" />
     <ProjectReference Include="AssemblyContracts.csproj" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyB.cs
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyB.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 public class ClassFromB : IGetTypeFromC
 {
@@ -11,9 +12,53 @@ public class ClassFromB : IGetTypeFromC
     {
         this._fromC = new ClassFromC();
     }
-    
+
     public object GetTypeFromC()
     {
         return this._fromC.GetType();
+    }
+}
+
+public class RegistrationTypeCallbacksFromB : IValidateRegistrationCallbacks
+{
+    [ComRegisterFunctionAttribute]
+    internal static void RegisterFunction(Type t) => s_didRegister = true;
+
+    [ComUnregisterFunctionAttribute]
+    internal static void UnregisterFunction(Type t) => s_didUnregister = true;
+
+    private static bool s_didRegister = false;
+    private static bool s_didUnregister = false;
+
+    bool IValidateRegistrationCallbacks.DidRegister() => s_didRegister;
+
+    bool IValidateRegistrationCallbacks.DidUnregister() => s_didUnregister;
+
+    void IValidateRegistrationCallbacks.Reset()
+    {
+        s_didRegister = false;
+        s_didUnregister = false;
+    }
+}
+
+public class RegistrationStringCallbacksFromB : IValidateRegistrationCallbacks
+{
+    [ComRegisterFunctionAttribute]
+    internal static void RegisterFunction(string t) => s_didRegister = true;
+
+    [ComUnregisterFunctionAttribute]
+    internal static void UnregisterFunction(string t) => s_didUnregister = true;
+
+    private static bool s_didRegister = false;
+    private static bool s_didUnregister = false;
+
+    bool IValidateRegistrationCallbacks.DidRegister() => s_didRegister;
+
+    bool IValidateRegistrationCallbacks.DidUnregister() => s_didUnregister;
+
+    void IValidateRegistrationCallbacks.Reset()
+    {
+        s_didRegister = false;
+        s_didUnregister = false;
     }
 }


### PR DESCRIPTION
We were only looking for functions with the `ComRegisterFunction` and `ComUnregisterFunction` attributes directly on the type being registered. This change updates that logic to also look at the base types of the type being registered. If a register/unregister function is defined on both the base and derived types, only the one on the derived type will be called. This matches the behaviour in Framework.

Fix #869 