### PR TITLE
Update WASM image

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -169,7 +169,7 @@ jobs:
       archType: wasm
       platform: WebAssembly_wasm
       container:
-        image: ubuntu-16.04-bfcd90a-20200121150106
+        image: ubuntu-16.04-20200401182342-fe8b85d
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}


### PR DESCRIPTION
Move to an Ubuntu image which has the `en_US.UTF-8` locale available.
This should remove the spurious warning that we're seeing during
PR / CI

closes #34280