### PR TITLE
Remove ElfReader #if ALPINE dependence

### DIFF
--- a/src/coreclr/src/debug/dbgutil/CMakeLists.txt
+++ b/src/coreclr/src/debug/dbgutil/CMakeLists.txt
@@ -8,10 +8,6 @@ endif(CLR_CMAKE_HOST_WIN32)
 
 add_definitions(-DPAL_STDCPP_COMPAT)
 
-if(CLR_CMAKE_TARGET_ALPINE_LINUX)
-    add_definitions(-DTARGET_ALPINE_LINUX)
-endif(CLR_CMAKE_TARGET_ALPINE_LINUX)
-
 set(DBGUTIL_SOURCES
     dbgutil.cpp
 )

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -8,6 +8,7 @@
 #include <cordebug.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <algorithm>
 #include "elfreader.h"
 
 #define Elf_Ehdr   ElfW(Ehdr)

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -74,7 +74,7 @@ bool
 TryGetSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress)
 {
     ElfReaderExport elfreader(dataTarget);
-    if (elfreader.PopulateForSymbolLookup(baseAddress))
+    if (elfreader.PopulateForSymbolLookup(baseAddress, symbolName))
     {
         uint64_t symbolOffset;
         if (elfreader.TryLookupSymbol(symbolName, &symbolOffset))
@@ -114,7 +114,7 @@ ElfReader::~ElfReader()
 // caches the info neccessary in the ElfReader class look up symbols.
 //
 bool
-ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
+ElfReader::PopulateForSymbolLookup(uint64_t baseAddress, std::string symbolName)
 {
     TRACE("PopulateForSymbolLookup: base %" PRIA PRIx64 "\n", baseAddress);
     Elf_Dyn* dynamicAddr = nullptr;
@@ -196,7 +196,7 @@ ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
         // Rather than making a compile time decision based on OS, we try to find a required symbol.
         // Try to find "g_dacTable" in the hash table w/o adding the loadbias
         uint64_t symbolOffset;
-        if (!InitializeGnuHashTable() || !TryLookupSymbol("g_dacTable", &symbolOffset)) {
+        if (!InitializeGnuHashTable() || !TryLookupSymbol(symbolName, &symbolOffset)) {
             // Since we cannot find the expected symbol assume we need to add the loadbias
             addLoadBias = true;
         }

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -165,12 +165,12 @@ ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
         return false;
     }
 
-    uint64_t minAddr = std::min(std::min((uint64_t)m_gnuHashTableAddr,
-                                         (uint64_t)m_stringTableAddr),
-                                         (uint64_t)m_symbolTableAddr);
-    uint64_t maxAddr = std::max(std::max((uint64_t)m_gnuHashTableAddr + sizeof(GnuHashTable) + sizeof(int32_t),
-                                         (uint64_t)m_stringTableAddr + m_stringTableSize),
-                                         (uint64_t)m_symbolTableAddr);
+    uint64_t minAddr = std::min<uint64_t>(std::min<uint64_t>((uint64_t)m_gnuHashTableAddr,
+                                                             (uint64_t)m_stringTableAddr),
+                                                             (uint64_t)m_symbolTableAddr);
+    uint64_t maxAddr = std::max<uint64_t>(std::max<uint64_t>((uint64_t)m_gnuHashTableAddr + sizeof(GnuHashTable) + sizeof(int32_t),
+                                                             (uint64_t)m_stringTableAddr + m_stringTableSize),
+                                                             (uint64_t)m_symbolTableAddr);
 
     bool addLoadBias = false;
 
@@ -550,7 +550,7 @@ ElfReader::EnumerateProgramHeaders(Elf_Phdr* phdrAddr, int phnum, uint64_t baseA
             break;
         case PT_LOAD:
             // Calculate the load size from the PT_LOAD program headers
-            loadsize = std::max(loadsize, ph.p_vaddr + ph.p_memsz);
+            loadsize = std::max<uint64_t>(loadsize, ph.p_vaddr + ph.p_memsz);
             break;
         }
 

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -498,7 +498,7 @@ ElfReader::EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias, El
         ehdr.e_type, ehdr.e_machine, ehdr.e_version, ehdr.e_flags, phnum, ehdr.e_phoff, ehdr.e_phentsize, ehdr.e_shnum, ehdr.e_shoff, ehdr.e_shentsize, ehdr.e_shstrndx);
 
     Elf_Phdr* phdrAddr = reinterpret_cast<Elf_Phdr*>(baseAddress + ehdr.e_phoff);
-    return EnumerateProgramHeaders(phdrAddr, phnum, baseAddress, ploadbias, pdynamicAddr);
+    return EnumerateProgramHeaders(phdrAddr, phnum, baseAddress, ploadbias, pdynamicAddr, ploadsize);
 }
 
 //

--- a/src/coreclr/src/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/src/debug/dbgutil/elfreader.cpp
@@ -550,7 +550,7 @@ ElfReader::EnumerateProgramHeaders(Elf_Phdr* phdrAddr, int phnum, uint64_t baseA
             break;
         case PT_LOAD:
             // Calculate the load size from the PT_LOAD program headers
-            loadsize = std::max<uint64_t>(loadsize, ph.p_vaddr + ph.p_memsz);
+            loadsize = std::max<size_t>(loadsize, (size_t)(ph.p_vaddr + ph.p_memsz));
             break;
         }
 

--- a/src/coreclr/src/debug/dbgutil/elfreader.h
+++ b/src/coreclr/src/debug/dbgutil/elfreader.h
@@ -50,7 +50,7 @@ public:
 #ifdef HOST_UNIX
     bool EnumerateElfInfo(ElfW(Phdr)* phdrAddr, int phnum);
 #endif
-    bool PopulateForSymbolLookup(uint64_t baseAddress);
+    bool PopulateForSymbolLookup(uint64_t baseAddress, std::string symbolName = "g_dacTable");
     bool TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset);
     bool EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias = nullptr, ElfW(Dyn)** pdynamicAddr = nullptr, size_t *ploadsize = nullptr);
 

--- a/src/coreclr/src/debug/dbgutil/elfreader.h
+++ b/src/coreclr/src/debug/dbgutil/elfreader.h
@@ -33,6 +33,8 @@ typedef struct {
 class ElfReader
 {
 private:
+    uint64_t m_elfLoadMin;
+    uint64_t m_elfLoadMax;
     void* m_gnuHashTableAddr;               // DT_GNU_HASH
     void* m_stringTableAddr;                // DT_STRTAB
     int m_stringTableSize;                  // DT_STRSIZ
@@ -66,6 +68,7 @@ private:
     bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr, size_t *ploadsize = nullptr);
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
+    bool ReadElfMemory(void* address, void* buffer, size_t size);
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;
     virtual void Trace(const char* format, ...) { };
 };

--- a/src/coreclr/src/debug/dbgutil/elfreader.h
+++ b/src/coreclr/src/debug/dbgutil/elfreader.h
@@ -50,11 +50,12 @@ public:
 #endif
     bool PopulateForSymbolLookup(uint64_t baseAddress);
     bool TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset);
-    bool EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias = nullptr, ElfW(Dyn)** pdynamicAddr = nullptr);
+    bool EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias = nullptr, ElfW(Dyn)** pdynamicAddr = nullptr, size_t *ploadsize = nullptr);
 
 private:
     bool GetSymbol(int32_t index, ElfW(Sym)* symbol);
     bool InitializeGnuHashTable();
+    void FreeGnuHashTable();
     bool GetPossibleSymbolIndex(const std::string& symbolName, std::vector<int32_t>& symbolIndexes);
     uint32_t Hash(const std::string& symbolName);
     bool GetChain(int index, int32_t* chain);
@@ -62,7 +63,7 @@ private:
 #ifdef HOST_UNIX
     bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
 #endif
-    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
+    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr, size_t *ploadsize = nullptr);
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;


### PR DESCRIPTION
The cross DAC wants to be build for only Alpine or Linux not both.

Remove the ElfReader's compile time dependence on TARGET_ALPINE_LINUX

Use a simple heuristic to determine whether we need to add the loadbias.

If all else fails look for a well known symbol g_dacTable in the symbol hash
to determine whether to add the loadbias. (Should be rare.)

Fixes #32756