### PR TITLE
[mono] Fix LLVM JIT on Arm64

### DIFF
--- a/src/mono/mono/mini/llvm-jit.cpp
+++ b/src/mono/mono/mini/llvm-jit.cpp
@@ -484,6 +484,7 @@ mono_llvm_jit_init ()
 
 	EB.setOptLevel(CodeGenOpt::Aggressive);
 	EB.setMCPU(sys::getHostCPUName());
+	EB.setMArch(llvm::Triple(llvm::sys::getDefaultTargetTriple()).getArchName());
 	auto TM = EB.selectTarget ();
 	assert (TM);
 


### PR DESCRIPTION
`EB.selectTarget ();` used to return `NULL` on arm64 (and hit an assert later)
Turns out it needs MArch on arm (e.g. `"aarch64"`) set. No idea why it doesn't use host arch by default (but works on x86).