### PR TITLE
[mono] Fix finalizer thread init in iOS sample

### DIFF
--- a/src/mono/netcore/sample/iOS/runtime.m
+++ b/src/mono/netcore/sample/iOS/runtime.m
@@ -279,7 +279,9 @@ mono_ios_runtime_init (void)
 
 #if DEVICE
     // device runtimes are configured to use lazy gc thread creation
+    MONO_ENTER_GC_UNSAFE;
     mono_gc_init_finalizer_thread ();
+    MONO_EXIT_GC_UNSAFE;
 #endif
 
     MonoAssembly *assembly = load_assembly (executable, NULL);


### PR DESCRIPTION
Starting with https://github.com/mono/mono/pull/16907 , the runtime ends in GC-Safe state (mode) after mono_jit_init_version() is called. mono_gc_init_finalizer_thread() expects the GC to not already be in safe mode.