### PR TITLE
[mono] fix iOS sample

### DIFF
--- a/src/mono/netcore/sample/iOS/CMakeLists.txt
+++ b/src/mono/netcore/sample/iOS/CMakeLists.txt
@@ -4,9 +4,11 @@ project(HelloiOS)
 
 file(GLOB DLLS *.dll)
 file(GLOB DLLS_AOT *.dll.o)
+file(GLOB DLLS_PDB *.pdb)
 
 set(APP_RESOURCES
     ${DLLS}
+    ${DLLS_PDB}
 )
 
 add_executable(

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -23,24 +23,28 @@ BCL_LIBS = \
 	Microsoft.Win32.Primitives.dll \
 	System.Console.dll
 
+all: mono-libraries aot-all xcode 
+
+# rebuild mono and libraries for iOS and arm64 or x64
+mono-libraries:
+	../../../../.././build.sh -os iOS -arch $(MONO_ARCH) --subsetCategory mono-libraries
+
 # once a new library is added here it should also be 
 # added in mono_ios_register_modules() (runtime.m)
-all: prepare
+aot-all: prepare
 	make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_MONO)/System.Private.CoreLib.dll
 	for lib in $(BCL_LIBS); do make aot-lib-${MONO_ARCH} LIB=$(ARTIFACTS_BCL)/$$lib; done
-	make Program.dll.o
+	make aot-program
 
 # recompile Program.cs AOT
-Program.dll.o: bin/Program.dll Makefile
+aot-program:
+	$(DOTNET) build -c Debug Program.csproj
 	make aot-lib-${MONO_ARCH} LIB=bin/Program.dll
 
 # we need to copy some BCL libs to ARTIFACTS_MONO
 # to be able to aot other bcl libs
 prepare:
 	for lib in $(BCL_LIBS); do cp $(ARTIFACTS_BCL)/$$lib $(ARTIFACTS_MONO); done
-
-bin/Program.dll: Program.cs
-	$(DOTNET) build -c Debug Program.csproj
 
 # we'll use regular jit for simulator
 aot-lib-x64:
@@ -54,7 +58,7 @@ aot-lib-arm64:
 	cp $(LIB) $(notdir $(LIB))
 
 # generate an xcode project
-xcode: all
+xcode:
 	cmake -S. -BXcode -GXcode \
 	-DCMAKE_SYSTEM_NAME=iOS \
 	"-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \

--- a/src/mono/netcore/sample/iOS/runtime.m
+++ b/src/mono/netcore/sample/iOS/runtime.m
@@ -12,6 +12,11 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 
+// no-op for iOS and tvOS.
+// watchOS is not supported yet.
+#define MONO_ENTER_GC_UNSAFE
+#define MONO_EXIT_GC_UNSAFE
+
 static os_log_t stdout_log;
 
 static char *bundle_path;


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/34405 seems broke it.
Also reorganize some rules in Makefile for consistency.

```
cd src/mono/netcore/sample/ios
make MONO_ARCH=arm64
```
should make everything including global build for iOS.