### PR TITLE
Enhance PAL initialization order

### DIFF
--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -359,18 +359,34 @@ Initialize(
         gPID = getpid();
         gSID = getsid(gPID);
 
+        // Initialize the TLS lookaside cache
+        if (FALSE == TLSInitialize())
+        {
+            palError = ERROR_PALINIT_TLS;
+            goto done;
+        }
+
+        // Initialize debug channel settings before anything else.
+        // This depends on the environment, so it must come after
+        // EnvironInitialize.
+        if (FALSE == DBG_init_channels())
+        {
+            palError = ERROR_PALINIT_DBG_CHANNELS;
+            goto CLEANUP0a;
+        }
+
         // The gSharedFilesPath is allocated dynamically so its destructor does not get
         // called unexpectedly during cleanup
         gSharedFilesPath = InternalNew<PathCharString>();
         if (gSharedFilesPath == nullptr)
         {
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-            goto done;
+            goto CLEANUP0a;
         }
 
         if (INIT_SharedFilesPath() == FALSE)
         {
-            goto done;
+            goto CLEANUP0a;
         }
 
         fFirstTimeInit = true;
@@ -400,28 +416,12 @@ Initialize(
         }
 #endif // FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
 
-        // Initialize the TLS lookaside cache
-        if (FALSE == TLSInitialize())
-        {
-            palError = ERROR_PALINIT_TLS;
-            goto done;
-        }
-
         InitializeCGroup();
 
         // Initialize the environment.
         if (FALSE == EnvironInitialize())
         {
             palError = ERROR_PALINIT_ENV;
-            goto CLEANUP0;
-        }
-
-        // Initialize debug channel settings before anything else.
-        // This depends on the environment, so it must come after
-        // EnvironInitialize.
-        if (FALSE == DBG_init_channels())
-        {
-            palError = ERROR_PALINIT_DBG_CHANNELS;
             goto CLEANUP0;
         }
 
@@ -726,6 +726,7 @@ CLEANUP1:
     SHMCleanup();
 CLEANUP0:
     CleanupCGroup();
+CLEANUP0a:
     TLSCleanup();
     ERROR("PAL_Initialize failed\n");
     SetLastError(palError);

--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -359,7 +359,7 @@ Initialize(
         gPID = getpid();
         gSID = getsid(gPID);
 
-        // Initialize the TLS lookaside cache
+        // Initialize the thread local storage  
         if (FALSE == TLSInitialize())
         {
             palError = ERROR_PALINIT_TLS;

--- a/src/coreclr/src/pal/src/init/pal.cpp
+++ b/src/coreclr/src/pal/src/init/pal.cpp
@@ -367,8 +367,6 @@ Initialize(
         }
 
         // Initialize debug channel settings before anything else.
-        // This depends on the environment, so it must come after
-        // EnvironInitialize.
         if (FALSE == DBG_init_channels())
         {
             palError = ERROR_PALINIT_DBG_CHANNELS;


### PR DESCRIPTION
The CGroups initialization has _ASSERTE that is not asserting because
debugging support was being initialized after the CGroups initialization.

This change moves the debugging support initialization to the earliest
possible point. It also modifies it so that it doesn't depend on the
PAL env functions and uses getenv instead. And finally, initialization
of the critical section for debug printf is moved to the very end
of DBG_init_channels just as a little cleanup.