### PR TITLE
Total digits invalid cast exception

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
@@ -309,7 +309,7 @@ namespace System.Xml.Schema
 
                 if ((_baseFixedFlags & RestrictionFlags.TotalDigits) != 0)
                 {
-                    if (!_datatype.IsEqual(_datatype.Restriction.TotalDigits, _derivedRestriction.TotalDigits))
+                    if (_datatype.Restriction.TotalDigits != _derivedRestriction.TotalDigits)
                     {
                         throw new XmlSchemaException(SR.Sch_FacetBaseFixed, facet);
                     }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -178,7 +178,6 @@ namespace System.Xml.Tests
             Assert.DoesNotContain("totalDigits", ex.Message);
         }
 
-
         [Fact]
         public void MinLengthLtBaseMinLength_Throws()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -151,6 +151,7 @@ namespace System.Xml.Tests
             }
         }
 
+
         [Fact]
         public void FractionDigitsMismatch_Throws()
         {
@@ -177,6 +178,7 @@ namespace System.Xml.Tests
             Assert.Contains("fractionDigits", ex.Message);
             Assert.DoesNotContain("totalDigits", ex.Message);
         }
+
 
         [Fact]
         public void MinLengthLtBaseMinLength_Throws()
@@ -1092,5 +1094,41 @@ namespace System.Xml.Tests
             Assert.Contains("maxOccurs", ex.Message);
         }
         #endregion
+
+        [Fact]
+        public void TotalDigitsParseValue_Succeeds()
+        {
+            string schema = @"<?xml version='1.0' encoding='utf-8' ?>
+<xs:schema elementFormDefault='qualified'
+           xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='foo'>
+        <xs:restriction base='xs:decimal'>
+            <xs:totalDigits value='8' fixed='true'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='bar'>
+        <xs:restriction base='foo'>
+            <xs:totalDigits value='8'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+";
+            XmlSchemaSet ss = new XmlSchemaSet();
+            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+
+            bool success;
+            try
+            {
+                ss.Compile();
+                success = true;
+            }
+            catch (Exception ex)
+            {
+                success = false;
+                Assert.IsNotType<InvalidCastException>(ex);
+            }
+
+            Assert.True(success);
+        }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1111,12 +1111,16 @@ namespace System.Xml.Tests
     </xs:simpleType>
 </xs:schema>
 ";
-            XmlSchemaSet ss = new XmlSchemaSet();
-            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+            using (StringReader srdr = new StringReader(schema))
+            using (XmlReader xmlrdr = XmlReader.Create(srdr))
+            {
+                XmlSchemaSet ss = new XmlSchemaSet();
 
-            ss.Compile();
+                ss.Add(null, xmlrdr);
 
-            Assert.True(true);
+                // Assert does not throw (Regression test for issue #34426)
+                ss.Compile();
+            }
         }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -151,7 +151,6 @@ namespace System.Xml.Tests
             }
         }
 
-
         [Fact]
         public void FractionDigitsMismatch_Throws()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1114,19 +1114,9 @@ namespace System.Xml.Tests
             XmlSchemaSet ss = new XmlSchemaSet();
             ss.Add(null, XmlReader.Create(new StringReader(schema)));
 
-            bool success;
-            try
-            {
-                ss.Compile();
-                success = true;
-            }
-            catch (Exception ex)
-            {
-                success = false;
-                Assert.IsNotType<InvalidCastException>(ex);
-            }
+            ss.Compile();
 
-            Assert.True(success);
+            Assert.True(true);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1094,6 +1094,7 @@ namespace System.Xml.Tests
         #endregion
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void TotalDigitsParseValue_Succeeds()
         {
             string schema = @"<?xml version='1.0' encoding='utf-8' ?>


### PR DESCRIPTION
This pull request adds the unit test from #34426, and changes the comparison of the totalDigits value to the base type's value so that it no longer casts the Int32 (the type of the TotalDigit property) to a Decimal (The .NET type underlying the XML type which uses the totalDigits facet).

fix #34426 