### PR TITLE
Crossgen2 fixes to enable composite build with shared framework

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/src/tools/Common/Compiler/TypeExtensions.cs
@@ -502,5 +502,15 @@ namespace ILCompiler
 
             return constrainedType ?? genericParam.Context.GetWellKnownType(WellKnownType.Object);
         }
+
+        /// <summary>
+        /// Return true when the type in question is marked with the NonVersionable attribute.
+        /// </summary>
+        /// <param name="type">Type to check</param>
+        /// <returns>True when the type is marked with the non-versionable custom attribute, false otherwise.</returns>
+        public static bool IsNonVersionable(this MetadataType type)
+        {
+            return type.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute");
+        }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
@@ -66,6 +66,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         continue;
                     }
 
+                    if (!factory.CompilationModuleGroup.VersionsWithMethodBody(inlinee))
+                    {
+                        // We cannot record inlining info across version bubble as cross-bubble assemblies
+                        // are not guaranteed to preserve token values.
+                        continue;
+                    }
+
                     if (!inlineeToInliners.TryGetValue(ecmaInlineeDefinition, out HashSet<EcmaMethod> inliners))
                     {
                         inliners = new HashSet<EcmaMethod>();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
@@ -69,7 +69,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     if (!factory.CompilationModuleGroup.VersionsWithMethodBody(inlinee))
                     {
                         // We cannot record inlining info across version bubble as cross-bubble assemblies
-                        // are not guaranteed to preserve token values.
+                        // are not guaranteed to preserve token values. Only non-versionable methods may be
+                        // inlined across the version bubble.
+                        Debug.Assert(inlinee.IsNonVersionable());
                         continue;
                     }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -310,6 +310,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
                 case TypeFlags.Enum:
+                    if (typeDesc == PrimitiveTypeProvider.GetPrimitiveType(typeDesc.Context, PrimitiveTypeCode.TypedReference))
+                    {
+                        EmitElementType(CorElementType.ELEMENT_TYPE_TYPEDBYREF);
+                        return;
+                    }
+
                     {
                         ModuleToken token = context.GetModuleTokenForType((EcmaType)typeDesc);
                         EmitModuleOverride(token.Module, context);
@@ -345,10 +351,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             EmitModuleOverride(targetModule, context);
             EmitElementType(CorElementType.ELEMENT_TYPE_GENERICINST);
             EmitTypeSignature(type.GetTypeDefinition(), context.InnerContext(targetModule));
+            SignatureContext outerContext = context.OuterContext;
             EmitUInt((uint)type.Instantiation.Length);
             for (int paramIndex = 0; paramIndex < type.Instantiation.Length; paramIndex++)
             {
-                EmitTypeSignature(type.Instantiation[paramIndex], context);
+                EmitTypeSignature(type.Instantiation[paramIndex], outerContext);
             }
         }
 
@@ -530,9 +537,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 Instantiation instantiation = method.Method.Instantiation;
                 EmitUInt((uint)instantiation.Length);
+                SignatureContext outerContext = context.OuterContext;
                 for (int typeParamIndex = 0; typeParamIndex < instantiation.Length; typeParamIndex++)
                 {
-                    EmitTypeSignature(instantiation[typeParamIndex], context);
+                    EmitTypeSignature(instantiation[typeParamIndex], outerContext);
                 }
             }
         }
@@ -616,7 +624,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 EmitByte((byte)(fixupKind | ReadyToRunFixupKind.ModuleOverride));
                 EmitUInt((uint)factory.ManifestMetadataTable.ModuleToIndex(targetModule));
-                return outerContext.InnerContext(targetModule);
+                return new SignatureContext(targetModule, outerContext.Resolver);
             }
         }
     }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -310,7 +310,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TypeFlags.ValueType:
                 case TypeFlags.Nullable:
                 case TypeFlags.Enum:
-                    if (typeDesc == PrimitiveTypeProvider.GetPrimitiveType(typeDesc.Context, PrimitiveTypeCode.TypedReference))
+                    if (typeDesc.IsWellKnownType(WellKnownType.TypedReference))
                     {
                         EmitElementType(CorElementType.ELEMENT_TYPE_TYPEDBYREF);
                         return;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -55,8 +55,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public EcmaModule GetTargetModule(TypeDesc type)
         {
-            if (type.IsPrimitive || type.IsString || type.IsObject
-                || type.IsByRefLike && type == PrimitiveTypeProvider.GetPrimitiveType(type.Context, PrimitiveTypeCode.TypedReference))
+            if (type.IsPrimitive || type.IsString || type.IsObject || type.IsWellKnownType(WellKnownType.TypedReference))
             {
                 return LocalContext;
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -32,6 +32,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// </summary>
         public readonly ModuleTokenResolver Resolver;
 
+        public SignatureContext OuterContext => new SignatureContext(GlobalContext, Resolver);
+
         public SignatureContext(EcmaModule context, ModuleTokenResolver resolver)
         {
             GlobalContext = context;
@@ -53,7 +55,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public EcmaModule GetTargetModule(TypeDesc type)
         {
-            if (type.IsPrimitive || type.IsString || type.IsObject)
+            if (type.IsPrimitive || type.IsString || type.IsObject
+                || type.IsByRefLike && type == PrimitiveTypeProvider.GetPrimitiveType(type.Context, PrimitiveTypeCode.TypedReference))
             {
                 return LocalContext;
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/MethodExtensions.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/MethodExtensions.cs
@@ -33,5 +33,17 @@ namespace ILCompiler
 
             return method.HasCustomAttribute("System.Runtime.InteropServices", "SuppressGCTransitionAttribute");
         }
+
+        /// <summary>
+        /// Return true when the method is marked as non-versionable. Non-versionable methods
+        /// may be freely inlined into ReadyToRun images even when they don't reside in the
+        /// same version bubble as the module being compiled.
+        /// </summary>
+        /// <param name="method">Method to check</param>
+        /// <returns>True when the method is marked as non-versionable, false otherwise.</returns>
+        public static bool IsNonVersionable(this MethodDesc method)
+        {
+            return method.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute");
+        }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -153,8 +153,7 @@ namespace ILCompiler
             // (because otherwise we may not be able to encode its tokens)
             // and if the callee is either in the same version bubble or is marked as non-versionable.
             bool canInline = VersionsWithMethodBody(callerMethod) &&
-                (VersionsWithMethodBody(calleeMethod) ||
-                    calleeMethod.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute"));
+                (VersionsWithMethodBody(calleeMethod) || calleeMethod.IsNonVersionable());
 
             return canInline;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2061,7 +2061,7 @@ namespace Internal.JitInterface
                 }
 
                 // Valuetypes with non-versionable attribute are candidates for fixed layout. Reject the rest.
-                return type is MetadataType metadataType && metadataType.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute");
+                return type is MetadataType metadataType && metadataType.IsNonVersionable();
             }
 
             return true;

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -44,6 +44,8 @@ namespace ILCompiler
 
         public string[] CodegenOptions { get; set; }
 
+        public bool CompositeOrInputBubble => Composite || InputBubble;
+
         public static Command RootCommand()
         {
             // For some reason, arity caps at 255 by default

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -81,7 +81,7 @@ namespace ILCompiler
 
             if (_commandLineOptions.CompileBubbleGenerics)
             {
-                if (!_commandLineOptions.InputBubble)
+                if (!_commandLineOptions.CompositeOrInputBubble)
                 {
                     Console.WriteLine(SR.WarningIgnoringBubbleGenerics);
                     _commandLineOptions.CompileBubbleGenerics = false;
@@ -223,7 +223,7 @@ namespace ILCompiler
                         rootingModules.Add(module);
                         versionBubbleModulesHash.Add(module);
 
-                        if (!_commandLineOptions.InputBubble)
+                        if (!_commandLineOptions.CompositeOrInputBubble)
                         {
                             break;
                         }
@@ -335,9 +335,12 @@ namespace ILCompiler
                         // For non-single-method compilations add compilation roots.
                         foreach (var module in rootingModules)
                         {
-                            compilationRoots.Add(new ReadyToRunRootProvider(module, profileDataManager, _commandLineOptions.Partial));
+                            compilationRoots.Add(new ReadyToRunRootProvider(
+                                module,
+                                profileDataManager,
+                                profileDrivenPartialNGen: _commandLineOptions.Partial));
 
-                            if (!_commandLineOptions.InputBubble)
+                            if (!_commandLineOptions.CompositeOrInputBubble)
                             {
                                 break;
                             }


### PR DESCRIPTION
These changes involve targeted fixes to issues seen due to the new
build mode and generic signature encoding fixes identified in
my offline investigation with JanV. While I locally see the tests
passing with just a handful of failures, I still seem unable to
make the tests run in the lab; I keep investigating that but
I believe it's useful to merge this delta in to let us parallelize
follow-up efforts.

Thanks

Tomas