### PR TITLE
Fix two issues detected by Valgrind

### DIFF
--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -1539,6 +1539,8 @@ Thread::Thread()
     m_DeserializationTracker = NULL;
 
     m_currentPrepareCodeConfig = nullptr;
+
+    memset(dangerousObjRefs, 0, sizeof(dangerousObjRefs));
 }
 
 //--------------------------------------------------------------------

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -1540,7 +1540,9 @@ Thread::Thread()
 
     m_currentPrepareCodeConfig = nullptr;
 
+#ifdef _DEBUG
     memset(dangerousObjRefs, 0, sizeof(dangerousObjRefs));
+#endif // _DEBUG
 }
 
 //--------------------------------------------------------------------

--- a/src/coreclr/src/vm/win32threadpool.cpp
+++ b/src/coreclr/src/vm/win32threadpool.cpp
@@ -4119,6 +4119,8 @@ DWORD WINAPI ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
     GetCPUBusyTime_NT(&prevCPUInfo);
 #else // !TARGET_UNIX
     PAL_IOCP_CPU_INFORMATION prevCPUInfo;
+    memset(&prevCPUInfo, 0, sizeof(prevCPUInfo));
+
     GetCPUBusyTime_NT(&prevCPUInfo);                  // ignore return value the first time
 #endif // !TARGET_UNIX
 


### PR DESCRIPTION
When I have used Valgrind to investigate a memory corruption issue recently,
I've noticed that it has also reported two cases when a conditional jump
was using an uninitialized variable as one of the inputs to the condition.

This change fixes these.