### PR TITLE
Enable nullable reference types for mono's Corelib

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.CoreCLR.cs
@@ -20,9 +20,9 @@ namespace System.Runtime.InteropServices
 #if DEBUG
         // The runtime performs additional checks in debug builds
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern object InternalGet(IntPtr handle);
+        internal static extern object? InternalGet(IntPtr handle);
 #else
-        internal static unsafe object InternalGet(IntPtr handle) =>
+        internal static unsafe object? InternalGet(IntPtr handle) =>
             Unsafe.As<IntPtr, object>(ref *(IntPtr*)handle);
 #endif
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1391,7 +1391,7 @@ namespace System
             private MemberInfoCache<RuntimePropertyInfo>? m_propertyInfoCache;
             private MemberInfoCache<RuntimeEventInfo>? m_eventInfoCache;
             private static CerHashtable<RuntimeMethodInfo, RuntimeMethodInfo> s_methodInstantiations;
-            private static object s_methodInstantiationsLock = null!;
+            private static object? s_methodInstantiationsLock;
             private string? m_defaultMemberName;
             private object? m_genericCache; // Generic cache for rare scenario specific data. It is used to cache Enum names and values.
             private object[]? _emptyArray; // Object array cache for Attribute.GetCustomAttributes() pathological no-result case.
@@ -2338,7 +2338,7 @@ namespace System
             {
                 if (m_cache != IntPtr.Zero)
                 {
-                    object cache = GCHandle.InternalGet(m_cache);
+                    object? cache = GCHandle.InternalGet(m_cache);
                     Debug.Assert(cache == null || cache is RuntimeTypeCache);
                     return Unsafe.As<RuntimeTypeCache>(cache);
                 }
@@ -2353,7 +2353,7 @@ namespace System
             {
                 if (m_cache != IntPtr.Zero)
                 {
-                    object cache = GCHandle.InternalGet(m_cache);
+                    object? cache = GCHandle.InternalGet(m_cache);
                     if (cache != null)
                     {
                         Debug.Assert(cache is RuntimeTypeCache);
@@ -2376,7 +2376,7 @@ namespace System
                     th.FreeGCHandle(newgcHandle);
             }
 
-            RuntimeTypeCache cache = (RuntimeTypeCache)GCHandle.InternalGet(m_cache);
+            RuntimeTypeCache? cache = (RuntimeTypeCache?)GCHandle.InternalGet(m_cache);
             if (cache == null)
             {
                 cache = new RuntimeTypeCache(this);

--- a/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs
@@ -12,7 +12,7 @@ namespace System
         {
             try
             {
-                object config = AppContext.GetData(configName);
+                object? config = AppContext.GetData(configName);
                 int result = defaultValue;
                 switch (config)
                 {
@@ -54,7 +54,7 @@ namespace System
         {
             try
             {
-                object config = AppContext.GetData(configName);
+                object? config = AppContext.GetData(configName);
                 short result = defaultValue;
                 switch (config)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldToken.cs
@@ -14,9 +14,9 @@ namespace System.Reflection.Emit
     {
         public static readonly FieldToken Empty = default;
 
-        private readonly object _class;
+        private readonly object? _class;
 
-        internal FieldToken(int fieldToken, Type fieldClass)
+        internal FieldToken(int fieldToken, Type? fieldClass)
         {
             Token = fieldToken;
             _class = fieldClass;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldToken.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldToken.cs
@@ -14,9 +14,9 @@ namespace System.Reflection.Emit
     {
         public static readonly FieldToken Empty = default;
 
-        private readonly object? _class;
+        private readonly object _class;
 
-        internal FieldToken(int fieldToken, Type? fieldClass)
+        internal FieldToken(int fieldToken, Type fieldClass)
         {
             Token = fieldToken;
             _class = fieldClass;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ManifestResourceInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ManifestResourceInfo.cs
@@ -6,8 +6,8 @@ namespace System.Reflection
 {
     public class ManifestResourceInfo
     {
-        public ManifestResourceInfo(Assembly containingAssembly,
-                                      string containingFileName,
+        public ManifestResourceInfo(Assembly? containingAssembly,
+                                      string? containingFileName,
                                       ResourceLocation resourceLocation)
         {
             ReferencedAssembly = containingAssembly;
@@ -15,8 +15,8 @@ namespace System.Reflection
             ResourceLocation = resourceLocation;
         }
 
-        public virtual Assembly ReferencedAssembly { get; }
-        public virtual string FileName { get; }
+        public virtual Assembly? ReferencedAssembly { get; }
+        public virtual string? FileName { get; }
         public virtual ResourceLocation ResourceLocation { get; }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -125,7 +125,7 @@ namespace System.Runtime.InteropServices
 
             // Get the address.
 
-            object target = InternalGet(GetHandleValue(handle));
+            object? target = InternalGet(GetHandleValue(handle));
             if (target is null)
             {
                 return default;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NoCom.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NoCom.cs
@@ -152,7 +152,7 @@ namespace System.Runtime.InteropServices
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
-        public static Type GetTypeFromCLSID(Guid clsid)
+        public static Type? GetTypeFromCLSID(Guid clsid)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -11,7 +11,7 @@ namespace System.Threading
         /// <summary>
         /// A linked list of <see cref="WaitThread"/>s.
         /// </summary>
-        private WaitThreadNode _waitThreadsHead;
+        private WaitThreadNode? _waitThreadsHead;
 
         private readonly LowLevelLock _waitThreadLock = new LowLevelLock();
 
@@ -34,10 +34,10 @@ namespace System.Threading
 
                 // Register the wait handle on the first wait thread that is not at capacity.
                 WaitThreadNode prev;
-                WaitThreadNode current = _waitThreadsHead;
+                WaitThreadNode? current = _waitThreadsHead;
                 do
                 {
-                    if (current.Thread.RegisterWaitHandle(handle))
+                    if (current.Thread!.RegisterWaitHandle(handle))
                     {
                         return;
                     }
@@ -88,14 +88,14 @@ namespace System.Threading
         /// <param name="thread">The wait thread to remove from the list.</param>
         private void RemoveWaitThread(WaitThread thread)
         {
-            if (_waitThreadsHead.Thread == thread)
+            if (_waitThreadsHead!.Thread == thread)
             {
                 _waitThreadsHead = _waitThreadsHead.Next;
                 return;
             }
 
             WaitThreadNode prev;
-            WaitThreadNode current = _waitThreadsHead;
+            WaitThreadNode? current = _waitThreadsHead;
 
             do
             {
@@ -113,8 +113,8 @@ namespace System.Threading
 
         private class WaitThreadNode
         {
-            public WaitThread Thread { get; set; }
-            public WaitThreadNode Next { get; set; }
+            public WaitThread? Thread { get; set; }
+            public WaitThreadNode? Next { get; set; }
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace System.Threading
             /// <summary>
             /// A list of removals of wait handles that are waiting for the wait thread to process.
             /// </summary>
-            private readonly RegisteredWaitHandle[] _pendingRemoves = new RegisteredWaitHandle[WaitHandle.MaxWaitHandles - 1];
+            private readonly RegisteredWaitHandle?[] _pendingRemoves = new RegisteredWaitHandle[WaitHandle.MaxWaitHandles - 1];
             /// <summary>
             /// The number of pending removals.
             /// </summary>
@@ -228,7 +228,7 @@ namespace System.Threading
                         continue;
                     }
 
-                    RegisteredWaitHandle signaledHandle = signaledHandleIndex != WaitHandle.WaitTimeout ? _registeredWaits[signaledHandleIndex - 1] : null;
+                    RegisteredWaitHandle? signaledHandle = signaledHandleIndex != WaitHandle.WaitTimeout ? _registeredWaits[signaledHandleIndex - 1] : null;
 
                     if (signaledHandle != null)
                     {
@@ -290,8 +290,8 @@ namespace System.Threading
                                 _registeredWaits[j].OnRemoveWait();
                                 _registeredWaits[j] = _registeredWaits[_numUserWaits - 1];
                                 _waitHandles[j + 1] = _waitHandles[_numUserWaits];
-                                _registeredWaits[_numUserWaits - 1] = null;
-                                _waitHandles[_numUserWaits] = null;
+                                _registeredWaits[_numUserWaits - 1] = null!;
+                                _waitHandles[_numUserWaits] = null!;
                                 --_numUserWaits;
                                 _pendingRemoves[i] = null;
                                 break;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -21,7 +21,7 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Increment()
         {
-            ThreadLocalNode node = _threadLocalNode.Value;
+            ThreadLocalNode? node = _threadLocalNode.Value;
             if (node != null)
             {
                 node.Increment();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.PlatformNotSupported.cs
@@ -8,7 +8,7 @@ namespace System.Threading
 {
     public sealed class ThreadPoolBoundHandle : IDisposable
     {
-        public SafeHandle Handle => null;
+        public SafeHandle Handle => null!;
 
         private ThreadPoolBoundHandle()
         {
@@ -26,7 +26,7 @@ namespace System.Threading
         }
 
         [CLSCompliant(false)]
-        public unsafe NativeOverlapped* AllocateNativeOverlapped(IOCompletionCallback callback, object state, object pinData)
+        public unsafe NativeOverlapped* AllocateNativeOverlapped(IOCompletionCallback callback, object? state, object? pinData)
         {
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));
@@ -53,7 +53,7 @@ namespace System.Threading
         }
 
         [CLSCompliant(false)]
-        public static unsafe object GetNativeOverlappedState(NativeOverlapped* overlapped)
+        public static unsafe object? GetNativeOverlappedState(NativeOverlapped* overlapped)
         {
             if (overlapped == null)
                 throw new ArgumentNullException(nameof(overlapped));

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/Ecma/EcmaAssembly.ManifestResources.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/Ecma/EcmaAssembly.ManifestResources.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.TypeLoading.Ecma
             {
                 // Must get resource info from other assembly, and OR in the contained in another assembly information
                 ManifestResourceInfo underlyingManifestResourceInfo = internalManifestResourceInfo.ReferencedAssembly.GetManifestResourceInfo(resourceName)!;
-                internalManifestResourceInfo.FileName = underlyingManifestResourceInfo.FileName;
+                internalManifestResourceInfo.FileName = underlyingManifestResourceInfo.FileName ?? string.Empty;
                 internalManifestResourceInfo.ResourceLocation = underlyingManifestResourceInfo.ResourceLocation | ResourceLocation.ContainedInAnotherAssembly;
                 if (underlyingManifestResourceInfo.ReferencedAssembly != null)
                     internalManifestResourceInfo.ReferencedAssembly = underlyingManifestResourceInfo.ReferencedAssembly;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7880,9 +7880,9 @@ namespace System.Reflection
     }
     public partial class ManifestResourceInfo
     {
-        public ManifestResourceInfo(System.Reflection.Assembly containingAssembly, string containingFileName, System.Reflection.ResourceLocation resourceLocation) { }
-        public virtual string FileName { get { throw null; } }
-        public virtual System.Reflection.Assembly ReferencedAssembly { get { throw null; } }
+        public ManifestResourceInfo(System.Reflection.Assembly? containingAssembly, string? containingFileName, System.Reflection.ResourceLocation resourceLocation) { }
+        public virtual string? FileName { get { throw null; } }
+        public virtual System.Reflection.Assembly? ReferencedAssembly { get { throw null; } }
         public virtual System.Reflection.ResourceLocation ResourceLocation { get { throw null; } }
     }
     public delegate bool MemberFilter(System.Reflection.MemberInfo m, object? filterCriteria);

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -120,8 +120,6 @@
 
   <!-- Mono specific build changes -->
   <PropertyGroup>
-    <!-- Disable nullability-related warnings -->
-    <NoWarn>$(NoWarn),CS8597,CS8600,CS8601,CS8602,CS8603,CS8604,CS8609,CS8611,CS8618,CS8620,CS8625,CS8631,CS8632,CS8634</NoWarn>
     <NoWarn>$(NoWarn),618,67</NoWarn>
 
     <DefineConstants>NETCORE;DISABLE_REMOTING;MONO_FEATURE_SRE;$(DefineConstants)</DefineConstants>

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/Console.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/Console.Mono.cs
@@ -10,7 +10,7 @@ namespace Internal
     // Some CoreCLR tests use it for internal printf-style debugging in System.Private.CoreLib
     public static class Console
     {
-        public static void Write(string? s) => DebugProvider.WriteCore(s);
+        public static void Write(string? s) => DebugProvider.WriteCore(s ?? string.Empty);
 
         public static void WriteLine(string? s) => Write(s + Environment.NewLineConst);
 

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
@@ -16,8 +16,8 @@ namespace Mono
         #endregion
 #pragma warning restore 169
 
-        public event UnhandledExceptionEventHandler UnhandledException;
+        public event UnhandledExceptionEventHandler? UnhandledException;
 
-        public event EventHandler ProcessExit;
+        public event EventHandler? ProcessExit;
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomainSetup.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomainSetup.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
 using System.Runtime.InteropServices;
 
 namespace Mono
@@ -11,31 +10,31 @@ namespace Mono
     internal sealed class MonoDomainSetup
     {
         #region Sync with object-internals.h
-        private string application_base;
-        private string application_name;
-        private string cache_path;
-        private string configuration_file;
-        private string dynamic_base;
-        private string license_file;
-        private string private_bin_path;
-        private string private_bin_path_probe;
-        private string shadow_copy_directories;
-        private string shadow_copy_files;
+        private string? application_base;
+        private string? application_name;
+        private string? cache_path;
+        private string? configuration_file;
+        private string? dynamic_base;
+        private string? license_file;
+        private string? private_bin_path;
+        private string? private_bin_path_probe;
+        private string? shadow_copy_directories;
+        private string? shadow_copy_files;
         private bool publisher_policy;
         private bool path_changed;
         private int loader_optimization;
         private bool disallow_binding_redirects;
         private bool disallow_code_downloads;
 
-        private object _activationArguments;
-        private object domain_initializer;
-        private object application_trust;
-        private string[] domain_initializer_args;
+        private object? _activationArguments;
+        private object? domain_initializer;
+        private object? application_trust;
+        private string[]? domain_initializer_args;
 
         private bool disallow_appbase_probe;
-        private byte[] configuration_bytes;
+        private byte[]? configuration_bytes;
 
-        private byte[] serialized_non_primitives;
+        private byte[]? serialized_non_primitives;
         #endregion
 
         public MonoDomainSetup()

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoListItem.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoListItem.cs
@@ -7,7 +7,7 @@ namespace Mono
     // Internal type used by Mono runtime only
     internal sealed class MonoListItem
     {
-        public MonoListItem next;
-        public object data;
+        public MonoListItem? next;
+        public object? data;
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/SafeStringMarshal.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/SafeStringMarshal.cs
@@ -16,7 +16,7 @@ namespace Mono
 {
     internal struct SafeStringMarshal : IDisposable
     {
-        private readonly string str;
+        private readonly string? str;
         private IntPtr marshaled_string;
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -30,7 +30,7 @@ namespace Mono
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern void GFree(IntPtr ptr);
 
-        public SafeStringMarshal(string str)
+        public SafeStringMarshal(string? str)
         {
             this.str = str;
             this.marshaled_string = IntPtr.Zero;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Array.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Array.Mono.cs
@@ -4,6 +4,7 @@
 
 using Internal.Runtime.CompilerServices;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -270,7 +271,7 @@ namespace System
             if (runtimeType == null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
-            Array array = null;
+            Array? array = null;
             InternalCreate(ref array, runtimeType._impl.Value, 1, &length, null);
             GC.KeepAlive(runtimeType);
             return array;
@@ -290,7 +291,7 @@ namespace System
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
             int* lengths = stackalloc int[] { length1, length2 };
-            Array array = null;
+            Array? array = null;
             InternalCreate(ref array, runtimeType._impl.Value, 2, lengths, null);
             GC.KeepAlive(runtimeType);
             return array;
@@ -312,7 +313,7 @@ namespace System
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
             int* lengths = stackalloc int[] { length1, length2, length3 };
-            Array array = null;
+            Array? array = null;
             InternalCreate(ref array, runtimeType._impl.Value, 3, lengths, null);
             GC.KeepAlive(runtimeType);
             return array;
@@ -335,7 +336,7 @@ namespace System
                 if (lengths[i] < 0)
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, i, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
-            Array array = null;
+            Array? array = null;
             fixed (int* pLengths = &lengths[0])
                 InternalCreate(ref array, runtimeType._impl.Value, lengths.Length, pLengths, null);
             GC.KeepAlive(runtimeType);
@@ -363,7 +364,7 @@ namespace System
             if (runtimeType == null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
-            Array array = null;
+            Array? array = null;
             fixed (int* pLengths = &lengths[0])
             fixed (int* pLowerBounds = &lowerBounds[0])
                 InternalCreate(ref array, runtimeType._impl.Value, lengths.Length, pLengths, pLowerBounds);
@@ -372,7 +373,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe void InternalCreate(ref Array result, IntPtr elementType, int rank, int* lengths, int* lowerBounds);
+        private static extern unsafe void InternalCreate([NotNull] ref Array? result, IntPtr elementType, int rank, int* lengths, int* lowerBounds);
 
         public object GetValue(int index)
         {
@@ -635,9 +636,9 @@ namespace System
             if ((uint)index >= (uint)Length)
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
-            if (this is object[] oarray)
+            if (this is object?[] oarray)
             {
-                oarray![index] = (object)item;
+                oarray[index] = item;
                 return;
             }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
 using System.Reflection;
 
 namespace System
@@ -24,14 +23,14 @@ namespace System
             return (Attribute)(attrs[0]);
         }
 
-        public static Attribute GetCustomAttribute(Assembly element, Type attributeType) => GetAttr(element, attributeType, true);
-        public static Attribute GetCustomAttribute(Assembly element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType) => GetAttr(element, attributeType, true);
-        public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(Module element, Type attributeType) => GetAttr(element, attributeType, true);
-        public static Attribute GetCustomAttribute(Module element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType) => GetAttr(element, attributeType, true);
-        public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
+        public static Attribute? GetCustomAttribute(Assembly element, Type attributeType) => GetAttr(element, attributeType, true);
+        public static Attribute? GetCustomAttribute(Assembly element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
+        public static Attribute? GetCustomAttribute(MemberInfo element, Type attributeType) => GetAttr(element, attributeType, true);
+        public static Attribute? GetCustomAttribute(MemberInfo element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
+        public static Attribute? GetCustomAttribute(Module element, Type attributeType) => GetAttr(element, attributeType, true);
+        public static Attribute? GetCustomAttribute(Module element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
+        public static Attribute? GetCustomAttribute(ParameterInfo element, Type attributeType) => GetAttr(element, attributeType, true);
+        public static Attribute? GetCustomAttribute(ParameterInfo element, Type attributeType, bool inherit) => GetAttr(element, attributeType, inherit);
 
         public static Attribute[] GetCustomAttributes(Assembly element) => (Attribute[])CustomAttribute.GetCustomAttributes(element, true);
         public static Attribute[] GetCustomAttributes(Assembly element, bool inherit) => (Attribute[])CustomAttribute.GetCustomAttributes(element, inherit);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Collections/Generic/Comparer.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Collections/Generic/Comparer.Mono.cs
@@ -9,13 +9,13 @@ namespace System.Collections.Generic
 {
     public partial class Comparer<T>
     {
-        private static volatile Comparer<T> defaultComparer;
+        private static volatile Comparer<T>? defaultComparer;
 
         public static Comparer<T> Default
         {
             get
             {
-                Comparer<T> comparer = defaultComparer;
+                Comparer<T>? comparer = defaultComparer;
                 if (comparer == null)
                 {
                     // Do not use static constructor. Generic static constructors are problematic for Mono AOT.

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.Mono.cs
@@ -9,14 +9,14 @@ namespace System.Collections.Generic
 {
     public partial class EqualityComparer<T>
     {
-        private static volatile EqualityComparer<T> defaultComparer;
+        private static volatile EqualityComparer<T>? defaultComparer;
 
         public static EqualityComparer<T> Default
         {
             [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
             get
             {
-                EqualityComparer<T> comparer = defaultComparer;
+                EqualityComparer<T>? comparer = defaultComparer;
                 if (comparer == null)
                 {
                     // Do not use static constructor. Generic static constructors are problematic for Mono AOT.

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -458,7 +458,7 @@ namespace System
                 }
             }
 
-            if (Method.IsStatic)
+            if (Method!.IsStatic)
             {
                 //
                 // The delegate is bound to _target
@@ -540,13 +540,13 @@ namespace System
                     method_info = GetVirtualMethod_internal();
             }
 
-            return method_info;
+            return method_info!;
         }
 
         private DelegateData CreateDelegateData()
         {
             DelegateData delegate_data = new DelegateData();
-            if (method_info.IsStatic)
+            if (method_info!.IsStatic)
             {
                 if (_target != null)
                 {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics
 {
     public static class Debugger
     {
-        public static readonly string DefaultCategory = "";
+        public static readonly string? DefaultCategory;
 
         public static bool IsAttached => IsAttached_internal();
 
@@ -32,8 +32,10 @@ namespace System.Diagnostics
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void Log_icall(int level, ref string category, ref string message);
 
-        public static void Log(int level, string category, string message)
+        public static void Log(int level, string? category, string? message)
         {
+            category ??= string.Empty;
+            message ??= string.Empty;
             Log_icall(level, ref category, ref message);
         }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Diagnostics/StackTrace.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Diagnostics/StackTrace.Mono.cs
@@ -20,12 +20,12 @@ namespace System.Diagnostics
         internal long methodAddress;
         // Unused
         internal uint methodIndex;
-        internal MethodBase methodBase;
-        internal string fileName;
+        internal MethodBase? methodBase;
+        internal string? fileName;
         internal int lineNumber;
         internal int columnNumber;
         // Unused
-        internal string internalMethodName;
+        internal string? internalMethodName;
         #endregion
 
         internal bool isLastFrameFromForeignException;
@@ -64,7 +64,7 @@ namespace System.Diagnostics
             _numOfFrames = frames.Length;
 
             int foreignFrames;
-            MonoStackFrame[] foreignExceptions = e.foreignExceptionsFrames;
+            MonoStackFrame[]? foreignExceptions = e.foreignExceptionsFrames;
 
             if (foreignExceptions != null)
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Mono.cs
@@ -51,20 +51,20 @@ namespace System
         public static extern string[] GetCommandLineArgs();
 
         [DoesNotReturn]
-        public static void FailFast(string message)
+        public static void FailFast(string? message)
         {
             FailFast(message, null, null);
         }
 
         [DoesNotReturn]
-        public static void FailFast(string message, Exception exception)
+        public static void FailFast(string? message, Exception? exception)
         {
             FailFast(message, exception, null);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [DoesNotReturn]
-        public static extern void FailFast(string message, Exception exception, string errorSource);
+        public static extern void FailFast(string? message, Exception? exception, string? errorSource);
     }
 
     #region referencesource dependencies - to be removed
@@ -81,7 +81,7 @@ namespace System
             return key;
         }
 
-        internal static string GetResourceString(string key, params object[] values)
+        internal static string GetResourceString(string key, params object?[] values)
         {
             return string.Format(CultureInfo.InvariantCulture, key, values);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.Unix.Mono.cs
@@ -13,9 +13,9 @@ namespace System
 {
     public partial class Environment
     {
-        private static Dictionary<string, string> s_environment;
+        private static Dictionary<string, string>? s_environment;
 
-        private static string GetEnvironmentVariableCore(string variable)
+        private static string? GetEnvironmentVariableCore(string variable)
         {
             Debug.Assert(variable != null);
 
@@ -27,7 +27,7 @@ namespace System
             variable = TrimStringOnFirstZero(variable);
             lock (s_environment)
             {
-                s_environment.TryGetValue(variable, out string value);
+                s_environment.TryGetValue(variable, out string? value);
                 return value;
             }
         }
@@ -45,7 +45,7 @@ namespace System
             Debug.Assert(variable != null);
 
             EnsureEnvironmentCached();
-            lock (s_environment)
+            lock (s_environment!)
             {
                 variable = TrimStringOnFirstZero(variable);
                 value = value == null ? null : TrimStringOnFirstZero(value);
@@ -65,7 +65,7 @@ namespace System
             var results = new Hashtable();
 
             EnsureEnvironmentCached();
-            lock (s_environment)
+            lock (s_environment!)
             {
                 foreach (var keyValuePair in s_environment)
                 {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.IO;
 using System.Threading;
 using System.Collections.Generic;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -21,7 +21,7 @@ namespace System
                 Interlocked.CompareExchange(ref s_specialFolders, new Dictionary<SpecialFolder, string>(), null);
             }
 
-            string path;
+            string? path;
             lock (s_specialFolders)
             {
                 if (!s_specialFolders.TryGetValue(folder, out path))
@@ -48,7 +48,7 @@ namespace System
                 case SpecialFolder.ApplicationData:
                     // note: at first glance that looked like a good place to return NSLibraryDirectory
                     // but it would break isolated storage for existing applications
-                    return Path.Combine(Interop.Sys.SearchPath(NSSearchPathDirectory.NSDocumentDirectory), ".config");
+                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, ".config");
 
                 case SpecialFolder.Resources:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSLibraryDirectory); // older (8.2 and previous) would return String.Empty
@@ -64,7 +64,7 @@ namespace System
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSPicturesDirectory);
 
                 case SpecialFolder.Templates:
-                    return Path.Combine(Interop.Sys.SearchPath(NSSearchPathDirectory.NSDocumentDirectory), "Templates");
+                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, "Templates");
 
                 case SpecialFolder.MyVideos:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSMoviesDirectory);
@@ -73,10 +73,10 @@ namespace System
                     return "/usr/share/templates";
 
                 case SpecialFolder.Fonts:
-                    return Path.Combine(Interop.Sys.SearchPath(NSSearchPathDirectory.NSDocumentDirectory), ".fonts");
+                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, ".fonts");
 
                 case SpecialFolder.Favorites:
-                    return Path.Combine(Interop.Sys.SearchPath(NSSearchPathDirectory.NSLibraryDirectory), "Favorites");
+                    return CombineSearchPath(NSSearchPathDirectory.NSLibraryDirectory, "Favorites");
 
                 case SpecialFolder.ProgramFiles:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSApplicationDirectory);
@@ -92,6 +92,14 @@ namespace System
 
                 default:
                     return string.Empty;
+            }
+
+            static string? CombineSearchPath(NSSearchPathDirectory searchPath, string subdirectory)
+            {
+                string? path = Interop.Sys.SearchPath(searchPath);
+                return path != null ?
+                    Path.Combine(path, subdirectory) :
+                    null;
             }
         }
     }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -94,12 +94,12 @@ namespace System
                     return string.Empty;
             }
 
-            static string? CombineSearchPath(NSSearchPathDirectory searchPath, string subdirectory)
+            static string CombineSearchPath(NSSearchPathDirectory searchPath, string subdirectory)
             {
                 string? path = Interop.Sys.SearchPath(searchPath);
                 return path != null ?
                     Path.Combine(path, subdirectory) :
-                    null;
+                    string.Empty;
             }
         }
     }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Exception.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Exception.Mono.cs
@@ -15,9 +15,9 @@ namespace System
     {
         internal readonly struct DispatchState
         {
-            public readonly MonoStackFrame[] StackFrames;
+            public readonly MonoStackFrame[]? StackFrames;
 
-            public DispatchState(MonoStackFrame[] stackFrames)
+            public DispatchState(MonoStackFrame[]? stackFrames)
             {
                 StackFrames = stackFrames;
             }
@@ -25,20 +25,20 @@ namespace System
 
         #region Keep in sync with MonoException in object-internals.h
         private string? _unused1;
-        internal string _message;
-        private IDictionary _data;
-        private Exception _innerException;
-        private string _helpURL;
-        private object _traceIPs;
+        internal string? _message;
+        private IDictionary? _data;
+        private Exception? _innerException;
+        private string? _helpURL;
+        private object? _traceIPs;
         private string? _stackTraceString;
         private string? _remoteStackTraceString;
         private int _unused4;
-        private object _dynamicMethods; // Dynamic methods referenced by the stack trace
+        private object? _dynamicMethods; // Dynamic methods referenced by the stack trace
         private int _HResult;
-        private string _source;
+        private string? _source;
         private object? _unused6;
-        internal MonoStackFrame[] foreignExceptionsFrames;
-        private IntPtr[] native_trace_ips;
+        internal MonoStackFrame[]? foreignExceptionsFrames;
+        private IntPtr[]? native_trace_ips;
         private int caught_in_unmanaged;
         #endregion
 
@@ -71,7 +71,7 @@ namespace System
 
         internal DispatchState CaptureDispatchState()
         {
-            MonoStackFrame[] stackFrames;
+            MonoStackFrame[]? stackFrames;
 
             if (_traceIPs != null)
             {
@@ -126,10 +126,10 @@ namespace System
             if (st.FrameCount > 0)
             {
                 StackFrame sf = st.GetFrame(0)!;
-                MethodBase method = sf.GetMethod();
+                MethodBase? method = sf.GetMethod();
 
-                Module module = method.Module;
-                RuntimeModule rtModule = module as RuntimeModule;
+                Module? module = method?.Module;
+                RuntimeModule? rtModule = module as RuntimeModule;
 
                 if (rtModule == null)
                 {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/GC.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/GC.Mono.cs
@@ -105,13 +105,13 @@ namespace System
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // disable optimizations
-        public static void KeepAlive(object obj)
+        public static void KeepAlive(object? obj)
         {
         }
 
         public static int GetGeneration(WeakReference wo)
         {
-            object obj = wo.Target;
+            object? obj = wo.Target;
             if (obj == null)
                 throw new ArgumentException();
             return GetGeneration(obj);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/IO/FileLoadException.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/IO/FileLoadException.Mono.cs
@@ -6,7 +6,7 @@ namespace System.IO
 {
     public partial class FileLoadException
     {
-        internal static string FormatFileLoadExceptionMessage(string fileName, int hResult)
+        internal static string FormatFileLoadExceptionMessage(string? fileName, int hResult)
         {
             return "";
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -36,7 +36,7 @@ namespace System
             }
             else
             {
-                object r;
+                object? r;
                 int i = 0, len = delegates.Length;
                 do
                 {
@@ -82,7 +82,7 @@ namespace System
             }
             else
             {
-                if (delegates.Length != d.delegates.Length)
+                if (delegates!.Length != d.delegates!.Length)
                     return false;
 
                 for (int i = 0; i < delegates.Length; ++i)
@@ -144,7 +144,7 @@ namespace System
             }
             else if (delegates == null)
             {
-                ret.delegates = new Delegate[1 + other.delegates.Length];
+                ret.delegates = new Delegate[1 + other.delegates!.Length];
 
                 ret.delegates[0] = this;
                 Array.Copy(other.delegates, 0, ret.delegates, 1, other.delegates.Length);
@@ -196,7 +196,7 @@ namespace System
             return -1;
         }
 
-        protected sealed override Delegate RemoveImpl(Delegate value)
+        protected sealed override Delegate? RemoveImpl(Delegate value)
         {
             if (value == null)
                 return this;
@@ -211,7 +211,7 @@ namespace System
             }
             else if (delegates == null)
             {
-                foreach (Delegate? d in other.delegates)
+                foreach (Delegate? d in other.delegates!)
                 {
                     if (this.Equals(d))
                         return null;
@@ -267,7 +267,7 @@ namespace System
             }
         }
 
-        public static bool operator ==(MulticastDelegate d1, MulticastDelegate d2)
+        public static bool operator ==(MulticastDelegate? d1, MulticastDelegate? d2)
         {
             if (d1 == null)
                 return d2 == null;
@@ -275,7 +275,7 @@ namespace System
             return d1.Equals(d2);
         }
 
-        public static bool operator !=(MulticastDelegate d1, MulticastDelegate d2)
+        public static bool operator !=(MulticastDelegate? d1, MulticastDelegate? d2)
         {
             if (d1 == null)
                 return d2 != null;
@@ -283,7 +283,7 @@ namespace System
             return !d1.Equals(d2);
         }
 
-        internal override object GetTarget()
+        internal override object? GetTarget()
         {
             return delegates?.Length > 0 ? delegates[delegates.Length - 1].GetTarget() : base.GetTarget();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
@@ -79,7 +79,7 @@ namespace System.Reflection
             return Load(assemblyRef, ref stackMark, AssemblyLoadContext.CurrentContextualReflectionContext);
         }
 
-        internal static Assembly Load(AssemblyName assemblyRef, ref StackCrawlMark stackMark, AssemblyLoadContext assemblyLoadContext)
+        internal static Assembly Load(AssemblyName assemblyRef, ref StackCrawlMark stackMark, AssemblyLoadContext? assemblyLoadContext)
         {
             // TODO: pass AssemblyName
             Assembly? assembly = InternalLoad(assemblyRef.FullName, ref stackMark, assemblyLoadContext != null ? assemblyLoadContext.NativeALC : IntPtr.Zero);
@@ -92,7 +92,7 @@ namespace System.Reflection
         internal static extern Assembly InternalLoad(string assemblyName, ref StackCrawlMark stackMark, IntPtr ptrLoadContextBinder);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal extern Type InternalGetType(Module module, string name, bool throwOnError, bool ignoreCase);
+        internal extern Type InternalGetType(Module? module, string name, bool throwOnError, bool ignoreCase);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void InternalGetAssemblyName(string assemblyFile, out Mono.MonoAssemblyName aname, out string codebase);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
@@ -41,7 +41,7 @@ namespace System.Reflection
             }
         }
 
-        private unsafe byte[] ComputePublicKeyToken()
+        private unsafe byte[]? ComputePublicKeyToken()
         {
             if (_publicKey == null)
                 return null;
@@ -55,7 +55,7 @@ namespace System.Reflection
             return token;
         }
 
-        internal static AssemblyName Create(IntPtr monoAssembly, string codeBase)
+        internal static AssemblyName Create(IntPtr monoAssembly, string? codeBase)
         {
             AssemblyName aname = new AssemblyName();
             unsafe
@@ -66,7 +66,7 @@ namespace System.Reflection
             return aname;
         }
 
-        internal unsafe void FillName(MonoAssemblyName* native, string codeBase, bool addVersion, bool addPublickey, bool defaultToken)
+        internal unsafe void FillName(MonoAssemblyName* native, string? codeBase, bool addVersion, bool addPublickey, bool defaultToken)
         {
             _name = RuntimeMarshal.PtrToUtf8String(native->name);
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
@@ -35,15 +35,15 @@ namespace System.Reflection
     {
         private class LazyCAttrData
         {
-            internal Assembly assembly;
+            internal Assembly assembly = null!; // only call site always sets it
             internal IntPtr data;
             internal uint data_length;
         }
 
-        private ConstructorInfo ctorInfo;
-        private IList<CustomAttributeTypedArgument> ctorArgs;
-        private IList<CustomAttributeNamedArgument> namedArgs;
-        private LazyCAttrData lazyData;
+        private ConstructorInfo ctorInfo = null!;
+        private IList<CustomAttributeTypedArgument> ctorArgs = null!;
+        private IList<CustomAttributeNamedArgument> namedArgs = null!;
+        private LazyCAttrData? lazyData;
 
         protected CustomAttributeData()
         {
@@ -149,7 +149,7 @@ namespace System.Reflection
 
         public virtual Type AttributeType
         {
-            get { return ctorInfo.DeclaringType; }
+            get { return ctorInfo.DeclaringType!; }
         }
 
         public override string ToString()
@@ -158,7 +158,7 @@ namespace System.Reflection
 
             StringBuilder sb = new StringBuilder();
 
-            sb.Append("[" + ctorInfo.DeclaringType.FullName + "(");
+            sb.Append('[').Append(ctorInfo.DeclaringType!.FullName).Append('(');
             for (int i = 0; i < ctorArgs.Count; i++)
             {
                 sb.Append(ctorArgs[i].ToString());
@@ -175,7 +175,7 @@ namespace System.Reflection
                 if (j + 1 < namedArgs.Count)
                     sb.Append(", ");
             }
-            sb.AppendFormat(")]");
+            sb.Append(")]");
 
             return sb.ToString();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.IO;
 using System.Globalization;
@@ -58,7 +57,7 @@ namespace System.Reflection.Emit
 
         private static bool IsBoundedVector(Type type)
         {
-            ArrayType at = type as ArrayType;
+            ArrayType? at = type as ArrayType;
             if (at != null)
                 return at.GetEffectiveRank() == 1;
             return type.ToString().EndsWith("[*]", StringComparison.Ordinal); /*Super uggly hack, SR doesn't allow one to query for it */
@@ -73,7 +72,7 @@ namespace System.Reflection.Emit
             {
                 if (!b.HasElementType)
                     return false;
-                if (!TypeEquals(a.GetElementType(), b.GetElementType()))
+                if (!TypeEquals(a.GetElementType()!, b.GetElementType()!))
                     return false;
                 if (a.IsArray)
                 {
@@ -138,9 +137,9 @@ namespace System.Reflection.Emit
             return a == b;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            GenericInstanceKey other = obj as GenericInstanceKey;
+            GenericInstanceKey? other = obj as GenericInstanceKey;
             if (other == null)
                 return false;
             if (gtd != other.gtd)
@@ -168,7 +167,7 @@ namespace System.Reflection.Emit
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public sealed partial class AssemblyBuilder : Assembly
+    public sealed class AssemblyBuilder : Assembly
     {
         //
         // AssemblyBuilder inherits from Assembly, but the runtime thinks its layout inherits from RuntimeAssembly
@@ -177,43 +176,43 @@ namespace System.Reflection.Emit
 #pragma warning disable 649
         internal IntPtr _mono_assembly;
 #pragma warning restore 649
-        private object _evidence;
+        private object? _evidence;
         #endregion
 
 #pragma warning disable 169, 414, 649
         #region Sync with object-internals.h
         private UIntPtr dynamic_assembly; /* GC-tracked */
-        private MethodInfo entry_point;
+        private MethodInfo? entry_point;
         private ModuleBuilder[] modules;
-        private string name;
-        private string dir;
-        private CustomAttributeBuilder[] cattrs;
-        private object resources;
-        private byte[] public_key;
-        private string version;
-        private string culture;
+        private string? name;
+        private string? dir;
+        private CustomAttributeBuilder[]? cattrs;
+        private object? resources;
+        private byte[]? public_key;
+        private string? version;
+        private string? culture;
         private uint algid;
         private uint flags;
         private PEFileKinds pekind = PEFileKinds.Dll;
         private bool delay_sign;
         private uint access;
-        private Module[] loaded_modules;
-        private object win32_resources;
-        private object permissions_minimum;
-        private object permissions_optional;
-        private object permissions_refused;
+        private Module[]? loaded_modules;
+        private object? win32_resources;
+        private object? permissions_minimum;
+        private object? permissions_optional;
+        private object? permissions_refused;
         private PortableExecutableKinds peKind;
         private ImageFileMachine machine;
         private bool corlib_internal;
-        private Type[] type_forwarders;
-        private byte[] pktoken;
+        private Type[]? type_forwarders;
+        private byte[]? pktoken;
         #endregion
 #pragma warning restore 169, 414, 649
 
         private AssemblyName aname;
-        private string assemblyName;
+        private string? assemblyName;
         private bool created;
-        private string versioninfo_culture;
+        private string? versioninfo_culture;
         private ModuleBuilder manifest_module;
         private bool manifest_module_used;
 
@@ -224,7 +223,7 @@ namespace System.Reflection.Emit
         private static extern void UpdateNativeCustomAttributes(AssemblyBuilder ab);
 
         [PreserveDependency("RuntimeResolve", "System.Reflection.Emit.ModuleBuilder")]
-        internal AssemblyBuilder(AssemblyName n, string directory, AssemblyBuilderAccess access, bool corlib_internal)
+        internal AssemblyBuilder(AssemblyName n, string? directory, AssemblyBuilderAccess access, bool corlib_internal)
         {
             aname = (AssemblyName)n.Clone();
 
@@ -245,7 +244,7 @@ namespace System.Reflection.Emit
                 culture = n.CultureInfo.Name;
                 versioninfo_culture = n.CultureInfo.Name;
             }
-            Version v = n.Version;
+            Version? v = n.Version;
             if (v != null)
             {
                 version = v.ToString();
@@ -258,12 +257,12 @@ namespace System.Reflection.Emit
             modules = new ModuleBuilder[] { manifest_module };
         }
 
-        public override string CodeBase
+        public override string? CodeBase
         {
             get { throw not_supported(); }
         }
 
-        public override MethodInfo EntryPoint
+        public override MethodInfo? EntryPoint
         {
             get
             {
@@ -292,7 +291,7 @@ namespace System.Reflection.Emit
             return new AssemblyBuilder(name, null, access, false);
         }
 
-        public static AssemblyBuilder DefineDynamicAssembly(AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+        public static AssemblyBuilder DefineDynamicAssembly(AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder>? assemblyAttributes)
         {
             AssemblyBuilder ab = DefineDynamicAssembly(name, access);
             if (assemblyAttributes != null)
@@ -324,7 +323,7 @@ namespace System.Reflection.Emit
             return manifest_module;
         }
 
-        public ModuleBuilder GetDynamicModule(string name)
+        public ModuleBuilder? GetDynamicModule(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -353,7 +352,7 @@ namespace System.Reflection.Emit
             throw not_supported();
         }
 
-        public override ManifestResourceInfo GetManifestResourceInfo(string resourceName)
+        public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
             throw not_supported();
         }
@@ -363,11 +362,11 @@ namespace System.Reflection.Emit
             throw not_supported();
         }
 
-        public override Stream GetManifestResourceStream(string name)
+        public override Stream? GetManifestResourceStream(string name)
         {
             throw not_supported();
         }
-        public override Stream GetManifestResourceStream(Type type, string name)
+        public override Stream? GetManifestResourceStream(Type type, string name)
         {
             throw not_supported();
         }
@@ -380,7 +379,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        internal string AssemblyDir
+        internal string? AssemblyDir
         {
             get
             {
@@ -483,7 +482,7 @@ namespace System.Reflection.Emit
             return new TypeBuilderInstantiation(gtd, typeArguments);
         }
 
-        public override Type GetType(string name, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string name, bool throwOnError, bool ignoreCase)
         {
             if (name == null)
                 throw new ArgumentNullException(name);
@@ -500,7 +499,7 @@ namespace System.Reflection.Emit
             return res;
         }
 
-        public override Module GetModule(string name)
+        public override Module? GetModule(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -556,7 +555,7 @@ namespace System.Reflection.Emit
 
         //FIXME MS has issues loading satelite assemblies from SRE
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
+        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version? version)
         {
             throw new NotImplementedException();
 #if FALSE
@@ -586,7 +585,7 @@ namespace System.Reflection.Emit
             get { return true; }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return base.Equals(obj);
         }
@@ -594,15 +593,6 @@ namespace System.Reflection.Emit
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            if (assemblyName != null)
-                return assemblyName;
-
-            assemblyName = FullName;
-            return assemblyName;
         }
 
         public override bool IsDefined(Type attributeType, bool inherit)
@@ -625,7 +615,7 @@ namespace System.Reflection.Emit
             return CustomAttributeData.GetCustomAttributes(this);
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -43,23 +42,23 @@ namespace System.Reflection.Emit
 
 #pragma warning disable 169, 414
         private RuntimeMethodHandle mhandle;
-        private ILGenerator ilgen;
-        internal Type[] parameters;
+        private ILGenerator? ilgen;
+        internal Type[]? parameters;
         private MethodAttributes attrs;
         private MethodImplAttributes iattrs;
         private int table_idx;
         private CallingConventions call_conv;
         private TypeBuilder type;
-        internal ParameterBuilder[] pinfo;
-        private CustomAttributeBuilder[] cattrs;
+        internal ParameterBuilder[]? pinfo;
+        private CustomAttributeBuilder[]? cattrs;
         private bool init_locals = true;
-        private Type[][] paramModReq;
-        private Type[][] paramModOpt;
-        private object permissions;
+        private Type[][]? paramModReq;
+        private Type[][]? paramModOpt;
+        private object? permissions;
 #pragma warning restore 169, 414
         internal bool finished;
 
-        internal ConstructorBuilder(TypeBuilder tb, MethodAttributes attributes, CallingConventions callingConvention, Type[] parameterTypes, Type[][] paramModReq, Type[][] paramModOpt)
+        internal ConstructorBuilder(TypeBuilder tb, MethodAttributes attributes, CallingConventions callingConvention, Type[]? parameterTypes, Type[][]? paramModReq, Type[][]? paramModOpt)
         {
             attrs = attributes | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
             call_conv = callingConvention;
@@ -144,7 +143,7 @@ namespace System.Reflection.Emit
 
         internal override Type GetParameterType(int pos)
         {
-            return parameters[pos];
+            return parameters![pos];
         }
 
         internal MethodBase RuntimeResolve()
@@ -152,12 +151,12 @@ namespace System.Reflection.Emit
             return type.RuntimeResolve().GetConstructor(this);
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             throw not_supported();
         }
 
-        public override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             throw not_supported();
         }
@@ -210,7 +209,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public ParameterBuilder DefineParameter(int iSequence, ParameterAttributes attributes, string strParamName)
+        public ParameterBuilder DefineParameter(int iSequence, ParameterAttributes attributes, string? strParamName)
         {
             // The 0th ParameterBuilder does not correspond to an
             // actual parameter, but .NETFramework lets you define
@@ -221,8 +220,7 @@ namespace System.Reflection.Emit
                 throw not_after_created();
 
             ParameterBuilder pb = new ParameterBuilder(this, iSequence, attributes, strParamName);
-            if (pinfo == null)
-                pinfo = new ParameterBuilder[parameters.Length + 1];
+            pinfo ??= new ParameterBuilder[parameters!.Length + 1];
             pinfo[iSequence] = pb;
             return pb;
         }
@@ -264,7 +262,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
 
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.CompilerServices.MethodImplAttribute")
             {
                 byte[] data = customBuilder.Data;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInst.cs
@@ -27,7 +27,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -125,10 +124,10 @@ namespace System.Reflection.Emit
             ParameterInfo[] res;
             if (cb is ConstructorBuilder cbuilder)
             {
-                res = new ParameterInfo[cbuilder.parameters.Length];
+                res = new ParameterInfo[cbuilder.parameters!.Length];
                 for (int i = 0; i < cbuilder.parameters.Length; i++)
                 {
-                    Type type = instantiation.InflateType(cbuilder.parameters[i]);
+                    Type? type = instantiation.InflateType(cbuilder.parameters[i]);
                     res[i] = RuntimeParameterInfo.New(cbuilder.pinfo?[i], type, this, i + 1);
                 }
             }
@@ -138,7 +137,7 @@ namespace System.Reflection.Emit
                 res = new ParameterInfo[parms.Length];
                 for (int i = 0; i < parms.Length; i++)
                 {
-                    Type type = instantiation.InflateType(parms[i].ParameterType);
+                    Type? type = instantiation.InflateType(parms[i].ParameterType);
                     res[i] = RuntimeParameterInfo.New(parms[i], type, this, i + 1);
                 }
             }
@@ -147,9 +146,9 @@ namespace System.Reflection.Emit
 
         internal override Type[] GetParameterTypes()
         {
-            if (cb is ConstructorBuilder)
+            if (cb is ConstructorBuilder builder)
             {
-                return (cb as ConstructorBuilder).parameters;
+                return builder.parameters!;
             }
             else
             {
@@ -183,10 +182,9 @@ namespace System.Reflection.Emit
             return cb.GetParametersCount();
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
-            return cb.Invoke(obj, invokeAttr, binder, parameters,
-                culture);
+            return cb.Invoke(obj, invokeAttr, binder, parameters, culture);
         }
 
         public override RuntimeMethodHandle MethodHandle
@@ -246,8 +244,8 @@ namespace System.Reflection.Emit
         // MethodBase members
         //
 
-        public override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters,
-                                       CultureInfo culture)
+        public override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters,
+                                       CultureInfo? culture)
         {
             throw new InvalidOperationException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -40,13 +39,13 @@ namespace System.Reflection.Emit
     [StructLayout(LayoutKind.Sequential)]
     public partial class CustomAttributeBuilder
     {
-        private ConstructorInfo ctor;
-        private byte[] data;
-        private object[] args;
-        private PropertyInfo[] namedProperties;
-        private object[] propertyValues;
-        private FieldInfo[] namedFields;
-        private object[] fieldValues;
+        private ConstructorInfo ctor = null!;
+        private byte[] data = null!;
+        private object?[]? args;
+        private PropertyInfo[] namedProperties = null!;
+        private object?[] propertyValues = null!;
+        private FieldInfo[] namedFields = null!;
+        private object?[] fieldValues = null!;
 
         internal ConstructorInfo Ctor
         {
@@ -59,7 +58,7 @@ namespace System.Reflection.Emit
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern byte[] GetBlob(Assembly asmb, ConstructorInfo con, object[] constructorArgs, PropertyInfo[] namedProperties, object[] propertyValues, FieldInfo[] namedFields, object[] fieldValues);
+        private static extern byte[] GetBlob(Assembly asmb, ConstructorInfo con, object?[] constructorArgs, PropertyInfo[] namedProperties, object[] propertyValues, FieldInfo[] namedFields, object[] fieldValues);
 
         internal object Invoke()
         {
@@ -85,24 +84,24 @@ namespace System.Reflection.Emit
             /* should we check that the user supplied data is correct? */
         }
 
-        public CustomAttributeBuilder(ConstructorInfo con, object[] constructorArgs)
+        public CustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs)
         {
             Initialize(con, constructorArgs, Array.Empty<PropertyInfo>(), Array.Empty<object>(),
                     Array.Empty<FieldInfo>(), Array.Empty<object>());
         }
-        public CustomAttributeBuilder(ConstructorInfo con, object[] constructorArgs,
+        public CustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs,
                 FieldInfo[] namedFields, object[] fieldValues)
         {
             Initialize(con, constructorArgs, Array.Empty<PropertyInfo>(), Array.Empty<object>(),
                     namedFields, fieldValues);
         }
-        public CustomAttributeBuilder(ConstructorInfo con, object[] constructorArgs,
+        public CustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs,
                 PropertyInfo[] namedProperties, object[] propertyValues)
         {
             Initialize(con, constructorArgs, namedProperties, propertyValues, Array.Empty<FieldInfo>(),
                     Array.Empty<object>());
         }
-        public CustomAttributeBuilder(ConstructorInfo con, object[] constructorArgs,
+        public CustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs,
                 PropertyInfo[] namedProperties, object[] propertyValues,
                 FieldInfo[] namedFields, object[] fieldValues)
         {
@@ -135,20 +134,20 @@ namespace System.Reflection.Emit
             if (paramType == typeof(object))
             {
                 if (t.IsArray && t.GetArrayRank() == 1)
-                    return IsValidType(t.GetElementType());
+                    return IsValidType(t.GetElementType()!);
                 if (!t.IsPrimitive && !typeof(Type).IsAssignableFrom(t) && t != typeof(string) && !t.IsEnum)
                     return false;
             }
             return true;
         }
 
-        private static bool IsValidValue(Type type, object value)
+        private static bool IsValidValue(Type type, object? value)
         {
             if (type.IsValueType && value == null)
                 return false;
-            if (type.IsArray && type.GetElementType().IsValueType)
+            if (type.IsArray && type.GetElementType()!.IsValueType)
             {
-                foreach (object v in (Array)value)
+                foreach (object? v in (Array)value!)
                 {
                     if (v == null)
                         return false;
@@ -157,7 +156,7 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        private void Initialize(ConstructorInfo con, object[] constructorArgs,
+        private void Initialize(ConstructorInfo con, object?[] constructorArgs,
                 PropertyInfo[] namedProperties, object[] propertyValues,
                 FieldInfo[] namedFields, object[] fieldValues)
         {
@@ -194,12 +193,12 @@ namespace System.Reflection.Emit
             // if ((con.CallingConvention & CallingConventions.Standard) != CallingConventions.Standard)
             //    throw new ArgumentException(SR.Argument_BadConstructorCallConv);
 
-            Type atype = ctor.DeclaringType;
+            Type atype = ctor.DeclaringType!;
             int i;
             i = 0;
             foreach (FieldInfo fi in namedFields)
             {
-                Type t = fi.DeclaringType;
+                Type t = fi.DeclaringType!;
                 if ((atype != t) && (!t.IsSubclassOf(atype)) && (!atype.IsSubclassOf(t)))
                     throw new ArgumentException("Field '" + fi.Name + "' does not belong to the same class as the constructor");
                 if (!IsValidType(fi.FieldType))
@@ -226,7 +225,7 @@ namespace System.Reflection.Emit
             {
                 if (!pi.CanWrite)
                     throw new ArgumentException("Property '" + pi.Name + "' does not have a setter.");
-                Type t = pi.DeclaringType;
+                Type t = pi.DeclaringType!;
                 if ((atype != t) && (!t.IsSubclassOf(atype)) && (!atype.IsSubclassOf(t)))
                     throw new ArgumentException("Property '" + pi.Name + "' does not belong to the same class as the constructor");
                 if (!IsValidType(pi.PropertyType))
@@ -258,8 +257,8 @@ namespace System.Reflection.Emit
                         if (!(paramType is TypeBuilder) && !paramType.IsEnum && !paramType.IsInstanceOfType(constructorArgs[i]))
                             if (!paramType.IsArray)
                                 throw new ArgumentException("Value of argument " + i + " does not match parameter type: " + paramType + " -> " + constructorArgs[i]);
-                        if (!IsValidParam(constructorArgs[i], paramType))
-                            throw new ArgumentException("Cannot emit a CustomAttribute with argument of type " + constructorArgs[i].GetType() + ".");
+                        if (!IsValidParam(constructorArgs[i]!, paramType))
+                            throw new ArgumentException("Cannot emit a CustomAttribute with argument of type " + constructorArgs[i]!.GetType() + ".");
                     }
                 }
                 i++;
@@ -295,7 +294,7 @@ namespace System.Reflection.Emit
             return Text.Encoding.UTF8.GetString(data, pos, len);
         }
 
-        internal static string decode_string(byte[] data, int pos, out int rpos)
+        internal static string? decode_string(byte[] data, int pos, out int rpos)
         {
             if (data[pos] == 0xff)
             {
@@ -312,7 +311,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        internal string string_arg()
+        internal string? string_arg()
         {
             int pos = 2;
             return decode_string(data, pos, out pos);
@@ -327,13 +326,13 @@ namespace System.Reflection.Emit
             bool hasSize = false;
             int value;
             int utype; /* the (stupid) ctor takes a short or an enum ... */
-            string marshalTypeName = null;
-            Type marshalTypeRef = null;
+            string? marshalTypeName = null;
+            Type? marshalTypeRef = null;
             string marshalCookie = string.Empty;
             utype = (int)data[2];
             utype |= ((int)data[3]) << 8;
 
-            string first_type_name = GetParameters(customBuilder.Ctor)[0].ParameterType.FullName;
+            string? first_type_name = GetParameters(customBuilder.Ctor)[0].ParameterType.FullName;
             int pos = 6;
             if (first_type_name == "System.Int16")
                 pos = 4;
@@ -353,7 +352,7 @@ namespace System.Reflection.Emit
                     /* enums, the value is preceeded by the type */
                     decode_string(data, pos, out pos);
                 }
-                string named_name = decode_string(data, pos, out pos);
+                string? named_name = decode_string(data, pos, out pos);
 
                 switch (named_name)
                 {
@@ -400,7 +399,7 @@ namespace System.Reflection.Emit
                             marshalTypeRef = Type.GetType(marshalTypeName);
                         break;
                     case "MarshalCookie":
-                        marshalCookie = decode_string(data, pos, out pos);
+                        marshalCookie = decode_string(data, pos, out pos)!;
                         break;
                     default:
                         throw new Exception("Unknown MarshalAsAttribute field: " + named_name);
@@ -454,7 +453,7 @@ namespace System.Reflection.Emit
                 _ => throw new Exception("Unknown element type '" + elementType + "'"),
             };
 
-        private static object decode_cattr_value(Type t, byte[] data, int pos, out int rpos)
+        private static object? decode_cattr_value(Type t, byte[] data, int pos, out int rpos)
         {
             switch (Type.GetTypeCode(t))
             {
@@ -489,9 +488,9 @@ namespace System.Reflection.Emit
         internal struct CustomAttributeInfo
         {
             public ConstructorInfo ctor;
-            public object[] ctorArgs;
+            public object?[] ctorArgs;
             public string[] namedParamNames;
-            public object[] namedParamValues;
+            public object?[] namedParamValues;
         }
 
         internal static CustomAttributeInfo decode_cattr(CustomAttributeBuilder customBuilder)
@@ -511,7 +510,7 @@ namespace System.Reflection.Emit
 
             ParameterInfo[] pi = GetParameters(ctor);
             info.ctor = ctor;
-            info.ctorArgs = new object[pi.Length];
+            info.ctorArgs = new object?[pi.Length];
             for (int i = 0; i < pi.Length; ++i)
                 info.ctorArgs[i] = decode_cattr_value(pi[i].ParameterType, data, pos, out pos);
 
@@ -524,7 +523,7 @@ namespace System.Reflection.Emit
             {
                 int named_type = data[pos++];
                 int data_type = data[pos++];
-                string enum_type_name = null;
+                string? enum_type_name = null;
 
                 if (data_type == 0x55)
                 {
@@ -541,15 +540,15 @@ namespace System.Reflection.Emit
                 if (named_type == 0x53)
                 {
                     /* Field */
-                    FieldInfo fi = ctor.DeclaringType.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    FieldInfo? fi = ctor.DeclaringType!.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                     if (fi == null)
                         throw new Exception("Custom attribute type '" + ctor.DeclaringType + "' doesn't contain a field named '" + name + "'");
 
-                    object val = decode_cattr_value(fi.FieldType, data, pos, out pos);
+                    object? val = decode_cattr_value(fi.FieldType, data, pos, out pos);
                     if (enum_type_name != null)
                     {
-                        Type enumType = Type.GetType(enum_type_name);
-                        val = Enum.ToObject(enumType, val);
+                        Type enumType = Type.GetType(enum_type_name)!;
+                        val = Enum.ToObject(enumType, val!);
                     }
 
                     info.namedParamValues[i] = val;
@@ -564,8 +563,7 @@ namespace System.Reflection.Emit
 
         private static ParameterInfo[] GetParameters(ConstructorInfo ctor)
         {
-            ConstructorBuilder cb = ctor as ConstructorBuilder;
-            if (cb != null)
+            if (ctor is ConstructorBuilder cb)
                 return cb.GetParametersInternal();
 
             return ctor.GetParametersInternal();

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
@@ -27,12 +27,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
-
 
 namespace System.Reflection.Emit
 {
@@ -46,7 +45,8 @@ namespace System.Reflection.Emit
             this.m_baseType = elementType;
         }
 
-        internal abstract string FormatName(string elementName);
+        [return: NotNullIfNotNull("elementName")]
+        internal abstract string? FormatName(string? elementName);
 
         protected override bool IsArrayImpl()
         {
@@ -90,11 +90,11 @@ namespace System.Reflection.Emit
             return FormatName(m_baseType.ToString());
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get
             {
-                string fullName = FormatName(m_baseType.FullName);
+                string? fullName = FormatName(m_baseType.FullName);
                 if (fullName == null)
                     return null;
                 return fullName + ", " + m_baseType.Assembly.FullName;
@@ -102,7 +102,7 @@ namespace System.Reflection.Emit
         }
 
 
-        public override string FullName
+        public override string? FullName
         {
             get
             {
@@ -145,8 +145,8 @@ namespace System.Reflection.Emit
             get { throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType")); }
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target,
-            object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+        public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target,
+            object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
@@ -179,7 +179,7 @@ namespace System.Reflection.Emit
             get { throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType")); }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get { return m_baseType.Namespace; }
         }
@@ -189,8 +189,8 @@ namespace System.Reflection.Emit
             get { return typeof(System.Array); }
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder,
-                CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder,
+                CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
@@ -200,8 +200,8 @@ namespace System.Reflection.Emit
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder,
-                CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder,
+                CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
@@ -241,8 +241,8 @@ namespace System.Reflection.Emit
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder,
-                Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder,
+                Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NonReflectedType"));
         }
@@ -388,7 +388,8 @@ namespace System.Reflection.Emit
             return (rank == 0) ? 1 : rank;
         }
 
-        internal override string FormatName(string elementName)
+        [return: NotNullIfNotNull("elementName")]
+        internal override string? FormatName(string? elementName)
         {
             if (elementName == null)
                 return null;
@@ -420,7 +421,8 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        internal override string FormatName(string elementName)
+        [return: NotNullIfNotNull("elementName")]
+        internal override string? FormatName(string? elementName)
         {
             if (elementName == null)
                 return null;
@@ -465,7 +467,8 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        internal override string FormatName(string elementName)
+        [return: NotNullIfNotNull("elementName")]
+        internal override string? FormatName(string? elementName)
         {
             if (elementName == null)
                 return null;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Runtime.InteropServices;
 
@@ -37,7 +36,7 @@ namespace System.Reflection.Emit
     public class DynamicILInfo
     {
 
-        private DynamicMethod method;
+        private DynamicMethod method = null!;
 
         internal DynamicILInfo()
         {
@@ -74,7 +73,7 @@ namespace System.Reflection.Emit
 
         public int GetTokenFor(RuntimeMethodHandle method)
         {
-            MethodBase mi = MethodBase.GetMethodFromHandle(method);
+            MethodBase mi = MethodBase.GetMethodFromHandle(method)!;
             return this.method.GetILGenerator().TokenGenerator.GetToken(mi, false);
         }
 
@@ -101,23 +100,24 @@ namespace System.Reflection.Emit
             throw new NotImplementedException();
         }
 
-        public void SetCode(byte[] code, int maxStackSize)
+        public void SetCode(byte[]? code, int maxStackSize)
         {
-            if (code == null)
-                throw new ArgumentNullException(nameof(code));
             method.GetILGenerator().SetCode(code, maxStackSize);
         }
 
         [CLSCompliantAttribute(false)]
         public unsafe void SetCode(byte* code, int codeSize, int maxStackSize)
         {
-            if (code == null)
+            if (codeSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(codeSize), SR.ArgumentOutOfRange_GenericPositive);
+            if (codeSize > 0 && code == null)
                 throw new ArgumentNullException(nameof(code));
+
             method.GetILGenerator().SetCode(code, codeSize, maxStackSize);
         }
 
         // FIXME:
-        public void SetExceptions(byte[] exceptions)
+        public void SetExceptions(byte[]? exceptions)
         {
             throw new NotImplementedException();
         }
@@ -130,7 +130,7 @@ namespace System.Reflection.Emit
         }
 
         // FIXME:
-        public void SetLocalSignature(byte[] localSignature)
+        public void SetLocalSignature(byte[]? localSignature)
         {
             throw new NotImplementedException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.notsupported.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.notsupported.cs
@@ -26,7 +26,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if !MONO_FEATURE_SRE
 
 using System.Globalization;
@@ -35,42 +34,42 @@ namespace System.Reflection.Emit
 {
 	public sealed class DynamicMethod : MethodInfo
 	{
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes, bool restrictedSkipVisibility)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes, bool restrictedSkipVisibility)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes, Module m)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes, Module m)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes, Type owner)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes, Type owner)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes, Module m, bool skipVisibility)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes, Module m, bool skipVisibility)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, Type returnType, Type[] parameterTypes, Type owner, bool skipVisibility)
+		public DynamicMethod (string name, Type? returnType, Type[]? parameterTypes, Type owner, bool skipVisibility)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, Module m, bool skipVisibility)
+		public DynamicMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, Module m, bool skipVisibility)
 		{
 			throw new PlatformNotSupportedException ();
 		}
 
-		public DynamicMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, Type owner, bool skipVisibility)
+		public DynamicMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, Type owner, bool skipVisibility)
 		{
 			throw new PlatformNotSupportedException ();
 		}
@@ -87,7 +86,7 @@ namespace System.Reflection.Emit
 			}
 		}
 
-		public override Type DeclaringType {
+		public override Type? DeclaringType {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -113,7 +112,7 @@ namespace System.Reflection.Emit
 			}
 		}
 
-		public override Type ReturnType {
+		public override Type? ReturnType {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -143,11 +142,11 @@ namespace System.Reflection.Emit
 		public override MethodImplAttributes GetMethodImplementationFlags () { throw new PlatformNotSupportedException (); }
 		public override MethodInfo GetBaseDefinition () { throw new PlatformNotSupportedException (); }
 
-		public override object Invoke (object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture) { throw new PlatformNotSupportedException (); }
+		public override object? Invoke (object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture) { throw new PlatformNotSupportedException (); }
 
 		public override bool IsDefined (Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
 
-		public ParameterBuilder DefineParameter (int position, ParameterAttributes attributes, string parameterName) => throw new PlatformNotSupportedException ();
+		public ParameterBuilder? DefineParameter (int position, ParameterAttributes attributes, string? parameterName) => throw new PlatformNotSupportedException ();
 		public DynamicILInfo GetDynamicILInfo () => throw new PlatformNotSupportedException ();
 	}
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.Mono.cs
@@ -30,8 +30,8 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -81,7 +81,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get
             {
@@ -89,7 +89,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get
             {
@@ -97,7 +97,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get
             {
@@ -105,7 +105,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get
             {
@@ -137,7 +137,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get
             {
@@ -145,7 +145,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get
             {
@@ -185,13 +185,12 @@ namespace System.Reflection.Emit
             }
         }
 
-        public Type CreateType()
+        public Type? CreateType()
         {
-            Type res = _tb.CreateType();
-            return res;
+            return _tb.CreateType();
         }
 
-        public TypeInfo CreateTypeInfo()
+        public TypeInfo? CreateTypeInfo()
         {
             return _tb.CreateTypeInfo();
         }
@@ -204,7 +203,7 @@ namespace System.Reflection.Emit
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern void setup_enum_type(Type t);
 
-        public FieldBuilder DefineLiteral(string literalName, object literalValue)
+        public FieldBuilder DefineLiteral(string literalName, object? literalValue)
         {
             Type fieldType = this;
             FieldBuilder fieldBuilder = _tb.DefineField(literalName,
@@ -219,12 +218,11 @@ namespace System.Reflection.Emit
             return _tb.attrs;
         }
 
-        protected override ConstructorInfo GetConstructorImpl(
-            BindingFlags bindingAttr, Binder binder, CallingConventions callConvention,
-            Type[] types, ParameterModifier[] modifiers)
+        protected override ConstructorInfo? GetConstructorImpl(
+            BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention,
+            Type[] types, ParameterModifier[]? modifiers)
         {
-            return _tb.GetConstructor(bindingAttr, binder, callConvention, types,
-                modifiers);
+            return _tb.GetConstructor(bindingAttr, binder, callConvention, types, modifiers);
         }
 
         [ComVisible(true)]
@@ -246,12 +244,12 @@ namespace System.Reflection.Emit
                 return _tb.GetCustomAttributes(attributeType, inherit);
         }
 
-        public override Type GetElementType()
+        public override Type? GetElementType()
         {
             return _tb.GetElementType();
         }
 
-        public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
+        public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
         {
             return _tb.GetEvent(name, bindingAttr);
         }
@@ -266,7 +264,7 @@ namespace System.Reflection.Emit
             return _tb.GetEvents(bindingAttr);
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             return _tb.GetField(name, bindingAttr);
         }
@@ -276,7 +274,7 @@ namespace System.Reflection.Emit
             return _tb.GetFields(bindingAttr);
         }
 
-        public override Type GetInterface(string name, bool ignoreCase)
+        public override Type? GetInterface(string name, bool ignoreCase)
         {
             return _tb.GetInterface(name, ignoreCase);
         }
@@ -302,10 +300,10 @@ namespace System.Reflection.Emit
             return _tb.GetMembers(bindingAttr);
         }
 
-        protected override MethodInfo GetMethodImpl(
-            string name, BindingFlags bindingAttr, Binder binder,
-            CallingConventions callConvention, Type[] types,
-            ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(
+            string name, BindingFlags bindingAttr, Binder? binder,
+            CallingConventions callConvention, Type[]? types,
+            ParameterModifier[]? modifiers)
         {
             if (types == null)
             {
@@ -321,7 +319,7 @@ namespace System.Reflection.Emit
             return _tb.GetMethods(bindingAttr);
         }
 
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
+        public override Type? GetNestedType(string name, BindingFlags bindingAttr)
         {
             return _tb.GetNestedType(name, bindingAttr);
         }
@@ -336,10 +334,10 @@ namespace System.Reflection.Emit
             return _tb.GetProperties(bindingAttr);
         }
 
-        protected override PropertyInfo GetPropertyImpl(
-            string name, BindingFlags bindingAttr, Binder binder,
-            Type returnType, Type[] types,
-            ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(
+            string name, BindingFlags bindingAttr, Binder? binder,
+            Type? returnType, Type[]? types,
+            ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException(SR.NotSupported_DynamicModule);
         }
@@ -349,11 +347,11 @@ namespace System.Reflection.Emit
             return _tb.HasElementType;
         }
 
-        public override object InvokeMember(
-            string name, BindingFlags invokeAttr, Binder binder,
-            object target, object[] args,
-            ParameterModifier[] modifiers, CultureInfo culture,
-            string[] namedParameters)
+        public override object? InvokeMember(
+            string name, BindingFlags invokeAttr, Binder? binder,
+            object? target, object?[]? args,
+            ParameterModifier[]? modifiers, CultureInfo? culture,
+            string[]? namedParameters)
         {
             return _tb.InvokeMember(name, invokeAttr, binder, target,
                 args, modifiers, culture, namedParameters);
@@ -448,7 +446,7 @@ namespace System.Reflection.Emit
             get { return false; }
         }
 
-        public override bool IsAssignableFrom(TypeInfo typeInfo)
+        public override bool IsAssignableFrom([NotNullWhen(true)] TypeInfo? typeInfo)
         {
             return base.IsAssignableFrom(typeInfo);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EventBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Runtime.InteropServices;
 
@@ -43,11 +42,11 @@ namespace System.Reflection.Emit
         internal string name;
         private Type type;
         private TypeBuilder typeb;
-        private CustomAttributeBuilder[] cattrs;
-        internal MethodBuilder add_method;
-        internal MethodBuilder remove_method;
-        internal MethodBuilder raise_method;
-        internal MethodBuilder[] other_methods;
+        private CustomAttributeBuilder[]? cattrs;
+        internal MethodBuilder? add_method;
+        internal MethodBuilder? remove_method;
+        internal MethodBuilder? raise_method;
+        internal MethodBuilder[]? other_methods;
         internal EventAttributes attrs;
         private int table_idx;
 #pragma warning restore 169, 414
@@ -115,7 +114,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
             RejectIfCreated();
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.CompilerServices.SpecialNameAttribute")
             {
                 attrs |= EventAttributes.SpecialName;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EventOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/EventOnTypeBuilderInst.cs
@@ -27,7 +27,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Collections;
 using System.Runtime.InteropServices;
@@ -41,8 +40,8 @@ namespace System.Reflection.Emit
     internal class EventOnTypeBuilderInst : EventInfo
     {
         private TypeBuilderInstantiation instantiation;
-        private EventBuilder event_builder;
-        private EventInfo event_info;
+        private EventBuilder? event_builder;
+        private EventInfo? event_info;
 
         internal EventOnTypeBuilderInst(TypeBuilderInstantiation instantiation, EventBuilder evt)
         {
@@ -58,28 +57,28 @@ namespace System.Reflection.Emit
 
         public override EventAttributes Attributes
         {
-            get { return event_builder != null ? event_builder.attrs : event_info.Attributes; }
+            get { return event_builder != null ? event_builder.attrs : event_info!.Attributes; }
         }
 
-        public override MethodInfo GetAddMethod(bool nonPublic)
+        public override MethodInfo? GetAddMethod(bool nonPublic)
         {
-            MethodInfo add = event_builder != null ? event_builder.add_method : event_info.GetAddMethod(nonPublic);
+            MethodInfo? add = event_builder != null ? event_builder.add_method : event_info!.GetAddMethod(nonPublic);
             if (add == null || (!nonPublic && !add.IsPublic))
                 return null;
             return TypeBuilder.GetMethod(instantiation, add);
         }
 
-        public override MethodInfo GetRaiseMethod(bool nonPublic)
+        public override MethodInfo? GetRaiseMethod(bool nonPublic)
         {
-            MethodInfo raise = event_builder != null ? event_builder.raise_method : event_info.GetRaiseMethod(nonPublic);
+            MethodInfo? raise = event_builder != null ? event_builder.raise_method : event_info!.GetRaiseMethod(nonPublic);
             if (raise == null || (!nonPublic && !raise.IsPublic))
                 return null;
             return TypeBuilder.GetMethod(instantiation, raise);
         }
 
-        public override MethodInfo GetRemoveMethod(bool nonPublic)
+        public override MethodInfo? GetRemoveMethod(bool nonPublic)
         {
-            MethodInfo remove = event_builder != null ? event_builder.remove_method : event_info.GetRemoveMethod(nonPublic);
+            MethodInfo? remove = event_builder != null ? event_builder.remove_method : event_info!.GetRemoveMethod(nonPublic);
             if (remove == null || (!nonPublic && !remove.IsPublic))
                 return null;
             return TypeBuilder.GetMethod(instantiation, remove);
@@ -87,7 +86,7 @@ namespace System.Reflection.Emit
 
         public override MethodInfo[] GetOtherMethods(bool nonPublic)
         {
-            MethodInfo[] other = event_builder != null ? event_builder.other_methods : event_info.GetOtherMethods(nonPublic);
+            MethodInfo[]? other = event_builder != null ? event_builder.other_methods : event_info!.GetOtherMethods(nonPublic);
             if (other == null)
                 return Array.Empty<MethodInfo>();
 
@@ -109,7 +108,7 @@ namespace System.Reflection.Emit
 
         public override string Name
         {
-            get { return event_builder != null ? event_builder.name : event_info.Name; }
+            get { return event_builder != null ? event_builder.name : event_info!.Name; }
         }
 
         public override Type ReflectedType

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // (C) 2001-2002 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -43,20 +42,20 @@ namespace System.Reflection.Emit
 
 #pragma warning disable 169, 414
         private FieldAttributes attrs;
-        private Type type;
+        private Type? type;
         private string name;
-        private object def_value;
+        private object? def_value;
         private int offset;
         internal TypeBuilder typeb;
-        private byte[] rva_data;
-        private CustomAttributeBuilder[] cattrs;
-        private UnmanagedMarshal marshal_info;
+        private byte[]? rva_data;
+        private CustomAttributeBuilder[]? cattrs;
+        private UnmanagedMarshal? marshal_info;
         private RuntimeFieldHandle handle;
-        private Type[] modReq;
-        private Type[] modOpt;
+        private Type[]? modReq;
+        private Type[]? modOpt;
 #pragma warning restore 169, 414
 
-        internal FieldBuilder(TypeBuilder tb, string fieldName, Type type, FieldAttributes attributes, Type[] modReq, Type[] modOpt)
+        internal FieldBuilder(TypeBuilder tb, string fieldName, Type type, FieldAttributes attributes, Type[]? modReq, Type[]? modOpt)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
@@ -77,7 +76,7 @@ namespace System.Reflection.Emit
             get { return attrs; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return typeb; }
         }
@@ -92,7 +91,7 @@ namespace System.Reflection.Emit
 
         public override Type FieldType
         {
-            get { return type; }
+            get { return type!; }
         }
 
         public override string Name
@@ -100,7 +99,7 @@ namespace System.Reflection.Emit
             get { return name; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return typeb; }
         }
@@ -133,7 +132,7 @@ namespace System.Reflection.Emit
             return new FieldToken(MetadataToken, type);
         }
 
-        public override object GetValue(object obj)
+        public override object? GetValue(object? obj)
         {
             throw CreateNotSupportedException();
         }
@@ -154,7 +153,7 @@ namespace System.Reflection.Emit
             rva_data = (byte[])data.Clone();
         }
 
-        public void SetConstant(object defaultValue)
+        public void SetConstant(object? defaultValue)
         {
             RejectIfCreated();
 
@@ -170,7 +169,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
 
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.InteropServices.FieldOffsetAttribute")
             {
                 byte[] data = customBuilder.Data;
@@ -226,7 +225,7 @@ namespace System.Reflection.Emit
             offset = iOffset;
         }
 
-        public override void SetValue(object obj, object val, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
+        public override void SetValue(object? obj, object? val, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture)
         {
             throw CreateNotSupportedException();
         }
@@ -254,7 +253,7 @@ namespace System.Reflection.Emit
         internal FieldInfo RuntimeResolve()
         {
             // typeb.CreateType() populates this.handle
-            var type_handle = new RuntimeTypeHandle(typeb.CreateType() as RuntimeType);
+            var type_handle = new RuntimeTypeHandle((typeb.CreateType() as RuntimeType)!);
             return GetFieldFromHandle(handle, type_handle);
         }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
@@ -42,7 +42,7 @@ namespace System.Reflection.Emit
 
 #pragma warning disable 169, 414
         private FieldAttributes attrs;
-        private Type? type;
+        private Type type;
         private string name;
         private object? def_value;
         private int offset;
@@ -91,7 +91,7 @@ namespace System.Reflection.Emit
 
         public override Type FieldType
         {
-            get { return type!; }
+            get { return type; }
         }
 
         public override string Name

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInst.cs
@@ -27,7 +27,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -134,12 +133,12 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override object GetValue(object obj)
+        public override object? GetValue(object? obj)
         {
             throw new NotSupportedException();
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture)
         {
             throw new NotSupportedException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -29,10 +29,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
-using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
 {
@@ -43,24 +43,24 @@ namespace System.Reflection.Emit
     {
         #region Sync with reflection.h
         private TypeBuilder tbuilder;
-        private MethodBuilder mbuilder;
+        private MethodBuilder? mbuilder;
         private string name;
         private int index;
-        private Type base_type;
+        private Type? base_type;
 #pragma warning disable 414
-        private Type[] iface_constraints;
-        private CustomAttributeBuilder[] cattrs;
+        private Type[]? iface_constraints;
+        private CustomAttributeBuilder[]? cattrs;
         private GenericParameterAttributes attrs;
 #pragma warning restore
         #endregion
 
-        public void SetBaseTypeConstraint(Type baseTypeConstraint)
+        public void SetBaseTypeConstraint(Type? baseTypeConstraint)
         {
             this.base_type = baseTypeConstraint ?? typeof(object);
         }
 
         [ComVisible(true)]
-        public void SetInterfaceConstraints(params Type[] interfaceConstraints)
+        public void SetInterfaceConstraints(params Type[]? interfaceConstraints)
         {
             this.iface_constraints = interfaceConstraints;
         }
@@ -71,7 +71,7 @@ namespace System.Reflection.Emit
         }
 
         internal GenericTypeParameterBuilder(TypeBuilder tbuilder,
-                              MethodBuilder mbuilder,
+                              MethodBuilder? mbuilder,
                               string name, int index)
         {
             this.tbuilder = tbuilder;
@@ -83,14 +83,14 @@ namespace System.Reflection.Emit
         internal override Type InternalResolve()
         {
             if (mbuilder != null)
-                return MethodBase.GetMethodFromHandle(mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.InternalResolve().TypeHandle).GetGenericArguments()[index];
+                return MethodBase.GetMethodFromHandle(mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.InternalResolve().TypeHandle)!.GetGenericArguments()[index];
             return tbuilder.InternalResolve().GetGenericArguments()[index];
         }
 
         internal override Type RuntimeResolve()
         {
             if (mbuilder != null)
-                return MethodBase.GetMethodFromHandle(mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.RuntimeResolve().TypeHandle).GetGenericArguments()[index];
+                return MethodBase.GetMethodFromHandle(mbuilder.MethodHandleInternal, mbuilder.TypeBuilder.RuntimeResolve().TypeHandle)!.GetGenericArguments()[index];
             return tbuilder.RuntimeResolve().GetGenericArguments()[index];
         }
 
@@ -105,11 +105,11 @@ namespace System.Reflection.Emit
             return TypeAttributes.Public;
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr,
-                                       Binder binder,
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr,
+                                       Binder? binder,
                                        CallingConventions callConvention,
                                        Type[] types,
-                                       ParameterModifier[] modifiers)
+                                       ParameterModifier[]? modifiers)
         {
             throw not_supported();
         }
@@ -170,10 +170,10 @@ namespace System.Reflection.Emit
             throw not_supported();
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr,
-                                 Binder binder,
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr,
+                                 Binder? binder,
                                  CallingConventions callConvention,
-                                 Type[] types, ParameterModifier[] modifiers)
+                                 Type[]? types, ParameterModifier[]? modifiers)
         {
             throw not_supported();
         }
@@ -193,10 +193,10 @@ namespace System.Reflection.Emit
             throw not_supported();
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr,
-                                 Binder binder, Type returnType,
-                                 Type[] types,
-                                 ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr,
+                                 Binder? binder, Type? returnType,
+                                 Type[]? types,
+                                 ParameterModifier[]? modifiers)
         {
             throw not_supported();
         }
@@ -206,12 +206,12 @@ namespace System.Reflection.Emit
             return false;
         }
 
-        public override bool IsAssignableFrom(Type c)
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c)
         {
             throw not_supported();
         }
 
-        public override bool IsAssignableFrom(TypeInfo typeInfo)
+        public override bool IsAssignableFrom([NotNullWhen(true)] TypeInfo? typeInfo)
         {
             if (typeInfo == null)
                 return false;
@@ -219,7 +219,7 @@ namespace System.Reflection.Emit
             return IsAssignableFrom(typeInfo.AsType());
         }
 
-        public override bool IsInstanceOfType(object o)
+        public override bool IsInstanceOfType(object? o)
         {
             throw not_supported();
         }
@@ -262,10 +262,10 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr,
-                             Binder binder, object target, object[] args,
-                             ParameterModifier[] modifiers,
-                             CultureInfo culture, string[] namedParameters)
+        public override object? InvokeMember(string name, BindingFlags invokeAttr,
+                             Binder? binder, object? target, object?[]? args,
+                             ParameterModifier[]? modifiers,
+                             CultureInfo? culture, string[]? namedParameters)
         {
             throw not_supported();
         }
@@ -288,17 +288,17 @@ namespace System.Reflection.Emit
             get { return tbuilder.Assembly; }
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get { return null; }
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get { return base_type; }
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get { return null; }
         }
@@ -334,7 +334,7 @@ namespace System.Reflection.Emit
             get { return name; }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get { return null; }
         }
@@ -344,12 +344,12 @@ namespace System.Reflection.Emit
             get { return tbuilder.Module; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return mbuilder != null ? mbuilder.DeclaringType : tbuilder; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return DeclaringType; }
         }
@@ -407,7 +407,7 @@ namespace System.Reflection.Emit
             throw new InvalidOperationException();
         }
 
-        public override MethodBase DeclaringMethod
+        public override MethodBase? DeclaringMethod
         {
             get { return mbuilder; }
         }
@@ -448,7 +448,7 @@ namespace System.Reflection.Emit
         }
 
         // FIXME:
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
             return base.Equals(o);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/LocalBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/LocalBuilder.Mono.cs
@@ -32,7 +32,6 @@
 // (C) 2001, 2002 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
@@ -45,7 +44,7 @@ namespace System.Reflection.Emit
         internal Type type;
         internal bool is_pinned;
         internal ushort position;
-        private string name;
+        private string? name;
         #endregion
 
         internal ILGenerator ilgen;
@@ -94,7 +93,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        internal string Name
+        internal string? Name
         {
             get { return name; }
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.Mono.cs
@@ -30,8 +30,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
@@ -42,36 +42,36 @@ namespace System.Reflection.Emit
     {
 #pragma warning disable 169, 414
         private RuntimeMethodHandle mhandle;
-        private Type rtype;
-        internal Type[] parameters;
+        private Type? rtype;
+        internal Type[]? parameters;
         private MethodAttributes attrs; /* It's used directly by MCS */
         private MethodImplAttributes iattrs;
         private string name;
         private int table_idx;
-        private byte[] code;
-        private ILGenerator ilgen;
+        private byte[]? code;
+        private ILGenerator? ilgen;
         private TypeBuilder type;
-        internal ParameterBuilder[] pinfo;
-        private CustomAttributeBuilder[] cattrs;
-        private MethodInfo[] override_methods;
-        private string pi_dll;
-        private string pi_entry;
+        internal ParameterBuilder[]? pinfo;
+        private CustomAttributeBuilder[]? cattrs;
+        private MethodInfo[]? override_methods;
+        private string? pi_dll;
+        private string? pi_entry;
         private CharSet charset;
         private uint extra_flags; /* this encodes set_last_error etc */
         private CallingConvention native_cc;
         private CallingConventions call_conv;
         private bool init_locals = true;
         private IntPtr generic_container;
-        internal GenericTypeParameterBuilder[] generic_params;
-        private Type[] returnModReq;
-        private Type[] returnModOpt;
-        private Type[][] paramModReq;
-        private Type[][] paramModOpt;
-        private object permissions;
+        internal GenericTypeParameterBuilder[]? generic_params;
+        private Type[]? returnModReq;
+        private Type[]? returnModOpt;
+        private Type[][]? paramModReq;
+        private Type[][]? paramModOpt;
+        private object? permissions;
 #pragma warning restore 169, 414
-        private RuntimeMethodInfo created;
+        private RuntimeMethodInfo? created;
 
-        internal MethodBuilder(TypeBuilder tb, string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnModReq, Type[] returnModOpt, Type[] parameterTypes, Type[][] paramModReq, Type[][] paramModOpt)
+        internal MethodBuilder(TypeBuilder tb, string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? returnModReq, Type[]? returnModOpt, Type[]? parameterTypes, Type[][]? paramModReq, Type[][]? paramModOpt)
         {
             this.name = name;
             this.attrs = attributes;
@@ -101,7 +101,7 @@ namespace System.Reflection.Emit
         }
 
         internal MethodBuilder(TypeBuilder tb, string name, MethodAttributes attributes,
-                                CallingConventions callingConvention, Type returnType, Type[] returnModReq, Type[] returnModOpt, Type[] parameterTypes, Type[][] paramModReq, Type[][] paramModOpt,
+                                CallingConventions callingConvention, Type? returnType, Type[]? returnModReq, Type[]? returnModOpt, Type[]? parameterTypes, Type[][]? paramModReq, Type[][]? paramModOpt,
             string dllName, string entryName, CallingConvention nativeCConv, CharSet nativeCharset)
             : this(tb, name, attributes, callingConvention, returnType, returnModReq, returnModOpt, parameterTypes, paramModReq, paramModOpt)
         {
@@ -145,15 +145,15 @@ namespace System.Reflection.Emit
 
         public override Type ReturnType
         {
-            get { return rtype; }
+            get { return rtype!; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return type; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return type; }
         }
@@ -170,7 +170,7 @@ namespace System.Reflection.Emit
 
         public override ICustomAttributeProvider ReturnTypeCustomAttributes
         {
-            get { return null; }
+            get { return null!; } // FIXME: coreclr returns an empty instance
         }
 
         public override CallingConventions CallingConvention
@@ -249,7 +249,7 @@ namespace System.Reflection.Emit
         internal override ParameterInfo[] GetParametersInternal()
         {
             if (parameters == null)
-                return null;
+                return Array.Empty<ParameterInfo>();
 
             ParameterInfo[] retval = new ParameterInfo[parameters.Length];
             for (int i = 0; i < parameters.Length; i++)
@@ -269,7 +269,7 @@ namespace System.Reflection.Emit
 
         internal override Type GetParameterType(int pos)
         {
-            return parameters[pos];
+            return parameters![pos];
         }
 
         internal MethodBase RuntimeResolve()
@@ -282,7 +282,7 @@ namespace System.Reflection.Emit
             return type.Module;
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             throw NotSupported();
         }
@@ -368,7 +368,7 @@ namespace System.Reflection.Emit
                 if (((ilgen == null) || (ilgen.ILOffset == 0)) && (code == null || code.Length == 0))
                     throw new InvalidOperationException(
                                          string.Format("Method '{0}.{1}' does not have a method body.",
-                                                DeclaringType.FullName, Name));
+                                                DeclaringType!.FullName, Name));
             }
             if (ilgen != null)
                 ilgen.label_fixup(this);
@@ -408,7 +408,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
 
-            switch (customBuilder.Ctor.ReflectedType.FullName)
+            switch (customBuilder.Ctor.ReflectedType!.FullName)
             {
                 case "System.Runtime.CompilerServices.MethodImplAttribute":
                     byte[] data = customBuilder.Data;
@@ -433,7 +433,7 @@ namespace System.Reflection.Emit
                      *   default in DllImportAttribute.
                      */
 
-                    pi_dll = (string)attr.ctorArgs[0];
+                    pi_dll = (string?)attr.ctorArgs[0];
                     if (pi_dll == null || pi_dll.Length == 0)
                         throw new ArgumentException("DllName cannot be empty");
 
@@ -442,24 +442,24 @@ namespace System.Reflection.Emit
                     for (int i = 0; i < attr.namedParamNames.Length; ++i)
                     {
                         string name = attr.namedParamNames[i];
-                        object value = attr.namedParamValues[i];
+                        object? value = attr.namedParamValues[i];
 
                         if (name == "CallingConvention")
-                            native_cc = (CallingConvention)value;
+                            native_cc = (CallingConvention)value!;
                         else if (name == "CharSet")
-                            charset = (CharSet)value;
+                            charset = (CharSet)value!;
                         else if (name == "EntryPoint")
-                            pi_entry = (string)value;
+                            pi_entry = (string)value!;
                         else if (name == "ExactSpelling")
-                            ExactSpelling = (bool)value;
+                            ExactSpelling = (bool)value!;
                         else if (name == "SetLastError")
-                            SetLastError = (bool)value;
+                            SetLastError = (bool)value!;
                         else if (name == "PreserveSig")
-                            preserveSig = (bool)value;
+                            preserveSig = (bool)value!;
                         else if (name == "BestFitMapping")
-                            BestFitMapping = (bool)value;
+                            BestFitMapping = (bool)value!;
                         else if (name == "ThrowOnUnmappableChar")
-                            ThrowOnUnmappableChar = (bool)value;
+                            ThrowOnUnmappableChar = (bool)value!;
                     }
 
                     attrs |= MethodAttributes.PinvokeImpl;
@@ -514,7 +514,7 @@ namespace System.Reflection.Emit
         }
 
         // FIXME:
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return base.Equals(obj);
         }
@@ -529,7 +529,7 @@ namespace System.Reflection.Emit
             return type.get_next_table_index(obj, table, count);
         }
 
-        private void ExtendArray<T>(ref T[] array, T elem)
+        private void ExtendArray<T>([NotNull] ref T[]? array, T elem)
         {
             if (array == null)
             {
@@ -566,7 +566,7 @@ namespace System.Reflection.Emit
                 throw new InvalidOperationException("Method is not a generic method definition");
             if (typeArguments == null)
                 throw new ArgumentNullException(nameof(typeArguments));
-            if (generic_params.Length != typeArguments.Length)
+            if (generic_params!.Length != typeArguments.Length)
                 throw new ArgumentException("Incorrect length", nameof(typeArguments));
             foreach (Type type in typeArguments)
             {
@@ -604,7 +604,7 @@ namespace System.Reflection.Emit
         public override Type[] GetGenericArguments()
         {
             if (generic_params == null)
-                return null;
+                return Type.EmptyTypes;
 
             Type[] result = new Type[generic_params.Length];
             for (int i = 0; i < generic_params.Length; i++)
@@ -632,12 +632,12 @@ namespace System.Reflection.Emit
             return generic_params;
         }
 
-        public void SetReturnType(Type returnType)
+        public void SetReturnType(Type? returnType)
         {
             rtype = returnType;
         }
 
-        public void SetParameters(params Type[] parameterTypes)
+        public void SetParameters(params Type[]? parameterTypes)
         {
             if (parameterTypes != null)
             {
@@ -650,7 +650,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public void SetSignature(Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
+        public void SetSignature(Type? returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
             SetReturnType(returnType);
             SetParameters(parameterTypes);
@@ -674,8 +674,7 @@ namespace System.Reflection.Emit
             {
                 if (!type.is_created)
                     throw new InvalidOperationException(SR.InvalidOperation_TypeNotCreated);
-                if (created == null)
-                    created = (RuntimeMethodInfo)GetMethodFromHandle(mhandle);
+                created ??= (RuntimeMethodInfo)GetMethodFromHandle(mhandle)!;
                 return created.ReturnParameter;
             }
         }
@@ -759,7 +758,7 @@ namespace System.Reflection.Emit
             return m_exceptionClass ^ m_tryStartOffset ^ m_tryEndOffset ^ m_filterOffset ^ m_handlerStartOffset ^ m_handlerEndOffset ^ (int)m_kind;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ExceptionHandler && Equals((ExceptionHandler)obj);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInst.cs
@@ -27,7 +27,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Text;
@@ -44,10 +43,10 @@ namespace System.Reflection.Emit
     {
         #region Keep in sync with object-internals.h
         private Type instantiation;
-        private MethodInfo base_method; /*This is the base method definition, it must be non-inflated and belong to a non-inflated type.*/
-        private Type[] method_arguments;
+        private MethodInfo base_method = null!; /*This is the base method definition, it must be non-inflated and belong to a non-inflated type.*/
+        private Type[]? method_arguments;
         #endregion
-        private MethodInfo generic_method_definition;
+        private MethodInfo? generic_method_definition;
 
         public MethodOnTypeBuilderInst(TypeBuilderInstantiation instantiation, MethodInfo base_method)
         {
@@ -66,7 +65,7 @@ namespace System.Reflection.Emit
 
         internal MethodOnTypeBuilderInst(MethodInfo method, Type[] typeArguments)
         {
-            this.instantiation = method.DeclaringType;
+            this.instantiation = method.DeclaringType!;
             this.base_method = ExtractBaseMethod(method);
             this.method_arguments = new Type[typeArguments.Length];
             typeArguments.CopyTo(this.method_arguments, 0);
@@ -84,14 +83,14 @@ namespace System.Reflection.Emit
             if (info.IsGenericMethod)
                 info = info.GetGenericMethodDefinition();
 
-            Type t = info.DeclaringType;
+            Type t = info.DeclaringType!;
             if (!t.IsGenericType || t.IsGenericTypeDefinition)
                 return info;
 
-            return (MethodInfo)t.Module.ResolveMethod(info.MetadataToken);
+            return (MethodInfo)t.Module.ResolveMethod(info.MetadataToken)!;
         }
 
-        internal Type[] GetTypeArgs()
+        internal Type[]? GetTypeArgs()
         {
             if (!instantiation.IsGenericType || instantiation.IsGenericParameter)
                 return null;
@@ -215,7 +214,7 @@ namespace System.Reflection.Emit
             return base_method.GetParametersCount();
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             throw new NotSupportedException();
         }
@@ -267,7 +266,7 @@ namespace System.Reflection.Emit
         public override Type[] GetGenericArguments()
         {
             if (!base_method.IsGenericMethodDefinition)
-                return null;
+                return Type.EmptyTypes;
             Type[] source = method_arguments ?? base_method.GetGenericArguments();
             Type[] result = new Type[source.Length];
             source.CopyTo(result, 0);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -58,32 +57,32 @@ namespace System.Reflection.Emit
         #endregion
         private UIntPtr dynamic_image; /* GC-tracked */
         private int num_types;
-        private TypeBuilder[] types;
-        private CustomAttributeBuilder[] cattrs;
+        private TypeBuilder[]? types;
+        private CustomAttributeBuilder[]? cattrs;
         private byte[] guid;
         private int table_idx;
         internal AssemblyBuilder assemblyb;
-        private MethodBuilder[] global_methods;
-        private FieldBuilder[] global_fields;
+        private MethodBuilder[]? global_methods;
+        private FieldBuilder[]? global_fields;
         private bool is_main;
-        private object resources;
+        private object? resources;
         private IntPtr unparented_classes;
-        private int[] table_indexes;
+        private int[]? table_indexes;
         #endregion
 #pragma warning restore 169, 414
 
-        private TypeBuilder global_type;
-        private Type global_type_created;
+        private TypeBuilder? global_type;
+        private Type? global_type_created;
         // name_cache keys are display names
         private Dictionary<ITypeName, TypeBuilder> name_cache;
         private Dictionary<string, int> us_string_cache;
-        private ModuleBuilderTokenGenerator token_gen;
+        private ModuleBuilderTokenGenerator? token_gen;
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void basic_init(ModuleBuilder ab);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void set_wrappers_type(ModuleBuilder mb, Type ab);
+        private static extern void set_wrappers_type(ModuleBuilder mb, Type? ab);
 
         internal ModuleBuilder(AssemblyBuilder assb, string name, bool emitSymbolInfo)
         {
@@ -100,7 +99,7 @@ namespace System.Reflection.Emit
             CreateGlobalType();
 
             TypeBuilder tb = new TypeBuilder(this, TypeAttributes.Abstract, 0xFFFFFF); /*last valid token*/
-            Type type = tb.CreateType();
+            Type? type = tb.CreateType();
             set_wrappers_type(this, type);
         }
 
@@ -110,7 +109,7 @@ namespace System.Reflection.Emit
             {
                 string fullyQualifiedName = fqname;
                 if (fullyQualifiedName == null)
-                    return null;
+                    return null!; // FIXME: this should not return null
                 if (assemblyb.AssemblyDir != null)
                 {
                     fullyQualifiedName = Path.Combine(assemblyb.AssemblyDir, fullyQualifiedName);
@@ -131,7 +130,7 @@ namespace System.Reflection.Emit
             if (global_type_created != null)
                 throw new InvalidOperationException("global methods already created");
             if (global_type != null)
-                global_type_created = global_type.CreateType();
+                global_type_created = global_type.CreateType()!;
         }
 
         public FieldBuilder DefineInitializedData(string name, byte[] data, FieldAttributes attributes)
@@ -165,7 +164,7 @@ namespace System.Reflection.Emit
             CreateGlobalType();
 
             string typeName = "$ArrayType$" + size;
-            Type datablobtype = GetType(typeName, false, false);
+            Type? datablobtype = GetType(typeName, false, false);
             if (datablobtype == null)
             {
                 TypeBuilder tb = DefineType(typeName,
@@ -174,7 +173,7 @@ namespace System.Reflection.Emit
                 tb.CreateType();
                 datablobtype = tb;
             }
-            FieldBuilder fb = global_type.DefineField(name, datablobtype, attributes | FieldAttributes.Static);
+            FieldBuilder fb = global_type!.DefineField(name, datablobtype, attributes | FieldAttributes.Static);
 
             if (global_fields != null)
             {
@@ -207,17 +206,17 @@ namespace System.Reflection.Emit
             }
         }
 
-        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, Type returnType, Type[] parameterTypes)
+        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, Type? returnType, Type[]? parameterTypes)
         {
             return DefineGlobalMethod(name, attributes, CallingConventions.Standard, returnType, parameterTypes);
         }
 
-        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
+        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes)
         {
             return DefineGlobalMethod(name, attributes, callingConvention, returnType, null, null, parameterTypes, null, null);
         }
 
-        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] requiredReturnTypeCustomModifiers, Type[] optionalReturnTypeCustomModifiers, Type[] parameterTypes, Type[][] requiredParameterTypeCustomModifiers, Type[][] optionalParameterTypeCustomModifiers)
+        public MethodBuilder DefineGlobalMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? requiredReturnTypeCustomModifiers, Type[]? optionalReturnTypeCustomModifiers, Type[]? parameterTypes, Type[][]? requiredParameterTypeCustomModifiers, Type[][]? optionalParameterTypeCustomModifiers)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -226,18 +225,18 @@ namespace System.Reflection.Emit
             if (global_type_created != null)
                 throw new InvalidOperationException("global methods already created");
             CreateGlobalType();
-            MethodBuilder mb = global_type.DefineMethod(name, attributes, callingConvention, returnType, requiredReturnTypeCustomModifiers, optionalReturnTypeCustomModifiers, parameterTypes, requiredParameterTypeCustomModifiers, optionalParameterTypeCustomModifiers);
+            MethodBuilder mb = global_type!.DefineMethod(name, attributes, callingConvention, returnType, requiredReturnTypeCustomModifiers, optionalReturnTypeCustomModifiers, parameterTypes, requiredParameterTypeCustomModifiers, optionalParameterTypeCustomModifiers);
 
             addGlobalMethod(mb);
             return mb;
         }
 
-        public MethodBuilder DefinePInvokeMethod(string name, string dllName, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
+        public MethodBuilder DefinePInvokeMethod(string name, string dllName, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
         {
             return DefinePInvokeMethod(name, dllName, name, attributes, callingConvention, returnType, parameterTypes, nativeCallConv, nativeCharSet);
         }
 
-        public MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
+        public MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -246,7 +245,7 @@ namespace System.Reflection.Emit
             if (global_type_created != null)
                 throw new InvalidOperationException("global methods already created");
             CreateGlobalType();
-            MethodBuilder mb = global_type.DefinePInvokeMethod(name, dllName, entryName, attributes, callingConvention, returnType, parameterTypes, nativeCallConv, nativeCharSet);
+            MethodBuilder mb = global_type!.DefinePInvokeMethod(name, dllName, entryName, attributes, callingConvention, returnType, parameterTypes, nativeCallConv, nativeCharSet);
 
             addGlobalMethod(mb);
             return mb;
@@ -264,7 +263,7 @@ namespace System.Reflection.Emit
             return DefineType(name, attr, typeof(object), null);
         }
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent)
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent)
         {
             return DefineType(name, attr, parent, null);
         }
@@ -288,7 +287,7 @@ namespace System.Reflection.Emit
             num_types++;
         }
 
-        private TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, Type[] interfaces, PackingSize packingSize, int typesize)
+        private TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, Type[]? interfaces, PackingSize packingSize, int typesize)
         {
             if (name == null)
                 throw new ArgumentNullException("fullname");
@@ -308,37 +307,37 @@ namespace System.Reflection.Emit
             name_cache.Add(name, tb);
         }
 
-        internal TypeBuilder GetRegisteredType(ITypeName name)
+        internal TypeBuilder? GetRegisteredType(ITypeName name)
         {
-            TypeBuilder result = null;
+            TypeBuilder? result = null;
             name_cache.TryGetValue(name, out result);
             return result;
         }
 
         [ComVisible(true)]
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, Type[] interfaces)
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, Type[]? interfaces)
         {
             return DefineType(name, attr, parent, interfaces, PackingSize.Unspecified, TypeBuilder.UnspecifiedTypeSize);
         }
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, int typesize)
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, int typesize)
         {
             return DefineType(name, attr, parent, null, PackingSize.Unspecified, typesize);
         }
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, PackingSize packsize)
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, PackingSize packsize)
         {
             return DefineType(name, attr, parent, null, packsize, TypeBuilder.UnspecifiedTypeSize);
         }
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, PackingSize packingSize, int typesize)
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type? parent, PackingSize packingSize, int typesize)
         {
             return DefineType(name, attr, parent, null, packingSize, typesize);
         }
 
-        public MethodInfo GetArrayMethod(Type arrayClass, string methodName, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
+        public MethodInfo GetArrayMethod(Type arrayClass, string methodName, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes)
         {
-            return new MonoArrayMethod(arrayClass, methodName, callingConvention, returnType, parameterTypes);
+            return new MonoArrayMethod(arrayClass, methodName, callingConvention, returnType!, parameterTypes!); // FIXME: nulls should be allowed
         }
 
         public EnumBuilder DefineEnum(string name, TypeAttributes visibility, Type underlyingType)
@@ -355,18 +354,18 @@ namespace System.Reflection.Emit
         }
 
         [ComVisible(true)]
-        public override Type GetType(string className)
+        public override Type? GetType(string className)
         {
             return GetType(className, false, false);
         }
 
         [ComVisible(true)]
-        public override Type GetType(string className, bool ignoreCase)
+        public override Type? GetType(string className, bool ignoreCase)
         {
             return GetType(className, false, ignoreCase);
         }
 
-        private TypeBuilder search_in_array(TypeBuilder[] arr, int validElementsInArray, ITypeName className)
+        private TypeBuilder? search_in_array(TypeBuilder[] arr, int validElementsInArray, ITypeName className)
         {
             int i;
             for (i = 0; i < validElementsInArray; ++i)
@@ -379,7 +378,7 @@ namespace System.Reflection.Emit
             return null;
         }
 
-        private TypeBuilder search_nested_in_array(TypeBuilder[] arr, int validElementsInArray, ITypeName className)
+        private TypeBuilder? search_nested_in_array(TypeBuilder[] arr, int validElementsInArray, ITypeName className)
         {
             int i;
             for (i = 0; i < validElementsInArray; ++i)
@@ -390,9 +389,9 @@ namespace System.Reflection.Emit
             return null;
         }
 
-        private TypeBuilder GetMaybeNested(TypeBuilder t, IEnumerable<ITypeName> nested)
+        private TypeBuilder? GetMaybeNested(TypeBuilder t, IEnumerable<ITypeName> nested)
         {
-            TypeBuilder result = t;
+            TypeBuilder? result = t;
 
             foreach (ITypeName pname in nested)
             {
@@ -406,14 +405,14 @@ namespace System.Reflection.Emit
         }
 
         [ComVisible(true)]
-        public override Type GetType(string className, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string className, bool throwOnError, bool ignoreCase)
         {
             if (className == null)
                 throw new ArgumentNullException(nameof(className));
             if (className.Length == 0)
                 throw new ArgumentException(SR.Argument_EmptyName, nameof(className));
 
-            TypeBuilder result = null;
+            TypeBuilder? result = null;
 
             if (types == null && throwOnError)
                 throw new TypeLoadException(className);
@@ -428,7 +427,7 @@ namespace System.Reflection.Emit
             else
             {
                 if (types != null)
-                    result = search_in_array(types, num_types, ts.Name);
+                    result = search_in_array(types, num_types, ts.Name!);
                 if (!ts.IsNested && result != null)
                 {
                     result = GetMaybeNested(result, ts.Nested);
@@ -443,15 +442,15 @@ namespace System.Reflection.Emit
                 {
                     var tb = result as TypeBuilder;
                     if (tb.is_created)
-                        mt = tb.CreateType();
+                        mt = tb.CreateType()!;
                 }
                 foreach (IModifierSpec mod in ts.Modifiers)
                 {
                     if (mod is PointerSpec)
-                        mt = mt.MakePointerType();
+                        mt = mt.MakePointerType()!;
                     else if (mod is IArraySpec)
                     {
-                        var spec = mod as IArraySpec;
+                        var spec = (mod as IArraySpec)!;
                         if (spec.IsBound)
                             return null;
                         if (spec.Rank == 1)
@@ -512,7 +511,7 @@ namespace System.Reflection.Emit
             SetCustomAttribute(new CustomAttributeBuilder(con, binaryAttribute));
         }
         /*
-                internal ISymbolDocumentWriter DefineDocument (string url, Guid language, Guid languageVendor, Guid documentType)
+                internal ISymbolDocumentWriter? DefineDocument (string url, Guid language, Guid languageVendor, Guid documentType)
                 {
                     if (symbolWriter != null)
                         return symbolWriter.DefineDocument (url, language, languageVendor, documentType);
@@ -532,7 +531,7 @@ namespace System.Reflection.Emit
             // MS replaces the typebuilders with their created types
             for (int i = 0; i < copy.Length; ++i)
                 if (types[i].is_created)
-                    copy[i] = types[i].CreateType();
+                    copy[i] = types[i].CreateType()!;
 
             return copy;
         }
@@ -545,7 +544,7 @@ namespace System.Reflection.Emit
             return new MethodToken(GetToken(method));
         }
 
-        public MethodToken GetArrayMethodToken(Type arrayClass, string methodName, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
+        public MethodToken GetArrayMethodToken(Type arrayClass, string methodName, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes)
         {
             return GetMethodToken(GetArrayMethod(arrayClass, methodName, callingConvention, returnType, parameterTypes));
         }
@@ -601,7 +600,7 @@ namespace System.Reflection.Emit
 
         public TypeToken GetTypeToken(string name)
         {
-            return GetTypeToken(GetType(name));
+            return GetTypeToken(GetType(name)!);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -631,7 +630,7 @@ namespace System.Reflection.Emit
         private static int typespec_tokengen = 0x1bffffff;
         private static int memberref_tokengen = 0x0affffff;
         private static int methoddef_tokengen = 0x06ffffff;
-        private Dictionary<MemberInfo, int> inst_tokens, inst_tokens_open;
+        private Dictionary<MemberInfo, int>? inst_tokens, inst_tokens_open;
 
         //
         // Assign a pseudo token to the various TypeBuilderInst objects, so the runtime
@@ -643,10 +642,10 @@ namespace System.Reflection.Emit
         private int GetPseudoToken(MemberInfo member, bool create_open_instance)
         {
             int token;
-            Dictionary<MemberInfo, int> dict = create_open_instance ? inst_tokens_open : inst_tokens;
+            Dictionary<MemberInfo, int>? dict = create_open_instance ? inst_tokens_open : inst_tokens;
             if (dict == null)
             {
-                dict = new Dictionary<MemberInfo, int>(ReferenceEqualityComparer<MemberInfo>.Instance);
+                dict = new Dictionary<MemberInfo, int>(ReferenceEqualityComparer.Instance);
                 if (create_open_instance)
                     inst_tokens_open = dict;
                 else
@@ -669,32 +668,31 @@ namespace System.Reflection.Emit
                 token = memberref_tokengen--;
             else if (member is FieldBuilder)
                 token = memberref_tokengen--;
-            else if (member is TypeBuilder)
+            else if (member is TypeBuilder tb)
             {
-                if (create_open_instance && (member as TypeBuilder).ContainsGenericParameters)
+                if (create_open_instance && tb.ContainsGenericParameters)
                     token = typespec_tokengen--;
                 else if (member.Module == this)
                     token = typedef_tokengen--;
                 else
                     token = typeref_tokengen--;
             }
-            else if (member is EnumBuilder)
+            else if (member is EnumBuilder eb)
             {
-                token = GetPseudoToken((member as EnumBuilder).GetTypeBuilder(), create_open_instance);
+                token = GetPseudoToken(eb.GetTypeBuilder(), create_open_instance);
                 dict[member] = token;
                 // n.b. don't register with the runtime, the TypeBuilder already did it.
                 return token;
             }
-            else if (member is ConstructorBuilder)
+            else if (member is ConstructorBuilder cb)
             {
-                if (member.Module == this && !(member as ConstructorBuilder).TypeBuilder.ContainsGenericParameters)
+                if (member.Module == this && !cb.TypeBuilder.ContainsGenericParameters)
                     token = methoddef_tokengen--;
                 else
                     token = memberref_tokengen--;
             }
-            else if (member is MethodBuilder)
+            else if (member is MethodBuilder mb)
             {
-                var mb = member as MethodBuilder;
                 if (member.Module == this && !mb.TypeBuilder.ContainsGenericParameters && !mb.IsGenericMethodDefinition)
                     token = methoddef_tokengen--;
                 else
@@ -774,22 +772,22 @@ namespace System.Reflection.Emit
         // Called from the runtime to return the corresponding finished reflection object
         internal static object RuntimeResolve(object obj)
         {
-            if (obj is MethodBuilder)
-                return (obj as MethodBuilder).RuntimeResolve();
-            if (obj is ConstructorBuilder)
-                return (obj as ConstructorBuilder).RuntimeResolve();
-            if (obj is FieldBuilder)
-                return (obj as FieldBuilder).RuntimeResolve();
-            if (obj is GenericTypeParameterBuilder)
-                return (obj as GenericTypeParameterBuilder).RuntimeResolve();
-            if (obj is FieldOnTypeBuilderInst)
-                return (obj as FieldOnTypeBuilderInst).RuntimeResolve();
-            if (obj is MethodOnTypeBuilderInst)
-                return (obj as MethodOnTypeBuilderInst).RuntimeResolve();
-            if (obj is ConstructorOnTypeBuilderInst)
-                return (obj as ConstructorOnTypeBuilderInst).RuntimeResolve();
-            if (obj is Type)
-                return (obj as Type).RuntimeResolve();
+            if (obj is MethodBuilder mb)
+                return mb.RuntimeResolve();
+            if (obj is ConstructorBuilder cb)
+                return cb.RuntimeResolve();
+            if (obj is FieldBuilder fb)
+                return fb.RuntimeResolve();
+            if (obj is GenericTypeParameterBuilder gtpb)
+                return gtpb.RuntimeResolve();
+            if (obj is FieldOnTypeBuilderInst fotbi)
+                return fotbi.RuntimeResolve();
+            if (obj is MethodOnTypeBuilderInst motbi)
+                return motbi.RuntimeResolve();
+            if (obj is ConstructorOnTypeBuilderInst cotbi)
+                return cotbi.RuntimeResolve();
+            if (obj is Type t)
+                return t.RuntimeResolve();
             throw new NotImplementedException(obj.GetType().FullName);
         }
 
@@ -843,7 +841,7 @@ namespace System.Reflection.Emit
             return false;
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             if (global_type_created == null)
                 return null;
@@ -852,12 +850,12 @@ namespace System.Reflection.Emit
             return global_type_created.GetMethod(name, bindingAttr, binder, callConvention, types, modifiers);
         }
 
-        public override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override FieldInfo? ResolveField(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return RuntimeModule.ResolveField(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        public override MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MemberInfo? ResolveMember(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return RuntimeModule.ResolveMember(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
@@ -865,7 +863,7 @@ namespace System.Reflection.Emit
         internal MemberInfo ResolveOrGetRegisteredToken(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
         {
             ResolveTokenError error;
-            MemberInfo m = RuntimeModule.ResolveMemberToken(_impl, metadataToken, RuntimeModule.ptrs_from_types(genericTypeArguments), RuntimeModule.ptrs_from_types(genericMethodArguments), out error);
+            MemberInfo? m = RuntimeModule.ResolveMemberToken(_impl, metadataToken, RuntimeModule.ptrs_from_types(genericTypeArguments), RuntimeModule.ptrs_from_types(genericMethodArguments), out error);
             if (m != null)
                 return m;
 
@@ -876,7 +874,7 @@ namespace System.Reflection.Emit
                 return m;
         }
 
-        public override MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MethodBase? ResolveMethod(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return RuntimeModule.ResolveMethod(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
@@ -891,12 +889,12 @@ namespace System.Reflection.Emit
             return RuntimeModule.ResolveSignature(this, _impl, metadataToken);
         }
 
-        public override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override Type ResolveType(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return RuntimeModule.ResolveType(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return base.Equals(obj);
         }
@@ -913,7 +911,7 @@ namespace System.Reflection.Emit
 
         public override object[] GetCustomAttributes(bool inherit)
         {
-            return GetCustomAttributes(null, inherit);
+            return GetCustomAttributes(null!, inherit); // FIXME: coreclr doesn't allow null attributeType
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
@@ -944,7 +942,7 @@ namespace System.Reflection.Emit
             return CustomAttributeData.GetCustomAttributes(this);
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             if (global_type_created == null)
                 throw new InvalidOperationException("Module-level fields cannot be retrieved until after the CreateGlobalFunctions method has been called for the module.");
@@ -1004,26 +1002,6 @@ namespace System.Reflection.Emit
             return mb.GetToken(helper);
         }
     }
-
-    internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
-    {
-        internal static readonly ReferenceEqualityComparer<T> Instance = new ReferenceEqualityComparer<T>();
-
-        private ReferenceEqualityComparer()
-        {
-        }
-
-        public bool Equals(T x, T y)
-        {
-            return ReferenceEquals(x, y);
-        }
-
-        public int GetHashCode(T obj)
-        {
-            return RuntimeHelpers.GetHashCode(obj);
-        }
-    }
-
 }
 
 #endif

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MonoArrayMethod.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/MonoArrayMethod.cs
@@ -31,7 +31,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -76,7 +75,7 @@ namespace System.Reflection
         // FIXME: "Not implemented.  Always returns null"
         public override ICustomAttributeProvider ReturnTypeCustomAttributes
         {
-            get { return null; }
+            get { return null!; }
         }
 
         // FIXME: "Not implemented.  Always returns zero"
@@ -103,7 +102,7 @@ namespace System.Reflection
         }
 
         // FIXME: "Not implemented"
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             throw new NotImplementedException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.Mono.cs
@@ -31,7 +31,6 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Runtime.InteropServices;
 
@@ -42,16 +41,16 @@ namespace System.Reflection.Emit
     {
 #pragma warning disable 169, 414
         private MethodBase methodb; /* MethodBuilder, ConstructorBuilder or DynamicMethod */
-        private string name;
-        private CustomAttributeBuilder[] cattrs;
-        private UnmanagedMarshal marshal_info;
+        private string? name;
+        private CustomAttributeBuilder[]? cattrs;
+        private UnmanagedMarshal? marshal_info;
         private ParameterAttributes attrs;
         private int position;
         private int table_idx;
-        private object def_value;
+        private object? def_value;
 #pragma warning restore 169, 414
 
-        internal ParameterBuilder(MethodBase mb, int pos, ParameterAttributes attributes, string strParamName)
+        internal ParameterBuilder(MethodBase mb, int pos, ParameterAttributes attributes, string? strParamName)
         {
             name = strParamName;
             position = pos;
@@ -79,7 +78,7 @@ namespace System.Reflection.Emit
         {
             get { return ((int)attrs & (int)ParameterAttributes.Optional) != 0; }
         }
-        public virtual string Name
+        public virtual string? Name
         {
             get { return name; }
         }
@@ -93,7 +92,7 @@ namespace System.Reflection.Emit
             return new ParameterToken(0x08 | table_idx);
         }
 
-        public virtual void SetConstant(object defaultValue)
+        public virtual void SetConstant(object? defaultValue)
         {
             if (position > 0)
             {
@@ -107,7 +106,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)
         {
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.InteropServices.InAttribute")
             {
                 attrs |= ParameterAttributes.In;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.Mono.cs
@@ -30,7 +30,6 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -46,21 +45,21 @@ namespace System.Reflection.Emit
         private PropertyAttributes attrs;
         private string name;
         private Type type;
-        private Type[] parameters;
-        private CustomAttributeBuilder[] cattrs;
-        private object def_value;
-        private MethodBuilder set_method;
-        private MethodBuilder get_method;
+        private Type[]? parameters;
+        private CustomAttributeBuilder[]? cattrs;
+        private object? def_value;
+        private MethodBuilder? set_method;
+        private MethodBuilder? get_method;
         private int table_idx = 0;
         internal TypeBuilder typeb;
-        private Type[] returnModReq;
-        private Type[] returnModOpt;
-        private Type[][] paramModReq;
-        private Type[][] paramModOpt;
+        private Type[]? returnModReq;
+        private Type[]? returnModOpt;
+        private Type[][]? paramModReq;
+        private Type[][]? paramModOpt;
         private CallingConventions callingConvention;
 #pragma warning restore 169, 414
 
-        internal PropertyBuilder(TypeBuilder tb, string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnModReq, Type[] returnModOpt, Type[] parameterTypes, Type[][] paramModReq, Type[][] paramModOpt)
+        internal PropertyBuilder(TypeBuilder tb, string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[]? returnModReq, Type[]? returnModOpt, Type[]? parameterTypes, Type[][]? paramModReq, Type[][]? paramModOpt)
         {
             this.name = name;
             this.attrs = attributes;
@@ -121,7 +120,7 @@ namespace System.Reflection.Emit
 
         public override MethodInfo[] GetAccessors(bool nonPublic)
         {
-            return null;
+            return null!; // FIXME: coreclr throws
         }
         public override object[] GetCustomAttributes(bool inherit)
         {
@@ -131,7 +130,7 @@ namespace System.Reflection.Emit
         {
             throw not_supported();
         }
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
             return get_method;
         }
@@ -139,17 +138,17 @@ namespace System.Reflection.Emit
         {
             throw not_supported();
         }
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
             return set_method;
         }
 
-        public override object GetValue(object obj, object[] index)
+        public override object? GetValue(object? obj, object?[]? index)
         {
             throw not_supported();
         }
 
-        public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             throw not_supported();
         }
@@ -157,7 +156,7 @@ namespace System.Reflection.Emit
         {
             throw not_supported();
         }
-        public void SetConstant(object defaultValue)
+        public void SetConstant(object? defaultValue)
         {
             typeb.check_not_created();
             def_value = defaultValue;
@@ -168,7 +167,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
             typeb.check_not_created();
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.CompilerServices.SpecialNameAttribute")
             {
                 attrs |= PropertyAttributes.SpecialName;
@@ -210,12 +209,12 @@ namespace System.Reflection.Emit
             set_method = mdBuilder;
         }
 
-        public override void SetValue(object obj, object value, object[] index)
+        public override void SetValue(object? obj, object? value, object?[]? index)
         {
             throw not_supported();
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             throw not_supported();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/PropertyOnTypeBuilderInst.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/PropertyOnTypeBuilderInst.cs
@@ -27,7 +27,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -66,10 +65,10 @@ namespace System.Reflection.Emit
 
         public override Type PropertyType
         {
-            get { return instantiation.InflateType(prop.PropertyType); }
+            get { return instantiation.InflateType(prop.PropertyType)!; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return instantiation.InflateType(prop.DeclaringType); }
         }
@@ -86,8 +85,8 @@ namespace System.Reflection.Emit
 
         public override MethodInfo[] GetAccessors(bool nonPublic)
         {
-            MethodInfo getter = GetGetMethod(nonPublic);
-            MethodInfo setter = GetSetMethod(nonPublic);
+            MethodInfo? getter = GetGetMethod(nonPublic);
+            MethodInfo? setter = GetSetMethod(nonPublic);
 
             int methods = 0;
             if (getter != null)
@@ -107,9 +106,9 @@ namespace System.Reflection.Emit
         }
 
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
-            MethodInfo mi = prop.GetGetMethod(nonPublic);
+            MethodInfo? mi = prop.GetGetMethod(nonPublic);
             if (mi != null && prop.DeclaringType == instantiation.generic_type)
             {
                 mi = TypeBuilder.GetMethod(instantiation, mi);
@@ -119,16 +118,16 @@ namespace System.Reflection.Emit
 
         public override ParameterInfo[] GetIndexParameters()
         {
-            MethodInfo method = GetGetMethod(true);
+            MethodInfo? method = GetGetMethod(true);
             if (method != null)
                 return method.GetParameters();
 
             return Array.Empty<ParameterInfo>();
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
-            MethodInfo mi = prop.GetSetMethod(nonPublic);
+            MethodInfo? mi = prop.GetSetMethod(nonPublic);
             if (mi != null && prop.DeclaringType == instantiation.generic_type)
             {
                 mi = TypeBuilder.GetMethod(instantiation, mi);
@@ -141,12 +140,12 @@ namespace System.Reflection.Emit
             return string.Format("{0} {1}", PropertyType, Name);
         }
 
-        public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             throw new NotSupportedException();
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             throw new NotSupportedException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -30,8 +30,8 @@
 // (C) 2001 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -48,37 +48,37 @@ namespace System.Reflection.Emit
             HELPER_PROPERTY
         }
 
-        private ModuleBuilder module; // can be null in 2.0
-        private Type[] arguments;
+        private ModuleBuilder? module; // can be null in 2.0
+        private Type[]? arguments;
         private SignatureHelperType type;
-        private Type returnType;
+        private Type? returnType;
         private CallingConventions callConv;
         private CallingConvention unmanagedCallConv;
 #pragma warning disable 649
-        private Type[][] modreqs;
-        private Type[][] modopts;
+        private Type[][]? modreqs;
+        private Type[][]? modopts;
 #pragma warning restore 649
 
-        internal SignatureHelper(ModuleBuilder module, SignatureHelperType type)
+        internal SignatureHelper(ModuleBuilder? module, SignatureHelperType type)
         {
             this.type = type;
             this.module = module;
         }
 
-        public static SignatureHelper GetFieldSigHelper(Module mod)
+        public static SignatureHelper GetFieldSigHelper(Module? mod)
         {
             if (mod != null && !(mod is ModuleBuilder))
                 throw new ArgumentException("ModuleBuilder is expected");
 
-            return new SignatureHelper((ModuleBuilder)mod, SignatureHelperType.HELPER_FIELD);
+            return new SignatureHelper((ModuleBuilder?)mod, SignatureHelperType.HELPER_FIELD);
         }
 
-        public static SignatureHelper GetLocalVarSigHelper(Module mod)
+        public static SignatureHelper GetLocalVarSigHelper(Module? mod)
         {
             if (mod != null && !(mod is ModuleBuilder))
                 throw new ArgumentException("ModuleBuilder is expected");
 
-            return new SignatureHelper((ModuleBuilder)mod, SignatureHelperType.HELPER_LOCAL);
+            return new SignatureHelper((ModuleBuilder?)mod, SignatureHelperType.HELPER_LOCAL);
         }
 
         public static SignatureHelper GetLocalVarSigHelper()
@@ -86,57 +86,57 @@ namespace System.Reflection.Emit
             return new SignatureHelper(null, SignatureHelperType.HELPER_LOCAL);
         }
 
-        public static SignatureHelper GetMethodSigHelper(CallingConventions callingConvention, Type returnType)
+        public static SignatureHelper GetMethodSigHelper(CallingConventions callingConvention, Type? returnType)
         {
             return GetMethodSigHelper(null, callingConvention, (CallingConvention)0, returnType, null);
         }
 
-        public static SignatureHelper GetMethodSigHelper(CallingConvention unmanagedCallingConvention, Type returnType)
+        public static SignatureHelper GetMethodSigHelper(CallingConvention unmanagedCallingConvention, Type? returnType)
         {
             return GetMethodSigHelper(null, CallingConventions.Standard, unmanagedCallingConvention, returnType, null);
         }
 
-        public static SignatureHelper GetMethodSigHelper(Module mod, CallingConventions callingConvention, Type returnType)
+        public static SignatureHelper GetMethodSigHelper(Module? mod, CallingConventions callingConvention, Type? returnType)
         {
             return GetMethodSigHelper(mod, callingConvention, (CallingConvention)0, returnType, null);
         }
 
-        public static SignatureHelper GetMethodSigHelper(Module mod, CallingConvention unmanagedCallConv, Type returnType)
+        public static SignatureHelper GetMethodSigHelper(Module? mod, CallingConvention unmanagedCallConv, Type? returnType)
         {
             return GetMethodSigHelper(mod, CallingConventions.Standard, unmanagedCallConv, returnType, null);
         }
 
-        public static SignatureHelper GetMethodSigHelper(Module mod, Type returnType, Type[] parameterTypes)
+        public static SignatureHelper GetMethodSigHelper(Module? mod, Type? returnType, Type[]? parameterTypes)
         {
             return GetMethodSigHelper(mod, CallingConventions.Standard, (CallingConvention)0, returnType, parameterTypes);
         }
 
         // FIXME: "Not implemented"
-        public static SignatureHelper GetPropertySigHelper(Module mod, Type returnType, Type[] parameterTypes)
+        public static SignatureHelper GetPropertySigHelper(Module? mod, Type? returnType, Type[]? parameterTypes)
         {
             throw new NotImplementedException();
         }
 
         // FIXME: "Not implemented"
-        public static SignatureHelper GetPropertySigHelper(Module mod, Type returnType,
-                                    Type[] requiredReturnTypeCustomModifiers,
-                                    Type[] optionalReturnTypeCustomModifiers,
-                                    Type[] parameterTypes,
-                                    Type[][] requiredParameterTypeCustomModifiers,
-                                    Type[][] optionalParameterTypeCustomModifiers)
+        public static SignatureHelper GetPropertySigHelper(Module? mod, Type? returnType,
+                                    Type[]? requiredReturnTypeCustomModifiers,
+                                    Type[]? optionalReturnTypeCustomModifiers,
+                                    Type[]? parameterTypes,
+                                    Type[][]? requiredParameterTypeCustomModifiers,
+                                    Type[][]? optionalParameterTypeCustomModifiers)
         {
             throw new NotImplementedException();
         }
 
         // FIXME: "Not implemented"
-        public static SignatureHelper GetPropertySigHelper(Module mod,
+        public static SignatureHelper GetPropertySigHelper(Module? mod,
                                     CallingConventions callingConvention,
-                                    Type returnType,
-                                    Type[] requiredReturnTypeCustomModifiers,
-                                    Type[] optionalReturnTypeCustomModifiers,
-                                    Type[] parameterTypes,
-                                    Type[][] requiredParameterTypeCustomModifiers,
-                                    Type[][] optionalParameterTypeCustomModifiers)
+                                    Type? returnType,
+                                    Type[]? requiredReturnTypeCustomModifiers,
+                                    Type[]? optionalReturnTypeCustomModifiers,
+                                    Type[]? parameterTypes,
+                                    Type[][]? requiredParameterTypeCustomModifiers,
+                                    Type[][]? optionalParameterTypeCustomModifiers)
         {
             throw new NotImplementedException();
         }
@@ -145,7 +145,7 @@ namespace System.Reflection.Emit
         // Grows the given array, and returns the index where the element
         // was added
         //
-        private static int AppendArray(ref Type[] array, Type t)
+        private static int AppendArray([NotNull] ref Type[]? array, Type t)
         {
             if (array != null)
             {
@@ -172,7 +172,7 @@ namespace System.Reflection.Emit
         // is stored.
         //
         //
-        private static void AppendArrayAt(ref Type[][] array, Type[] t, int pos)
+        private static void AppendArrayAt([NotNull] ref Type[][]? array, Type[] t, int pos)
         {
             int top = Math.Max(pos, array == null ? 0 : array.Length);
             Type[][] new_a = new Type[top + 1][];
@@ -195,7 +195,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        private static void ValidateCustomModifier(int n, Type[][] custom_modifiers, string name)
+        private static void ValidateCustomModifier(int n, Type[][]? custom_modifiers, string name)
         {
             if (custom_modifiers == null)
                 return;
@@ -218,7 +218,7 @@ namespace System.Reflection.Emit
         }
 
         // FIXME: "Currently we ignore requiredCustomModifiers and optionalCustomModifiers"
-        public void AddArguments(Type[] arguments, Type[][] requiredCustomModifiers, Type[][] optionalCustomModifiers)
+        public void AddArguments(Type[]? arguments, Type[][]? requiredCustomModifiers, Type[][]? optionalCustomModifiers)
         {
             if (arguments == null)
                 throw new ArgumentNullException(nameof(arguments));
@@ -244,7 +244,7 @@ namespace System.Reflection.Emit
             AddArgument(argument);
         }
 
-        public void AddArgument(Type argument, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers)
+        public void AddArgument(Type argument, Type[]? requiredCustomModifiers, Type[]? optionalCustomModifiers)
         {
             if (argument == null)
                 throw new ArgumentNullException(nameof(argument));
@@ -275,7 +275,7 @@ namespace System.Reflection.Emit
             throw new NotImplementedException();
         }
 
-        private static bool CompareOK(Type[][] one, Type[][] two)
+        private static bool CompareOK(Type[][]? one, Type[][]? two)
         {
             if (one == null)
             {
@@ -302,7 +302,7 @@ namespace System.Reflection.Emit
                 else if (ttwo == null)
                     return false;
 
-                if (tone.Length != ttwo.Length)
+                if (tone!.Length != ttwo.Length)
                     return false;
 
                 for (int j = 0; j < tone.Length; j++)
@@ -326,9 +326,9 @@ namespace System.Reflection.Emit
             return true;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            SignatureHelper other = obj as SignatureHelper;
+            SignatureHelper? other = obj as SignatureHelper;
             if (other == null)
                 return false;
 
@@ -385,8 +385,8 @@ namespace System.Reflection.Emit
             return "SignatureHelper";
         }
 
-        internal static SignatureHelper GetMethodSigHelper(Module mod, CallingConventions callingConvention, CallingConvention unmanagedCallingConvention, Type returnType,
-                                                           Type[] parameters)
+        internal static SignatureHelper GetMethodSigHelper(Module? mod, CallingConventions callingConvention, CallingConvention unmanagedCallingConvention, Type? returnType,
+                                                           Type[]? parameters)
         {
             if (mod != null && !(mod is ModuleBuilder))
                 throw new ArgumentException("ModuleBuilder is expected");
@@ -404,8 +404,7 @@ namespace System.Reflection.Emit
 
             }
 
-            SignatureHelper helper =
-                new SignatureHelper((ModuleBuilder)mod, SignatureHelperType.HELPER_METHOD);
+            SignatureHelper helper = new SignatureHelper((ModuleBuilder?)mod, SignatureHelperType.HELPER_METHOD);
             helper.returnType = returnType;
             helper.callConv = callingConvention;
             helper.unmanagedCallConv = unmanagedCallingConvention;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -31,12 +31,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Globalization;
-using System.Collections;
 
 namespace System.Reflection.Emit
 {
@@ -47,34 +47,34 @@ namespace System.Reflection.Emit
         #region Sync with reflection.h
         private string tname; // name in internal form
         private string nspace; // namespace in internal form
-        private Type parent;
-        private Type nesting_type;
-        internal Type[] interfaces;
+        private Type? parent;
+        private Type? nesting_type;
+        internal Type[]? interfaces;
         internal int num_methods;
-        internal MethodBuilder[] methods;
-        internal ConstructorBuilder[] ctors;
-        internal PropertyBuilder[] properties;
+        internal MethodBuilder[]? methods;
+        internal ConstructorBuilder[]? ctors;
+        internal PropertyBuilder[]? properties;
         internal int num_fields;
-        internal FieldBuilder[] fields;
-        internal EventBuilder[] events;
-        private CustomAttributeBuilder[] cattrs;
-        internal TypeBuilder[] subtypes;
+        internal FieldBuilder[]? fields;
+        internal EventBuilder[]? events;
+        private CustomAttributeBuilder[]? cattrs;
+        internal TypeBuilder[]? subtypes;
         internal TypeAttributes attrs;
         private int table_idx;
         private ModuleBuilder pmodule;
         private int class_size;
         private PackingSize packing_size;
         private IntPtr generic_container;
-        private GenericTypeParameterBuilder[] generic_params;
-        private object permissions;
-        private TypeInfo created;
+        private GenericTypeParameterBuilder[]? generic_params;
+        private object? permissions;
+        private TypeInfo? created;
         private int state;
         #endregion
 #pragma warning restore 169
 
         private ITypeName fullname;
         private bool createTypeCalled;
-        private Type underlying_type;
+        private Type? underlying_type;
 
         public const int UnspecifiedTypeSize = 0;
 
@@ -95,7 +95,7 @@ namespace System.Reflection.Emit
             pmodule = mb;
         }
 
-        internal TypeBuilder(ModuleBuilder mb, string fullname, TypeAttributes attr, Type parent, Type[] interfaces, PackingSize packing_size, int type_size, Type nesting_type)
+        internal TypeBuilder(ModuleBuilder mb, string fullname, TypeAttributes attr, Type? parent, Type[]? interfaces, PackingSize packing_size, int type_size, Type? nesting_type)
         {
             int sep_index;
             this.parent = ResolveUserType(parent);
@@ -140,7 +140,7 @@ namespace System.Reflection.Emit
             get { return pmodule.Assembly; }
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get
             {
@@ -148,7 +148,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get
             {
@@ -156,7 +156,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return nesting_type; }
         }
@@ -164,7 +164,7 @@ namespace System.Reflection.Emit
         [ComVisible(true)]
         public override bool IsSubclassOf(Type c)
         {
-            Type t;
+            Type? t;
             if (c == null)
                 return false;
             if (c == this)
@@ -184,7 +184,7 @@ namespace System.Reflection.Emit
             get
             {
                 if (is_created)
-                    return created.UnderlyingSystemType;
+                    return created!.UnderlyingSystemType;
 
                 if (IsEnum)
                 {
@@ -202,13 +202,13 @@ namespace System.Reflection.Emit
         {
             ITypeIdentifier ident = TypeIdentifiers.FromInternal(tname);
             if (nesting_type != null)
-                return TypeNames.FromDisplay(nesting_type.FullName).NestedName(ident);
+                return TypeNames.FromDisplay(nesting_type.FullName!).NestedName(ident);
             if ((nspace != null) && (nspace.Length > 0))
                 return TypeIdentifiers.FromInternal(nspace, ident);
             return ident;
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get
             {
@@ -221,7 +221,7 @@ namespace System.Reflection.Emit
             get
             {
                 check_created();
-                return created.GUID;
+                return created!.GUID;
             }
         }
 
@@ -235,7 +235,7 @@ namespace System.Reflection.Emit
             get { return tname; }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get { return nspace; }
         }
@@ -250,7 +250,7 @@ namespace System.Reflection.Emit
             get { return class_size; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return nesting_type; }
         }
@@ -283,9 +283,9 @@ namespace System.Reflection.Emit
             }
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder,
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder,
                                        CallingConventions callConvention, Type[] types,
-                                       ParameterModifier[] modifiers)
+                                       ParameterModifier[]? modifiers)
         {
             check_created();
 
@@ -300,7 +300,7 @@ namespace System.Reflection.Emit
                 if (ctors == null)
                     return null;
 
-                ConstructorBuilder found = null;
+                ConstructorBuilder? found = null;
                 int count = 0;
 
                 foreach (ConstructorBuilder cb in ctors)
@@ -321,7 +321,7 @@ namespace System.Reflection.Emit
                 }
                 MethodBase[] match = new MethodBase[count];
                 if (count == 1)
-                    match[0] = found;
+                    match[0] = found!;
                 else
                 {
                     count = 0;
@@ -332,14 +332,12 @@ namespace System.Reflection.Emit
                         match[count++] = m;
                     }
                 }
-                if (binder == null)
-                    binder = DefaultBinder;
-                return (ConstructorInfo)binder.SelectMethod(bindingAttr, match,
-                                                              types, modifiers);
+
+                binder ??= DefaultBinder;
+                return (ConstructorInfo?)binder.SelectMethod(bindingAttr, match, types, modifiers);
             }
 
-            return created.GetConstructor(bindingAttr, binder,
-                callConvention, types, modifiers);
+            return created!.GetConstructor(bindingAttr, binder, callConvention, types!, modifiers); // FIXME: types shouldn't be null
         }
 
         public override bool IsDefined(Type attributeType, bool inherit)
@@ -357,14 +355,14 @@ namespace System.Reflection.Emit
         {
             check_created();
 
-            return created.GetCustomAttributes(inherit);
+            return created!.GetCustomAttributes(inherit);
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
             check_created();
 
-            return created.GetCustomAttributes(attributeType, inherit);
+            return created!.GetCustomAttributes(attributeType, inherit);
         }
 
         public TypeBuilder DefineNestedType(string name)
@@ -378,12 +376,12 @@ namespace System.Reflection.Emit
             return DefineNestedType(name, attr, typeof(object), null);
         }
 
-        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent)
+        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent)
         {
             return DefineNestedType(name, attr, parent, null);
         }
 
-        private TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent, Type[] interfaces,
+        private TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent, Type[]? interfaces,
                               PackingSize packSize, int typeSize)
         {
             // Visibility must be NestedXXX
@@ -422,35 +420,35 @@ namespace System.Reflection.Emit
         }
 
         [ComVisible(true)]
-        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent, Type[] interfaces)
+        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent, Type[]? interfaces)
         {
             return DefineNestedType(name, attr, parent, interfaces, PackingSize.Unspecified, UnspecifiedTypeSize);
         }
 
-        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent, int typeSize)
+        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent, int typeSize)
         {
             return DefineNestedType(name, attr, parent, null, PackingSize.Unspecified, typeSize);
         }
 
-        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent, PackingSize packSize)
+        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent, PackingSize packSize)
         {
             return DefineNestedType(name, attr, parent, null, packSize, UnspecifiedTypeSize);
         }
 
-        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type parent, PackingSize packSize,
+        public TypeBuilder DefineNestedType(string name, TypeAttributes attr, Type? parent, PackingSize packSize,
                                          int typeSize)
         {
             return DefineNestedType(name, attr, parent, null, packSize, typeSize);
         }
 
         [ComVisible(true)]
-        public ConstructorBuilder DefineConstructor(MethodAttributes attributes, CallingConventions callingConvention, Type[] parameterTypes)
+        public ConstructorBuilder DefineConstructor(MethodAttributes attributes, CallingConventions callingConvention, Type[]? parameterTypes)
         {
             return DefineConstructor(attributes, callingConvention, parameterTypes, null, null);
         }
 
         [ComVisible(true)]
-        public ConstructorBuilder DefineConstructor(MethodAttributes attributes, CallingConventions callingConvention, Type[] parameterTypes, Type[][] requiredCustomModifiers, Type[][] optionalCustomModifiers)
+        public ConstructorBuilder DefineConstructor(MethodAttributes attributes, CallingConventions callingConvention, Type[]? parameterTypes, Type[][]? requiredCustomModifiers, Type[][]? optionalCustomModifiers)
         {
             check_not_created();
             if (IsInterface && (attributes & MethodAttributes.Static) == 0)
@@ -494,7 +492,7 @@ namespace System.Reflection.Emit
             if (parent_type == typeof(object) || parent_type == typeof(ValueType))
                 parent_type = old_parent_type;
 
-            ConstructorInfo parent_constructor =
+            ConstructorInfo? parent_constructor =
                 parent_type.GetConstructor(
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     null, EmptyTypes, null);
@@ -541,13 +539,13 @@ namespace System.Reflection.Emit
                 returnType, parameterTypes);
         }
 
-        public MethodBuilder DefineMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
+        public MethodBuilder DefineMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes)
         {
             return DefineMethod(name, attributes, callingConvention, returnType,
                 null, null, parameterTypes, null, null);
         }
 
-        public MethodBuilder DefineMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
+        public MethodBuilder DefineMethod(string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
             check_name(nameof(name), name);
             check_not_created();
@@ -569,7 +567,7 @@ namespace System.Reflection.Emit
             return res;
         }
 
-        public MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
+        public MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
         {
             return DefinePInvokeMethod(name, dllName, entryName, attributes,
                 callingConvention, returnType, null, null, parameterTypes,
@@ -581,12 +579,12 @@ namespace System.Reflection.Emit
                         string dllName,
                         string entryName, MethodAttributes attributes,
                         CallingConventions callingConvention,
-                        Type returnType,
-                        Type[] returnTypeRequiredCustomModifiers,
-                        Type[] returnTypeOptionalCustomModifiers,
-                        Type[] parameterTypes,
-                        Type[][] parameterTypeRequiredCustomModifiers,
-                        Type[][] parameterTypeOptionalCustomModifiers,
+                        Type? returnType,
+                        Type[]? returnTypeRequiredCustomModifiers,
+                        Type[]? returnTypeOptionalCustomModifiers,
+                        Type[]? parameterTypes,
+                        Type[][]? parameterTypeRequiredCustomModifiers,
+                        Type[][]? parameterTypeOptionalCustomModifiers,
                         CallingConvention nativeCallConv,
                         CharSet nativeCharSet)
         {
@@ -619,7 +617,7 @@ namespace System.Reflection.Emit
             return res;
         }
 
-        public MethodBuilder DefinePInvokeMethod(string name, string dllName, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
+        public MethodBuilder DefinePInvokeMethod(string name, string dllName, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, CallingConvention nativeCallConv, CharSet nativeCharSet)
         {
             return DefinePInvokeMethod(name, dllName, name, attributes, callingConvention, returnType, parameterTypes,
                 nativeCallConv, nativeCharSet);
@@ -656,7 +654,7 @@ namespace System.Reflection.Emit
             return DefineField(fieldName, type, null, null, attributes);
         }
 
-        public FieldBuilder DefineField(string fieldName, Type type, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers, FieldAttributes attributes)
+        public FieldBuilder DefineField(string fieldName, Type type, Type[]? requiredCustomModifiers, Type[]? optionalCustomModifiers, FieldAttributes attributes)
         {
             check_name(nameof(fieldName), fieldName);
             if (type == typeof(void))
@@ -691,22 +689,22 @@ namespace System.Reflection.Emit
             return res;
         }
 
-        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, Type returnType, Type[] parameterTypes)
+        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, Type returnType, Type[]? parameterTypes)
         {
             return DefineProperty(name, attributes, 0, returnType, null, null, parameterTypes, null, null);
         }
 
-        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
+        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[]? parameterTypes)
         {
             return DefineProperty(name, attributes, callingConvention, returnType, null, null, parameterTypes, null, null);
         }
 
-        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
+        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, Type returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
             return DefineProperty(name, attributes, 0, returnType, returnTypeRequiredCustomModifiers, returnTypeOptionalCustomModifiers, parameterTypes, parameterTypeRequiredCustomModifiers, parameterTypeOptionalCustomModifiers);
         }
 
-        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
+        public PropertyBuilder DefineProperty(string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
             check_name(nameof(name), name);
             if (parameterTypes != null)
@@ -741,7 +739,7 @@ namespace System.Reflection.Emit
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern TypeInfo create_runtime_class();
 
-        private bool is_nested_in(Type t)
+        private bool is_nested_in(Type? t)
         {
             while (t != null)
             {
@@ -760,7 +758,7 @@ namespace System.Reflection.Emit
 
             for (int i = 0; i < num_methods; ++i)
             {
-                MethodBuilder mb = (MethodBuilder)(methods[i]);
+                MethodBuilder mb = (MethodBuilder)(methods![i]);
 
                 if (mb.Name == ConstructorInfo.ConstructorName && (mb.Attributes & ctor_attrs) == ctor_attrs)
                     return true;
@@ -769,13 +767,13 @@ namespace System.Reflection.Emit
             return false;
         }
 
-        public Type CreateType()
+        public Type? CreateType()
         {
             return CreateTypeInfo();
         }
 
         public
-        TypeInfo CreateTypeInfo()
+        TypeInfo? CreateTypeInfo()
         {
             /* handle nesting_type */
             if (createTypeCalled)
@@ -916,14 +914,14 @@ namespace System.Reflection.Emit
             }
         }
 
-        internal static void ResolveUserTypes(Type[] types)
+        internal static void ResolveUserTypes(Type?[]? types)
         {
             if (types != null)
                 for (int i = 0; i < types.Length; ++i)
                     types[i] = ResolveUserType(types[i]);
         }
 
-        internal static Type ResolveUserType(Type t)
+        internal static Type? ResolveUserType(Type? t)
         {
             if (t != null && ((t.GetType().Assembly != typeof(int).Assembly) || (t is TypeDelegator)))
             {
@@ -966,7 +964,7 @@ namespace System.Reflection.Emit
         public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr)
         {
             if (is_created)
-                return created.GetConstructors(bindingAttr);
+                return created!.GetConstructors(bindingAttr);
 
             throw new NotSupportedException();
         }
@@ -1020,10 +1018,10 @@ namespace System.Reflection.Emit
             throw new NotSupportedException();
         }
 
-        public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
+        public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetEvent(name, bindingAttr);
+            return created!.GetEvent(name, bindingAttr);
         }
 
         /* Needed to keep signature compatibility with MS.NET */
@@ -1036,32 +1034,32 @@ namespace System.Reflection.Emit
         public override EventInfo[] GetEvents(BindingFlags bindingAttr)
         {
             if (is_created)
-                return created.GetEvents(bindingAttr);
+                return created!.GetEvents(bindingAttr);
             throw new NotSupportedException();
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetField(name, bindingAttr);
+            return created!.GetField(name, bindingAttr);
         }
 
         public override FieldInfo[] GetFields(BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetFields(bindingAttr);
+            return created!.GetFields(bindingAttr);
         }
 
-        public override Type GetInterface(string name, bool ignoreCase)
+        public override Type? GetInterface(string name, bool ignoreCase)
         {
             check_created();
-            return created.GetInterface(name, ignoreCase);
+            return created!.GetInterface(name, ignoreCase);
         }
 
         public override Type[] GetInterfaces()
         {
             if (is_created)
-                return created.GetInterfaces();
+                return created!.GetInterfaces();
 
             if (interfaces != null)
             {
@@ -1079,18 +1077,18 @@ namespace System.Reflection.Emit
                                                 BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetMember(name, type, bindingAttr);
+            return created!.GetMember(name, type, bindingAttr);
         }
 
         public override MemberInfo[] GetMembers(BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetMembers(bindingAttr);
+            return created!.GetMembers(bindingAttr);
         }
 
-        private MethodInfo[] GetMethodsByName(string name, BindingFlags bindingAttr, bool ignoreCase, Type reflected_type)
+        private MethodInfo[] GetMethodsByName(string? name, BindingFlags bindingAttr, bool ignoreCase, Type reflected_type)
         {
-            MethodInfo[] candidates;
+            MethodInfo[]? candidates;
             bool match;
             MethodAttributes mattrs;
 
@@ -1193,20 +1191,20 @@ namespace System.Reflection.Emit
             return GetMethodsByName(null, bindingAttr, false, this);
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr,
-                                 Binder binder,
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr,
+                                 Binder? binder,
                                  CallingConventions callConvention,
-                                 Type[] types, ParameterModifier[] modifiers)
+                                 Type[]? types, ParameterModifier[]? modifiers)
         {
             check_created();
 
             if (types == null)
-                return created.GetMethod(name, bindingAttr);
+                return created!.GetMethod(name, bindingAttr);
 
-            return created.GetMethod(name, bindingAttr, binder, callConvention, types, modifiers);
+            return created!.GetMethod(name, bindingAttr, binder, callConvention, types, modifiers);
         }
 
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
+        public override Type? GetNestedType(string name, BindingFlags bindingAttr)
         {
             check_created();
 
@@ -1269,10 +1267,10 @@ namespace System.Reflection.Emit
         public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
         {
             check_created();
-            return created.GetProperties(bindingAttr);
+            return created!.GetProperties(bindingAttr);
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
             throw not_supported();
         }
@@ -1283,13 +1281,13 @@ namespace System.Reflection.Emit
             if (!is_created)
                 return false;
 
-            return created.HasElementType;
+            return created!.HasElementType;
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+        public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             check_created();
-            return created.InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
+            return created!.InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
         }
 
         protected override bool IsArrayImpl()
@@ -1321,7 +1319,7 @@ namespace System.Reflection.Emit
         // FIXME: I doubt just removing this still works.
         protected override bool IsValueTypeImpl()
         {
-            Type parent_type = parent;
+            Type? parent_type = parent;
             while (parent_type != null)
             {
                 if (parent_type == typeof(ValueType))
@@ -1365,7 +1363,7 @@ namespace System.Reflection.Emit
             if (typeArguments == null)
                 throw new ArgumentNullException(nameof(typeArguments));
 
-            if (generic_params.Length != typeArguments.Length)
+            if (generic_params!.Length != typeArguments.Length)
                 throw new ArgumentException(string.Format("The type or method has {0} generic parameter(s) but {1} generic argument(s) where provided. A generic argument must be provided for each generic parameter.", generic_params.Length, typeArguments.Length), nameof(typeArguments));
 
             foreach (Type t in typeArguments)
@@ -1389,7 +1387,7 @@ namespace System.Reflection.Emit
             get
             {
                 check_created();
-                return created.TypeHandle;
+                return created!.TypeHandle;
             }
         }
 
@@ -1398,7 +1396,7 @@ namespace System.Reflection.Emit
             if (customBuilder == null)
                 throw new ArgumentNullException(nameof(customBuilder));
 
-            string attrname = customBuilder.Ctor.ReflectedType.FullName;
+            string? attrname = customBuilder.Ctor.ReflectedType!.FullName;
             if (attrname == "System.Runtime.InteropServices.StructLayoutAttribute")
             {
                 byte[] data = customBuilder.Data;
@@ -1414,7 +1412,7 @@ namespace System.Reflection.Emit
                     _ => throw new Exception("Error in customattr"), // we should ignore it since it can be any value anyway...
                 };
 
-                Type ctor_type = customBuilder.Ctor is ConstructorBuilder builder ? builder.parameters[0] : customBuilder.Ctor.GetParametersInternal()[0].ParameterType;
+                Type ctor_type = customBuilder.Ctor is ConstructorBuilder builder ? builder.parameters![0] : customBuilder.Ctor.GetParametersInternal()[0].ParameterType;
                 int pos = 6;
                 if (ctor_type.FullName == "System.Int16")
                     pos = 4;
@@ -1565,7 +1563,7 @@ namespace System.Reflection.Emit
 
             string typeName = "$ArrayType$" + size;
             ITypeIdentifier ident = TypeIdentifiers.WithoutEscape(typeName);
-            Type datablobtype = pmodule.GetRegisteredType(fullname.NestedName(ident));
+            Type? datablobtype = pmodule.GetRegisteredType(fullname.NestedName(ident));
             if (datablobtype == null)
             {
                 TypeBuilder tb = DefineNestedType(typeName,
@@ -1585,7 +1583,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public void SetParent(Type parent)
+        public void SetParent(Type? parent)
         {
             check_not_created();
 
@@ -1628,13 +1626,13 @@ namespace System.Reflection.Emit
         internal override Type InternalResolve()
         {
             check_created();
-            return created;
+            return created!;
         }
 
         internal override Type RuntimeResolve()
         {
             check_created();
-            return created;
+            return created!;
         }
 
         internal bool is_created
@@ -1672,22 +1670,22 @@ namespace System.Reflection.Emit
 
         public override string ToString()
         {
-            return FullName;
+            return FullName!;
         }
 
         // FIXME:
-        public override bool IsAssignableFrom(Type c)
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c)
         {
             return base.IsAssignableFrom(c);
         }
 
         // FIXME: "arrays"
-        internal bool IsAssignableTo(Type c)
+        internal bool IsAssignableTo([NotNullWhen(true)] Type? c)
         {
             if (c == this)
                 return true;
 
-            if (c.IsInterface)
+            if (c!.IsInterface)
             {
                 if (parent != null && is_created)
                 {
@@ -1718,7 +1716,7 @@ namespace System.Reflection.Emit
         public override Type[] GetGenericArguments()
         {
             if (generic_params == null)
-                return null;
+                return Type.EmptyTypes;
             Type[] args = new Type[generic_params.Length];
             generic_params.CopyTo(args, 0);
             return args;
@@ -1774,7 +1772,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override MethodBase DeclaringMethod
+        public override MethodBase? DeclaringMethod
         {
             get
             {
@@ -1816,7 +1814,7 @@ namespace System.Reflection.Emit
             if (constructor == null)
                 throw new NullReferenceException(); //MS raises this instead of an ArgumentNullException
 
-            if (!constructor.DeclaringType.IsGenericTypeDefinition)
+            if (!constructor.DeclaringType!.IsGenericTypeDefinition)
                 throw new ArgumentException("constructor declaring type is not a generic type definition", nameof(constructor));
             if (constructor.DeclaringType != type.GetGenericTypeDefinition())
                 throw new ArgumentException("constructor declaring type is not the generic type definition of type", nameof(constructor));
@@ -1860,7 +1858,7 @@ namespace System.Reflection.Emit
             if (!type.IsGenericType)
                 throw new ArgumentException("type is not a generic type", nameof(type));
 
-            if (!method.DeclaringType.IsGenericTypeDefinition)
+            if (!method.DeclaringType!.IsGenericTypeDefinition)
                 throw new ArgumentException("method declaring type is not a generic type definition", nameof(method));
             if (method.DeclaringType != type.GetGenericTypeDefinition())
                 throw new ArgumentException("method declaring type is not the generic type definition of type", nameof(method));
@@ -1910,12 +1908,12 @@ namespace System.Reflection.Emit
             get { return false; }
         }
 
-        public override bool IsAssignableFrom(TypeInfo typeInfo)
+        public override bool IsAssignableFrom([NotNullWhen(true)] TypeInfo? typeInfo)
         {
             return base.IsAssignableFrom(typeInfo);
         }
 
-        internal static bool SetConstantValue(Type destType, object value, ref object destValue)
+        internal static bool SetConstantValue(Type destType, object? value, ref object? destValue)
         {
             // Mono: This is based on the CoreCLR
             // TypeBuilder.SetConstantValue except it writes to an
@@ -1933,7 +1931,7 @@ namespace System.Reflection.Emit
 
                 // We should allow setting a constant value on a ByRef parameter
                 if (destType.IsByRef)
-                    destType = destType.GetElementType();
+                    destType = destType.GetElementType()!;
 
                 // Convert nullable types to their underlying type.
                 // This is necessary for nullable enum types to pass the IsEnum check that's coming next.
@@ -1954,10 +1952,8 @@ namespace System.Reflection.Emit
 
                     // The above behaviors might not be the most consistent but we have to live with them.
 
-                    Type underlyingType;
-                    EnumBuilder enumBldr;
-                    TypeBuilder typeBldr;
-                    if ((enumBldr = destType as EnumBuilder) != null)
+                    Type? underlyingType;
+                    if (destType is EnumBuilder enumBldr)
                     {
                         underlyingType = enumBldr.GetEnumUnderlyingType();
 
@@ -1967,7 +1963,7 @@ namespace System.Reflection.Emit
                               type == underlyingType))
                             throw_argument_ConstantDoesntMatch();
                     }
-                    else if ((typeBldr = destType as TypeBuilder) != null)
+                    else if (destType is TypeBuilder typeBldr)
                     {
                         underlyingType = typeBldr.underlying_type;
 
@@ -1989,7 +1985,7 @@ namespace System.Reflection.Emit
                             throw_argument_ConstantDoesntMatch();
                     }
 
-                    type = underlyingType;
+                    type = underlyingType!;
                 }
                 else
                 {
@@ -2025,7 +2021,7 @@ namespace System.Reflection.Emit
                         destValue = ticks;
                         return true;
                     default:
-                        throw new ArgumentException(type.ToString() + " is not a supported constant type.");
+                        throw new ArgumentException(type!.ToString() + " is not a supported constant type.");
                 }
             }
             else

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -921,6 +921,7 @@ namespace System.Reflection.Emit
                     types[i] = ResolveUserType(types[i]);
         }
 
+        [return: NotNullIfNotNull("t")]
         internal static Type? ResolveUserType(Type? t)
         {
             if (t != null && ((t.GetType().Assembly != typeof(int).Assembly) || (t is TypeDelegator)))

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -31,7 +31,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Collections;
 using System.Globalization;
@@ -54,7 +53,7 @@ namespace System.Reflection.Emit
 #pragma warning restore 649
         #endregion
 
-        private Hashtable fields, ctors, methods;
+        private Hashtable? fields, ctors, methods;
 
         internal TypeBuilderInstantiation()
         {
@@ -80,12 +79,12 @@ namespace System.Reflection.Emit
         // Called from the runtime to return the corresponding finished Type object
         internal override Type RuntimeResolve()
         {
-            if (generic_type is TypeBuilder && !(generic_type as TypeBuilder).IsCreated())
+            if (generic_type is TypeBuilder tb && !tb.IsCreated())
                 throw new NotImplementedException();
             for (int i = 0; i < type_arguments.Length; ++i)
             {
                 Type t = type_arguments[i];
-                if (t is TypeBuilder && !(t as TypeBuilder).IsCreated())
+                if (t is TypeBuilder ttb && !ttb.IsCreated())
                     throw new NotImplementedException();
             }
             return InternalResolve();
@@ -101,22 +100,22 @@ namespace System.Reflection.Emit
 
         private const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
-        private Type GetParentType()
+        private Type? GetParentType()
         {
             return InflateType(generic_type.BaseType);
         }
 
-        internal Type InflateType(Type type)
+        internal Type? InflateType(Type? type)
         {
             return InflateType(type, type_arguments, null);
         }
 
-        internal Type InflateType(Type type, Type[] method_args)
+        internal Type? InflateType(Type type, Type[] method_args)
         {
             return InflateType(type, type_arguments, method_args);
         }
 
-        internal static Type InflateType(Type type, Type[] type_args, Type[] method_args)
+        internal static Type? InflateType(Type? type, Type[]? type_args, Type[]? method_args)
         {
             if (type == null)
                 return null;
@@ -129,28 +128,28 @@ namespace System.Reflection.Emit
                 return method_args == null ? type : method_args[type.GenericParameterPosition];
             }
             if (type.IsPointer)
-                return InflateType(type.GetElementType(), type_args, method_args).MakePointerType();
+                return InflateType(type.GetElementType(), type_args, method_args)!.MakePointerType();
             if (type.IsByRef)
-                return InflateType(type.GetElementType(), type_args, method_args).MakeByRefType();
+                return InflateType(type.GetElementType(), type_args, method_args)!.MakeByRefType();
             if (type.IsArray)
             {
                 if (type.GetArrayRank() > 1)
-                    return InflateType(type.GetElementType(), type_args, method_args).MakeArrayType(type.GetArrayRank());
+                    return InflateType(type.GetElementType(), type_args, method_args)!.MakeArrayType(type.GetArrayRank());
 
                 if (type.ToString().EndsWith("[*]", StringComparison.Ordinal)) /*FIXME, the reflection API doesn't offer a way around this*/
-                    return InflateType(type.GetElementType(), type_args, method_args).MakeArrayType(1);
-                return InflateType(type.GetElementType(), type_args, method_args).MakeArrayType();
+                    return InflateType(type.GetElementType(), type_args, method_args)!.MakeArrayType(1);
+                return InflateType(type.GetElementType(), type_args, method_args)!.MakeArrayType();
             }
 
             Type[] args = type.GetGenericArguments();
             for (int i = 0; i < args.Length; ++i)
-                args[i] = InflateType(args[i], type_args, method_args);
+                args[i] = InflateType(args[i], type_args, method_args)!;
 
             Type gtd = type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition();
             return gtd.MakeGenericType(args);
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get { return generic_type.BaseType; }
         }
@@ -171,7 +170,7 @@ namespace System.Reflection.Emit
                 methods = new Hashtable();
             if (!methods.ContainsKey(fromNoninstanciated))
                 methods[fromNoninstanciated] = new MethodOnTypeBuilderInst(this, fromNoninstanciated);
-            return (MethodInfo)methods[fromNoninstanciated];
+            return (MethodInfo)methods[fromNoninstanciated]!;
         }
 
         internal override ConstructorInfo GetConstructor(ConstructorInfo fromNoninstanciated)
@@ -180,7 +179,7 @@ namespace System.Reflection.Emit
                 ctors = new Hashtable();
             if (!ctors.ContainsKey(fromNoninstanciated))
                 ctors[fromNoninstanciated] = new ConstructorOnTypeBuilderInst(this, fromNoninstanciated);
-            return (ConstructorInfo)ctors[fromNoninstanciated];
+            return (ConstructorInfo)ctors[fromNoninstanciated]!;
         }
 
         internal override FieldInfo GetField(FieldInfo fromNoninstanciated)
@@ -189,7 +188,7 @@ namespace System.Reflection.Emit
                 fields = new Hashtable();
             if (!fields.ContainsKey(fromNoninstanciated))
                 fields[fromNoninstanciated] = new FieldOnTypeBuilderInst(this, fromNoninstanciated);
-            return (FieldInfo)fields[fromNoninstanciated];
+            return (FieldInfo)fields[fromNoninstanciated]!;
         }
 
         public override MethodInfo[] GetMethods(BindingFlags bf)
@@ -222,7 +221,7 @@ namespace System.Reflection.Emit
             throw new NotSupportedException();
         }
 
-        public override bool IsAssignableFrom(Type c)
+        public override bool IsAssignableFrom(Type? c)
         {
             throw new NotSupportedException();
         }
@@ -247,17 +246,17 @@ namespace System.Reflection.Emit
             get { return generic_type.Name; }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get { return generic_type.Namespace; }
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get { return format_name(true, false); }
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get { return format_name(true, true); }
         }
@@ -267,7 +266,7 @@ namespace System.Reflection.Emit
             get { throw new NotSupportedException(); }
         }
 
-        private string format_name(bool full_name, bool assembly_qualified)
+        private string? format_name(bool full_name, bool assembly_qualified)
         {
             StringBuilder sb = new StringBuilder(generic_type.FullName);
 
@@ -277,10 +276,10 @@ namespace System.Reflection.Emit
                 if (i > 0)
                     sb.Append(",");
 
-                string name;
+                string? name;
                 if (full_name)
                 {
-                    string assemblyName = type_arguments[i].Assembly.FullName;
+                    string? assemblyName = type_arguments[i].Assembly.FullName;
                     name = type_arguments[i].FullName;
                     if (name != null && assemblyName != null)
                         name = name + ", " + assemblyName;
@@ -310,7 +309,7 @@ namespace System.Reflection.Emit
 
         public override string ToString()
         {
-            return format_name(false, false);
+            return format_name(false, false)!;
         }
 
         public override Type GetGenericTypeDefinition()
@@ -348,7 +347,7 @@ namespace System.Reflection.Emit
             get { return true; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return generic_type.DeclaringType; }
         }
@@ -449,32 +448,32 @@ namespace System.Reflection.Emit
             throw new NotSupportedException();
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr,
-                             Binder binder, object target, object[] args,
-                             ParameterModifier[] modifiers,
-                             CultureInfo culture, string[] namedParameters)
+        public override object? InvokeMember(string name, BindingFlags invokeAttr,
+                             Binder? binder, object? target, object?[]? args,
+                             ParameterModifier[]? modifiers,
+                             CultureInfo? culture, string[]? namedParameters)
         {
             throw new NotSupportedException();
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder,
-                                                     CallingConventions callConvention, Type[] types,
-                                                     ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder,
+                                                     CallingConventions callConvention, Type[]? types,
+                                                     ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException();
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder,
-                                                         Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder,
+                                                         Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException();
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr,
-                                       Binder binder,
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr,
+                                       Binder? binder,
                                        CallingConventions callConvention,
-                                       Type[] types,
-                                       ParameterModifier[] modifiers)
+                                       Type[]? types,
+                                       ParameterModifier[]? modifiers)
         {
             throw new NotSupportedException();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/UnmanagedMarshal.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/UnmanagedMarshal.cs
@@ -30,7 +30,6 @@
 // (C) 2001-2002 Ximian, Inc.  http://www.ximian.com
 //
 
-#nullable disable
 #if MONO_FEATURE_SRE
 using System.Runtime.InteropServices;
 
@@ -47,10 +46,10 @@ namespace System.Reflection.Emit
         private int count;
         private UnmanagedType t;
         private UnmanagedType tbase;
-        private string guid;
-        private string mcookie;
-        private string marshaltype;
-        internal Type marshaltyperef;
+        private string? guid;
+        private string? mcookie;
+        private string? marshaltype;
+        internal Type? marshaltyperef;
         private int param_num;
         private bool has_size;
 #pragma warning restore 169, 414
@@ -95,7 +94,7 @@ namespace System.Reflection.Emit
 
         public Guid IIDGuid
         {
-            get { return new Guid(guid); }
+            get { return new Guid(guid!); }
         }
 
         public static UnmanagedMarshal DefineByValArray(int elemCount)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/FieldInfo.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/FieldInfo.Mono.cs
@@ -37,14 +37,14 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern MarshalAsAttribute get_marshal_info();
 
-        internal object[] GetPseudoCustomAttributes()
+        internal object[]? GetPseudoCustomAttributes()
         {
             int count = 0;
 
             if (IsNotSerialized)
                 count++;
 
-            if (DeclaringType.IsExplicitLayout)
+            if (DeclaringType!.IsExplicitLayout)
                 count++;
 
             MarshalAsAttribute marshalAs = get_marshal_info();
@@ -66,14 +66,14 @@ namespace System.Reflection
             return attrs;
         }
 
-        internal CustomAttributeData[] GetPseudoCustomAttributesData()
+        internal CustomAttributeData[]? GetPseudoCustomAttributesData()
         {
             int count = 0;
 
             if (IsNotSerialized)
                 count++;
 
-            if (DeclaringType.IsExplicitLayout)
+            if (DeclaringType!.IsExplicitLayout)
                 count++;
 
             MarshalAsAttribute marshalAs = get_marshal_info();
@@ -86,12 +86,12 @@ namespace System.Reflection
             count = 0;
 
             if (IsNotSerialized)
-                attrsData[count++] = new CustomAttributeData((typeof(NonSerializedAttribute)).GetConstructor(Type.EmptyTypes));
+                attrsData[count++] = new CustomAttributeData((typeof(NonSerializedAttribute)).GetConstructor(Type.EmptyTypes)!);
             if (DeclaringType.IsExplicitLayout)
             {
                 var ctorArgs = new CustomAttributeTypedArgument[] { new CustomAttributeTypedArgument(typeof(int), GetFieldOffset()) };
                 attrsData[count++] = new CustomAttributeData(
-                    (typeof(FieldOffsetAttribute)).GetConstructor(new[] { typeof(int) }),
+                    (typeof(FieldOffsetAttribute)).GetConstructor(new[] { typeof(int) })!,
                     ctorArgs,
                     Array.Empty<CustomAttributeNamedArgument>());
             }
@@ -100,7 +100,7 @@ namespace System.Reflection
             {
                 var ctorArgs = new CustomAttributeTypedArgument[] { new CustomAttributeTypedArgument(typeof(UnmanagedType), marshalAs.Value) };
                 attrsData[count++] = new CustomAttributeData(
-                    (typeof(MarshalAsAttribute)).GetConstructor(new[] { typeof(UnmanagedType) }),
+                    (typeof(MarshalAsAttribute)).GetConstructor(new[] { typeof(UnmanagedType) })!,
                     ctorArgs,
                     Array.Empty<CustomAttributeNamedArgument>());//FIXME Get named params
             }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/MethodBase.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/MethodBase.Mono.cs
@@ -8,16 +8,16 @@ namespace System.Reflection
 {
     public partial class MethodBase
     {
-        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle)
+        public static MethodBase? GetMethodFromHandle(RuntimeMethodHandle handle)
         {
             if (handle.IsNullHandle())
                 throw new ArgumentException(SR.Argument_InvalidHandle);
 
-            MethodBase m = RuntimeMethodInfo.GetMethodFromHandleInternalType(handle.Value, IntPtr.Zero);
+            MethodBase? m = RuntimeMethodInfo.GetMethodFromHandleInternalType(handle.Value, IntPtr.Zero);
             if (m == null)
                 throw new ArgumentException(SR.Argument_InvalidHandle);
 
-            Type declaringType = m.DeclaringType;
+            Type? declaringType = m.DeclaringType;
             if (declaringType != null && declaringType.IsGenericType)
                 throw new ArgumentException(string.Format(SR.Argument_MethodDeclaringTypeGeneric,
                                                             m, declaringType.GetGenericTypeDefinition()));
@@ -25,7 +25,7 @@ namespace System.Reflection
             return m;
         }
 
-        public static MethodBase GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType)
+        public static MethodBase? GetMethodFromHandle(RuntimeMethodHandle handle, RuntimeTypeHandle declaringType)
         {
             if (handle.IsNullHandle())
                 throw new ArgumentException(SR.Argument_InvalidHandle);
@@ -36,7 +36,7 @@ namespace System.Reflection
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public static extern MethodBase GetCurrentMethod();
+        public static extern MethodBase? GetCurrentMethod();
 
         internal virtual ParameterInfo[] GetParametersNoCopy()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.IO;
 using System.Globalization;
 using System.Collections.Generic;
@@ -37,7 +36,7 @@ namespace System.Reflection
     {
         private sealed class ResolveEventHolder
         {
-            public event ModuleResolveEventHandler ModuleResolve;
+            public event ModuleResolveEventHandler? ModuleResolve;
         }
 
         private sealed class UnmanagedMemoryStreamForModule : UnmanagedMemoryStream
@@ -56,10 +55,10 @@ namespace System.Reflection
         //
         #region VM dependency
         private IntPtr _mono_assembly;
-        private object _evidence;       // Unused, kept for layout compatibility
+        private object? _evidence;       // Unused, kept for layout compatibility
         #endregion
 
-        private ResolveEventHolder resolve_event_holder;
+        private ResolveEventHolder? resolve_event_holder;
 
         public extern override MethodInfo? EntryPoint
         {
@@ -89,19 +88,19 @@ namespace System.Reflection
         // We can't store the event directly in this class, since the
         // compiler would silently insert the fields before _mono_assembly
         //
-        public override event ModuleResolveEventHandler ModuleResolve
+        public override event ModuleResolveEventHandler? ModuleResolve
         {
             add
             {
-                resolve_event_holder.ModuleResolve += value;
+                resolve_event_holder!.ModuleResolve += value;
             }
             remove
             {
-                resolve_event_holder.ModuleResolve -= value;
+                resolve_event_holder!.ModuleResolve -= value;
             }
         }
 
-        public override Module? ManifestModule => GetManifestModuleInternal();
+        public override Module ManifestModule => GetManifestModuleInternal();
 
         public override bool GlobalAssemblyCache => false;
 
@@ -118,9 +117,9 @@ namespace System.Reflection
         }
 
         // TODO: consider a dedicated icall instead
-        public override bool IsCollectible => AssemblyLoadContext.GetLoadContext((Assembly)this).IsCollectible;
+        public override bool IsCollectible => AssemblyLoadContext.GetLoadContext((Assembly)this)!.IsCollectible;
 
-        internal static AssemblyName CreateAssemblyName(string assemblyString, out RuntimeAssembly assemblyFromResolveEvent)
+        internal static AssemblyName? CreateAssemblyName(string assemblyString, out RuntimeAssembly? assemblyFromResolveEvent)
         {
             if (assemblyString == null)
                 throw new ArgumentNullException(nameof(assemblyString));
@@ -136,7 +135,7 @@ namespace System.Reflection
             }
             catch (Exception)
             {
-                assemblyFromResolveEvent = (RuntimeAssembly)AssemblyLoadContext.DoAssemblyResolve(assemblyString);
+                assemblyFromResolveEvent = (RuntimeAssembly?)AssemblyLoadContext.DoAssemblyResolve(assemblyString);
                 if (assemblyFromResolveEvent == null)
                     throw new FileLoadException(assemblyString);
                 return null;
@@ -192,7 +191,7 @@ namespace System.Reflection
             }
         }
 
-        public override ManifestResourceInfo GetManifestResourceInfo(string resourceName)
+        public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
             if (resourceName == null)
                 throw new ArgumentNullException(nameof(resourceName));
@@ -206,7 +205,7 @@ namespace System.Reflection
                 return null;
         }
 
-        public override Stream GetManifestResourceStream(string name)
+        public override Stream? GetManifestResourceStream(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -227,12 +226,12 @@ namespace System.Reflection
             }
         }
 
-        public override Stream GetManifestResourceStream(Type type, string name)
+        public override Stream? GetManifestResourceStream(Type type, string name)
         {
             if (type == null && name == null)
                 throw new ArgumentNullException(nameof(type));
 
-            string nameSpace = type?.Namespace;
+            string? nameSpace = type?.Namespace;
 
             string resourceName = nameSpace != null && name != null ?
                 nameSpace + Type.Delimiter + name :
@@ -277,7 +276,7 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeType, inherit);
         }
 
-        public override Module GetModule(string name)
+        public override Module? GetModule(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -357,16 +356,16 @@ namespace System.Reflection
             return GetSatelliteAssembly(culture, null);
         }
 
-        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
+        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version? version)
         {
             if (culture == null)
                 throw new ArgumentNullException(nameof(culture));
 
-            return InternalGetSatelliteAssembly(culture, version, true);
+            return InternalGetSatelliteAssembly(culture, version, true)!;
         }
 
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        internal Assembly InternalGetSatelliteAssembly(CultureInfo culture, Version version, bool throwOnFileNotFound)
+        internal Assembly? InternalGetSatelliteAssembly(CultureInfo culture, Version? version, bool throwOnFileNotFound)
         {
             AssemblyName aname = GetName();
 
@@ -379,7 +378,7 @@ namespace System.Reflection
             an.CultureInfo = culture;
             an.Name = aname.Name + ".resources";
 
-            Assembly res = null;
+            Assembly? res = null;
             try
             {
                 StackCrawlMark unused = default;
@@ -396,7 +395,7 @@ namespace System.Reflection
             return res;
         }
 
-        public override FileStream GetFile(string name)
+        public override FileStream? GetFile(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name), SR.ArgumentNull_FileName);
@@ -438,7 +437,7 @@ namespace System.Reflection
             return res;
         }
 
-        internal static RuntimeAssembly InternalLoad(AssemblyName assemblyRef, ref StackCrawlMark stackMark, AssemblyLoadContext assemblyLoadContext)
+        internal static RuntimeAssembly InternalLoad(AssemblyName assemblyRef, ref StackCrawlMark stackMark, AssemblyLoadContext? assemblyLoadContext)
         {
             var assembly = (RuntimeAssembly)InternalLoad(assemblyRef.FullName, ref stackMark, assemblyLoadContext != null ? assemblyLoadContext.NativeALC : IntPtr.Zero);
             if (assembly == null)
@@ -476,7 +475,7 @@ namespace System.Reflection
         private static extern IntPtr InternalGetReferencedAssemblies(Assembly module);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private extern object GetFilesInternal(string name, bool getResourceModules);
+        private extern object GetFilesInternal(string? name, bool getResourceModules);
 
         internal string? GetSimpleName()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -22,7 +22,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -114,7 +113,7 @@ namespace System.Reflection
             }
         }
 
-        public override MethodInfo GetAddMethod(bool nonPublic)
+        public override MethodInfo? GetAddMethod(bool nonPublic)
         {
             MonoEventInfo info = GetEventInfo(this);
             if (nonPublic || (info.add_method != null && info.add_method.IsPublic))
@@ -122,7 +121,7 @@ namespace System.Reflection
             return null;
         }
 
-        public override MethodInfo GetRaiseMethod(bool nonPublic)
+        public override MethodInfo? GetRaiseMethod(bool nonPublic)
         {
             MonoEventInfo info = GetEventInfo(this);
             if (nonPublic || (info.raise_method != null && info.raise_method.IsPublic))
@@ -130,7 +129,7 @@ namespace System.Reflection
             return null;
         }
 
-        public override MethodInfo GetRemoveMethod(bool nonPublic)
+        public override MethodInfo? GetRemoveMethod(bool nonPublic)
         {
             MonoEventInfo info = GetEventInfo(this);
             if (nonPublic || (info.remove_method != null && info.remove_method.IsPublic))

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeExceptionHandlingClause.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeExceptionHandlingClause.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
     internal sealed class RuntimeExceptionHandlingClause : ExceptionHandlingClause
     {
         #region Keep in sync with MonoReflectionExceptionHandlingClause in object-internals.h
-        internal Type catch_type;
+        internal Type? catch_type;
         internal int filter_offset;
         internal ExceptionHandlingClauseOptions flags;
         internal int try_offset;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -43,8 +42,8 @@ namespace System.Reflection
 #pragma warning disable 649
         internal IntPtr klass;
         internal RuntimeFieldHandle fhandle;
-        private string name;
-        private Type type;
+        private string? name;
+        private Type? type;
         private FieldAttributes attrs;
 #pragma warning restore 649
 
@@ -66,7 +65,7 @@ namespace System.Reflection
 
         internal RuntimeType GetDeclaringTypeInternal()
         {
-            return (RuntimeType)DeclaringType;
+            return (RuntimeType)DeclaringType!;
         }
 
         private RuntimeType ReflectedTypeInternal
@@ -90,7 +89,7 @@ namespace System.Reflection
             // only test instance fields
             if ((Attributes & FieldAttributes.Static) != FieldAttributes.Static)
             {
-                if (!DeclaringType.IsInstanceOfType(target))
+                if (!DeclaringType!.IsInstanceOfType(target))
                 {
                     if (target == null)
                     {
@@ -108,7 +107,7 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        internal override void UnsafeSetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
+        internal override void UnsafeSetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture)
         {
             bool domainInitialized = false;
             RuntimeFieldHandle.SetValue(this, obj, value, null, Attributes, null, ref domainInitialized);
@@ -124,7 +123,7 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
-                RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType)DeclaringType);
+                RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType?)DeclaringType);
             }
         }
 
@@ -138,7 +137,7 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
-                return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType)DeclaringType);
+                return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
             }
         }
 
@@ -180,7 +179,7 @@ namespace System.Reflection
                 return GetParentType(false);
             }
         }
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get
             {
@@ -192,7 +191,7 @@ namespace System.Reflection
         {
             get
             {
-                return name;
+                return name!;
             }
         }
 
@@ -214,15 +213,15 @@ namespace System.Reflection
         internal extern override int GetFieldOffset();
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private extern object GetValueInternal(object obj);
+        private extern object? GetValueInternal(object? obj);
 
-        public override object GetValue(object obj)
+        public override object? GetValue(object? obj)
         {
             if (!IsStatic)
             {
                 if (obj == null)
                     throw new TargetException("Non-static field requires a target");
-                if (!DeclaringType.IsAssignableFrom(obj.GetType()))
+                if (!DeclaringType!.IsAssignableFrom(obj.GetType()))
                     throw new ArgumentException(string.Format(
                         "Field {0} defined on type {1} is not a field on the target object which is of type {2}.",
                          Name, DeclaringType, obj.GetType()),
@@ -240,15 +239,15 @@ namespace System.Reflection
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void SetValueInternal(FieldInfo fi, object obj, object value);
+        private static extern void SetValueInternal(FieldInfo fi, object? obj, object? value);
 
-        public override void SetValue(object obj, object val, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
+        public override void SetValue(object? obj, object? val, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture)
         {
             if (!IsStatic)
             {
                 if (obj == null)
                     throw new TargetException("Non-static field requires a target");
-                if (!DeclaringType.IsAssignableFrom(obj.GetType()))
+                if (!DeclaringType!.IsAssignableFrom(obj.GetType()))
                     throw new ArgumentException(string.Format(
                         "Field {0} defined on type {1} is not a field on the target object which is of type {2}.",
                          Name, DeclaringType, obj.GetType()),
@@ -288,7 +287,7 @@ namespace System.Reflection
 
         private void CheckGeneric()
         {
-            Type declaringType = DeclaringType;
+            Type? declaringType = DeclaringType;
             if (declaringType != null && declaringType.ContainsGenericParameters)
                 throw new InvalidOperationException("Late bound operations cannot be performed on fields with types for which Type.ContainsGenericParameters is true.");
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeLocalVariableInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeLocalVariableInfo.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
     internal sealed class RuntimeLocalVariableInfo : LocalVariableInfo
     {
         #region Keep in sync with MonoReflectionLocalVariableInfo in object-internals.h
-        internal Type type;
+        internal Type? type;
         internal bool is_pinned;
         internal ushort position;
         #endregion
@@ -19,7 +19,7 @@ namespace System.Reflection
 
         public override int LocalIndex => position;
 
-        public override Type LocalType => type;
+        public override Type LocalType => type!;
     }
 
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -23,7 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -139,8 +138,8 @@ namespace System.Reflection
     {
 #pragma warning disable 649
         internal IntPtr mhandle;
-        private string name;
-        private Type reftype;
+        private string? name;
+        private Type? reftype;
 #pragma warning restore 649
 
         internal BindingFlags BindingFlags
@@ -159,11 +158,11 @@ namespace System.Reflection
             }
         }
 
-        private RuntimeType ReflectedTypeInternal
+        private RuntimeType? ReflectedTypeInternal
         {
             get
             {
-                return (RuntimeType)ReflectedType;
+                return (RuntimeType?)ReflectedType;
             }
         }
 
@@ -187,7 +186,7 @@ namespace System.Reflection
             return Delegate.CreateDelegate(delegateType, this);
         }
 
-        public override Delegate CreateDelegate(Type delegateType, object target)
+        public override Delegate CreateDelegate(Type delegateType, object? target)
         {
             return Delegate.CreateDelegate(delegateType, target, this);
         }
@@ -323,11 +322,11 @@ namespace System.Reflection
          * Exceptions thrown by the called method propagate normally.
          */
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal extern object InternalInvoke(object obj, object[] parameters, out Exception exc);
+        internal extern object? InternalInvoke(object? obj, object?[]? parameters, out Exception? exc);
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             if (!IsStatic)
             {
@@ -350,8 +349,8 @@ namespace System.Reflection
             if (ContainsGenericParameters)
                 throw new InvalidOperationException("Late bound operations cannot be performed on types or methods for which ContainsGenericParameters is true.");
 
-            Exception exc;
-            object o = null;
+            Exception? exc;
+            object? o = null;
 
             if ((invokeAttr & BindingFlags.DoNotWrapExceptions) == 0)
             {
@@ -389,7 +388,7 @@ namespace System.Reflection
             return o;
         }
 
-        internal static void ConvertValues(Binder binder, object[] args, ParameterInfo[] pinfo, CultureInfo culture, BindingFlags invokeAttr)
+        internal static void ConvertValues(Binder binder, object?[]? args, ParameterInfo[] pinfo, CultureInfo? culture, BindingFlags invokeAttr)
         {
             if (args == null)
             {
@@ -404,7 +403,7 @@ namespace System.Reflection
 
             for (int i = 0; i < args.Length; ++i)
             {
-                object arg = args[i];
+                object? arg = args[i];
                 ParameterInfo pi = pinfo[i];
                 if (arg == Type.Missing)
                 {
@@ -444,7 +443,7 @@ namespace System.Reflection
             }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get
             {
@@ -485,7 +484,7 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal extern void GetPInvoke(out PInvokeAttributes flags, out string entryPoint, out string dllName);
 
-        internal object[] GetPseudoCustomAttributes()
+        internal object[]? GetPseudoCustomAttributes()
         {
             int count = 0;
 
@@ -514,7 +513,8 @@ namespace System.Reflection
 
         private Attribute GetDllImportAttribute()
         {
-            string entryPoint, dllName = null;
+            string entryPoint;
+            string? dllName = null;
             int token = MetadataToken;
             PInvokeAttributes flags = 0;
 
@@ -566,7 +566,7 @@ namespace System.Reflection
             };
         }
 
-        internal CustomAttributeData[] GetPseudoCustomAttributesData()
+        internal CustomAttributeData[]? GetPseudoCustomAttributesData()
         {
             int count = 0;
 
@@ -584,19 +584,20 @@ namespace System.Reflection
             count = 0;
 
             if ((info.iattrs & MethodImplAttributes.PreserveSig) != 0)
-                attrsData[count++] = new CustomAttributeData((typeof(PreserveSigAttribute)).GetConstructor(Type.EmptyTypes));
+                attrsData[count++] = new CustomAttributeData((typeof(PreserveSigAttribute)).GetConstructor(Type.EmptyTypes)!);
             if ((info.attrs & MethodAttributes.PinvokeImpl) != 0)
-                attrsData[count++] = GetDllImportAttributeData();
+                attrsData[count++] = GetDllImportAttributeData()!;
 
             return attrsData;
         }
 
-        private CustomAttributeData GetDllImportAttributeData()
+        private CustomAttributeData? GetDllImportAttributeData()
         {
             if ((Attributes & MethodAttributes.PinvokeImpl) == 0)
                 return null;
 
-            string entryPoint, dllName = null;
+            string entryPoint;
+            string? dllName = null;
             PInvokeAttributes flags = 0;
 
             GetPInvoke(out flags, out entryPoint, out dllName);
@@ -635,18 +636,18 @@ namespace System.Reflection
             Type attrType = typeof(DllImportAttribute);
 
             var namedArgs = new CustomAttributeNamedArgument[] {
-                new CustomAttributeNamedArgument (attrType.GetField ("EntryPoint"), entryPoint),
-                new CustomAttributeNamedArgument (attrType.GetField ("CharSet"), charSet),
-                new CustomAttributeNamedArgument (attrType.GetField ("ExactSpelling"), exactSpelling),
-                new CustomAttributeNamedArgument (attrType.GetField ("SetLastError"), setLastError),
-                new CustomAttributeNamedArgument (attrType.GetField ("PreserveSig"), preserveSig),
-                new CustomAttributeNamedArgument (attrType.GetField ("CallingConvention"), callingConvention),
-                new CustomAttributeNamedArgument (attrType.GetField ("BestFitMapping"), bestFitMapping),
-                new CustomAttributeNamedArgument (attrType.GetField ("ThrowOnUnmappableChar"), throwOnUnmappableChar)
+                new CustomAttributeNamedArgument (attrType.GetField ("EntryPoint")!, entryPoint),
+                new CustomAttributeNamedArgument (attrType.GetField ("CharSet")!, charSet),
+                new CustomAttributeNamedArgument (attrType.GetField ("ExactSpelling")!, exactSpelling),
+                new CustomAttributeNamedArgument (attrType.GetField ("SetLastError")!, setLastError),
+                new CustomAttributeNamedArgument (attrType.GetField ("PreserveSig")!, preserveSig),
+                new CustomAttributeNamedArgument (attrType.GetField ("CallingConvention")!, callingConvention),
+                new CustomAttributeNamedArgument (attrType.GetField ("BestFitMapping")!, bestFitMapping),
+                new CustomAttributeNamedArgument (attrType.GetField ("ThrowOnUnmappableChar")!, throwOnUnmappableChar)
             };
 
             return new CustomAttributeData(
-                attrType.GetConstructor(new[] { typeof(string) }),
+                attrType.GetConstructor(new[] { typeof(string) })!,
                 ctorArgs,
                 namedArgs);
         }
@@ -748,8 +749,8 @@ namespace System.Reflection
     {
 #pragma warning disable 649
         internal IntPtr mhandle;
-        private string name;
-        private Type reftype;
+        private string? name;
+        private Type? reftype;
 #pragma warning restore 649
 
         public override Module Module
@@ -773,11 +774,11 @@ namespace System.Reflection
             }
         }
 
-        private RuntimeType ReflectedTypeInternal
+        private RuntimeType? ReflectedTypeInternal
         {
             get
             {
-                return (RuntimeType)ReflectedType;
+                return (RuntimeType?)ReflectedType;
             }
         }
 
@@ -807,11 +808,11 @@ namespace System.Reflection
          * to match the types of the method signature.
          */
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal extern object InternalInvoke(object obj, object[] parameters, out Exception exc);
+        internal extern object InternalInvoke(object? obj, object?[]? parameters, out Exception exc);
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             if (obj == null)
             {
@@ -826,7 +827,7 @@ namespace System.Reflection
             return DoInvoke(obj, invokeAttr, binder, parameters, culture);
         }
 
-        private object DoInvoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        private object DoInvoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             if (binder == null)
                 binder = Type.DefaultBinder;
@@ -843,13 +844,13 @@ namespace System.Reflection
                 throw new MemberAccessException(string.Format("Cannot create an instance of {0} because it is an abstract class", DeclaringType));
             }
 
-            return InternalInvoke(obj, parameters, (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0);
+            return InternalInvoke(obj, parameters, (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0)!;
         }
 
-        public object InternalInvoke(object obj, object[] parameters, bool wrapExceptions)
+        public object? InternalInvoke(object? obj, object?[]? parameters, bool wrapExceptions)
         {
             Exception exc;
-            object o = null;
+            object? o = null;
 
             if (wrapExceptions)
             {
@@ -883,7 +884,7 @@ namespace System.Reflection
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             return DoInvoke(null, invokeAttr, binder, parameters, culture);
         }
@@ -920,7 +921,7 @@ namespace System.Reflection
             }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -36,10 +35,10 @@ namespace System.Reflection
         #region Sync with object-internals.h
         #region Sync with ModuleBuilder
         internal IntPtr _impl; /* a pointer to a MonoImage */
-        internal Assembly assembly;
-        internal string fqname;
-        internal string name;
-        internal string scopename;
+        internal Assembly assembly = null!;
+        internal string fqname = null!;
+        internal string name = null!;
+        internal string scopename = null!;
         internal bool is_resource;
         internal int token;
         #endregion
@@ -108,12 +107,11 @@ namespace System.Reflection
         }
 
         public override
-        Type[] FindTypes(TypeFilter filter, object filterCriteria)
+        Type[] FindTypes(TypeFilter? filter, object? filterCriteria)
         {
             var filtered = new List<Type>();
-            Type[] types = GetTypes();
-            foreach (Type t in types)
-                if (filter(t, filterCriteria))
+            foreach (Type t in GetTypes())
+                if (filter != null && filter(t, filterCriteria))
                     filtered.Add(t);
             return filtered.ToArray();
         }
@@ -131,7 +129,7 @@ namespace System.Reflection
         }
 
         public override
-        FieldInfo GetField(string name, BindingFlags bindingAttr)
+        FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -164,7 +162,7 @@ namespace System.Reflection
 
         protected
         override
-        MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             if (IsResource())
                 return null;
@@ -212,12 +210,12 @@ namespace System.Reflection
 
         public
         override
-        FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        FieldInfo ResolveField(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return ResolveField(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        internal static FieldInfo ResolveField(Module module, IntPtr monoModule, int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        internal static FieldInfo ResolveField(Module module, IntPtr monoModule, int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             ResolveTokenError error;
 
@@ -230,12 +228,12 @@ namespace System.Reflection
 
         public
         override
-        MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        MemberInfo ResolveMember(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return ResolveMember(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        internal static MemberInfo ResolveMember(Module module, IntPtr monoModule, int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        internal static MemberInfo ResolveMember(Module module, IntPtr monoModule, int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             ResolveTokenError error;
 
@@ -248,12 +246,12 @@ namespace System.Reflection
 
         public
         override
-        MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        MethodBase ResolveMethod(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return ResolveMethod(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        internal static MethodBase ResolveMethod(Module module, IntPtr monoModule, int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        internal static MethodBase ResolveMethod(Module module, IntPtr monoModule, int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             ResolveTokenError error;
 
@@ -284,12 +282,12 @@ namespace System.Reflection
 
         public
         override
-        Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        Type ResolveType(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return ResolveType(this, _impl, metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        internal static Type ResolveType(Module module, IntPtr monoModule, int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        internal static Type ResolveType(Module module, IntPtr monoModule, int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             ResolveTokenError error;
 
@@ -357,7 +355,7 @@ namespace System.Reflection
                 return new ArgumentException(string.Format("Token 0x{0:x} is not a valid {1} token in the scope of module {2}", metadataToken, tokenType, name), nameof(metadataToken));
         }
 
-        internal static IntPtr[] ptrs_from_types(Type[] types)
+        internal static IntPtr[]? ptrs_from_types(Type[]? types)
         {
             if (types == null)
                 return null;
@@ -394,19 +392,19 @@ namespace System.Reflection
         internal static extern Type GetGlobalType(IntPtr module);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr ResolveTypeToken(IntPtr module, int token, IntPtr[] type_args, IntPtr[] method_args, out ResolveTokenError error);
+        internal static extern IntPtr ResolveTypeToken(IntPtr module, int token, IntPtr[]? type_args, IntPtr[]? method_args, out ResolveTokenError error);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr ResolveMethodToken(IntPtr module, int token, IntPtr[] type_args, IntPtr[] method_args, out ResolveTokenError error);
+        internal static extern IntPtr ResolveMethodToken(IntPtr module, int token, IntPtr[]? type_args, IntPtr[]? method_args, out ResolveTokenError error);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr ResolveFieldToken(IntPtr module, int token, IntPtr[] type_args, IntPtr[] method_args, out ResolveTokenError error);
+        internal static extern IntPtr ResolveFieldToken(IntPtr module, int token, IntPtr[]? type_args, IntPtr[]? method_args, out ResolveTokenError error);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string ResolveStringToken(IntPtr module, int token, out ResolveTokenError error);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern MemberInfo ResolveMemberToken(IntPtr module, int token, IntPtr[] type_args, IntPtr[] method_args, out ResolveTokenError error);
+        internal static extern MemberInfo ResolveMemberToken(IntPtr module, int token, IntPtr[]? type_args, IntPtr[]? method_args, out ResolveTokenError error);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern byte[] ResolveSignature(IntPtr module, int metadataToken, out ResolveTokenError error);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -13,7 +12,7 @@ namespace System.Reflection
 {
     internal class RuntimeParameterInfo : ParameterInfo
     {
-        internal MarshalAsAttribute marshalAs;
+        internal MarshalAsAttribute? marshalAs;
 
         // Called by the runtime
         internal RuntimeParameterInfo(string name, Type type, int position, int attrs, object defaultValue, MemberInfo member, MarshalAsAttribute marshalAs)
@@ -60,7 +59,7 @@ namespace System.Reflection
             }
         }
 
-        internal RuntimeParameterInfo(ParameterBuilder pb, Type type, MemberInfo member, int position)
+        internal RuntimeParameterInfo(ParameterBuilder? pb, Type? type, MemberInfo member, int position)
         {
             this.ClassImpl = type;
             this.MemberImpl = member;
@@ -78,13 +77,13 @@ namespace System.Reflection
             }
         }
 
-        internal static ParameterInfo New(ParameterBuilder pb, Type type, MemberInfo member, int position)
+        internal static ParameterInfo New(ParameterBuilder? pb, Type? type, MemberInfo member, int position)
         {
             return new RuntimeParameterInfo(pb, type, member, position);
         }
 
         /*FIXME this constructor looks very broken in the position parameter*/
-        internal RuntimeParameterInfo(ParameterInfo pinfo, Type type, MemberInfo member, int position)
+        internal RuntimeParameterInfo(ParameterInfo? pinfo, Type? type, MemberInfo member, int position)
         {
             this.ClassImpl = type;
             this.MemberImpl = member;
@@ -124,7 +123,7 @@ namespace System.Reflection
         }
 
         public override
-        object DefaultValue
+        object? DefaultValue
         {
             get
             {
@@ -147,7 +146,7 @@ namespace System.Reflection
         }
 
         public override
-        object RawDefaultValue
+        object? RawDefaultValue
         {
             get
             {
@@ -166,7 +165,7 @@ namespace System.Reflection
             {
                 if (MemberImpl is PropertyInfo prop)
                 {
-                    MethodInfo mi = prop.GetGetMethod(true) ?? prop.GetSetMethod(true);
+                    MethodInfo mi = prop.GetGetMethod(true) ?? prop.GetSetMethod(true)!;
 
                     return mi.GetParametersInternal()[PositionImpl].MetadataToken;
                 }
@@ -193,9 +192,9 @@ namespace System.Reflection
             return CustomAttribute.GetCustomAttributes(this, attributeType, inherit);
         }
 
-        internal object GetDefaultValueImpl(ParameterInfo pinfo)
+        internal object? GetDefaultValueImpl(ParameterInfo pinfo)
         {
-            FieldInfo field = typeof(ParameterInfo).GetField("DefaultValueImpl", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo field = typeof(ParameterInfo).GetField("DefaultValueImpl", BindingFlags.Instance | BindingFlags.NonPublic)!;
             return field.GetValue(pinfo);
         }
 
@@ -216,7 +215,7 @@ namespace System.Reflection
 
         public override Type[] GetOptionalCustomModifiers() => GetCustomModifiers(true);
 
-        internal object[] GetPseudoCustomAttributes()
+        internal object[]? GetPseudoCustomAttributes()
         {
             int count = 0;
 
@@ -249,7 +248,7 @@ namespace System.Reflection
             return attrs;
         }
 
-        internal CustomAttributeData[] GetPseudoCustomAttributesData()
+        internal CustomAttributeData[]? GetPseudoCustomAttributesData()
         {
             int count = 0;
 
@@ -268,16 +267,16 @@ namespace System.Reflection
             count = 0;
 
             if (IsIn)
-                attrsData[count++] = new CustomAttributeData((typeof(InAttribute)).GetConstructor(Type.EmptyTypes));
+                attrsData[count++] = new CustomAttributeData((typeof(InAttribute)).GetConstructor(Type.EmptyTypes)!);
             if (IsOut)
-                attrsData[count++] = new CustomAttributeData((typeof(OutAttribute)).GetConstructor(Type.EmptyTypes));
+                attrsData[count++] = new CustomAttributeData((typeof(OutAttribute)).GetConstructor(Type.EmptyTypes)!);
             if (IsOptional)
-                attrsData[count++] = new CustomAttributeData((typeof(OptionalAttribute)).GetConstructor(Type.EmptyTypes));
+                attrsData[count++] = new CustomAttributeData((typeof(OptionalAttribute)).GetConstructor(Type.EmptyTypes)!);
             if (marshalAs != null)
             {
                 var ctorArgs = new CustomAttributeTypedArgument[] { new CustomAttributeTypedArgument(typeof(UnmanagedType), marshalAs.Value) };
                 attrsData[count++] = new CustomAttributeData(
-                    (typeof(MarshalAsAttribute)).GetConstructor(new[] { typeof(UnmanagedType) }),
+                    (typeof(MarshalAsAttribute)).GetConstructor(new[] { typeof(UnmanagedType) })!,
                     ctorArgs,
                     Array.Empty<CustomAttributeNamedArgument>());//FIXME Get named params
             }
@@ -291,7 +290,7 @@ namespace System.Reflection
         {
             get
             {
-                object defaultValue = DefaultValue;
+                object? defaultValue = DefaultValue;
                 if (defaultValue == null)
                     return true;
 
@@ -305,7 +304,7 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern Type[] GetTypeModifiers(Type type, MemberInfo member, int position, bool optional);
 
-        internal static ParameterInfo New(ParameterInfo pinfo, Type type, MemberInfo member, int position)
+        internal static ParameterInfo New(ParameterInfo pinfo, Type? type, MemberInfo member, int position)
         {
             return new RuntimeParameterInfo(pinfo, type, member, position);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -23,7 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#nullable disable
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -66,7 +65,7 @@ namespace System.Reflection
         internal IntPtr prop;
         private MonoPropertyInfo info;
         private PInfo cached;
-        private GetterAdapter cached_getter;
+        private GetterAdapter? cached_getter;
 #pragma warning restore 649
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -265,13 +264,13 @@ namespace System.Reflection
             MethodInfo[] res = new MethodInfo[nget + nset];
             int n = 0;
             if (nset != 0)
-                res[n++] = info.set_method;
+                res[n++] = info.set_method!;
             if (nget != 0)
-                res[n++] = info.get_method;
+                res[n++] = info.get_method!;
             return res;
         }
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
             CachePropertyInfo(PInfo.GetMethod);
             if (info.get_method != null && (nonPublic || info.get_method.IsPublic))
@@ -306,7 +305,7 @@ namespace System.Reflection
             return dest;
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
             CachePropertyInfo(PInfo.SetMethod);
             if (info.set_method != null && (nonPublic || info.set_method.IsPublic))
@@ -346,18 +345,18 @@ namespace System.Reflection
         }
 
 
-        private delegate object GetterAdapter(object _this);
+        private delegate object? GetterAdapter(object? _this);
         private delegate R Getter<T, R>(T _this);
         private delegate R StaticGetter<R>();
 
 #pragma warning disable 169
         // Used via reflection
-        private static object GetterAdapterFrame<T, R>(Getter<T, R> getter, object obj)
+        private static object? GetterAdapterFrame<T, R>(Getter<T, R> getter, object? obj)
         {
-            return getter((T)obj);
+            return getter((T)obj!);
         }
 
-        private static object StaticGetterAdapterFrame<R>(StaticGetter<R> getter, object obj)
+        private static object? StaticGetterAdapterFrame<R>(StaticGetter<R> getter, object? obj)
         {
             return getter();
         }
@@ -384,30 +383,31 @@ namespace System.Reflection
             }
             else
             {
-                typeVector = new Type[] { method.DeclaringType, method.ReturnType };
+                typeVector = new Type[] { method.DeclaringType!, method.ReturnType };
                 getterDelegateType = typeof(Getter<,>);
                 frameName = "GetterAdapterFrame";
             }
 
             getterType = getterDelegateType.MakeGenericType(typeVector);
             getterDelegate = Delegate.CreateDelegate(getterType, method);
-            adapterFrame = typeof(RuntimePropertyInfo).GetMethod(frameName, BindingFlags.Static | BindingFlags.NonPublic);
+            adapterFrame = typeof(RuntimePropertyInfo).GetMethod(frameName, BindingFlags.Static | BindingFlags.NonPublic)!;
             adapterFrame = adapterFrame.MakeGenericMethod(typeVector);
             return (GetterAdapter)Delegate.CreateDelegate(typeof(GetterAdapter), getterDelegate, adapterFrame, true);
         }
 
-        public override object GetValue(object obj, object[] index)
+        public override object? GetValue(object? obj, object?[]? index)
         {
             if ((index == null || index.Length == 0) && RuntimeFeature.IsDynamicCodeSupported)
             {
                 /*FIXME we should check if the number of arguments matches the expected one, otherwise the error message will be pretty criptic.*/
                 if (cached_getter == null)
                 {
-                    MethodInfo method = GetGetMethod(true);
+                    MethodInfo? method = GetGetMethod(true);
                     if (method == null)
                         throw new ArgumentException($"Get Method not found for '{Name}'");
                     if (!DeclaringType.IsValueType && !PropertyType.IsByRef && !method.ContainsGenericParameters)
-                    { //FIXME find a way to build an invoke delegate for value types.
+                    {
+                        //FIXME find a way to build an invoke delegate for value types.
                         cached_getter = CreateGetterDelegate(method);
                         // The try-catch preserves the .Invoke () behaviour
                         try
@@ -436,11 +436,11 @@ namespace System.Reflection
             return GetValue(obj, BindingFlags.Default, null, index, null);
         }
 
-        public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            object ret = null;
+            object? ret = null;
 
-            MethodInfo method = GetGetMethod(true);
+            MethodInfo? method = GetGetMethod(true);
             if (method == null)
                 throw new ArgumentException($"Get Method not found for '{Name}'");
 
@@ -452,15 +452,15 @@ namespace System.Reflection
             return ret;
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            MethodInfo method = GetSetMethod(true);
+            MethodInfo? method = GetSetMethod(true);
             if (method == null)
                 throw new ArgumentException("Set Method not found for '" + Name + "'");
 
-            object[] parms;
+            object?[] parms;
             if (index == null || index.Length == 0)
-                parms = new object[] { value };
+                parms = new object?[] { value };
             else
             {
                 int ilen = index.Length;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.Mono.cs
@@ -9,7 +9,7 @@ namespace System.Resources
 {
     internal partial class ManifestBasedResourceGroveler
     {
-        private static Assembly InternalGetSatelliteAssembly(Assembly mainAssembly, CultureInfo culture, Version version)
+        private static Assembly? InternalGetSatelliteAssembly(Assembly mainAssembly, CultureInfo culture, Version? version)
         {
             return ((RuntimeAssembly)mainAssembly).InternalGetSatelliteAssembly(culture, version, throwOnFileNotFound: false);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/DependentHandle.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/DependentHandle.cs
@@ -6,8 +6,8 @@ namespace System.Runtime.CompilerServices
 {
     internal struct Ephemeron
     {
-        public object key;
-        public object value;
+        public object? key;
+        public object? value;
     }
 
     //
@@ -17,7 +17,7 @@ namespace System.Runtime.CompilerServices
     {
         private Ephemeron[] data;
 
-        public DependentHandle(object primary, object secondary)
+        public DependentHandle(object? primary, object? secondary)
         {
             data = new Ephemeron[1];
             data[0].key = primary;
@@ -30,7 +30,7 @@ namespace System.Runtime.CompilerServices
         // Getting the secondary object is more expensive than getting the first so
         // we provide a separate primary-only accessor for those times we only want the
         // primary.
-        public object GetPrimary()
+        public object? GetPrimary()
         {
             if (!IsAllocated)
                 throw new NotSupportedException();
@@ -39,7 +39,7 @@ namespace System.Runtime.CompilerServices
             return data[0].key;
         }
 
-        public object GetPrimaryAndSecondary(out object secondary)
+        public object? GetPrimaryAndSecondary(out object? secondary)
         {
             if (!IsAllocated)
                 throw new NotSupportedException();
@@ -52,14 +52,14 @@ namespace System.Runtime.CompilerServices
             return data[0].key;
         }
 
-        public void SetPrimary(object primary)
+        public void SetPrimary(object? primary)
         {
             if (!IsAllocated)
                 throw new NotSupportedException();
             data[0].key = primary;
         }
 
-        public void SetSecondary(object secondary)
+        public void SetSecondary(object? secondary)
         {
             if (!IsAllocated)
                 throw new NotSupportedException();
@@ -68,7 +68,7 @@ namespace System.Runtime.CompilerServices
 
         public void Free()
         {
-            data = null;
+            data = null!;
         }
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public static extern object GetObjectValue(object obj);
+        public static extern object? GetObjectValue(object? obj);
 
         public static void RunClassConstructor(RuntimeTypeHandle type)
         {
@@ -80,13 +80,13 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        public static void PrepareMethod(RuntimeMethodHandle method, RuntimeTypeHandle[] instantiation)
+        public static void PrepareMethod(RuntimeMethodHandle method, RuntimeTypeHandle[]? instantiation)
         {
             if (method.IsNullHandle())
                 throw new ArgumentException(SR.Argument_InvalidHandle);
             unsafe
             {
-                IntPtr[] instantiations = RuntimeTypeHandle.CopyRuntimeTypeHandles(instantiation, out int length);
+                IntPtr[]? instantiations = RuntimeTypeHandle.CopyRuntimeTypeHandles(instantiation, out int length);
                 fixed (IntPtr* pinst = instantiations)
                 {
                     PrepareMethod(method.Value, pinst, length);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.Mono.cs
@@ -9,15 +9,15 @@ namespace System.Runtime.InteropServices
     public partial struct GCHandle
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern IntPtr InternalAlloc(object value, GCHandleType type);
+        private static extern IntPtr InternalAlloc(object? value, GCHandleType type);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void InternalFree(IntPtr handle);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern object InternalGet(IntPtr handle);
+        private static extern object? InternalGet(IntPtr handle);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void InternalSet(IntPtr handle, object value);
+        private static extern void InternalSet(IntPtr handle, object? value);
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern bool IsPinnableType(Type type);
 
-        internal static bool IsPinnable(object obj)
+        internal static bool IsPinnable(object? obj)
         {
             if (obj == null || obj is string)
                 return true;
@@ -63,7 +63,7 @@ namespace System.Runtime.InteropServices
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void SetLastWin32Error(int error);
 
-        private static Exception GetExceptionForHRInternal(int errorCode, IntPtr errorInfo)
+        private static Exception? GetExceptionForHRInternal(int errorCode, IntPtr errorInfo)
         {
             switch (errorCode)
             {
@@ -307,7 +307,7 @@ namespace System.Runtime.InteropServices
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void PtrToStructureInternal(IntPtr ptr, object structure, bool allowValueClasses);
 
-        private static void PtrToStructureHelper(IntPtr ptr, object structure, bool allowValueClasses)
+        private static void PtrToStructureHelper(IntPtr ptr, object? structure, bool allowValueClasses)
         {
             if (structure == null)
                 throw new ArgumentNullException(nameof(structure));
@@ -316,7 +316,7 @@ namespace System.Runtime.InteropServices
 
         private static object PtrToStructureHelper(IntPtr ptr, Type structureType)
         {
-            object? obj = Activator.CreateInstance(structureType);
+            object obj = Activator.CreateInstance(structureType)!;
             PtrToStructureHelper(ptr, obj, true);
             return obj;
         }
@@ -346,7 +346,7 @@ namespace System.Runtime.InteropServices
             return res;
         }
 
-        public static unsafe IntPtr StringToBSTR(string s)
+        public static unsafe IntPtr StringToBSTR(string? s)
         {
             if (s == null)
                 return IntPtr.Zero;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
@@ -29,16 +29,16 @@ namespace System.Runtime.Loader
         private static extern void PrepareForAssemblyLoadContextRelease (IntPtr nativeAssemblyLoadContext, IntPtr assemblyLoadContextStrong);
 
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        private Assembly InternalLoadFromPath(string assemblyPath, string nativeImagePath)
+        private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
 
-            assemblyPath = assemblyPath.Replace('\\', Path.DirectorySeparatorChar);
+            assemblyPath = assemblyPath?.Replace('\\', Path.DirectorySeparatorChar);
             // TODO: Handle nativeImagePath
             return InternalLoadFile(NativeALC, assemblyPath, ref stackMark);
         }
 
-        internal Assembly InternalLoad(byte[] arrAssembly, byte[] arrSymbols)
+        internal Assembly InternalLoad(byte[] arrAssembly, byte[]? arrSymbols)
         {
             unsafe
             {
@@ -84,12 +84,12 @@ namespace System.Runtime.Loader
         {
         }
 
-        public void StartProfileOptimization(string profile)
+        public void StartProfileOptimization(string? profile)
         {
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern Assembly InternalLoadFile(IntPtr nativeAssemblyLoadContext, string assemblyFile, ref StackCrawlMark stackMark);
+        private static extern Assembly InternalLoadFile(IntPtr nativeAssemblyLoadContext, string? assemblyFile, ref StackCrawlMark stackMark);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern IntPtr InternalInitializeNativeALC(IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible);
@@ -100,9 +100,9 @@ namespace System.Runtime.Loader
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern Assembly[] InternalGetLoadedAssemblies();
 
-        internal static Assembly DoAssemblyResolve(string name)
+        internal static Assembly? DoAssemblyResolve(string name)
         {
-            return AssemblyResolve(null, new ResolveEventArgs(name));
+            return AssemblyResolve?.Invoke(null, new ResolveEventArgs(name));
         }
 
         // Invoked by Mono to resolve using the load method.

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
@@ -70,18 +70,18 @@ namespace System
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void SetValueInternal(FieldInfo fi, object obj, object value);
+        private static extern void SetValueInternal(FieldInfo fi, object? obj, object? value);
 
-        internal static void SetValue(RuntimeFieldInfo field, object obj, object value, RuntimeType fieldType, FieldAttributes fieldAttr, RuntimeType declaringType, ref bool domainInitialized)
+        internal static void SetValue(RuntimeFieldInfo field, object? obj, object? value, RuntimeType? fieldType, FieldAttributes fieldAttr, RuntimeType? declaringType, ref bool domainInitialized)
         {
             SetValueInternal(field, obj, value);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern unsafe object GetValueDirect(RuntimeFieldInfo field, RuntimeType fieldType, void* pTypedRef, RuntimeType contextType);
+        internal static extern unsafe object GetValueDirect(RuntimeFieldInfo field, RuntimeType fieldType, void* pTypedRef, RuntimeType? contextType);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void SetValueDirect(RuntimeFieldInfo field, RuntimeType fieldType, void* pTypedRef, object value, RuntimeType contextType);
+        internal static extern unsafe void SetValueDirect(RuntimeFieldInfo field, RuntimeType fieldType, void* pTypedRef, object value, RuntimeType? contextType);
     }
 
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -28,9 +28,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
-using System.Reflection;
 using System.Threading;
 
 namespace System
@@ -187,10 +188,10 @@ namespace System
         internal static extern bool IsComObject(RuntimeType type);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern bool IsInstanceOfType(RuntimeType type, object o);
+        internal static extern bool IsInstanceOfType(RuntimeType type, [NotNullWhen(true)] object? o);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern bool HasReferences(RuntimeType type);
+        internal static extern bool HasReferences(RuntimeType? type);
 
         internal static bool IsComObject(RuntimeType type, bool isGenericCOM)
         {
@@ -280,9 +281,9 @@ namespace System
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern RuntimeType internal_from_name(string name, ref StackCrawlMark stackMark, Assembly callerAssembly, bool throwOnError, bool ignoreCase, bool reflectionOnly);
+        private static extern RuntimeType internal_from_name(string name, ref StackCrawlMark stackMark, Assembly? callerAssembly, bool throwOnError, bool ignoreCase, bool reflectionOnly);
 
-        internal static RuntimeType GetTypeByName(string typeName, bool throwOnError, bool ignoreCase, bool reflectionOnly, ref StackCrawlMark stackMark,
+        internal static RuntimeType? GetTypeByName(string typeName, bool throwOnError, bool ignoreCase, bool reflectionOnly, ref StackCrawlMark stackMark,
                                                   bool loadTypeFromPartialName)
         {
             if (typeName == null)
@@ -311,7 +312,7 @@ namespace System
                         throw;
                     return null;
                 }
-                return (RuntimeType)a.GetType(typeName.Substring(0, idx), throwOnError, ignoreCase);
+                return (RuntimeType?)a.GetType(typeName.Substring(0, idx), throwOnError, ignoreCase);
             }
 
             RuntimeType? t = internal_from_name(typeName, ref stackMark, null, throwOnError, ignoreCase, false);
@@ -320,7 +321,7 @@ namespace System
             return t;
         }
 
-        internal static IntPtr[] CopyRuntimeTypeHandles(RuntimeTypeHandle[] inHandles, out int length)
+        internal static IntPtr[]? CopyRuntimeTypeHandles(RuntimeTypeHandle[]? inHandles, out int length)
         {
             if (inHandles == null || inHandles.Length == 0)
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/String.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/String.Mono.cs
@@ -8,8 +8,10 @@ namespace System
 {
     public partial class String
     {
+#pragma warning disable CS8618 // compiler sees this non-nullable static string as uninitialized
         [Intrinsic]
         public static readonly string Empty;
+#pragma warning restore CS8618
 
         public int Length
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Text/Utf8Span.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Text/Utf8Span.cs
@@ -6,8 +6,6 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 0809  //warning CS0809: Obsolete member 'Utf8Span.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
-
 namespace System.Text
 {
     [StructLayout(LayoutKind.Auto)]
@@ -39,7 +37,9 @@ namespace System.Text
 
         [Obsolete("Equals(object) on Utf8Span will always throw an exception. Use Equals(Utf8Span) or operator == instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable 0809  // Obsolete member 'Utf8Span.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
         public override bool Equals(object? obj)
+#pragma warning restore 0809
         {
             throw new NotSupportedException(SR.Utf8Span_CannotCallEqualsObject);
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.Mono.cs
@@ -39,7 +39,7 @@ namespace System.Threading
             }
         }
 
-        private unsafe void CreateEventCore(bool initialState, EventResetMode mode, string name, out bool createdNew)
+        private unsafe void CreateEventCore(bool initialState, EventResetMode mode, string? name, out bool createdNew)
         {
             if (name != null)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Interlocked.Mono.cs
@@ -16,10 +16,11 @@ namespace System.Threading
 
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void CompareExchange(ref object location1, ref object value, ref object comparand, ref object result);
+        private static extern void CompareExchange(ref object? location1, ref object? value, ref object? comparand, [NotNullIfNotNull("location1")] ref object? result);
 
         [Intrinsic]
-        public static object CompareExchange(ref object location1, object value, object comparand)
+        [return: NotNullIfNotNull("location1")]
+        public static object? CompareExchange(ref object? location1, object? value, object? comparand)
         {
             // This avoids coop handles, esp. on the output which would be particularly inefficient.
             // Passing everything by ref is equivalent to coop handles -- ref to locals at least.
@@ -33,7 +34,7 @@ namespace System.Threading
             //
             // This is usually intrinsified. Ideally it is always intrinisified.
             //
-            object result = null;
+            object? result = null;
             CompareExchange(ref location1, ref value, ref comparand, ref result);
             return result;
         }
@@ -62,12 +63,13 @@ namespace System.Threading
         public static extern int Exchange(ref int location1, int value);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void Exchange(ref object location1, ref object value, ref object result);
+        private static extern void Exchange([NotNullIfNotNull("value")] ref object? location1, ref object? value, [NotNullIfNotNull("location1")] ref object? result);
 
-        public static object Exchange(ref object location1, object value)
+        [return: NotNullIfNotNull("location1")]
+        public static object? Exchange([NotNullIfNotNull("value")] ref object? location1, object? value)
         {
             // See CompareExchange(object) for comments.
-            object result = null;
+            object? result = null;
             Exchange(ref location1, ref value, ref result);
             return result;
         }
@@ -107,7 +109,7 @@ namespace System.Threading
             T result = null;
 #pragma warning restore 8654
             // T : class so call the object overload.
-            CompareExchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref comparand), ref Unsafe.As<T, object?>(ref result));
+            CompareExchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref comparand), ref Unsafe.As<T, object?>(ref result!));
             return result;
         }
 
@@ -125,7 +127,7 @@ namespace System.Threading
 
         [return: NotNullIfNotNull("location1")]
         [Intrinsic]
-        public static T Exchange<T>(ref T location1, T value) where T : class?
+        public static T Exchange<T>([NotNullIfNotNull("value")] ref T location1, T value) where T : class?
         {
             unsafe
             {
@@ -140,7 +142,7 @@ namespace System.Threading
             T result = null;
 #pragma warning restore 8654
             // T : class so call the object overload.
-            Exchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref result));
+            Exchange(ref Unsafe.As<T, object?>(ref location1), ref Unsafe.As<T, object?>(ref value), ref Unsafe.As<T, object?>(ref result!));
             return result;
         }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Mutex.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Mutex.Unix.Mono.cs
@@ -17,17 +17,17 @@ namespace System.Threading
                 throw new ApplicationException(SR.Arg_SynchronizationLockException);
         }
 
-        private void CreateMutexCore(bool initiallyOwned, string name, out bool createdNew) =>
+        private void CreateMutexCore(bool initiallyOwned, string? name, out bool createdNew) =>
             Handle = CreateMutex_internal(initiallyOwned, name, out createdNew);
 
-        private static unsafe IntPtr CreateMutex_internal(bool initiallyOwned, string name, out bool created)
+        private static unsafe IntPtr CreateMutex_internal(bool initiallyOwned, string? name, out bool created)
         {
             fixed (char* fixed_name = name)
                 return CreateMutex_icall(initiallyOwned, fixed_name,
                     name?.Length ?? 0, out created);
         }
 
-        private static OpenExistingResult OpenExistingWorker(string name, out Mutex result)
+        private static OpenExistingResult OpenExistingWorker(string name, out Mutex? result)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -47,7 +47,7 @@ namespace System.Threading
                 else
                 {
                     // We got here because of Pack
-                    var helper = (_IOCompletionCallback)overlapped._callback;
+                    var helper = (_IOCompletionCallback)overlapped._callback!;
                     helper._errorCode = errorCode;
                     helper._numBytes = numBytes;
                     helper._pNativeOverlapped = pNativeOverlapped;
@@ -67,23 +67,23 @@ namespace System.Threading
 
     internal sealed unsafe class OverlappedData
     {
-        internal IAsyncResult _asyncResult;
-        internal object _callback; // IOCompletionCallback or _IOCompletionCallback
-        internal Overlapped _overlapped;
-        private object _userObject;
+        internal IAsyncResult? _asyncResult;
+        internal object? _callback; // IOCompletionCallback or _IOCompletionCallback
+        internal Overlapped? _overlapped;
+        private object? _userObject;
         private NativeOverlapped* _pNativeOverlapped;
         private IntPtr _eventHandle;
         private int _offsetLow;
         private int _offsetHigh;
-        private GCHandle[] _pinnedData;
+        private GCHandle[]? _pinnedData;
 
-        internal ref IAsyncResult AsyncResult => ref _asyncResult;
+        internal ref IAsyncResult? AsyncResult => ref _asyncResult;
 
         internal ref int OffsetLow => ref (_pNativeOverlapped != null) ? ref _pNativeOverlapped->OffsetLow : ref _offsetLow;
         internal ref int OffsetHigh => ref (_pNativeOverlapped != null) ? ref _pNativeOverlapped->OffsetHigh : ref _offsetHigh;
         internal ref IntPtr EventHandle => ref (_pNativeOverlapped != null) ? ref _pNativeOverlapped->EventHandle : ref _eventHandle;
 
-        internal unsafe NativeOverlapped* Pack(IOCompletionCallback iocb, object userData)
+        internal unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb, object? userData)
         {
             if (_pNativeOverlapped != null)
             {
@@ -92,7 +92,7 @@ namespace System.Threading
 
             if (iocb != null)
             {
-                ExecutionContext ec = ExecutionContext.Capture();
+                ExecutionContext? ec = ExecutionContext.Capture();
                 _callback = (ec != null && !ec.IsDefault) ? new _IOCompletionCallback(iocb, ec) : (object)iocb;
             }
             else
@@ -103,7 +103,7 @@ namespace System.Threading
             return AllocateNativeOverlapped();
         }
 
-        internal unsafe NativeOverlapped* UnsafePack(IOCompletionCallback iocb, object userData)
+        internal unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb, object? userData)
         {
             if (_pNativeOverlapped != null)
             {
@@ -199,7 +199,7 @@ namespace System.Threading
         internal static unsafe OverlappedData GetOverlappedFromNative(NativeOverlapped* pNativeOverlapped)
         {
             GCHandle handle = *(GCHandle*)(pNativeOverlapped + 1);
-            return (OverlappedData)handle.Target;
+            return (OverlappedData)handle.Target!;
         }
     }
 
@@ -217,7 +217,7 @@ namespace System.Threading
             _overlappedData._overlapped = this;
         }
 
-        public Overlapped(int offsetLo, int offsetHi, IntPtr hEvent, IAsyncResult ar) : this()
+        public Overlapped(int offsetLo, int offsetHi, IntPtr hEvent, IAsyncResult? ar) : this()
         {
             _overlappedData.OffsetLow = offsetLo;
             _overlappedData.OffsetHigh = offsetHi;
@@ -226,11 +226,11 @@ namespace System.Threading
         }
 
         [Obsolete("This constructor is not 64-bit compatible.  Use the constructor that takes an IntPtr for the event handle.  http://go.microsoft.com/fwlink/?linkid=14202")]
-        public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
+        public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult? ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
         {
         }
 
-        public IAsyncResult AsyncResult
+        public IAsyncResult? AsyncResult
         {
             get { return _overlappedData.AsyncResult; }
             set { _overlappedData.AsyncResult = value; }
@@ -268,26 +268,26 @@ namespace System.Threading
         ====================================================================*/
         [Obsolete("This method is not safe.  Use Pack (iocb, userData) instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         [CLSCompliant(false)]
-        public unsafe NativeOverlapped* Pack(IOCompletionCallback iocb)
+        public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb)
         {
             return Pack(iocb, null);
         }
 
         [CLSCompliant(false)]
-        public unsafe NativeOverlapped* Pack(IOCompletionCallback iocb, object userData)
+        public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb, object? userData)
         {
             return _overlappedData.Pack(iocb, userData);
         }
 
         [Obsolete("This method is not safe.  Use UnsafePack (iocb, userData) instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
         [CLSCompliant(false)]
-        public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback iocb)
+        public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb)
         {
             return UnsafePack(iocb, null);
         }
 
         [CLSCompliant(false)]
-        public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback iocb, object userData)
+        public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb, object? userData)
         {
             return _overlappedData.UnsafePack(iocb, userData);
         }
@@ -302,7 +302,7 @@ namespace System.Threading
             if (nativeOverlappedPtr == null)
                 throw new ArgumentNullException(nameof(nativeOverlappedPtr));
 
-            return OverlappedData.GetOverlappedFromNative(nativeOverlappedPtr)._overlapped;
+            return OverlappedData.GetOverlappedFromNative(nativeOverlappedPtr)._overlapped!;
         }
 
         [CLSCompliant(false)]
@@ -311,7 +311,7 @@ namespace System.Threading
             if (nativeOverlappedPtr == null)
                 throw new ArgumentNullException(nameof(nativeOverlappedPtr));
 
-            OverlappedData.GetOverlappedFromNative(nativeOverlappedPtr)._overlapped._overlappedData = null;
+            OverlappedData.GetOverlappedFromNative(nativeOverlappedPtr)._overlapped!._overlappedData = null!;
             OverlappedData.FreeNativeOverlapped(nativeOverlappedPtr);
         }
     }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/PreAllocatedOverlapped.cs
@@ -7,7 +7,7 @@ namespace System.Threading
     public sealed class PreAllocatedOverlapped : System.IDisposable
     {
         [System.CLSCompliantAttribute(false)]
-        public PreAllocatedOverlapped(System.Threading.IOCompletionCallback callback, object state, object pinData) { }
+        public PreAllocatedOverlapped(System.Threading.IOCompletionCallback callback, object? state, object? pinData) { }
         public void Dispose() { }
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.Mono.cs
@@ -22,7 +22,7 @@ namespace System.Threading
             return previousCount;
         }
 
-        private static OpenExistingResult OpenExistingWorker(string name, out Semaphore result)
+        private static OpenExistingResult OpenExistingWorker(string name, out Semaphore? result)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -59,7 +59,7 @@ namespace System.Threading
             return OpenExistingResult.Success;
         }
 
-        private void CreateSemaphoreCore(int initialCount, int maximumCount, string name, out bool createdNew)
+        private void CreateSemaphoreCore(int initialCount, int maximumCount, string? name, out bool createdNew)
         {
             if (name?.Length > MAX_PATH)
                 throw new ArgumentException(SR.Argument_WaitHandleNameTooLong);
@@ -78,7 +78,7 @@ namespace System.Threading
             createdNew = errorCode != MonoIOError.ERROR_ALREADY_EXISTS;
         }
 
-        private static unsafe IntPtr CreateSemaphore_internal(int initialCount, int maximumCount, string name, out MonoIOError errorCode)
+        private static unsafe IntPtr CreateSemaphore_internal(int initialCount, int maximumCount, string? name, out MonoIOError errorCode)
         {
             // FIXME Check for embedded nuls in name.
             fixed (char* fixed_name = name)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -25,7 +26,7 @@ namespace System.Threading
         private int name_free; // bool
         private int name_length;
         private ThreadState state;
-        private object abort_exc;
+        private object? abort_exc;
         private int abort_state_handle;
         /* thread_id is only accessed from unmanaged code */
         internal long thread_id;
@@ -34,9 +35,9 @@ namespace System.Threading
         private IntPtr runtime_thread_info;
         /* current System.Runtime.Remoting.Contexts.Context instance
            keep as an object to avoid triggering its class constructor when not needed */
-        private object current_appcontext;
-        private object root_domain_thread;
-        internal byte[] _serialized_principal;
+        private object? current_appcontext;
+        private object? root_domain_thread;
+        internal byte[]? _serialized_principal;
         internal int _serialized_principal_version;
         private IntPtr appdomain_refs;
         private int interruption_requested;
@@ -59,9 +60,9 @@ namespace System.Threading
         private int self_suspended;
         private IntPtr thread_state;
 
-        private Thread self;
-        private object pending_exception;
-        private object start_obj;
+        private Thread self = null!;
+        private object? pending_exception;
+        private object? start_obj;
 
         /* This is used only to check that we are in sync between the representation
          * of MonoInternalThread in native and InternalThread in managed
@@ -71,12 +72,12 @@ namespace System.Threading
         #endregion
 #pragma warning restore 169, 414, 649
 
-        private string _name;
-        private Delegate m_start;
-        private object m_start_arg;
-        private CultureInfo culture, ui_culture;
-        internal ExecutionContext _executionContext;
-        internal SynchronizationContext _synchronizationContext;
+        private string? _name;
+        private Delegate? m_start;
+        private object? m_start_arg;
+        private CultureInfo? culture, ui_culture;
+        internal ExecutionContext? _executionContext;
+        internal SynchronizationContext? _synchronizationContext;
 
         private Thread()
         {
@@ -279,7 +280,7 @@ namespace System.Threading
             }
             else
             {
-                var pdel = (ParameterizedThreadStart)m_start;
+                var pdel = (ParameterizedThreadStart)m_start!;
                 object? arg = m_start_arg;
                 m_start = null;
                 m_start_arg = null;
@@ -287,7 +288,7 @@ namespace System.Threading
             }
         }
 
-        partial void ThreadNameChanged(string value)
+        partial void ThreadNameChanged(string? value)
         {
             // TODO: Should only raise the events
             SetName(this, value);
@@ -311,16 +312,17 @@ namespace System.Threading
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern ulong GetCurrentOSThreadId();
 
+        [MemberNotNull("self")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void InitInternal(Thread thread);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void InitializeCurrentThread_icall(ref Thread thread);
+        private static extern void InitializeCurrentThread_icall([NotNull] ref Thread? thread);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Thread InitializeCurrentThread()
         {
-            Thread thread = null;
+            Thread? thread = null;
             InitializeCurrentThread_icall(ref thread);
             return thread;
         }
@@ -343,7 +345,7 @@ namespace System.Threading
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void SetName_icall(Thread thread, char* name, int nameLength);
 
-        private static unsafe void SetName(Thread thread, string name)
+        private static unsafe void SetName(Thread thread, string? name)
         {
             fixed (char* fixed_name = name)
                 SetName_icall(thread, fixed_name, name?.Length ?? 0);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -76,17 +76,17 @@ namespace System
             return TypeNameParser.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
         }
 
-        public static Type? GetTypeFromHandle(RuntimeTypeHandle handle)
+        public static Type GetTypeFromHandle(RuntimeTypeHandle handle)
         {
             if (handle.Value == IntPtr.Zero)
-                return null;
+                return null!; // FIXME: shouldn't return null
 
             return internal_from_handle(handle.Value);
         }
 
-        public static Type GetTypeFromCLSID(Guid clsid, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
+        public static Type? GetTypeFromCLSID(Guid clsid, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
 
-        public static Type GetTypeFromProgID(string progID, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
+        public static Type? GetTypeFromProgID(string progID, string? server, bool throwOnError) => throw new PlatformNotSupportedException();
 
         internal virtual Type InternalResolve()
         {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/TypeIdentifier.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/TypeIdentifier.cs
@@ -135,7 +135,7 @@ namespace System
         private class Display : TypeNames.ATypeName, ITypeIdentifier
         {
             private readonly string displayName;
-            private string internal_name; //cached
+            private string? internal_name; //cached
 
             internal Display(string displayName)
             {
@@ -147,32 +147,18 @@ namespace System
                 get { return displayName; }
             }
 
-            public string InternalName
-            {
-                get
-                {
-                    if (internal_name == null)
-                        internal_name = GetInternalName();
-                    return internal_name;
-                }
-            }
+            public string InternalName => internal_name ??= GetInternalName();
 
-            private string GetInternalName()
-            {
-                return TypeSpec.UnescapeInternalName(displayName);
-            }
+            private string GetInternalName() => TypeSpec.UnescapeInternalName(displayName);
 
-            public override ITypeName NestedName(ITypeIdentifier innerName)
-            {
-                return TypeNames.FromDisplay(DisplayName + "+" + innerName.DisplayName);
-            }
+            public override ITypeName NestedName(ITypeIdentifier innerName) =>
+                TypeNames.FromDisplay(DisplayName + "+" + innerName.DisplayName);
         }
-
 
         private class Internal : TypeNames.ATypeName, ITypeIdentifier
         {
             private readonly string internalName;
-            private string display_name; //cached
+            private string? display_name; //cached
 
             internal Internal(string internalName)
             {
@@ -184,31 +170,14 @@ namespace System
                 this.internalName = nameSpaceInternal + "." + typeName.InternalName;
             }
 
-            public override string DisplayName
-            {
-                get
-                {
-                    if (display_name == null)
-                        display_name = GetDisplayName();
-                    return display_name;
-                }
-            }
+            public override string DisplayName => display_name ??= GetDisplayName();
 
-            public string InternalName
-            {
-                get { return internalName; }
-            }
+            public string InternalName => internalName;
 
-            private string GetDisplayName()
-            {
-                return TypeSpec.EscapeDisplayName(internalName);
-            }
+            private string GetDisplayName() => TypeSpec.EscapeDisplayName(internalName);
 
-            public override ITypeName NestedName(ITypeIdentifier innerName)
-            {
-                return TypeNames.FromDisplay(DisplayName + "+" + innerName.DisplayName);
-            }
-
+            public override ITypeName NestedName(ITypeIdentifier innerName) =>
+                TypeNames.FromDisplay(DisplayName + "+" + innerName.DisplayName);
         }
 
         private class NoEscape : TypeNames.ATypeName, ITypeIdentifier

--- a/src/mono/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -14,10 +14,10 @@ namespace System
     {
         private static readonly char[] SPECIAL_CHARS = { ',', '[', ']', '&', '*', '+', '\\' };
 
-        internal static Type GetType(
+        internal static Type? GetType(
             string typeName,
-            Func<AssemblyName, Assembly> assemblyResolver,
-            Func<Assembly, string, bool, Type> typeResolver,
+            Func<AssemblyName, Assembly?>? assemblyResolver,
+            Func<Assembly, string, bool, Type?>? typeResolver,
             bool throwOnError,
             bool ignoreCase,
             ref StackCrawlMark stackMark)
@@ -25,7 +25,7 @@ namespace System
             if (typeName == null)
                 throw new ArgumentNullException(nameof(typeName));
 
-            ParsedName pname = ParseName(typeName, false, 0, out int end_pos);
+            ParsedName? pname = ParseName(typeName, false, 0, out int end_pos);
             if (pname == null)
             {
                 if (throwOnError)
@@ -36,16 +36,16 @@ namespace System
             return ConstructType(pname, assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
         }
 
-        private static Type ConstructType(
+        private static Type? ConstructType(
             ParsedName pname,
-            Func<AssemblyName, Assembly> assemblyResolver,
-            Func<Assembly, string, bool, Type> typeResolver,
+            Func<AssemblyName, Assembly?>? assemblyResolver,
+            Func<Assembly, string, bool, Type?>? typeResolver,
             bool throwOnError,
             bool ignoreCase,
             ref StackCrawlMark stackMark)
         {
             // Resolve assembly
-            Assembly assembly = null;
+            Assembly? assembly = null;
             if (pname.AssemblyName != null)
             {
                 assembly = ResolveAssembly(pname.AssemblyName, assemblyResolver, throwOnError, ref stackMark);
@@ -55,21 +55,21 @@ namespace System
             }
 
             // Resolve base type
-            Type? type = ResolveType(assembly, pname.Names, typeResolver, throwOnError, ignoreCase, ref stackMark);
+            Type? type = ResolveType(assembly!, pname.Names!, typeResolver, throwOnError, ignoreCase, ref stackMark);
             if (type == null)
                 return null;
 
             // Resolve type arguments
             if (pname.TypeArguments != null)
             {
-                var args = new Type[pname.TypeArguments.Count];
+                var args = new Type?[pname.TypeArguments.Count];
                 for (int i = 0; i < pname.TypeArguments.Count; ++i)
                 {
                     args[i] = ConstructType(pname.TypeArguments[i], assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
                     if (args[i] == null)
                         return null;
                 }
-                type = type.MakeGenericType(args);
+                type = type.MakeGenericType(args!);
             }
 
             // Resolve modifiers
@@ -105,7 +105,7 @@ namespace System
             return type;
         }
 
-        private static Assembly ResolveAssembly(string name, Func<AssemblyName, Assembly> assemblyResolver, bool throwOnError,
+        private static Assembly? ResolveAssembly(string name, Func<AssemblyName, Assembly?>? assemblyResolver, bool throwOnError,
                                          ref StackCrawlMark stackMark)
         {
             var aname = new AssemblyName(name);
@@ -137,9 +137,9 @@ namespace System
             }
         }
 
-        private static Type ResolveType(Assembly assembly, List<string> names, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
+        private static Type? ResolveType(Assembly assembly, List<string> names, Func<Assembly, string, bool, Type?>? typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
         {
-            Type type = null;
+            Type? type = null;
 
             string name = EscapeTypeName(names[0]);
             // Resolve the top level type.
@@ -218,10 +218,10 @@ namespace System
 
         private class ParsedName
         {
-            public List<string> Names;
-            public List<ParsedName> TypeArguments;
-            public List<int> Modifiers;
-            public string AssemblyName;
+            public List<string>? Names;
+            public List<ParsedName>? TypeArguments;
+            public List<int>? Modifiers;
+            public string? AssemblyName;
 
             /* For debugging
             public override string ToString () {
@@ -251,7 +251,7 @@ namespace System
         // Entries to the Names list are unescaped to internal form while AssemblyName is not, in an effort to maintain
         // consistency with our native parser. Since this function is just called recursively, that should also be true
         // for ParsedNames in TypeArguments.
-        private static ParsedName ParseName(string name, bool recursed, int pos, out int end_pos)
+        private static ParsedName? ParseName(string name, bool recursed, int pos, out int end_pos)
         {
             end_pos = 0;
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/TypeSpec.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/TypeSpec.cs
@@ -121,14 +121,14 @@ namespace System
 
     internal class TypeSpec
     {
-        private ITypeIdentifier name;
-        private string assembly_name;
-        private List<ITypeIdentifier> nested;
-        private List<TypeSpec> generic_params;
-        private List<IModifierSpec> modifier_spec;
+        private ITypeIdentifier? name;
+        private string? assembly_name;
+        private List<ITypeIdentifier>? nested;
+        private List<TypeSpec>? generic_params;
+        private List<IModifierSpec>? modifier_spec;
         private bool is_byref;
 
-        private string display_fullname; // cache
+        private string? display_fullname; // cache
 
         internal bool HasModifiers
         {
@@ -145,7 +145,7 @@ namespace System
             get { return is_byref; }
         }
 
-        internal ITypeName Name
+        internal ITypeName? Name
         {
             get { return name; }
         }
@@ -190,7 +190,7 @@ namespace System
         {
             bool wantAssembly = (flags & DisplayNameFormat.WANT_ASSEMBLY) != 0;
             bool wantModifiers = (flags & DisplayNameFormat.NO_MODIFIERS) == 0;
-            var sb = new Text.StringBuilder(name.DisplayName);
+            var sb = new Text.StringBuilder(name!.DisplayName);
             if (nested != null)
             {
                 foreach (ITypeIdentifier? n in nested)
@@ -323,9 +323,9 @@ namespace System
             return false;
         }
 
-        internal Type Resolve(Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
+        internal Type? Resolve(Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
         {
-            Assembly asm = null;
+            Assembly? asm = null;
             if (assemblyResolver == null && typeResolver == null)
                 return RuntimeType.GetType(DisplayFullName, throwOnError, ignoreCase, false, ref stackMark);
 
@@ -344,11 +344,11 @@ namespace System
                 }
             }
 
-            Type type = null;
+            Type? type = null;
             if (typeResolver != null)
-                type = typeResolver(asm, name.DisplayName, ignoreCase);
+                type = typeResolver(asm!, name!.DisplayName, ignoreCase);
             else
-                type = asm.GetType(name.DisplayName, false, ignoreCase);
+                type = asm!.GetType(name!.DisplayName, false, ignoreCase);
             if (type == null)
             {
                 if (throwOnError)
@@ -376,7 +376,7 @@ namespace System
                 Type[] args = new Type[generic_params.Count];
                 for (int i = 0; i < args.Length; ++i)
                 {
-                    Type? tmp = generic_params[i].Resolve(assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
+                    Type? tmp = generic_params[i].Resolve(assemblyResolver!, typeResolver!, throwOnError, ignoreCase, ref stackMark);
                     if (tmp == null)
                     {
                         if (throwOnError)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Utf8String.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Utf8String.cs
@@ -14,7 +14,10 @@ namespace System
     /// </summary>
     public sealed partial class Utf8String : IComparable<Utf8String?>, IEquatable<Utf8String?>
     {
+#pragma warning disable CS8618
         public static readonly Utf8String Empty;
+#pragma warning restore CS8618
+
         public static bool operator ==(Utf8String? left, Utf8String? right) => throw new PlatformNotSupportedException();
         public static bool operator !=(Utf8String? left, Utf8String? right) => throw new PlatformNotSupportedException();
         public static implicit operator Utf8Span(Utf8String? value) => throw new PlatformNotSupportedException();

--- a/src/mono/netcore/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/ValueType.cs
@@ -63,7 +63,7 @@ namespace System
             return result;
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return GetType().ToString();
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.Mono.cs
@@ -13,7 +13,7 @@ namespace System
 
         public virtual bool IsAlive => Target != null;
 
-        public virtual object Target
+        public virtual object? Target
         {
             get
             {
@@ -34,7 +34,7 @@ namespace System
             handle.Free();
         }
 
-        private void Create(object target, bool trackResurrection)
+        private void Create(object? target, bool trackResurrection)
         {
             if (trackResurrection)
             {

--- a/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.T.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/WeakReference.T.Mono.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace System
@@ -11,6 +12,7 @@ namespace System
         private GCHandle handle;
         private bool trackResurrection;
 
+        [MaybeNull]
         private T Target
         {
             get


### PR DESCRIPTION
Corelib had nullable reference types enabled, but all warnings were suppressed.  This fixes the thousands of warnings that were being hidden and fully enables nullable reference types for mono's corelib, as it is for coreclr's corelib.

I copied over the public API annotations from coreclr's corelib and tried to annotate the mono source as accurately as possible.  However, I'm 100% sure there are issues, both places I misexpressed the contract of an internal API and places where I suppresed warnings with `!` where it likely could actually null ref.  Along the way, when there was an obvious null ref where coreclr was doing a null check and providing different behavior, I fixed it or at least added a comment, but I expect there are more issues lurking.

cc: @buyaa-n, @jeffhandley, @marek-safar, @EgorBo, @akoeplinger 