### PR TITLE
CoreCLR runtime fixes for composite R2R build with shared framework

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -536,7 +536,7 @@ namespace ILCompiler.DependencyAnalysis
 
             AssemblyTableNode assemblyTable = null;
 
-            if (CompilationModuleGroup.CompilationModuleSet.Skip(1).Any())
+            if (CompilationModuleGroup.IsCompositeBuildMode)
             {
                 assemblyTable = new AssemblyTableNode(Target);
                 Header.Add(Internal.Runtime.ReadyToRunSectionType.ComponentAssemblies, assemblyTable, assemblyTable);

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -413,7 +413,7 @@ namespace R2RDump
                         MetadataReader globalReader = _r2r.GetGlobalMetadataReader();
                         assemblyRefCount = globalReader.GetTableRowCount(TableIndex.AssemblyRef) + 1;
                         _writer.WriteLine($"MSIL AssemblyRef's ({assemblyRefCount} entries):");
-                        for (int assemblyRefIndex = 1; assemblyRefIndex <= assemblyRefCount; assemblyRefIndex++)
+                        for (int assemblyRefIndex = 1; assemblyRefIndex < assemblyRefCount; assemblyRefIndex++)
                         {
                             AssemblyReference assemblyRef = globalReader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(assemblyRefIndex));
                             string assemblyRefName = globalReader.GetString(assemblyRef.Name);

--- a/src/coreclr/src/vm/jithelpers.cpp
+++ b/src/coreclr/src/vm/jithelpers.cpp
@@ -3231,7 +3231,7 @@ CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc * pMD, MethodTable * p
 #ifdef _DEBUG
             // Only in R2R mode are the module, dictionary index and dictionary slot provided as an input
             _ASSERTE(dictionaryIndexAndSlot != (DWORD)-1);
-            _ASSERT(ExecutionManager::FindReadyToRunModule(dac_cast<TADDR>(signature)) == pModule);
+            _ASSERT(ReadyToRunInfo::IsNativeImageSharedBy(pModule, ExecutionManager::FindReadyToRunModule(dac_cast<TADDR>(signature))));
 #endif
             dictionaryIndex = (dictionaryIndexAndSlot >> 16);
         }

--- a/src/coreclr/src/vm/nativeimage.cpp
+++ b/src/coreclr/src/vm/nativeimage.cpp
@@ -53,7 +53,7 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 
     m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
-    m_componentAssemblyCount = (m_pComponentAssemblies != NULL ? m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY) : 1);
+    m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
     
     // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
     m_pManifestMetadata = LoadManifestMetadata();
@@ -130,11 +130,6 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
 {
     STANDARD_VM_CONTRACT;
 
-    if (m_componentAssemblyCount == 1)
-    {
-        return dac_cast<PTR_READYTORUN_CORE_HEADER>(&m_pReadyToRunInfo->GetReadyToRunHeader()->CoreHeader);
-    }
-
     const AssemblyNameIndex *assemblyNameIndex = m_assemblySimpleNameToIndexMap.LookupPtr(simpleName);
     if (assemblyNameIndex != NULL)
     {
@@ -143,7 +138,6 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
             (const READYTORUN_COMPONENT_ASSEMBLIES_ENTRY *)&pImageBase[m_pComponentAssemblies->VirtualAddress] + assemblyNameIndex->Index;
         return (PTR_READYTORUN_CORE_HEADER)&pImageBase[componentAssembly->ReadyToRunCoreHeader.VirtualAddress];
     }
-
     return NULL;
 }
 #endif

--- a/src/coreclr/src/vm/nativeimage.cpp
+++ b/src/coreclr/src/vm/nativeimage.cpp
@@ -53,7 +53,7 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 
     m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
-    m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
+    m_componentAssemblyCount = (m_pComponentAssemblies != NULL ? m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY) : 1);
     
     // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
     m_pManifestMetadata = LoadManifestMetadata();
@@ -130,6 +130,11 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
 {
     STANDARD_VM_CONTRACT;
 
+    if (m_componentAssemblyCount == 1)
+    {
+        return dac_cast<PTR_READYTORUN_CORE_HEADER>(&m_pReadyToRunInfo->GetReadyToRunHeader()->CoreHeader);
+    }
+
     const AssemblyNameIndex *assemblyNameIndex = m_assemblySimpleNameToIndexMap.LookupPtr(simpleName);
     if (assemblyNameIndex != NULL)
     {
@@ -138,6 +143,7 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
             (const READYTORUN_COMPONENT_ASSEMBLIES_ENTRY *)&pImageBase[m_pComponentAssemblies->VirtualAddress] + assemblyNameIndex->Index;
         return (PTR_READYTORUN_CORE_HEADER)&pImageBase[componentAssembly->ReadyToRunCoreHeader.VirtualAddress];
     }
+
     return NULL;
 }
 #endif

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -711,7 +711,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 4.1 and later, there is an optional inlining table
-    if (pModule != NULL && IsImageVersionAtLeast(4, 1))
+    if (IsImageVersionAtLeast(4, 1))
     {
         IMAGE_DATA_DIRECTORY* pInlineTrackingInfoDir = m_component.FindSection(ReadyToRunSectionType::InliningInfo2);
         if (pInlineTrackingInfoDir != NULL)
@@ -723,7 +723,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 2.1 and later, there is an optional inlining table
-    if (pModule != NULL && m_pPersistentInlineTrackingMap == nullptr && IsImageVersionAtLeast(2, 1))
+    if (m_pPersistentInlineTrackingMap == nullptr && IsImageVersionAtLeast(2, 1))
     {
         IMAGE_DATA_DIRECTORY * pInlineTrackingInfoDir = m_component.FindSection(ReadyToRunSectionType::InliningInfo);
         if (pInlineTrackingInfoDir != NULL)
@@ -735,7 +735,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 2.2 and later, there is an optional profile-data section
-    if (pModule != NULL && IsImageVersionAtLeast(2, 2))
+    if (IsImageVersionAtLeast(2, 2))
     {
         IMAGE_DATA_DIRECTORY * pProfileDataInfoDir = m_pComposite->FindSection(ReadyToRunSectionType::ProfileDataInfo);
         if (pProfileDataInfoDir != NULL)
@@ -748,19 +748,16 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 3.1 and later, there is an optional attributes section
-    if (pModule != NULL)
+    IMAGE_DATA_DIRECTORY *attributesPresenceDataInfoDir = m_component.FindSection(ReadyToRunSectionType::AttributePresence);
+    if (attributesPresenceDataInfoDir != NULL)
     {
-        IMAGE_DATA_DIRECTORY *attributesPresenceDataInfoDir = m_component.FindSection(ReadyToRunSectionType::AttributePresence);
-        if (attributesPresenceDataInfoDir != NULL)
-        {
-            NativeCuckooFilter newFilter(
-                (BYTE *)m_pComposite->GetLayout()->GetBase(),
-                m_pComposite->GetLayout()->GetVirtualSize(),
-                attributesPresenceDataInfoDir->VirtualAddress,
-                attributesPresenceDataInfoDir->Size);
-    
-            m_attributesPresence = newFilter;
-        }
+        NativeCuckooFilter newFilter(
+            (BYTE *)m_pComposite->GetLayout()->GetBase(),
+            m_pComposite->GetLayout()->GetVirtualSize(),
+            attributesPresenceDataInfoDir->VirtualAddress,
+            attributesPresenceDataInfoDir->Size);
+
+        m_attributesPresence = newFilter;
     }
 }
 

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -618,6 +618,11 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     return new (pMemory) ReadyToRunInfo(pModule, pLayout, pHeader, nativeImage, pamTracker);
 }
 
+bool ReadyToRunInfo::IsNativeImageSharedBy(PTR_Module pModule1, PTR_Module pModule2)
+{
+    return pModule1->GetReadyToRunInfo()->m_pComposite == pModule2->GetReadyToRunInfo()->m_pComposite;
+}
+
 ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYTORUN_HEADER * pHeader, NativeImage *pNativeImage, AllocMemTracker *pamTracker)
     : m_pModule(pModule),
     m_pHeader(pHeader),
@@ -706,9 +711,9 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 4.1 and later, there is an optional inlining table
-    if (IsImageVersionAtLeast(4, 1))
+    if (pModule != NULL && IsImageVersionAtLeast(4, 1))
     {
-        IMAGE_DATA_DIRECTORY* pInlineTrackingInfoDir = m_pComposite->FindSection(ReadyToRunSectionType::InliningInfo2);
+        IMAGE_DATA_DIRECTORY* pInlineTrackingInfoDir = m_component.FindSection(ReadyToRunSectionType::InliningInfo2);
         if (pInlineTrackingInfoDir != NULL)
         {
             const BYTE* pInlineTrackingMapData = (const BYTE*)m_pComposite->GetImage()->GetDirectoryData(pInlineTrackingInfoDir);
@@ -718,9 +723,9 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 2.1 and later, there is an optional inlining table
-    if (m_pPersistentInlineTrackingMap == nullptr && IsImageVersionAtLeast(2, 1))
+    if (pModule != NULL && m_pPersistentInlineTrackingMap == nullptr && IsImageVersionAtLeast(2, 1))
     {
-        IMAGE_DATA_DIRECTORY * pInlineTrackingInfoDir = m_pComposite->FindSection(ReadyToRunSectionType::InliningInfo);
+        IMAGE_DATA_DIRECTORY * pInlineTrackingInfoDir = m_component.FindSection(ReadyToRunSectionType::InliningInfo);
         if (pInlineTrackingInfoDir != NULL)
         {
             const BYTE* pInlineTrackingMapData = (const BYTE*)m_pComposite->GetImage()->GetDirectoryData(pInlineTrackingInfoDir);
@@ -730,7 +735,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 2.2 and later, there is an optional profile-data section
-    if (IsImageVersionAtLeast(2, 2))
+    if (pModule != NULL && IsImageVersionAtLeast(2, 2))
     {
         IMAGE_DATA_DIRECTORY * pProfileDataInfoDir = m_pComposite->FindSection(ReadyToRunSectionType::ProfileDataInfo);
         if (pProfileDataInfoDir != NULL)
@@ -743,16 +748,19 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYT
     }
 
     // For format version 3.1 and later, there is an optional attributes section
-    IMAGE_DATA_DIRECTORY *attributesPresenceDataInfoDir = m_component.FindSection(ReadyToRunSectionType::AttributePresence);
-    if (attributesPresenceDataInfoDir != NULL)
+    if (pModule != NULL)
     {
-        NativeCuckooFilter newFilter(
-            (BYTE *)m_pComposite->GetLayout()->GetBase(),
-            m_pComposite->GetLayout()->GetVirtualSize(),
-            attributesPresenceDataInfoDir->VirtualAddress,
-            attributesPresenceDataInfoDir->Size);
-
-        m_attributesPresence = newFilter;
+        IMAGE_DATA_DIRECTORY *attributesPresenceDataInfoDir = m_component.FindSection(ReadyToRunSectionType::AttributePresence);
+        if (attributesPresenceDataInfoDir != NULL)
+        {
+            NativeCuckooFilter newFilter(
+                (BYTE *)m_pComposite->GetLayout()->GetBase(),
+                m_pComposite->GetLayout()->GetVirtualSize(),
+                attributesPresenceDataInfoDir->VirtualAddress,
+                attributesPresenceDataInfoDir->Size);
+    
+            m_attributesPresence = newFilter;
+        }
     }
 }
 

--- a/src/coreclr/src/vm/readytoruninfo.h
+++ b/src/coreclr/src/vm/readytoruninfo.h
@@ -88,6 +88,8 @@ public:
 
     bool IsComponentAssembly() const { return m_isComponentAssembly; }
 
+    static bool IsNativeImageSharedBy(PTR_Module pModule1, PTR_Module pModule2);
+
     PTR_READYTORUN_HEADER GetReadyToRunHeader() const { return m_pHeader; }
 
     PTR_NativeImage GetNativeImage() const { return m_pNativeImage; }


### PR DESCRIPTION
In jithelpers, switch the query over to use a ReadyToRunInfo method
to make it work in composite mode. Other than that these are mostly
tiny fixes for the special case of composite image with just 1
assembly where we don't have the component assembly table and a few
things must collapse.

Thanks

Tomas