### PR TITLE
Prevent return address hijacking of NativeCallable method

### DIFF
--- a/src/coreclr/src/inc/eetwain.h
+++ b/src/coreclr/src/inc/eetwain.h
@@ -308,10 +308,12 @@ virtual bool IsInSynchronizedRegion(
 virtual size_t GetFunctionSize(GCInfoToken gcInfoToken) = 0;
 
 /*
-Returns the ReturnKind of a given function as reported in the GC info.
+*  Get information necessary for return address hijacking of the method represented by the gcInfoToken.
+*  If it can be hijacked, it sets the returnKind output parameter to the kind of the return value and
+*  returns true.
+*  If hijacking is not possible for some reason, it return false.
 */
-
-virtual ReturnKind GetReturnKind(GCInfoToken gcInfotoken) = 0;
+virtual bool GetReturnAddressHijackInfo(GCInfoToken gcInfoToken, ReturnKind * returnKind) = 0;
 
 #ifndef USE_GC_INFO_DECODER
 /*
@@ -585,9 +587,12 @@ virtual
 size_t GetFunctionSize(GCInfoToken gcInfoToken);
 
 /*
-Returns the ReturnKind of a given function.
+*  Get information necessary for return address hijacking of the method represented by the gcInfoToken.
+*  If it can be hijacked, it sets the returnKind output parameter to the kind of the return value and
+*  returns true.
+*  If hijacking is not possible for some reason, it return false.
 */
-virtual ReturnKind GetReturnKind(GCInfoToken gcInfotoken);
+virtual bool GetReturnAddressHijackInfo(GCInfoToken gcInfoToken, ReturnKind * returnKind);
 
 #ifndef USE_GC_INFO_DECODER
 /*

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -3412,7 +3412,7 @@ public:
 
 private:
 #ifdef FEATURE_HIJACK
-    void    HijackThread(VOID *pvHijackAddr, ExecutionState *esb);
+    void    HijackThread(ReturnKind returnKind, ExecutionState *esb);
 
     VOID        *m_pvHJRetAddr;           // original return address (before hijack)
     VOID       **m_ppvHJRetAddrPtr;       // place we bashed a new return address

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -6091,18 +6091,24 @@ BOOL Thread::HandledJITCase(BOOL ForTaskSwitchIn)
             // the method returns an object reference, so we know whether to protect
             // it or not.
             EECodeInfo codeInfo(ip);
-            VOID *pvHijackAddr = GetHijackAddr(this, &codeInfo);
+
+            GcInfoDecoder gcInfoDecoder(codeInfo.GetGCInfoToken(), DECODE_REVERSE_PINVOKE_VAR);
+
+            if (gcInfoDecoder.GetReversePInvokeFrameStackSlot() == NO_REVERSE_PINVOKE_FRAME)
+            {
+                VOID *pvHijackAddr = GetHijackAddr(this, &codeInfo);
 
 #ifdef FEATURE_ENABLE_GCPOLL
-            // On platforms that support both hijacking and GC polling
-            // decide whether to hijack based on a configuration value.
-            // COMPlus_GCPollType = 1 is the setting that enables hijacking
-            // in GCPOLL enabled builds.
-            EEConfig::GCPollType pollType = g_pConfig->GetGCPollType();
-            if (EEConfig::GCPOLL_TYPE_HIJACK == pollType || EEConfig::GCPOLL_TYPE_DEFAULT == pollType)
+                // On platforms that support both hijacking and GC polling
+                // decide whether to hijack based on a configuration value.
+                // COMPlus_GCPollType = 1 is the setting that enables hijacking
+                // in GCPOLL enabled builds.
+                EEConfig::GCPollType pollType = g_pConfig->GetGCPollType();
+                if (EEConfig::GCPOLL_TYPE_HIJACK == pollType || EEConfig::GCPOLL_TYPE_DEFAULT == pollType)
 #endif // FEATURE_ENABLE_GCPOLL
-            {
-                HijackThread(pvHijackAddr, &esb);
+                {
+                    HijackThread(pvHijackAddr, &esb);
+                }
             }
         }
     }

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -5293,7 +5293,7 @@ void Thread::HijackThread(ReturnKind returnKind, ExecutionState *esb)
 #ifdef TARGET_X86
     if (returnKind == RT_Float)
     {
-        hijackAddress = reinterpret_cast<VOID *>(OnHijackFPTripThread);
+        pvHijackAddr = reinterpret_cast<VOID *>(OnHijackFPTripThread);
     }
 #endif // TARGET_X86
 
@@ -5625,7 +5625,7 @@ void STDCALL OnHijackWorker(HijackArgs * pArgs)
 #endif // HIJACK_NONINTERRUPTIBLE_THREADS
 }
 
-bool GetReturnAddressHijackInfo(Thread *pThread, EECodeInfo *pCodeInfo, ReturnKind *pReturnKind)
+static bool GetReturnAddressHijackInfo(EECodeInfo *pCodeInfo, ReturnKind *pReturnKind)
 {
     GCInfoToken gcInfoToken = pCodeInfo->GetGCInfoToken();
     return pCodeInfo->GetCodeManager()->GetReturnAddressHijackInfo(gcInfoToken, pReturnKind);
@@ -6086,7 +6086,7 @@ BOOL Thread::HandledJITCase(BOOL ForTaskSwitchIn)
 
             ReturnKind returnKind;
 
-            if (GetReturnAddressHijackInfo(this, &codeInfo, &returnKind))
+            if (GetReturnAddressHijackInfo(&codeInfo, &returnKind))
             {
 
 #ifdef FEATURE_ENABLE_GCPOLL
@@ -6639,7 +6639,7 @@ void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
 
         ReturnKind returnKind;
 
-        if (!GetReturnAddressHijackInfo(pThread, &codeInfo, &returnKind))
+        if (!GetReturnAddressHijackInfo(&codeInfo, &returnKind))
         {
             return;
         }

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -6646,6 +6646,11 @@ void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
         if (executionState.m_ppvRetAddrPtr == NULL)
             return;
 
+        void *pvHijackAddr;
+        if (!GetReturnAddressHijackInfo(pThread, &codeInfo, &pvHijackAddr))
+        {
+            return;
+        }
 
         // Calling this turns off the GC_TRIGGERS/THROWS/INJECT_FAULT contract in LoadTypeHandle.
         // We should not trigger any loads for unresolved types.
@@ -6656,7 +6661,6 @@ void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
         StackWalkerWalkingThreadHolder threadStackWalking(pThread);
 
         // Hijack the return address to point to the appropriate routine based on the method's return type.
-        void *pvHijackAddr = GetHijackAddr(pThread, &codeInfo);
         pThread->HijackThread(pvHijackAddr, &executionState);
     }
 }


### PR DESCRIPTION
We have seen a failure in the CI where the OnHijackWorkerTripThread was
called in preemptive mode and so a contract in Thread::SetFrame down its
call chain has fired when checking that the thread is in cooperative
mode.
I have found that the issue is caused by hijacking a NativeCallable
method. Such methods switch to preemptive mode before they return and so
when they are hijacked, the OnHijackWorkerTripThread is called in
preemptive mode.

The fix is to prevent return address hijacking for NativeCallable
methods.