### PR TITLE
Issue incorrect exception message

### DIFF
--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -3451,5 +3452,8 @@ Usage: dotnet {0} [--assembly &lt;assembly file path&gt;] [--type &lt;type name&
   </data>
   <data name="CompilingScriptsNotSupported" xml:space="preserve">
     <value>Compiling JScript/CSharp scripts is not supported</value>
+  </data>
+  <data name="Sch_FractionDigitsMismatch" xml:space="preserve">
+    <value>It is an error if the derived 'fractionDigits' facet value is greater than the parent 'fractionDigits' facet value.</value>
   </data>
 </root>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1764,6 +1764,9 @@
   <data name="Sch_TotalDigitsMismatch" xml:space="preserve">
     <value>It is an error if the derived 'totalDigits' facet value is greater than the parent 'totalDigits' facet value.</value>
   </data>
+  <data name="Sch_FractionDigitsMismatch" xml:space="preserve">
+    <value>It is an error if the derived 'fractionDigits' facet value is greater than the parent 'fractionDigits' facet value.</value>
+  </data>
   <data name="Sch_FacetBaseFixed" xml:space="preserve">
     <value>Values that are declared as {fixed} in a base type can not be changed in a derived type.</value>
   </data>
@@ -3452,8 +3455,5 @@ Usage: dotnet {0} [--assembly &lt;assembly file path&gt;] [--type &lt;type name&
   </data>
   <data name="CompilingScriptsNotSupported" xml:space="preserve">
     <value>Compiling JScript/CSharp scripts is not supported</value>
-  </data>
-  <data name="Sch_FractionDigitsMismatch" xml:space="preserve">
-    <value>It is an error if the derived 'fractionDigits' facet value is greater than the parent 'fractionDigits' facet value.</value>
   </data>
 </root>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
@@ -338,7 +338,7 @@ namespace System.Xml.Schema
                 {
                     if (_derivedRestriction.FractionDigits > _datatype.Restriction.FractionDigits)
                     {
-                        throw new XmlSchemaException(SR.Sch_TotalDigitsMismatch, string.Empty);
+                        throw new XmlSchemaException(SR.Sch_FractionDigitsMismatch, string.Empty);
                     }
                 }
                 SetFlag(facet, RestrictionFlags.FractionDigits);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -149,5 +149,33 @@ namespace System.Xml.Tests
                 Assert.Equal(0, errorCount);
             }
         }
+
+
+        [Fact]
+        public void FractionDigitsMismatch_Throws()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:decimal'>
+            <xs:fractionDigits value='8' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:fractionDigits value='9'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+";
+
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+            Assert.Contains("fractionDigits", ex.Message);
+            Assert.DoesNotContain("totalDigits", ex.Message);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -150,7 +150,6 @@ namespace System.Xml.Tests
             }
         }
 
-
         [Fact]
         public void FractionDigitsMismatch_Throws()
         {


### PR DESCRIPTION
Incorporated unit test from Issue #34413 
Corrected the exception message being thrown.  Since it is the fractionDigits facet which is illegal, this is now the one mentioned in the exception message.