### PR TITLE
[mono] Don't build System.Utf8String.Experimental.Tests.csproj tests for mono

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -6,6 +6,10 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'"> 
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)\System.Utf8String.Experimental\tests\System.Utf8String.Experimental.Tests.csproj" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(EnableCoverageSupport)' == 'true'">
     <CoverageReportInputPath>$(ArtifactsBinDir)*.Tests/**/coverage.xml</CoverageReportInputPath>
     <CoverageReportDir>$(ArtifactsDir)coverage</CoverageReportDir>


### PR DESCRIPTION
It fails when we build repo with `--subsetCategory mono-libraries`

`System.Utf8String.Experimental.csproj` was already disabled:
https://github.com/dotnet/runtime/blob/master/src/libraries/src.builds#L5