### PR TITLE
Enable running libraries tests with crossgen2 compiled runtime

### DIFF
--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -68,11 +68,31 @@
              ContinueOnError="ErrorAndContinue" />
   </Target>
 
+  <Target Name="RunCrossgen2OnHost" Condition="'$(Crossgen2Host)' == 'true'">
+    <ItemGroup>
+      <FilesToCrossgen Include="$(TestHostRuntimePath)\Microsoft.*.dll" Exclude="$(TestHostRuntimePath)\Microsoft.CodeAnalysis*.dll;$(TestHostRuntimePath)\Microsoft.DiaSymReader.Native.*.dll" />
+      <FilesToCrossgen Include="$(TestHostRuntimePath)\System.*.dll" Exclude="$(TestHostRuntimePath)\System.Runtime.WindowsRuntime.dll" />
+    </ItemGroup>
+
+    <MakeDir Directories="$(TestHostRuntimePath)\crossgen2out" />
+    <Exec Command="$(TestHostRootPath)\dotnet $(TestHostRuntimePath)\crossgen2.dll %(FilesToCrossgen.FullPath) --targetarch=x64 -O --inputbubble -r:$(TestHostRuntimePath)\System.*.dll -r:$(TestHostRuntimePath)\Microsoft.*.dll -r:$(TestHostRuntimePath)\mscorlib.dll -r:$(TestHostRuntimePath)\netstandard.dll -o:$(TestHostRuntimePath)\crossgen2out\%(FilesToCrossgen.Filename)%(FilesToCrossgen.Extension)" 
+          IgnoreStandardErrorWarningFormat="true"/>
+  </Target>
+
+  <Target Name="MoveCrossgen2ResultsToHostRuntime" DependsOnTargets="RunCrossgen2OnHost">
+    <ItemGroup>
+      <FilesToCopy Include="$(TestHostRuntimePath)\crossgen2out\*.dll" />
+    </ItemGroup>
+
+    <Move SourceFiles="@(FilesToCopy)" DestinationFolder="$(TestHostRuntimePath)" />
+    <RemoveDir Directories="$(TestHostRuntimePath)\crossgen2out" />
+  </Target>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <Target Name="Build"
           Condition="'$(SkipPrepareTest)' != 'true'"
-          DependsOnTargets="GenerateLaunchSettingsFiles;GenerateTestSharedFrameworkDepsFile;GenerateFileVersionProps">
+          DependsOnTargets="GenerateLaunchSettingsFiles;GenerateTestSharedFrameworkDepsFile;GenerateFileVersionProps;MoveCrossgen2ResultsToHostRuntime">
 
     <MSBuild Targets="Build"
              Projects="@(Project)"

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -85,6 +85,27 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GetCrossgen2"
+          DependsOnTargets="ResolveCoreCLRFilesFromLocalBuild"
+          AfterTargets="AfterResolveReferences;FilterNugetPackages"
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(Crossgen2Host)' == 'true'">
+    <ItemGroup>
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/crossgen2.dll" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/crossgen2.deps.json" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/crossgen2.runtimeconfig.json" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/Microsoft.DiaSymReader.dll" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/System.CommandLine.dll" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/ILCompiler.DependencyAnalysisFramework.dll" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/ILCompiler.ReadyToRun.dll " />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/ILCompiler.TypeSystem.ReadyToRun.dll " />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/api-ms-win-core-console-l1-2-0.dll" Condition="'$(TargetOS)' == 'Windows_NT'" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/*mscordaccore_*.*" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/*jitinterface.*" />
+      <CoreCLRFiles Include="$(CoreCLRArtifactsPath)/crossgen2/*clrjitilc.*" />
+      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="OverrideRuntimeMono"
           DependsOnTargets="ResolveMonoFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"


### PR DESCRIPTION
This change adds support for precompiling testhost assemblies 
for libraries tests with crossgen2. The msbuild property Crossgen2Host
is used to enable that (passing `/p:Crossgen2Host=true` to the build command)