### PR TITLE
Fix testhost publish condition and omptimize assets we publish in official builds

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -138,7 +138,7 @@
 
   <Target Name="EnsureLocalArtifactsExist">
     <Error Condition="!Exists('$(LibrariesSharedFrameworkRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkRefArtifactsPath)" />
-    <Error Condition="!Exists('$(LibrariesAllRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllRefArtifactsPath)" />
+    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllRefArtifactsPath)" />
   </Target>
 
   <!--
@@ -148,7 +148,7 @@
   <Target Name="EnsureLocalOSGroupConfigurationArchitectureSpecificArtifactsExist"
           Condition="'$(LibrariesTargetOSConfigurationArchitecture)' != '*'">
     <Error Condition="!Exists('$(LibrariesSharedFrameworkBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkBinArtifactsPath)" />
-    <Error Condition="!Exists('$(LibrariesAllBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllBinArtifactsPath)" />
+    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllBinArtifactsPath)" />
     <Error Condition="!Exists('$(LibrariesNativeArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesNativeArtifactsPath)" />
   </Target>
 

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -87,7 +87,6 @@ jobs:
           - _extraHelixArguments: /p:BuildAllConfigurations=true
 
         - ${{ if eq(parameters.isOfficialAllConfigurations, true) }}:
-          - _skipTestHostCopy: true
           - librariesBuildArtifactName: 'libraries_bin_official_allconfigurations'
 
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -123,11 +123,11 @@ jobs:
                 sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/runtime
                 targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/runtime
 
-          - task: CopyFiles@2
-            displayName: Prepare ref folder to publish
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
-              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
+            - task: CopyFiles@2
+              displayName: Prepare ref folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
 
           - task: CopyFiles@2
             displayName: Prepare shared framework ref assemblies to publish

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -104,13 +104,7 @@ jobs:
           displayName: Build
 
         - ${{ if eq(parameters.runTests, false) }}:
-          - ${{ if ne(parameters.isOfficialBuild, true) }}:
-            - task: CopyFiles@2
-              displayName: Prepare ref folder to publish
-              inputs:
-                sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
-                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
-            
+          - ${{ if ne(parameters.isOfficialBuild, true) }}:            
             - task: CopyFiles@2
               displayName: Prepare testhost folder to publish
               inputs:
@@ -128,6 +122,12 @@ jobs:
               inputs:
                 sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/runtime
                 targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/runtime
+
+          - task: CopyFiles@2
+            displayName: Prepare ref folder to publish
+            inputs:
+              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
+              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
 
           - task: CopyFiles@2
             displayName: Prepare shared framework ref assemblies to publish

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -104,17 +104,30 @@ jobs:
           displayName: Build
 
         - ${{ if eq(parameters.runTests, false) }}:
-          - task: CopyFiles@2
-            displayName: Prepare ref folder to publish
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
-              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
+          - ${{ if ne(parameters.isOfficialBuild, true) }}:
+            - task: CopyFiles@2
+              displayName: Prepare ref folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/ref
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/ref
+            
+            - task: CopyFiles@2
+              displayName: Prepare testhost folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/testhost
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/testhost
 
-          - task: CopyFiles@2
-            displayName: Prepare runtime folder to publish
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/runtime
-              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/runtime
+            - task: CopyFiles@2
+              displayName: Prepare artifacts toolset folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/toolset
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/toolset
+
+            - task: CopyFiles@2
+              displayName: Prepare runtime folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/runtime
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/runtime
 
           - task: CopyFiles@2
             displayName: Prepare shared framework ref assemblies to publish
@@ -139,19 +152,6 @@ jobs:
             inputs:
               sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/native
               targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/native
-
-          - task: CopyFiles@2
-            displayName: Prepare testhost folder to publish
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/bin/testhost
-              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/bin/testhost
-            condition: ne(variables['_skipTestHostCopy'], 'true')
-
-          - task: CopyFiles@2
-            displayName: Prepare artifacts toolset folder to publish
-            inputs:
-              sourceFolder: $(Build.SourcesDirectory)/artifacts/toolset
-              targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/toolset
 
           - task: CopyFiles@2
             displayName: Prepare artifacts packages folder to publish


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/33449

@jkoritzinsky I've also conditioned some stuff we published always to just publish when we're not in an official build and that should only be used to build tests and run them. 

Here is the official build test: https://dev.azure.com/dnceng/internal/_build/results?buildId=587801
