### PR TITLE
Improve System.Numerics.Matrix3x2 and Matrix4x4 hash codes

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
@@ -528,9 +528,9 @@ namespace System.Numerics.Tests
         public void Matrix3x2GetHashCodeTest()
         {
             Matrix3x2 target = GenerateIncrementalMatrixNumber();
-            int expected = unchecked(target.M11.GetHashCode() + target.M12.GetHashCode() +
-                                     target.M21.GetHashCode() + target.M22.GetHashCode() +
-                                     target.M31.GetHashCode() + target.M32.GetHashCode());
+            int expected = HashCode.Combine(target.M11.GetHashCode(), target.M12.GetHashCode(),
+                                     target.M21.GetHashCode(), target.M22.GetHashCode(),
+                                     target.M31.GetHashCode(), target.M32.GetHashCode());
             int actual;
 
             actual = target.GetHashCode();

--- a/src/libraries/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix3x2Tests.cs
@@ -528,9 +528,9 @@ namespace System.Numerics.Tests
         public void Matrix3x2GetHashCodeTest()
         {
             Matrix3x2 target = GenerateIncrementalMatrixNumber();
-            int expected = HashCode.Combine(target.M11.GetHashCode(), target.M12.GetHashCode(),
-                                     target.M21.GetHashCode(), target.M22.GetHashCode(),
-                                     target.M31.GetHashCode(), target.M32.GetHashCode());
+            int expected = HashCode.Combine(target.M11, target.M12,
+                                     target.M21, target.M22,
+                                     target.M31, target.M32);
             int actual;
 
             actual = target.GetHashCode();

--- a/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -1593,15 +1593,32 @@ namespace System.Numerics.Tests
         public void Matrix4x4GetHashCodeTest()
         {
             Matrix4x4 target = GenerateIncrementalMatrixNumber();
-            int expected = HashCode.Combine(HashCode.Combine(
-                    target.M11.GetHashCode(), target.M12.GetHashCode(), target.M13.GetHashCode(), target.M14.GetHashCode(),
-                    target.M21.GetHashCode(), target.M22.GetHashCode(), target.M23.GetHashCode(), target.M24.GetHashCode()),
-                HashCode.Combine(
-                    target.M31.GetHashCode(), target.M32.GetHashCode(), target.M33.GetHashCode(), target.M34.GetHashCode(),
-                    target.M41.GetHashCode(), target.M42.GetHashCode(), target.M43.GetHashCode(), target.M44.GetHashCode()));
-            int actual;
 
-            actual = target.GetHashCode();
+            var hash = new HashCode();
+
+            hash.Add(target.M11);
+            hash.Add(target.M12);
+            hash.Add(target.M13);
+            hash.Add(target.M14);
+
+            hash.Add(target.M21);
+            hash.Add(target.M22);
+            hash.Add(target.M23);
+            hash.Add(target.M24);
+
+            hash.Add(target.M31);
+            hash.Add(target.M32);
+            hash.Add(target.M33);
+            hash.Add(target.M34);
+
+            hash.Add(target.M41);
+            hash.Add(target.M42);
+            hash.Add(target.M43);
+            hash.Add(target.M44);
+
+            int expected = hash.ToHashCode();
+            int actual = target.GetHashCode();
+
             Assert.Equal(expected, actual);
         }
 

--- a/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -1593,11 +1593,12 @@ namespace System.Numerics.Tests
         public void Matrix4x4GetHashCodeTest()
         {
             Matrix4x4 target = GenerateIncrementalMatrixNumber();
-            int expected = unchecked(
-                target.M11.GetHashCode() + target.M12.GetHashCode() + target.M13.GetHashCode() + target.M14.GetHashCode() +
-                target.M21.GetHashCode() + target.M22.GetHashCode() + target.M23.GetHashCode() + target.M24.GetHashCode() +
-                target.M31.GetHashCode() + target.M32.GetHashCode() + target.M33.GetHashCode() + target.M34.GetHashCode() +
-                target.M41.GetHashCode() + target.M42.GetHashCode() + target.M43.GetHashCode() + target.M44.GetHashCode());
+            int expected = HashCode.Combine(HashCode.Combine(
+                    target.M11.GetHashCode(), target.M12.GetHashCode(), target.M13.GetHashCode(), target.M14.GetHashCode(),
+                    target.M21.GetHashCode(), target.M22.GetHashCode(), target.M23.GetHashCode(), target.M24.GetHashCode()),
+                HashCode.Combine(
+                    target.M31.GetHashCode(), target.M32.GetHashCode(), target.M33.GetHashCode(), target.M34.GetHashCode(),
+                    target.M41.GetHashCode(), target.M42.GetHashCode(), target.M43.GetHashCode(), target.M44.GetHashCode()));
             int actual;
 
             actual = target.GetHashCode();

--- a/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -1594,7 +1594,7 @@ namespace System.Numerics.Tests
         {
             Matrix4x4 target = GenerateIncrementalMatrixNumber();
 
-            var hash = new HashCode();
+            HashCode hash = default;
 
             hash.Add(target.M11);
             hash.Add(target.M12);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
@@ -799,10 +799,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return HashCode.Combine(
-                M11.GetHashCode(), M12.GetHashCode(),
-                M21.GetHashCode(), M22.GetHashCode(),
-                M31.GetHashCode(), M32.GetHashCode());
+            return HashCode.Combine(M11, M12, M21, M22, M31, M32);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
@@ -799,9 +799,10 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return unchecked(M11.GetHashCode() + M12.GetHashCode() +
-                             M21.GetHashCode() + M22.GetHashCode() +
-                             M31.GetHashCode() + M32.GetHashCode());
+            return HashCode.Combine(
+                M11.GetHashCode(), M12.GetHashCode(),
+                M21.GetHashCode(), M22.GetHashCode(),
+                M31.GetHashCode(), M32.GetHashCode());
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -2196,7 +2196,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            var hash = new HashCode();
+            HashCode hash = default;
 
             hash.Add(M11);
             hash.Add(M12);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -2196,13 +2196,12 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            unchecked
-            {
-                return M11.GetHashCode() + M12.GetHashCode() + M13.GetHashCode() + M14.GetHashCode() +
-                       M21.GetHashCode() + M22.GetHashCode() + M23.GetHashCode() + M24.GetHashCode() +
-                       M31.GetHashCode() + M32.GetHashCode() + M33.GetHashCode() + M34.GetHashCode() +
-                       M41.GetHashCode() + M42.GetHashCode() + M43.GetHashCode() + M44.GetHashCode();
-            }
+            return HashCode.Combine(HashCode.Combine(
+                    M11.GetHashCode(), M12.GetHashCode(), M13.GetHashCode(), M14.GetHashCode(),
+                    M21.GetHashCode(), M22.GetHashCode(), M23.GetHashCode(), M24.GetHashCode()),
+                HashCode.Combine(
+                    M31.GetHashCode(), M32.GetHashCode(), M33.GetHashCode(), M34.GetHashCode(),
+                    M41.GetHashCode(), M42.GetHashCode(), M43.GetHashCode(), M44.GetHashCode()));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -2196,12 +2196,29 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return HashCode.Combine(HashCode.Combine(
-                    M11.GetHashCode(), M12.GetHashCode(), M13.GetHashCode(), M14.GetHashCode(),
-                    M21.GetHashCode(), M22.GetHashCode(), M23.GetHashCode(), M24.GetHashCode()),
-                HashCode.Combine(
-                    M31.GetHashCode(), M32.GetHashCode(), M33.GetHashCode(), M34.GetHashCode(),
-                    M41.GetHashCode(), M42.GetHashCode(), M43.GetHashCode(), M44.GetHashCode()));
+            var hash = new HashCode();
+
+            hash.Add(M11);
+            hash.Add(M12);
+            hash.Add(M13);
+            hash.Add(M14);
+
+            hash.Add(M21);
+            hash.Add(M22);
+            hash.Add(M23);
+            hash.Add(M24);
+
+            hash.Add(M31);
+            hash.Add(M32);
+            hash.Add(M33);
+            hash.Add(M34);
+
+            hash.Add(M41);
+            hash.Add(M42);
+            hash.Add(M43);
+            hash.Add(M44);
+
+            return hash.ToHashCode();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -54,7 +54,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return HashCode.Combine(this.X.GetHashCode(), this.Y.GetHashCode());
+            return HashCode.Combine(this.X, this.Y);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -59,7 +59,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return HashCode.Combine(this.X.GetHashCode(), this.Y.GetHashCode(), this.Z.GetHashCode());
+            return HashCode.Combine(this.X, this.Y, this.Z);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -62,7 +62,7 @@ namespace System.Numerics
         /// <returns>The hash code.</returns>
         public override readonly int GetHashCode()
         {
-            return HashCode.Combine(this.X.GetHashCode(), this.Y.GetHashCode(), this.Z.GetHashCode(), this.W.GetHashCode());
+            return HashCode.Combine(this.X, this.Y, this.Z, this.W);
         }
 
         /// <summary>


### PR DESCRIPTION
Used `System.HashCode` type to construct the final hash

Fixes #20308

Please review
Thank you in advance