### PR TITLE
CastTable perf tweaks.

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -104,57 +104,53 @@ namespace System.Runtime.CompilerServices
         private static CastResult TryGet(nuint source, nuint target)
         {
             const int BUCKET_SIZE = 8;
-            int[]? table = s_table;
 
-            // we use NULL as a sentinel for a rare case when a table could not be allocated
-            // because we avoid OOMs.
-            // we could use 0-element table instead, but then we would have to check the size here.
-            if (table != null)
+            // table is initialized and updated by native code that guarantees it is not null.
+            int[] table = s_table!;
+
+            int index = KeyToBucket(table, source, target);
+            for (int i = 0; i < BUCKET_SIZE;)
             {
-                int index = KeyToBucket(table, source, target);
-                for (int i = 0; i < BUCKET_SIZE;)
+                ref CastCacheEntry pEntry = ref Element(table, index);
+
+                // must read in this order: version -> entry parts -> version
+                // if version is odd or changes, the entry is inconsistent and thus ignored
+                int version = Volatile.Read(ref pEntry._version);
+                nuint entrySource = pEntry._source;
+
+                // mask the lower version bit to make it even.
+                // This way we can check if version is odd or changing in just one compare.
+                version &= ~1;
+
+                if (entrySource == source)
                 {
-                    ref CastCacheEntry pEntry = ref Element(table, index);
-
-                    // must read in this order: version -> entry parts -> version
-                    // if version is odd or changes, the entry is inconsistent and thus ignored
-                    int version = Volatile.Read(ref pEntry._version);
-                    nuint entrySource = pEntry._source;
-
-                    // mask the lower version bit to make it even.
-                    // This way we can check if version is odd or changing in just one compare.
-                    version &= ~1;
-
-                    if (entrySource == source)
+                    nuint entryTargetAndResult = Volatile.Read(ref pEntry._targetAndResult);
+                    // target never has its lower bit set.
+                    // a matching entryTargetAndResult would the have same bits, except for the lowest one, which is the result.
+                    entryTargetAndResult ^= target;
+                    if (entryTargetAndResult <= 1)
                     {
-                        nuint entryTargetAndResult = Volatile.Read(ref pEntry._targetAndResult);
-                        // target never has its lower bit set.
-                        // a matching entryTargetAndResult would the have same bits, except for the lowest one, which is the result.
-                        entryTargetAndResult ^= target;
-                        if (entryTargetAndResult <= 1)
+                        if (version != pEntry._version)
                         {
-                            if (version != pEntry._version)
-                            {
-                                // oh, so close, the entry is in inconsistent state.
-                                // it is either changing or has changed while we were reading.
-                                // treat it as a miss.
-                                break;
-                            }
-
-                            return (CastResult)entryTargetAndResult;
+                            // oh, so close, the entry is in inconsistent state.
+                            // it is either changing or has changed while we were reading.
+                            // treat it as a miss.
+                            break;
                         }
-                    }
 
-                    if (version == 0)
-                    {
-                        // the rest of the bucket is unclaimed, no point to search further
-                        break;
+                        return (CastResult)entryTargetAndResult;
                     }
-
-                    // quadratic reprobe
-                    i++;
-                    index = (index + i) & TableMask(table);
                 }
+
+                if (version == 0)
+                {
+                    // the rest of the bucket is unclaimed, no point to search further
+                    break;
+                }
+
+                // quadratic reprobe
+                i++;
+                index = (index + i) & TableMask(table);
             }
             return CastResult.MaybeCast;
         }

--- a/src/coreclr/src/vm/castcache.h
+++ b/src/coreclr/src/vm/castcache.h
@@ -241,7 +241,7 @@ private:
         TrySet(source, target, result);
     }
 
-    FORCEINLINE static bool TryGrow(BASEARRAYREF table)
+    FORCEINLINE static bool TryGrow(DWORD* tableData)
     {
         CONTRACTL
         {
@@ -251,7 +251,7 @@ private:
         }
         CONTRACTL_END;
 
-        DWORD newSize = CacheElementCount(table) * 2;
+        DWORD newSize = CacheElementCount(tableData) * 2;
         if (newSize <= MAXIMUM_CACHE_SIZE)
         {
             return MaybeReplaceCacheWithLarger(newSize);
@@ -260,22 +260,23 @@ private:
         return false;
     }
 
-    FORCEINLINE static DWORD KeyToBucket(BASEARRAYREF table, TADDR source, TADDR target)
+    FORCEINLINE static DWORD KeyToBucket(DWORD* tableData, TADDR source, TADDR target)
     {
         // upper bits of addresses do not vary much, so to reduce loss due to cancelling out,
         // we do `rotl(source, <half-size>) ^ target` for mixing inputs.
         // then we use fibonacci hashing to reduce the value to desired size.
 
+        int hashShift = HashShift(tableData);
 #if HOST_64BIT
         UINT64 hash = (((UINT64)source << 32) | ((UINT64)source >> 32)) ^ (UINT64)target;
-        return (DWORD)((hash * 11400714819323198485llu) >> HashShift(table));
+        return (DWORD)((hash * 11400714819323198485llu) >> hashShift);
 #else
         UINT32 hash = (((UINT32)source << 16) | ((UINT32)source >> 16)) ^ (UINT32)target;
-        return (DWORD)((hash * 2654435769ul) >> HashShift(table));
+        return (DWORD)((hash * 2654435769ul) >> hashShift);
 #endif
     }
 
-    FORCEINLINE static DWORD* AuxData(BASEARRAYREF table)
+    FORCEINLINE static DWORD* TableData(BASEARRAYREF table)
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -283,37 +284,37 @@ private:
         return (DWORD*)((BYTE*)OBJECTREFToObject(table) + ARRAYBASE_SIZE);
     }
 
-    FORCEINLINE static CastCacheEntry* Elements(BASEARRAYREF table)
+    FORCEINLINE static CastCacheEntry* Elements(DWORD* tableData)
     {
         LIMITED_METHOD_CONTRACT;
         // element 0 is used for embedded aux data, skip it
-        return (CastCacheEntry*)AuxData(table) + 1;
+        return (CastCacheEntry*)tableData + 1;
+    }
+
+    FORCEINLINE static DWORD& HashShift(DWORD* tableData)
+    {
+        LIMITED_METHOD_CONTRACT;
+        return *tableData;
     }
 
     // TableMask is "size - 1"
     // we need that more often that we need size
-    FORCEINLINE static DWORD& TableMask(BASEARRAYREF table)
+    FORCEINLINE static DWORD& TableMask(DWORD* tableData)
     {
         LIMITED_METHOD_CONTRACT;
-        return *AuxData(table);
+        return *(tableData + 1);
     }
 
-    FORCEINLINE static DWORD& HashShift(BASEARRAYREF table)
+    FORCEINLINE static DWORD& VictimCounter(DWORD* tableData)
     {
         LIMITED_METHOD_CONTRACT;
-        return *(AuxData(table) + 1);
+        return *(tableData + 2);
     }
 
-    FORCEINLINE static DWORD& VictimCounter(BASEARRAYREF table)
+    FORCEINLINE static DWORD CacheElementCount(DWORD* tableData)
     {
         LIMITED_METHOD_CONTRACT;
-        return *(AuxData(table) + 2);
-    }
-
-    FORCEINLINE static DWORD CacheElementCount(BASEARRAYREF table)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return TableMask(table) + 1;
+        return TableMask(tableData) + 1;
     }
 
     static BASEARRAYREF CreateCastCache(DWORD size);

--- a/src/coreclr/src/vm/castcache.h
+++ b/src/coreclr/src/vm/castcache.h
@@ -199,7 +199,12 @@ private:
 // We pick 8 as the probe limit (hoping for 4 probes on average), but the number can be refined further.
     static const DWORD BUCKET_SIZE = 8;
 
+    // current cache table
     static BASEARRAYREF*  s_pTableRef;
+
+    // sentinel table that never contains elements and used for flushing the old table when we cannot allocate a new one.
+    static OBJECTHANDLE s_sentinelTable;
+
     static DWORD          s_lastFlushSize;
 
     FORCEINLINE static TypeHandle::CastResult TryGetFromCache(TADDR source, TADDR target)


### PR DESCRIPTION
A few tweaks to the cast table implementation. 

Nothing changed algorithmically. These are small tweaks to help compilers emit better code.
- use a small sentinel table, that never contains elements, for the initial table and for flushing (eliminates null check in Get)
- reduce indirections and register pressure by operating with a ref to the `tableData` (first element) instead of the whole table when iterating.
- the above also ensures that `hashShift`  is stored at 0 offset off the `tableData`. (simpler address math in the most common path)

I see better codegen in both managed and C++ code. It results in 12% improvements on directed microbenchmarks such as invoking a method that casts  `List<string>` to `IReadOnlyCollection<object>`  in a loop. 

(Ex:  200000000 iterations changes from 894ms to  794ms )

This is not enough to switch ordinary interface and class casts to use cache lookup. Linear scan of interfaces is still faster, at least for common cases involving < 4-6 interfaces. Same goes for looking through bases.

This is still an improvement.

Other things tried (unsuccessfully):
- using simpler hash functions 
none provided a noticeable gain while collisions generally increased. Current hash seems to be very good for the data in use.
- using fixed size table
provided some gains (5% or so depending on scenario). But fixed size implies the max size right from the start. The gains are not big enough, IMO, to justify that. 

Considered: 
- using "colored" pointers for the source and destination handles. (version is embedded in upper bits of the source/destination values). 
This would make the table 1.5x denser, since no need for an extra version field and would eliminate any need for synchronization. This is, however, only feasible on 64bit. 32bit would need a separate implementation. I have doubts that gains here would be big, especially big enough to justify the trouble of dual implementations.

