### PR TITLE
Disable test on windows and enable on other platforms

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -410,7 +410,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public void HttpClientUsesSslCertEnvironmentVariables()
         {
             // We set SSL_CERT_DIR and SSL_CERT_FILE to empty locations.

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -410,8 +410,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.Linux)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33558")]
+        [PlatformSpecific(~TestPlatforms.Windows)]
         public void HttpClientUsesSslCertEnvironmentVariables()
         {
             // We set SSL_CERT_DIR and SSL_CERT_FILE to empty locations.


### PR DESCRIPTION
The change enables test only on OpenSSL platforms. 
Two years ago, the test was disabled for MacOs, however, I decided to enable it as it passes.

Contributes to #33558 