### PR TITLE
Fix write behind allocated memory in thread name setting

### DIFF
--- a/src/coreclr/src/pal/src/thread/thread.cpp
+++ b/src/coreclr/src/pal/src/thread/thread.cpp
@@ -1666,7 +1666,10 @@ CorUnix::InternalSetThreadDescription(
 
     // Null terminate early.
     // pthread_setname_np only accepts up to 16 chars.
-    nameBuf[15] = '\0';
+    if (nameSize > 15)
+    {
+        nameBuf[15] = '\0';
+    }
 
     error = pthread_setname_np(pTargetThread->GetPThreadSelf(), nameBuf);
 


### PR DESCRIPTION
The code in CorUnix::InternalSetThreadDescription is writing behind
the end of the allocated memory in case the name is shorter than 16
characters. That is causing memory heap corruption.

The problem was discovered in https://github.com/dotnet/installer/pull/6876