### PR TITLE
[mono] Use $(HostArch) for LLVM packages

### DIFF
--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -6,6 +6,7 @@
   
   <!-- Set default Platform -->
   <PropertyGroup>
+    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</HostArch>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Platform>$(TargetArchitecture)</Platform>
 

--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -5,22 +5,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(TargetOS)' == 'Linux'" Include="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'Linux'" Include="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'Linux'" Include="runtime.linux-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'Linux'" Include="runtime.linux-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
   </ItemGroup>
 
   <Target Name="CopyLLVMToTree" AfterTargets="Restore">
     <ItemGroup>
-      <LLVMFiles Condition="'$(TargetOS)' == 'Linux'" Include="$(NuGetPackageRoot)\runtime.linux-x64.microsoft.netcore.runtime.mono.llvm.sdk\$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\linux-x64\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'Linux'" Include="$(NuGetPackageRoot)\runtime.linux-x64.microsoft.netcore.runtime.mono.llvm.tools\$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\linux-x64\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-x64.microsoft.netcore.runtime.mono.llvm.sdk\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\win-x64\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-x64.microsoft.netcore.runtime.mono.llvm.tools\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\win-x64\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-x64.microsoft.netcore.runtime.mono.llvm.sdk\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\osx.10.12-x64\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-x64.microsoft.netcore.runtime.mono.llvm.tools\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\osx.10.12-x64\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'Linux'" Include="$(NuGetPackageRoot)\runtime.linux-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\linux-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'Linux'" Include="$(NuGetPackageRoot)\runtime.linux-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\linux-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\win-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\win-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\osx.10.12-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\osx.10.12-$(HostArch)\**" />
     </ItemGroup>
 
     <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(RecursiveDir)">


### PR DESCRIPTION
Currently we always download x64 packages -- it's ok for our workloads since we can use them for cross-compilation to arm64 but it's not possbile to use them when you compile dotnet/runtime on an arm64 machine.

Fixes https://github.com/dotnet/runtime/issues/34311

@akoeplinger should I also duplicate these: https://github.com/dotnet/runtime/blob/master/eng/Versions.props#L127-L132 ?