### PR TITLE
Fix WriteLargeJsonToStreamWithoutFlushing test

### DIFF
--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -752,7 +752,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(1_050_097_521, writer.BytesPending);
 
                 // Next write forces a grow beyond 2 GB
-                Assert.Throws<OverflowException>(() => writer.WriteStringValue(text3));
+                Assert.Throws<OutOfMemoryException>(() => writer.WriteStringValue(text3));
 
                 Assert.Equal(1_050_097_521, writer.BytesPending);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/34481.

This test wasn't updated following https://github.com/dotnet/runtime/pull/32587, where the exception for this scenario changed from `OverflowException` to `OutOfMemoryException`.