### PR TITLE
Fix crossgen2 delegates to static generic methods

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -412,8 +412,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(CompilationModuleGroup.ContainsMethodBody(targetMethod.Method, false));
 
-            MethodDesc localMethod = targetMethod.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
-            return _localMethodCache.GetOrAdd(localMethod);
+            return _localMethodCache.GetOrAdd(targetMethod.Method);
         }
 
         public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods()


### PR DESCRIPTION
In crossgen2 we convert all methods to their canon versions in
CreateMethodEntrypointNodeHelper, which causes a problem for
delegates set to generic static methods. When these methods are called
via a delegate, at runtime it gets a hidden generic argument that
is a MethodDesc of a canon version of the static method instead of the
specific instantiation.

I've investigated why we convert all methods to their canon versions in
the CreateMethodEntrypointNodeHelper and I've found a PR by @trylek
in CoreRT repo that has introduced it. I've discussed that with him, but
he wasn't able to figure out why the change was made and it seems like
it was either accidental or fixing some problem that no longer exists.

Removing this conversion fixes the problem and I have verified that it
doesn't introduce new ones by running both pri 1 CoreCLR tests and the
libraries tests. It has also made the diff between code generated by
crossgen1 and crossgen2 e.g. for System.Private.CoreLib.dll smaller.