### PR TITLE
Fixed bug in shell scripts used to run tests.

### DIFF
--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -49,9 +49,10 @@ if [ ! -z ${RunCrossGen+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
-          echo $__Command
-          $__Command
+	  # Note, __Command contains NOT expanded variables, which should be expanded via eval.
+          __Command='$_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll'
+          eval QuoteSpaces $__Command
+          eval $__Command
           __cgExitCode=$?
           if [ $__cgExitCode -ne 0 ]
           then
@@ -71,9 +72,10 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/crossgen2/crossgen2.dll" -r:$CORE_ROOT/System.*.dll -r:$CORE_ROOT/Microsoft.*.dll -r:$CORE_ROOT/mscorlib.dll -r:$CORE_ROOT/netstandard.dll -r:$PWD/*.dll --targetarch=x64 -O --inputbubble $ExtraCrossGen2Args -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
-          echo $__Command
-          $__Command
+	  # Note, __Command contains NOT expanded variables, which should be expanded via eval.
+          __Command='$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/crossgen2/crossgen2.dll" -r:$CORE_ROOT/System.*.dll -r:$CORE_ROOT/Microsoft.*.dll -r:$CORE_ROOT/mscorlib.dll -r:$CORE_ROOT/netstandard.dll -r:$PWD/*.dll -O --inputbubble $ExtraCrossGen2Args -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org'
+          eval QuoteSpaces $__Command
+          eval $__Command
           __cg2ExitCode=$?
           if [ $__cg2ExitCode -ne 0 ]
           then

--- a/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
+++ b/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
@@ -371,6 +371,22 @@ ReleaseLock()
         return 3
     fi
 }
+
+# This function prints given arguments in single line,
+# arguments containing spaces (and newlines) will be enclosed in double quotes.
+# Note, this function doesn't perform escaping of double quote of other
+# special symbols.
+QuoteSpaces()
+{
+    local each nargs=$# q='"'
+    for each in "$@"; do
+        set -- "$@" "%24(set -- $each; test $# -gt 1 && cat <<< $q$*$q || cat <<< $*)"
+    done
+    shift $nargs
+    cat <<< $*
+}
+
+
 cd "$%28dirname "${BASH_SOURCE[0]}")"
 LockFile="lock"
 


### PR DESCRIPTION
This commit fixes following two issues in file src/coreclr/tests/src/CLRTest.CrossGen.targets.

Also this commit address the issue #34345

First issue is that command line passed to crossgen2 includes
"--targetarch=x64", and because of that script, which runs a tests,
might be executed only on x64 platform. I think this is not right,
and the architecture should be determined by crossgen2 itself,
this allows us to run the tests on arm.

Second issue exists, because in unix shell (bash) programming language
variable assignment expression is interpreted until first space, not
like in a windows bactch language where all symbols till end of line
is assigned to a variable (in expressions like "set x=1 2 3....")

So, assigments like following:

  __Command=string string string...

should be replaced with:

  __Command='string string...'

But in latter case variables expansion in single quotes will not be
performed, so we need expand vaiables later, using "eval" expression.

We can't just use double quotes instead, because the string which is
assigned already contains double quotes which should be properly
escaped. But we can't escape double quotes with backslash symbol because
template system, which generates the scripts (this is separate issue)
replaces all backslashes (\) with slashes (/). Because of this trick
with "eval" expression is used.

Practically,  before this commit, __Command variable is assigned
with a value of _DebuggerFullPath variable. And rest of the string,
after first space, will be interpreted as a command, which will be
executed by bash. As a result, "echo" on next line prints wrong result.
And what is more critical, __cgExitCode will be always 0 (because
it will contain exit code of the "echo" command, but not the result
of the command executed on previous line).

Another nuance is that output of the echo command hard to interpret, if
result of variable expansion on previous line includes spaces
(for example, we can't distinguish between cases when file path
contains spaces or this is two ditinct arguments separated by
spaces). Because of this I have added QuoteSpaces function, which
printes all arguments containing spaces withing double quotes.