### PR TITLE
Move StrongNameKeyId=Open default value down after arcade is imported

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -81,8 +81,6 @@
   <PropertyGroup>
     <!-- By default make all libraries to be AnyCPU but individual projects can override it if they need to -->
     <Platform>AnyCPU</Platform>
-    <!-- Default any assembly not specifying a key to use the Open Key -->
-    <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -168,6 +166,8 @@
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
 
+    <!-- Default any assembly not specifying a key to use the Open Key -->
+    <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- Microsoft.Extensions projects have a separate StrongNameKeyId -->
     <StrongNameKeyId Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">MicrosoftAspNetCore</StrongNameKeyId>
 


### PR DESCRIPTION
I noticed that in: https://github.com/dotnet/runtime/commit/87e7991b847a1c80654e05d81005f0931a04ab71 we moved down the StrongNameKeyId for `Microsoft.Extensions.*` projects. However for projects in libraries that don't declare a `StrongNameKeyId` we default it to `Open`, but our declaration of its default value, also has the ordering problem, so arcade would set their default `StrongNameKeyId` for any projects in libraries that doesn't set this property and meaning to use `Open` as the key id.

cc: @ericstj @maryamariyan @ViktorHofer 