### PR TITLE
Fix ordering of the instructions

### DIFF
--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -12,11 +12,11 @@ git pull upstream master & git push origin master
 build -subsetCategory coreclr-libraries -runtimeConfiguration Release
 :: The above you may only perform once in a day, or when you pull down significant new changes.
 
-:: Switch to working on a given library (RegularExpressions in this case)
-cd src\libraries\System.Text.RegularExpressions
-
 :: If you use Visual Studio, you might open System.Text.RegularExpressions.sln here.
 build -vs System.Text.RegularExpressions
+
+:: Switch to working on a given library (RegularExpressions in this case)
+cd src\libraries\System.Text.RegularExpressions
 
 :: Change to test directory
 cd tests


### PR DESCRIPTION
Command for opening Visual Studio works from root folder,
but not inside library folder as was implied by ordering in the instructions.