### PR TITLE
Fix subsetCategory is just one `-` not two `--`

### DIFF
--- a/docs/workflow/building/coreclr/README.md
+++ b/docs/workflow/building/coreclr/README.md
@@ -1,25 +1,25 @@
 # Building
 
-To build just CoreCLR, use the `--subsetCategory` flag to the `build.sh` (or `build.cmd`) script at the repo root:
+To build just CoreCLR, use the `-subsetCategory` flag to the `build.sh` (or `build.cmd`) script at the repo root:
 
 For Linux:
 ```
-./build.sh --subsetCategory coreclr
+./build.sh -subsetCategory coreclr
 ```
 
 For Windows:
 ```
-build.cmd --subsetCategory coreclr
+build.cmd -subsetCategory coreclr
 ```
 
 By default, build generates a 'debug' build type, that includes asserts and is easier for some people to debug. If you want to make performance measurements, or just want tests to execute more quickly, you can also build the 'release' version (which does not have these checks) by adding the flag `-configuration release` (or `-c release`), for example:
 ```
-./build.sh --subsetCategory coreclr -configuration release
+./build.sh -subsetCategory coreclr -configuration release
 ```
 
 CoreCLR also supports a 'checked' build type which has asserts enabled like 'debug', but is built with the native compiler optimizer enabled, so it runs much faster. This is the usual mode used for running tests in the CI system. You can build that using, for example:
 ```
-./build.sh --subsetCategory coreclr -configuration checked
+./build.sh -subsetCategory coreclr -configuration checked
 ```
 
 This will produce outputs as follows:


### PR DESCRIPTION
Otherwise fails with:
```
MSBUILD : error MSB1001: Unknown switch.
Switch: --subsetCategory
```
on Windows