### PR TITLE
BitOperations arm64 intrinsic for LeadingZeroCount, TrailingZeroCount and Log2

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
 
 #if SYSTEM_PRIVATE_CORELIB
 using Internal.Runtime.CompilerServices;
@@ -61,6 +62,11 @@ namespace System.Numerics
                 return (int)Lzcnt.LeadingZeroCount(value);
             }
 
+            if (ArmBase.IsSupported)
+            {
+                return (int)ArmBase.LeadingZeroCount(value);
+            }
+
             // Unguarded fallback contract is 0->31
             if (value == 0)
             {
@@ -83,6 +89,11 @@ namespace System.Numerics
             {
                 // LZCNT contract is 0->64
                 return (int)Lzcnt.X64.LeadingZeroCount(value);
+            }
+
+            if (ArmBase.Arm64.IsSupported)
+            {
+                return (int)ArmBase.Arm64.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -115,6 +115,12 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static int Log2(uint value)
         {
+            // Enforce conventional contract 0->0 (Log(0) is undefined)
+            if (value == 0)
+            {
+                return 0;
+            }
+
             // value    lzcnt   actual  expected
             // ..0000   32      0        0 (by convention, guard clause)
             // ..0001   31      31-31    0
@@ -124,14 +130,13 @@ namespace System.Numerics
             // 1000..    0      31-0    31
             if (Lzcnt.IsSupported)
             {
-                // Enforce conventional contract 0->0 (Log(0) is undefined)
-                if (value == 0)
-                {
-                    return 0;
-                }
-
                 // LZCNT contract is 0->32
                 return 31 - (int)Lzcnt.LeadingZeroCount(value);
+            }
+
+            if (ArmBase.IsSupported)
+            {
+                return 31 - (int)ArmBase.LeadingZeroCount(value);
             }
 
             // Fallback contract is 0->0
@@ -147,16 +152,21 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static int Log2(ulong value)
         {
+            // Enforce conventional contract 0->0 (Log(0) is undefined)
+            if (value == 0)
+            {
+                return 0;
+            }
+
             if (Lzcnt.X64.IsSupported)
             {
-                // Enforce conventional contract 0->0 (Log(0) is undefined)
-                if (value == 0)
-                {
-                    return 0;
-                }
-
                 // LZCNT contract is 0->64
                 return 63 - (int)Lzcnt.X64.LeadingZeroCount(value);
+            }
+
+            if (ArmBase.Arm64.IsSupported)
+            {
+                return 63 - (int)ArmBase.Arm64.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -296,6 +296,11 @@ namespace System.Numerics
                 return (int)Bmi1.TrailingZeroCount(value);
             }
 
+            if (ArmBase.IsSupported)
+            {
+                return (int)ArmBase.LeadingZeroCount(ArmBase.ReverseElementBits(value));
+            }
+
             // Unguarded fallback contract is 0->0
             if (value == 0)
             {
@@ -334,6 +339,10 @@ namespace System.Numerics
                 return (int)Bmi1.X64.TrailingZeroCount(value);
             }
 
+            if (ArmBase.Arm64.IsSupported)
+            {
+                return (int)ArmBase.Arm64.LeadingZeroCount(ArmBase.Arm64.ReverseElementBits(value));
+            }
             uint lo = (uint)value;
 
             if (lo == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -4,8 +4,8 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 
 #if SYSTEM_PRIVATE_CORELIB
 using Internal.Runtime.CompilerServices;
@@ -64,7 +64,7 @@ namespace System.Numerics
 
             if (ArmBase.IsSupported)
             {
-                return (int)ArmBase.LeadingZeroCount(value);
+                return ArmBase.LeadingZeroCount(value);
             }
 
             // Unguarded fallback contract is 0->31
@@ -93,7 +93,7 @@ namespace System.Numerics
 
             if (ArmBase.Arm64.IsSupported)
             {
-                return (int)ArmBase.Arm64.LeadingZeroCount(value);
+                return ArmBase.Arm64.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);
@@ -136,7 +136,7 @@ namespace System.Numerics
 
             if (ArmBase.IsSupported)
             {
-                return 31 - (int)ArmBase.LeadingZeroCount(value);
+                return 31 - ArmBase.LeadingZeroCount(value);
             }
 
             // Fallback contract is 0->0
@@ -166,7 +166,7 @@ namespace System.Numerics
 
             if (ArmBase.Arm64.IsSupported)
             {
-                return 63 - (int)ArmBase.Arm64.LeadingZeroCount(value);
+                return 63 - ArmBase.Arm64.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);
@@ -298,7 +298,7 @@ namespace System.Numerics
 
             if (ArmBase.IsSupported)
             {
-                return (int)ArmBase.LeadingZeroCount(ArmBase.ReverseElementBits(value));
+                return ArmBase.LeadingZeroCount(ArmBase.ReverseElementBits(value));
             }
 
             // Unguarded fallback contract is 0->0
@@ -341,7 +341,7 @@ namespace System.Numerics
 
             if (ArmBase.Arm64.IsSupported)
             {
-                return (int)ArmBase.Arm64.LeadingZeroCount(ArmBase.Arm64.ReverseElementBits(value));
+                return ArmBase.Arm64.LeadingZeroCount(ArmBase.Arm64.ReverseElementBits(value));
             }
             uint lo = (uint)value;
 

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -103,3 +103,19 @@ namespace System.Runtime.Intrinsics.X86
         public static bool TestZ(Vector128<ushort> left, Vector128<ushort> right) => throw new PlatformNotSupportedException();
     }
 }
+
+namespace System.Runtime.Intrinsics.Arm
+{
+    internal abstract class ArmBase
+    {
+        public abstract class Arm64
+        {
+            public const bool IsSupported = false;
+            public static int LeadingZeroCount(ulong value) => throw new PlatformNotSupportedException();
+            public static uint ReverseElementBits(ulong value) => throw new PlatformNotSupportedException();
+        }
+        public const bool IsSupported = false;
+        public static int LeadingZeroCount(uint value) => throw new PlatformNotSupportedException();
+        public static uint ReverseElementBits(uint value) => throw new PlatformNotSupportedException();
+    }
+}


### PR DESCRIPTION
Use arm64 intrinsics for BitOperations's `LeadingZeroCount`, `TrailingZeroCount` and `Log2` methods. 

Below are the performance improvement details of each API.

| API                      | before (in us) | after (in us) |  % diff  |
|--------------------------|--------|-------|---|
| LeadingZeroCount_uint  |     6.538   | 1.544      | 76%  |  
| LeadingZeroCount_ulong |   6.614      |   1.544     |  77% | 
| Log2_uint |  5.774      |    1.920     |  67%|  
| Log2_ulong |  6.925      |    1.921    |  72% |  
| TrailingZeroCount_uint |   2.722      |     1.665    | 39%   | 
| TrailingZeroCount_ulong |  2.891      |     1.666    | 42%  |  


I didn't include `PopCount()` as part of this PR because it needs special handling of `CreateScalar` in JIT. Once https://github.com/dotnet/runtime/issues/34485 is fixed, I will send a separate PR for it `PopCount()`.

Contributes to https://github.com/dotnet/runtime/issues/33308 and https://github.com/dotnet/runtime/issues/33495 .

