### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -35,6 +35,18 @@ For information about the different options available, supply the argument `--he
 build -h
 ```
 
+Alternatively, you can build and install runtime using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+```bat
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.bat
+./vcpkg integrate install
+./vcpkg install nethost
+```
+
+The nethost port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 On Unix like systems, arguments can be passed in with a single `-` or double hyphen `--`.
 
 The repository currently consists of different major parts: the runtimes, the libraries, and the installer.


### PR DESCRIPTION
Hi,

dotnet/runtime is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build runtime, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for runtime and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/nethost/portfile.cmake) . We try to keep the library maintained as close as possible to the original library.