### PR TITLE
[mono] Fix LLVM JIT build on arm64 host

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -30,6 +30,11 @@ For both `build.sh` and `mono.sh`
 
 `/p:MonoEnableLlvm=true` - Builds mono w/ LLVM
 
+`/p:MonoEnableLlvm=true /p:MonoLLVMDir=path/to/llvm` - Builds mono w/ LLVM from a custom path
+
+`/p:MonoEnableLlvm=true /p:MonoLLVMDir=path/to/llvm /p:MonoLLVMUseCxx11Abi=true` - Builds mono w/ LLVM 
+from a custom path (and that LLVM was built with C++11 ABI)
+
 For `build.sh`
 
 `/p:DisableCrossgen=true` - Skips building the installer if you don't need it (builds faster)

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -61,7 +61,7 @@
       <_MonoCXXFLAGS Include="-O0" />
       <_MonoCXXFLAGS Include="-ggdb3" />
       <_MonoCXXFLAGS Include="-fno-omit-frame-pointer" />
-      <_MonoCXXFLAGS Condition="$(HostArch.Contains('arm')) and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+      <_MonoCXXFLAGS Condition="!$(HostArch.Contains('arm')) or '$(MonoEnableLLVM)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- Release specific options -->
@@ -71,7 +71,7 @@
 
       <_MonoCXXFLAGS Include="-O2" />
       <_MonoCXXFLAGS Include="-g" />
-      <_MonoCXXFLAGS Condition="$(HostArch.Contains('arm')) and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+      <_MonoCXXFLAGS Condition="!$(HostArch.Contains('arm')) or '$(MonoEnableLLVM)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- iOS device specific options -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -71,7 +71,7 @@
 
       <_MonoCXXFLAGS Include="-O2" />
       <_MonoCXXFLAGS Include="-g" />
-      <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+      <_MonoCXXFLAGS Condition="$(HostArch.Contains('arm')) and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- iOS device specific options -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -61,7 +61,6 @@
       <_MonoCXXFLAGS Include="-O0" />
       <_MonoCXXFLAGS Include="-ggdb3" />
       <_MonoCXXFLAGS Include="-fno-omit-frame-pointer" />
-      <_MonoCXXFLAGS Condition="'$(HostArch)' == 'x64' and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- Release specific options -->
@@ -71,12 +70,11 @@
 
       <_MonoCXXFLAGS Include="-O2" />
       <_MonoCXXFLAGS Include="-g" />
-      <_MonoCXXFLAGS Condition="!$(HostArch.Contains('arm')) or '$(MonoEnableLLVM)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
-    <ItemGroup>
-      <!-- We build LLVM bits for x64 without C++11 ABI -->
-      <_MonoCXXFLAGS Condition="'$(HostArch)' == 'x64' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+    <!-- We build LLVM bits for x64 without C++11 ABI -->
+    <ItemGroup Condition="'$(HostArch)' == 'x64' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'">
+      <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- iOS device specific options -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -61,7 +61,7 @@
       <_MonoCXXFLAGS Include="-O0" />
       <_MonoCXXFLAGS Include="-ggdb3" />
       <_MonoCXXFLAGS Include="-fno-omit-frame-pointer" />
-      <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+      <_MonoCXXFLAGS Condition="$(HostArch.Contains('arm')) and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- Release specific options -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -61,7 +61,7 @@
       <_MonoCXXFLAGS Include="-O0" />
       <_MonoCXXFLAGS Include="-ggdb3" />
       <_MonoCXXFLAGS Include="-fno-omit-frame-pointer" />
-      <_MonoCXXFLAGS Condition="!$(HostArch.Contains('arm')) or '$(MonoEnableLLVM)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+      <_MonoCXXFLAGS Condition="'$(HostArch)' == 'x64' and '$(MonoEnableLLVM)' == 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- Release specific options -->
@@ -72,6 +72,11 @@
       <_MonoCXXFLAGS Include="-O2" />
       <_MonoCXXFLAGS Include="-g" />
       <_MonoCXXFLAGS Condition="!$(HostArch.Contains('arm')) or '$(MonoEnableLLVM)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- We build LLVM bits for x64 without C++11 ABI -->
+      <_MonoCXXFLAGS Condition="'$(HostArch)' == 'x64' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'" Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- iOS device specific options -->


### PR DESCRIPTION
Currently LLVM-JIT refuses to build on arm64.

cc @filipnavara @imhameed 

fixes https://github.com/dotnet/runtime/issues/34311#issuecomment-606719340