### PR TITLE
[release/5.0-preview3] Cache parameterized ctor delegates in class info rather than converter

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -429,7 +429,7 @@ namespace System.Text.Json.Serialization.Converters
 
             if (state.Current.JsonClassInfo.ParameterCount != state.Current.JsonClassInfo.ParameterCache!.Count)
             {
-                ThrowHelper.ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(ConstructorInfo, TypeToConvert);
+                ThrowHelper.ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(ConstructorInfo!, TypeToConvert);
             }
 
             // Set current JsonPropertyInfo to null to avoid conflicts on push.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json
 
         public ConstructorDelegate? CreateObject { get; private set; }
 
+        public object? CreateObjectWithParameterizedCtor { get; set; }
+
         public ClassType ClassType { get; private set; }
 
         public JsonPropertyInfo? DataExtensionProperty { get; private set; }
@@ -159,8 +161,7 @@ namespace System.Text.Json
 
                         if (converter.ConstructorIsParameterized)
                         {
-                            converter.CreateConstructorDelegate(options);
-                            InitializeConstructorParameters(converter.ConstructorInfo);
+                            InitializeConstructorParameters(converter.ConstructorInfo!);
                         }
                     }
                     break;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -78,8 +78,6 @@ namespace System.Text.Json.Serialization
         // Whether a type (ClassType.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized => false;
 
-        internal ConstructorInfo ConstructorInfo { get; set; } = null!;
-
-        internal virtual void CreateConstructorDelegate(JsonSerializerOptions options) { }
+        internal ConstructorInfo? ConstructorInfo { get; set; }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests.ParameterMatching.cs
@@ -8,14 +8,14 @@ using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
-    public class ConstructorTests_StringTValue : ConstructorTests
+    public class ConstructorTests_String : ConstructorTests
     {
-        public ConstructorTests_StringTValue() : base(DeserializationWrapper.StringTValueSerializer) { }
+        public ConstructorTests_String() : base(DeserializationWrapper.StringDeserializer) { }
     }
 
-    public class ConstructorTests_StreamTValue : ConstructorTests
+    public class ConstructorTests_Stream : ConstructorTests
     {
-        public ConstructorTests_StreamTValue() : base(DeserializationWrapper.StreamTValueSerializer) { }
+        public ConstructorTests_Stream() : base(DeserializationWrapper.StreamDeserializer) { }
     }
 
     public abstract partial class ConstructorTests
@@ -301,7 +301,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => Serializer.Deserialize<ClassWrapper_For_Int_Point_3D_String>(@"{""MyPoint3DStruct"":null,""MyString"":""1""}"));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/33928")]
         [Fact]
         public void OtherPropertiesAreSet()
         {


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/runtime/pull/34248 to preview 3.
Fixes https://github.com/dotnet/runtime/issues/33928 in preview 3.

A `JsonSerializer` feature that enables the deserialization of POCOs using parameterized ctors was recently checked in - https://github.com/dotnet/runtime/pull/33444.

CI caught an issue where `JsonSerializer` leaks a null ref in some cases where deserialization of objects using parameterized ctors is occurring on multiple threads: https://github.com/dotnet/runtime/issues/33928. This PR fixes the issue.

#### Customer Impact

Prevents a null ref in multi-threaded deserialization scenarios. Users are likely to hit this when deserializing objects using parameterized ctors on mutliple threads. This proactively fixes the issue.

#### Regression?

This feature is shipping for the first time in this preview.

#### Risk

Tests have been added for this scenario.