### PR TITLE
Enable xunit1024

### DIFF
--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -336,7 +336,6 @@
     <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
-    <Rule Id="xUnit1024" Action="None" /> <!-- Test methods cannot have overloads -->
     <Rule Id="xUnit2013" Action="None" /> <!-- Do not use equality check to check for collection size. -->
     <Rule Id="xUnit2017" Action="None" /> <!-- Do not use Contains() to check if a value exists in a collection -->
   </Rules>

--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -662,20 +662,20 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task CompressDecompress_RoundTrip_BaseTests()
+        public async Task CompressDecompress_RoundTrip()
         {
-            await CompressDecompress_RoundTrip(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await CompressDecompress_RoundTrip(ReadWriteMode.SyncSpan, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await CompressDecompress_RoundTrip(ReadWriteMode.AsyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await CompressDecompress_RoundTrip(ReadWriteMode.AsyncMemory, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await CompressDecompress_RoundTrip(ReadWriteMode.AsyncBeginEnd, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await CompressDecompress_RoundTrip(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.SyncSpan, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.AsyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.AsyncMemory, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.AsyncBeginEnd, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
         }
 
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
-        public async Task CompressDecompress_RoundTrip(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
+        public async Task CompressDecompress_RoundTrip_OuterLoop(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
         {
             byte[] data = new byte[totalSize];
             new Random(42).NextBytes(data);
@@ -711,18 +711,18 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_RoundTrip_BaseTests()
+        public async Task Flush_RoundTrip()
         {
             if (FlushNoOps)
                 return;
-            await Flush_RoundTrip(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await Flush_RoundTrip(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
+            await Flush_RoundTrip_OuterLoop(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await Flush_RoundTrip_OuterLoop(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
         }
 
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
-        public async Task Flush_RoundTrip(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
+        public async Task Flush_RoundTrip_OuterLoop(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
         {
             if (FlushNoOps)
                 return;
@@ -773,18 +773,18 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_Consecutive_BaseTests()
+        public async Task Flush_Consecutive()
         {
             if (FlushNoOps)
                 return;
-            await Flush_Consecutive(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await Flush_Consecutive(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
+            await Flush_Consecutive_OuterLoop(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await Flush_Consecutive_OuterLoop(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
         }
 
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
-        public async Task Flush_Consecutive(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
+        public async Task Flush_Consecutive_OuterLoop(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
         {
             if (FlushNoOps)
                 return;
@@ -847,18 +847,18 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_BeforeFirstWrites_BaseTests()
+        public async Task Flush_BeforeFirstWrites()
         {
             if (FlushNoOps)
                 return;
-            await Flush_BeforeFirstWrites(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
-            await Flush_BeforeFirstWrites(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
+            await Flush_BeforeFirstWrites_OuterLoop(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
+            await Flush_BeforeFirstWrites_OuterLoop(ReadWriteMode.AsyncArray, chunkSize: 1024, totalSize: 8192, level: CompressionLevel.Optimal);
         }
 
         [OuterLoop]
         [Theory]
         [MemberData(nameof(RoundtripCompressDecompressOuterData))]
-        public async Task Flush_BeforeFirstWrites(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
+        public async Task Flush_BeforeFirstWrites_OuterLoop(ReadWriteMode readWriteMode, int chunkSize, int totalSize, CompressionLevel level)
         {
             if (FlushNoOps)
                 return;

--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -662,7 +662,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task CompressDecompress_RoundTrip()
+        public async Task CompressDecompress_RoundTrip_BaseTests()
         {
             await CompressDecompress_RoundTrip(ReadWriteMode.SyncArray, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
             await CompressDecompress_RoundTrip(ReadWriteMode.SyncSpan, chunkSize: 1, totalSize: 10, level: CompressionLevel.Fastest);
@@ -711,7 +711,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_RoundTrip()
+        public async Task Flush_RoundTrip_BaseTests()
         {
             if (FlushNoOps)
                 return;
@@ -773,7 +773,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_Consecutive()
+        public async Task Flush_Consecutive_BaseTests()
         {
             if (FlushNoOps)
                 return;
@@ -847,7 +847,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async Task Flush_BeforeFirstWrites()
+        public async Task Flush_BeforeFirstWrites_BaseTests()
         {
             if (FlushNoOps)
                 return;
@@ -1168,7 +1168,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
-        public void BaseStream(CompressionMode mode)
+        public void BaseStreamTest(CompressionMode mode)
         {
             using (var baseStream = new MemoryStream())
             using (var compressor = CreateStream(baseStream, mode))

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -5018,7 +5018,7 @@ namespace System.Tests
         [InlineData("hElLo", "hello")]
         [InlineData("HeLlO", "hello")]
         [InlineData("", "")]
-        public static void ToLower(string s, string expected)
+        public static void ToLower_String(string s, string expected)
         {
             Assert.Equal(expected, s.ToLower());
 
@@ -5222,7 +5222,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ToLower_2()
+        public static void ToLower_CharArray()
         {
             var expectedSource = new char[3] { 'a', 'B', 'c' };
             var expectedDestination = new char[3] { 'a', 'b', 'c' };
@@ -5434,7 +5434,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ToUpper_2()
+        public static void ToUpper_CharArray()
         {
             var expectedSource = new char[3] { 'a', 'B', 'c' };
             var expectedDestination = new char[3] { 'A', 'B', 'C' };
@@ -5559,7 +5559,7 @@ namespace System.Tests
         [InlineData("hElLo", "HELLO")]
         [InlineData("HeLlO", "HELLO")]
         [InlineData("", "")]
-        public static void ToUpper(string s, string expected)
+        public static void ToUpper_String(string s, string expected)
         {
             Assert.Equal(expected, s.ToUpper());
 

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -1666,7 +1666,7 @@ namespace System.Tests
         [InlineData("Hello", "llo" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "a", StringComparison.OrdinalIgnoreCase, false)]
-        public static void EndsWith_ExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
+        public static void EndsWith_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
             {
@@ -4639,7 +4639,7 @@ namespace System.Tests
         [InlineData("Hello", SoftHyphen + "Hel", StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "hello", StringComparison.OrdinalIgnoreCase, false)]
-        public static void StartsWith_WithExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
+        public static void StartsWith_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
             {

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -1119,7 +1119,7 @@ namespace System.Tests
         [InlineData("", "", true)]
         [InlineData("", "hello", false)]
         [InlineData("Hello", "", true)]
-        public static void Contains(string s, string value, bool expected)
+        public static void Contains_String(string s, string value, bool expected)
         {
             Assert.Equal(expected, s.Contains(value));
             Assert.Equal(expected, s.AsSpan().Contains(value.AsSpan(), StringComparison.Ordinal));
@@ -1666,7 +1666,7 @@ namespace System.Tests
         [InlineData("Hello", "llo" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "a", StringComparison.OrdinalIgnoreCase, false)]
-        public static void EndsWith(string s, string value, StringComparison comparisonType, bool expected)
+        public static void EndsWith_ExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
             {
@@ -2482,7 +2482,7 @@ namespace System.Tests
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("123", 123, StringComparison.OrdinalIgnoreCase, false)] // Not a string
         [InlineData("\0AAAAAAAAA", "\0BBBBBBBBBBBB", StringComparison.OrdinalIgnoreCase, false)]
-        public static void Equals(string s1, object obj, StringComparison comparisonType, bool expected)
+        public static void EqualsTest(string s1, object obj, StringComparison comparisonType, bool expected)
         {
             string s2 = obj as string;
             if (s1 != null)
@@ -4518,7 +4518,7 @@ namespace System.Tests
                     "Mauris nulla sapien, convallis et quam quis, accumsan sodales mi. Praesent dapibus urna fermentum, sollicitudin posuere.",
                     'e', 'E',
                     "LorEm ipsum dolor sit amEt, consEctEtur adipiscing Elit. Proin maximus convallis luctus. Curabitur porttitor mi blandit tEllus maximus varius. " +
-                    "Mauris nulla sapiEn, convallis Et quam quis, accumsan sodalEs mi. PraEsEnt dapibus urna fErmEntum, sollicitudin posuErE.")] 
+                    "Mauris nulla sapiEn, convallis Et quam quis, accumsan sodalEs mi. PraEsEnt dapibus urna fErmEntum, sollicitudin posuErE.")]
         public static void Replace_Char_Char(string s, char oldChar, char newChar, string expected)
         {
             Assert.Equal(expected, s.Replace(oldChar, newChar));
@@ -4639,7 +4639,7 @@ namespace System.Tests
         [InlineData("Hello", SoftHyphen + "Hel", StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "hello", StringComparison.OrdinalIgnoreCase, false)]
-        public static void StartsWith(string s, string value, StringComparison comparisonType, bool expected)
+        public static void StartsWith_WithExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
             {
@@ -5125,7 +5125,7 @@ namespace System.Tests
             Assert.Equal(expected, s1.ToLower(CultureInfo.CurrentCulture).ToArray());
             Assert.Equal(expected, s1.ToLowerInvariant().ToArray());
             {
-                AssertExtensions.AssertThrows<InvalidOperationException, char>(a, a => 
+                AssertExtensions.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5158,7 +5158,7 @@ namespace System.Tests
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
                 AssertExtensions.AssertThrows<InvalidOperationException,char>(source, source =>
-                { 
+                {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToLower(destination, CultureInfo.CurrentCulture);
                 });
@@ -5222,7 +5222,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ToLower()
+        public static void ToLower_2()
         {
             var expectedSource = new char[3] { 'a', 'B', 'c' };
             var expectedDestination = new char[3] { 'a', 'b', 'c' };
@@ -5434,7 +5434,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ToUpper()
+        public static void ToUpper_2()
         {
             var expectedSource = new char[3] { 'a', 'B', 'c' };
             var expectedDestination = new char[3] { 'A', 'B', 'C' };
@@ -5544,7 +5544,7 @@ namespace System.Tests
         [Theory]
         [InlineData("")]
         [InlineData("hello")]
-        public static void ToString(string s)
+        public static void ToStringTest(string s)
         {
             Assert.Same(s, s.ToString());
             Assert.Same(s, s.ToString(null));

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData(-1)]
         [InlineData(7)]
         [InlineData(int.MinValue)]
-        public void ErrorToString(int errorNumber)
+        public void ErrorToString_WithErrorNumber(int errorNumber)
         {
             Assert.NotNull(Conversion.ErrorToString(errorNumber));
         }
@@ -165,49 +165,49 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(Fix_Single_TestData))]
         [MemberData(nameof(Fix_Double_TestData))]
         [MemberData(nameof(Fix_Decimal_TestData))]
-        public void Fix(object value, object expected)
+        public void Fix_Object(object value, object expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Short_TestData))]
-        public void Fix(short value, short expected)
+        public void Fix_Short(short value, short expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Integer_TestData))]
-        public void Fix(int value, int expected)
+        public void Fix_Int(int value, int expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Long_TestData))]
-        public void Fix(long value, long expected)
+        public void Fix_Long(long value, long expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Single_TestData))]
-        public void Fix(float value, float expected)
+        public void Fix_Float(float value, float expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Double_TestData))]
-        public void Fix(double value, double expected)
+        public void Fix_Double(double value, double expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
 
         [Theory]
         [MemberData(nameof(Fix_Decimal_TestData))]
-        public void Fix(decimal value, decimal expected)
+        public void Fix_Decimal(decimal value, decimal expected)
         {
             Assert.Equal(expected, Conversion.Fix(value));
         }
@@ -305,56 +305,56 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(Hex_Single_TestData))]
         [MemberData(nameof(Hex_Double_TestData))]
         [MemberData(nameof(Hex_Decimal_TestData))]
-        public void Hex(object value, string expected)
+        public void Hex_Object(object value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Byte_TestData))]
-        public void Hex(byte value, string expected)
+        public void Hex_Byte(byte value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_SByte_TestData))]
-        public void Hex(sbyte value, string expected)
+        public void Hex_Sbyte(sbyte value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_UShort_TestData))]
-        public void Hex(ushort value, string expected)
+        public void Hex_Ushort(ushort value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Short_TestData))]
-        public void Hex(short value, string expected)
+        public void Hex_Short(short value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_UInteger_TestData))]
-        public void Hex(uint value, string expected)
+        public void Hex_Uint(uint value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Integer_TestData))]
-        public void Hex(int value, string expected)
+        public void Hex_Int(int value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_ULong_TestData))]
-        public void Hex(ulong value, string expected)
+        public void Hex_Ulong(ulong value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
@@ -362,28 +362,28 @@ namespace Microsoft.VisualBasic.Tests
         [Theory]
         [InlineData((long)-1, "FFFFFFFFFFFFFFFF")] // expected for object overload: "FFFFFFFF"
         [MemberData(nameof(Hex_Long_TestData))]
-        public void Hex(long value, string expected)
+        public void Hex_Long(long value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Single_TestData))]
-        public void Hex(float value, string expected)
+        public void Hex_Float(float value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Double_TestData))]
-        public void Hex(double value, string expected)
+        public void Hex_Double(double value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
 
         [Theory]
         [MemberData(nameof(Hex_Decimal_TestData))]
-        public void Hex(decimal value, string expected)
+        public void Hex_Decimal(decimal value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
         }
@@ -502,49 +502,49 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(Int_Single_TestData))]
         [MemberData(nameof(Int_Double_TestData))]
         [MemberData(nameof(Int_Decimal_TestData))]
-        public void Int(object value, object expected)
+        public void Int_Object_Object(object value, object expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Short_TestData))]
-        public void Int(short value, short expected)
+        public void Int_Short(short value, short expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Integer_TestData))]
-        public void Int(int value, int expected)
+        public void Int_Int(int value, int expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Long_TestData))]
-        public void Int(long value, long expected)
+        public void Int_Long(long value, long expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Single_TestData))]
-        public void Int(float value, float expected)
+        public void Int_Float(float value, float expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Double_TestData))]
-        public void Int(double value, double expected)
+        public void Int_Double(double value, double expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
 
         [Theory]
         [MemberData(nameof(Int_Decimal_TestData))]
-        public void Int(decimal value, decimal expected)
+        public void Int_Decimal(decimal value, decimal expected)
         {
             Assert.Equal(expected, Conversion.Int(value));
         }
@@ -636,56 +636,56 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(Oct_Single_TestData))]
         [MemberData(nameof(Oct_Double_TestData))]
         [MemberData(nameof(Oct_Decimal_TestData))]
-        public void Oct(object value, string expected)
+        public void Oct_Object(object value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Byte_TestData))]
-        public void Oct(byte value, string expected)
+        public void Oct_Byte(byte value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_SByte_TestData))]
-        public void Oct(sbyte value, string expected)
+        public void Oct_Sbyte(sbyte value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_UShort_TestData))]
-        public void Oct(ushort value, string expected)
+        public void Oct_Ushort(ushort value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Short_TestData))]
-        public void Oct(short value, string expected)
+        public void Oct_Short(short value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_UInteger_TestData))]
-        public void Oct(uint value, string expected)
+        public void Oct_Uint(uint value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Integer_TestData))]
-        public void Oct(int value, string expected)
+        public void Oct_Int(int value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_ULong_TestData))]
-        public void Oct(ulong value, string expected)
+        public void Oct_Ulong(ulong value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
@@ -693,28 +693,28 @@ namespace Microsoft.VisualBasic.Tests
         [Theory]
         [InlineData((long)-1, "1777777777777777777777")] // expected for object overload: "37777777777"
         [MemberData(nameof(Oct_Long_TestData))]
-        public void Oct(long value, string expected)
+        public void Oct_Long(long value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Single_TestData))]
-        public void Oct(float value, string expected)
+        public void Oct_Float(float value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Double_TestData))]
-        public void Oct(double value, string expected)
+        public void Oct_Double(double value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
 
         [Theory]
         [MemberData(nameof(Oct_Decimal_TestData))]
-        public void Oct(decimal value, string expected)
+        public void Oct_Decimal(decimal value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
         }
@@ -868,56 +868,56 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(Val_Object_TestData))]
         [MemberData(nameof(Val_Char_TestData))]
         [MemberData(nameof(Val_String_TestData))]
-        public void Val(object value, double expected)
+        public void Val_Object_Double(object value, double expected)
         {
             Assert.Equal(expected, Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_Object_ArgumentException_TestData))]
-        public void Val_ArgumentException(object value)
+        public void Val_ArgumentException_Object(object value)
         {
             Assert.Throws<ArgumentException>(() => Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_Object_OverflowException_TestData))]
-        public void Val_OverflowException(object value)
+        public void Val_OverflowException_Object(object value)
         {
             Assert.Throws<OverflowException>(() => Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_Char_TestData))]
-        public void Val(char value, int expected)
+        public void Val_Char_Int(char value, int expected)
         {
             Assert.Equal(expected, Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_Char_ArgumentException_TestData))]
-        public void Val_ArgumentException(char value)
+        public void Val_ArgumentException_Char(char value)
         {
             Assert.Throws<ArgumentException>(() => Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_Char_OverflowException_TestData))]
-        public void Val_OverflowException(char value)
+        public void Val_OverflowException_Char(char value)
         {
             Assert.Throws<OverflowException>(() => Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_String_TestData))]
-        public void Val(string value, double expected)
+        public void Val_String_Double(string value, double expected)
         {
             Assert.Equal(expected, Conversion.Val(value));
         }
 
         [Theory]
         [MemberData(nameof(Val_String_ArgumentException_TestData))]
-        public void Val_ArgumentException(string value)
+        public void Val_ArgumentException_String(string value)
         {
             Assert.Throws<ArgumentException>(() => Conversion.Val(value));
         }
@@ -931,7 +931,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Val_String_OverflowException_TestData))]
-        public void Val_OverflowException(string value)
+        public void Val_OverflowException_String(string value)
         {
             Assert.Throws<OverflowException>(() => Conversion.Val(value));
         }

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/DateAndTimeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/DateAndTimeTests.cs
@@ -13,14 +13,14 @@ namespace Microsoft.VisualBasic.Tests
     {
         [Theory]
         [MemberData(nameof(DateAdd_DateInterval_TestData))]
-        public void DateAdd(DateInterval interval, double number, DateTime dateValue, DateTime expected)
+        public void DateAdd_DateInterval(DateInterval interval, double number, DateTime dateValue, DateTime expected)
         {
             Assert.Equal(expected, DateAndTime.DateAdd(interval, number, dateValue));
         }
 
         [Theory]
         [MemberData(nameof(DateAdd_DateInterval_ArgumentOutOfRangeException_TestData))]
-        public void DateAdd_ArgumentOutOfRangeException(DateInterval interval, double number, DateTime dateValue)
+        public void DateAdd_DateInterval_ArgumentOutOfRangeException(DateInterval interval, double number, DateTime dateValue)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => DateAndTime.DateAdd(interval, number, dateValue));
         }
@@ -125,14 +125,14 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(DateAdd_StringInterval_TestData))]
-        public void DateAdd(string interval, double number, object dateValue, DateTime expected)
+        public void DateAdd_StringInterval(string interval, double number, object dateValue, DateTime expected)
         {
             Assert.Equal(expected, DateAndTime.DateAdd(interval, number, dateValue));
         }
 
         [Theory]
         [MemberData(nameof(DateAdd_StringInterval_ArgumentOutOfRangeException_TestData))]
-        public void DateAdd_ArgumentOutOfRangeException(string interval, double number, object dateValue)
+        public void DateAdd_StringInterval_ArgumentOutOfRangeException(string interval, double number, object dateValue)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => DateAndTime.DateAdd(interval, number, dateValue));
         }
@@ -237,7 +237,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(DateDiff_DateInterval_TestData))]
-        public void DateDiff(DateInterval interval, DateTime dateTime1, DateTime dateTime2, long expected)
+        public void DateDiff_DateInterval(DateInterval interval, DateTime dateTime1, DateTime dateTime2, long expected)
         {
             Assert.Equal(expected, DateAndTime.DateDiff(interval, dateTime1, dateTime2));
         }
@@ -277,7 +277,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(DateDiff_StringInterval_TestData))]
-        public void DateDiff(string interval, object dateTime1, object dateTime2, long expected)
+        public void DateDiff_StringInterval(string interval, object dateTime1, object dateTime2, long expected)
         {
             Assert.Equal(expected, DateAndTime.DateDiff(interval, dateTime1, dateTime2));
         }
@@ -317,7 +317,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(DatePart_DateInterval_TestData))]
-        public void DatePart(DateInterval interval, DateTime dateValue, int expected)
+        public void DatePart_DateInterval(DateInterval interval, DateTime dateValue, int expected)
         {
             Assert.Equal(expected, DateAndTime.DatePart(interval, dateValue));
         }
@@ -337,7 +337,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(DatePart_StringInterval_TestData))]
-        public void DatePart(string interval, object dateValue, int expected)
+        public void DatePart_StringInterval(string interval, object dateValue, int expected)
         {
             Assert.Equal(expected, DateAndTime.DatePart(interval, dateValue));
         }

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/ComClassAttributeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/ComClassAttributeTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData(null, null, null)]
         [InlineData("", "", "")]
         [InlineData("classID", "interfaceID", "eventID")]
-        public void Ctor_String_String(string classID, string interfaceID, string eventID)
+        public void Ctor_String_String_String(string classID, string interfaceID, string eventID)
         {
             var attribute = new ComClassAttribute(classID, interfaceID, eventID);
             Assert.Equal(classID, attribute.ClassID);

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(FromDecimal_Format_TestData))]
-        public void FromDecimal(decimal value, NumberFormatInfo format, string expected)
+        public void FromDecimal_Format(decimal value, NumberFormatInfo format, string expected)
         {
             Assert.Equal(expected, StringType.FromDecimal(value, format));
         }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(FromDouble_Format_TestData))]
-        public void FromDouble(double value, NumberFormatInfo format, string expected)
+        public void FromDouble_Format(double value, NumberFormatInfo format, string expected)
         {
             Assert.Equal(expected, StringType.FromDouble(value, format));
         }
@@ -139,7 +139,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(FromSingle_Format_TestData))]
-        public void FromSingle(float value, NumberFormatInfo format, string expected)
+        public void FromSingle_Format(float value, NumberFormatInfo format, string expected)
         {
             Assert.Equal(expected, StringType.FromSingle(value, format));
         }

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -514,7 +514,7 @@ namespace Microsoft.VisualBasic.Tests
         [Theory]
         [MemberData(nameof(Join_Object_TestData))]
         [MemberData(nameof(Join_String_TestData))]
-        public void Join(object[] source, string delimiter, string expected)
+        public void Join_ObjectArray(object[] source, string delimiter, string expected)
         {
             Assert.Equal(expected, Strings.Join(source, delimiter));
         }
@@ -531,7 +531,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Join_String_TestData))]
-        public void Join(string[] source, string delimiter, string expected)
+        public void Join_StringArray(string[] source, string delimiter, string expected)
         {
             Assert.Equal(expected, Strings.Join(source, delimiter));
         }
@@ -552,7 +552,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData('a', 'a')]
         [InlineData('A', 'a')]
         [InlineData('1', '1')]
-        public void LCase(char value, char expected)
+        public void LCase_Char(char value, char expected)
         {
             Assert.Equal(expected, Strings.LCase(value));
         }
@@ -565,7 +565,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData("abc", "abc")]
         [InlineData("ABC", "abc")]
         [InlineData("123", "123")]
-        public void LCase(string value, string expected)
+        public void LCase_String(string value, string expected)
         {
             Assert.Equal(expected, Strings.LCase(value));
         }
@@ -576,7 +576,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData('a', 'A')]
         [InlineData('A', 'A')]
         [InlineData('1', '1')]
-        public void UCase(char value, char expected)
+        public void UCase_Char(char value, char expected)
         {
             Assert.Equal(expected, Strings.UCase(value));
         }
@@ -589,7 +589,7 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData("abc", "ABC")]
         [InlineData("ABC", "ABC")]
         [InlineData("123", "123")]
-        public void UCase(string value, string expected)
+        public void UCase_String(string value, string expected)
         {
             Assert.Equal(expected, Strings.UCase(value));
         }
@@ -877,42 +877,42 @@ namespace Microsoft.VisualBasic.Tests
         [MemberData(nameof(StrDup_Object_TestData))]
         [MemberData(nameof(StrDup_Char_TestData))]
         [MemberData(nameof(StrDup_String_TestData))]
-        public void StrDup(int number, object character, object expected)
+        public void StrDup_Int_Object_Object(int number, object character, object expected)
         {
             Assert.Equal(expected, Strings.StrDup(number, character));
         }
 
         [Theory]
         [MemberData(nameof(StrDup_Object_ArgumentException_TestData))]
-        public void StrDup_ArgumentException(int number, object character)
+        public void StrDup_ArgumentException_Int_Object(int number, object character)
         {
             Assert.Throws< ArgumentException>(() => Strings.StrDup(number, character));
         }
 
         [Theory]
         [MemberData(nameof(StrDup_Char_TestData))]
-        public void StrDup(int number, char character, string expected)
+        public void StrDup_Int_Char_String(int number, char character, string expected)
         {
             Assert.Equal(expected, Strings.StrDup(number, character));
         }
 
         [Theory]
         [MemberData(nameof(StrDup_Char_ArgumentException_TestData))]
-        public void StrDup_ArgumentException(int number, char character)
+        public void StrDup_ArgumentException_Int_Char(int number, char character)
         {
             Assert.Throws<ArgumentException>(() => Strings.StrDup(number, character));
         }
 
         [Theory]
         [MemberData(nameof(StrDup_String_TestData))]
-        public void StrDup(int number, string character, string expected)
+        public void StrDup_Int_String_String(int number, string character, string expected)
         {
             Assert.Equal(expected, Strings.StrDup(number, character));
         }
 
         [Theory]
         [MemberData(nameof(StrDup_String_ArgumentException_TestData))]
-        public void StrDup_ArgumentException(int number, string character)
+        public void StrDup_ArgumentException_Int_String(int number, string character)
         {
             Assert.Throws<ArgumentException>(() => Strings.StrDup(number, character));
         }

--- a/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
+++ b/src/libraries/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_DeleteSubKeyTree_str.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestRegistrySubKeyNames))]
-        public void Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(string expected, string subKeyName) =>
+        public void DeleteSubKeyTree_KeyDoesNotExists_Throws(string expected, string subKeyName) =>
             Verify_DeleteSubKeyTree_KeyDoesNotExists_Throws(expected, () => TestRegistryKey.DeleteSubKeyTree(subKeyName));
     }
 }

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeMethodInvokeExpressionTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeMethodInvokeExpressionTests.cs
@@ -28,7 +28,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_CodeMethodReferenceExpression_ParamsCodeExpression_TestData))]
-        public void Ctor(CodeMethodReferenceExpression method, CodeExpression[] parameters)
+        public void Ctor_Method_Parameters(CodeMethodReferenceExpression method, CodeExpression[] parameters)
         {
             var methodInvoke = new CodeMethodInvokeExpression(method, parameters);
             Assert.Equal((method ?? new CodeMethodReferenceExpression()).TargetObject, methodInvoke.Method.TargetObject);
@@ -45,7 +45,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_CodeExpression_String_ParamsCodeExpression_TestData))]
-        public void Ctor(CodeExpression targetObject, string methodName, CodeExpression[] parameters)
+        public void Ctor_TargetObject_MethodName_Parameters(CodeExpression targetObject, string methodName, CodeExpression[] parameters)
         {
             var methodInvoke = new CodeMethodInvokeExpression(targetObject, methodName, parameters);
             Assert.Equal(targetObject, methodInvoke.Method.TargetObject);

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeMethodReferenceExpressionTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeMethodReferenceExpressionTests.cs
@@ -28,7 +28,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_CodeExpression_String_TestData))]
-        public void Ctor(CodeExpression targetObject, string methodName)
+        public void Ctor_TargetObject_MethodName(CodeExpression targetObject, string methodName)
         {
             var methodReference = new CodeMethodReferenceExpression(targetObject, methodName);
             Assert.Equal(targetObject, methodReference.TargetObject);
@@ -44,7 +44,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_CodeExpression_String_ParamsCodeExpression_TestData))]
-        public void Ctor(CodeExpression targetObject, string methodName, CodeTypeReference[] typeArguments)
+        public void Ctor_TargetObject_MethodName_TypeArguments(CodeExpression targetObject, string methodName, CodeTypeReference[] typeArguments)
         {
             var methodReference = new CodeMethodReferenceExpression(targetObject, methodName, typeArguments);
             Assert.Equal(targetObject, methodReference.TargetObject);

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeObjectCreateExpressionTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeObjectCreateExpressionTests.cs
@@ -27,7 +27,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_CodeTypeReference_ParamsCodeExpression_TestData))]
-        public void Ctor(CodeTypeReference type, CodeExpression[] parameters)
+        public void Ctor_Type_Parameters(CodeTypeReference type, CodeExpression[] parameters)
         {
             var objectCreate = new CodeObjectCreateExpression(type, parameters);
             Assert.Equal((type ?? new CodeTypeReference("")).BaseType, objectCreate.CreateType.BaseType);
@@ -43,7 +43,7 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_String_ParamsCodeExpression_TestData))]
-        public void Ctor(string type, CodeExpression[] parameters, string expectedBaseType)
+        public void Ctor_Type_Parameters_ExpectedBaseType(string type, CodeExpression[] parameters, string expectedBaseType)
         {
             var objectCreate = new CodeObjectCreateExpression(type, parameters);
             Assert.Equal(expectedBaseType, objectCreate.CreateType.BaseType);

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -124,20 +124,16 @@ namespace System.Collections.Concurrent.Tests
             Assert.Throws<ArgumentException>(action);
         }
 
-        [Fact]
-        public static void TestAdd1()
-        {
-            TestAdd1(1, 1, 1, 10000);
-            TestAdd1(5, 1, 1, 10000);
-            TestAdd1(1, 1, 2, 5000);
-            TestAdd1(1, 1, 5, 2000);
-            TestAdd1(4, 0, 4, 2000);
-            TestAdd1(16, 31, 4, 2000);
-            TestAdd1(64, 5, 5, 5000);
-            TestAdd1(5, 5, 5, 2500);
-        }
-
-        private static void TestAdd1(int cLevel, int initSize, int threads, int addsPerThread)
+        [Theory]
+        [InlineData(1, 1, 1, 10000)]
+        [InlineData(5, 1, 1, 10000)]
+        [InlineData(1, 1, 2, 5000)]
+        [InlineData(1, 1, 5, 2000)]
+        [InlineData(4, 0, 4, 2000)]
+        [InlineData(16, 31, 4, 2000)]
+        [InlineData(64, 5, 5, 5000)]
+        [InlineData(5, 5, 5, 2500)]
+        public static void TestAdd(int cLevel, int initSize, int threads, int addsPerThread)
         {
             ConcurrentDictionary<int, int> dictConcurrent = new ConcurrentDictionary<int, int>(cLevel, 1);
             IDictionary<int, int> dict = dictConcurrent;
@@ -193,20 +189,16 @@ namespace System.Collections.Concurrent.Tests
             Assert.Equal(expectedCount, dictConcurrent.ToArray().Length);
         }
 
-        [Fact]
-        public static void TestUpdate1()
-        {
-            TestUpdate1(1, 1, 10000);
-            TestUpdate1(5, 1, 10000);
-            TestUpdate1(1, 2, 5000);
-            TestUpdate1(1, 5, 2001);
-            TestUpdate1(4, 4, 2001);
-            TestUpdate1(15, 5, 2001);
-            TestUpdate1(64, 5, 5000);
-            TestUpdate1(5, 5, 25000);
-        }
-
-        private static void TestUpdate1(int cLevel, int threads, int updatesPerThread)
+        [Theory]
+        [InlineData(1, 1, 10000)]
+        [InlineData(5, 1, 10000)]
+        [InlineData(1, 2, 5000)]
+        [InlineData(1, 5, 2001)]
+        [InlineData(4, 4, 2001)]
+        [InlineData(15, 5, 2001)]
+        [InlineData(64, 5, 5000)]
+        [InlineData(5, 5, 25000)]
+        public static void TestUpdate(int cLevel, int threads, int updatesPerThread)
         {
             IDictionary<int, int> dict = new ConcurrentDictionary<int, int>(cLevel, 1);
 
@@ -261,20 +253,16 @@ namespace System.Collections.Concurrent.Tests
             }
         }
 
-        [Fact]
-        public static void TestRead1()
-        {
-            TestRead1(1, 1, 10000);
-            TestRead1(5, 1, 10000);
-            TestRead1(1, 2, 5000);
-            TestRead1(1, 5, 2001);
-            TestRead1(4, 4, 2001);
-            TestRead1(15, 5, 2001);
-            TestRead1(64, 5, 5000);
-            TestRead1(5, 5, 25000);
-        }
-
-        private static void TestRead1(int cLevel, int threads, int readsPerThread)
+        [Theory]
+        [InlineData(1, 1, 10000)]
+        [InlineData(5, 1, 10000)]
+        [InlineData(1, 2, 5000)]
+        [InlineData(1, 5, 2001)]
+        [InlineData(4, 4, 2001)]
+        [InlineData(15, 5, 2001)]
+        [InlineData(64, 5, 5000)]
+        [InlineData(5, 5, 25000)]
+        public static void TestRead1(int cLevel, int threads, int readsPerThread)
         {
             IDictionary<int, int> dict = new ConcurrentDictionary<int, int>(cLevel, 1);
 
@@ -309,18 +297,14 @@ namespace System.Collections.Concurrent.Tests
             }
         }
 
-        [Fact]
-        public static void TestRemove1()
-        {
-            TestRemove1(1, 1, 10000);
-            TestRemove1(5, 1, 1000);
-            TestRemove1(1, 5, 2001);
-            TestRemove1(4, 4, 2001);
-            TestRemove1(15, 5, 2001);
-            TestRemove1(64, 5, 5000);
-        }
-
-        private static void TestRemove1(int cLevel, int threads, int removesPerThread)
+        [Theory]
+        [InlineData(1, 1, 10000)]
+        [InlineData(5, 1, 1000)]
+        [InlineData(1, 5, 2001)]
+        [InlineData(4, 4, 2001)]
+        [InlineData(15, 5, 2001)]
+        [InlineData(64, 5, 5000)]
+        public static void TestRemove1(int cLevel, int threads, int removesPerThread)
         {
             ConcurrentDictionary<int, int> dict = new ConcurrentDictionary<int, int>(cLevel, 1);
             string methodparameters = string.Format("* TestRemove1(cLevel={0}, threads={1}, removesPerThread={2})", cLevel, threads, removesPerThread);
@@ -381,15 +365,11 @@ namespace System.Collections.Concurrent.Tests
             Assert.Equal(expectKeys.Count, dict.ToArray().Length);
         }
 
-        [Fact]
-        public static void TestRemove2()
-        {
-            TestRemove2(1);
-            TestRemove2(10);
-            TestRemove2(5000);
-        }
-
-        private static void TestRemove2(int removesPerThread)
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(5000)]
+        public static void TestRemove2(int removesPerThread)
         {
             ConcurrentDictionary<int, int> dict = new ConcurrentDictionary<int, int>();
 

--- a/src/libraries/System.Collections.Concurrent/tests/IntRangePartitionerTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/IntRangePartitionerTests.cs
@@ -49,17 +49,13 @@ namespace System.Collections.Concurrent.Tests
         /// We unroll the tuples and flatten them to a single sequence
         /// The single sequence is compared to the original range for verification
         /// </summary>
-        [Fact]
-        public static void CheckGetPartitions()
-        {
-            CheckGetPartitions(0, 1, 1);
-            CheckGetPartitions(1, 1999, 3);
-            CheckGetPartitions(2147473647, 9999, 4);
-            CheckGetPartitions(-1999, 5000, 63);
-            CheckGetPartitions(-2147483648, 5000, 63);
-        }
-
-        private static void CheckGetPartitions(int from, int count, int dop)
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(1, 1999, 3)]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(-1999, 5000, 63)]
+        [InlineData(-2147483648, 5000, 63)]
+        public static void CheckGetPartitions(int from, int count, int dop)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -82,17 +78,13 @@ namespace System.Collections.Concurrent.Tests
         /// </summary>
         /// <param name="from"></param>
         /// <param name="count"></param>
-        [Fact]
-        public static void CheckGetDynamicPartitions()
-        {
-            CheckGetDynamicPartitions(0, 1);
-            CheckGetDynamicPartitions(1, 1999);
-            CheckGetDynamicPartitions(2147473647, 9999);
-            CheckGetDynamicPartitions(-1999, 5000);
-            CheckGetDynamicPartitions(-2147483648, 5000);
-        }
-
-        private static void CheckGetDynamicPartitions(int from, int count)
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1999)]
+        [InlineData(2147473647, 9999)]
+        [InlineData(-1999, 5000)]
+        [InlineData(-2147483648, 5000)]
+        public static void CheckGetDynamicPartitions(int from, int count)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -114,17 +106,13 @@ namespace System.Collections.Concurrent.Tests
         /// The single sequence is compared to the original range for verification
         /// Also the indices are extracted to ensure that they are ordered & normalized
         /// </summary>
-        [Fact]
-        public static void CheckGetOrderablePartitions()
-        {
-            CheckGetOrderablePartitions(0, 1, 1);
-            CheckGetOrderablePartitions(1, 1999, 3);
-            CheckGetOrderablePartitions(2147473647, 9999, 4);
-            CheckGetOrderablePartitions(-1999, 5000, 63);
-            CheckGetOrderablePartitions(-2147483648, 5000, 63);
-        }
-
-        private static void CheckGetOrderablePartitions(int from, int count, int dop)
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(1, 1999, 3)]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(-1999, 5000, 63)]
+        [InlineData(-2147483648, 5000, 63)]
+        public static void CheckGetOrderablePartitions(int from, int count, int dop)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -155,17 +143,13 @@ namespace System.Collections.Concurrent.Tests
         /// The single sequence is compared to the original range for verification
         /// Also the indices are extracted to ensure that they are ordered & normalized
         /// </summary>
-        [Fact]
-        public static void GetOrderableDynamicPartitions()
-        {
-            GetOrderableDynamicPartitions(0, 1);
-            GetOrderableDynamicPartitions(1, 1999);
-            GetOrderableDynamicPartitions(2147473647, 9999);
-            GetOrderableDynamicPartitions(-1999, 5000);
-            GetOrderableDynamicPartitions(-2147483648, 5000);
-        }
-
-        private static void GetOrderableDynamicPartitions(int from, int count)
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1999)]
+        [InlineData(2147473647, 9999)]
+        [InlineData(-1999, 5000)]
+        [InlineData(-2147483648, 5000)]
+        public static void GetOrderableDynamicPartitions(int from, int count)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -197,17 +181,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetPartitionsWithRange()
-        {
-            CheckGetPartitionsWithRange(1999, 1000, 20, 1);
-            CheckGetPartitionsWithRange(-1999, 1000, 100, 2);
-            CheckGetPartitionsWithRange(1999, 1, 2000, 3);
-            CheckGetPartitionsWithRange(2147482647, 999, 600, 4);
-            CheckGetPartitionsWithRange(-2147483648, 1000, 19, 63);
-        }
-
-        private static void CheckGetPartitionsWithRange(int from, int count, int desiredRangeSize, int dop)
+        [Theory]
+        [InlineData(1999, 1000, 20, 1)]
+        [InlineData(-1999, 1000, 100, 2)]
+        [InlineData(1999, 1, 2000, 3)]
+        [InlineData(2147482647, 999, 600, 4)]
+        [InlineData(-2147483648, 1000, 19, 63)]
+        public static void CheckGetPartitionsWithRange(int from, int count, int desiredRangeSize, int dop)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -240,17 +220,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetDynamicPartitionsWithRange()
-        {
-            CheckGetDynamicPartitionsWithRange(1999, 1000, 20);
-            CheckGetDynamicPartitionsWithRange(-1999, 1000, 100);
-            CheckGetDynamicPartitionsWithRange(1999, 1, 2000);
-            CheckGetDynamicPartitionsWithRange(2147482647, 999, 600);
-            CheckGetDynamicPartitionsWithRange(-2147483648, 1000, 19);
-        }
-
-        private static void CheckGetDynamicPartitionsWithRange(int from, int count, int desiredRangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 20)]
+        [InlineData(-1999, 1000, 100)]
+        [InlineData(1999, 1, 2000)]
+        [InlineData(2147482647, 999, 600)]
+        [InlineData(-2147483648, 1000, 19)]
+        public static void CheckGetDynamicPartitionsWithRange(int from, int count, int desiredRangeSize)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -284,17 +260,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetOrderablePartitionsWithRange()
-        {
-            CheckGetOrderablePartitionsWithRange(1999, 1000, 20, 1);
-            CheckGetOrderablePartitionsWithRange(-1999, 1000, 100, 2);
-            CheckGetOrderablePartitionsWithRange(1999, 1, 2000, 3);
-            CheckGetOrderablePartitionsWithRange(2147482647, 999, 600, 4);
-            CheckGetOrderablePartitionsWithRange(-2147483648, 1000, 19, 63);
-        }
-
-        private static void CheckGetOrderablePartitionsWithRange(int from, int count, int desiredRangeSize, int dop)
+        [Theory]
+        [InlineData(1999, 1000, 20, 1)]
+        [InlineData(-1999, 1000, 100, 2)]
+        [InlineData(1999, 1, 2000, 3)]
+        [InlineData(2147482647, 999, 600, 4)]
+        [InlineData(-2147483648, 1000, 19, 63)]
+        public static void CheckGetOrderablePartitionsWithRange(int from, int count, int desiredRangeSize, int dop)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -337,17 +309,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void GetOrderableDynamicPartitionsWithRange()
-        {
-            GetOrderableDynamicPartitionsWithRange(1999, 1000, 20);
-            GetOrderableDynamicPartitionsWithRange(-1999, 1000, 100);
-            GetOrderableDynamicPartitionsWithRange(1999, 1, 2000);
-            GetOrderableDynamicPartitionsWithRange(2147482647, 999, 600);
-            GetOrderableDynamicPartitionsWithRange(-2147483648, 1000, 19);
-        }
-
-        private static void GetOrderableDynamicPartitionsWithRange(int from, int count, int desiredRangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 20)]
+        [InlineData(-1999, 1000, 100)]
+        [InlineData(1999, 1, 2000)]
+        [InlineData(2147482647, 999, 600)]
+        [InlineData(-2147483648, 1000, 19)]
+        public static void GetOrderableDynamicPartitionsWithRange(int from, int count, int desiredRangeSize)
         {
             int to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -400,20 +368,16 @@ namespace System.Collections.Concurrent.Tests
             Assert.InRange(rangeSizes[rangeSizes.Count - 1], 0, desiredRangeSize);
         }
 
-        [Fact]
-        public static void RangePartitionerChunking()
-        {
-            RangePartitionerChunking(1999, 1000, 10);
-            RangePartitionerChunking(89, 17823, -1);
-        }
-
         /// <summary>
         /// Ensure that the range partitioner doesn't chunk up elements i.e. uses chunk size = 1
         /// </summary>
         /// <param name="from"></param>
         /// <param name="count"></param>
         /// <param name="rangeSize"></param>
-        private static void RangePartitionerChunking(int from, int count, int rangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 10)]
+        [InlineData(89, 17823, -1)]
+        public static void RangePartitionerChunking(int from, int count, int rangeSize)
         {
             int to = from + count;
 
@@ -480,20 +444,16 @@ namespace System.Collections.Concurrent.Tests
             Assert.Equal(count, actualCount);
         }
 
-        [Fact]
-        public static void RangePartitionerDynamicChunking()
-        {
-            RangePartitionerDynamicChunking(1999, 1000, 10);
-            RangePartitionerDynamicChunking(1, 884354, -1);
-        }
-
         /// <summary>
         /// Ensure that the range partitioner doesn't chunk up elements i.e. uses chunk size = 1
         /// </summary>
         /// <param name="from"></param>
         /// <param name="count"></param>
         /// <param name="rangeSize"></param>
-        private static void RangePartitionerDynamicChunking(int from, int count, int rangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 10)]
+        [InlineData(1, 884354, -1)]
+        public static void RangePartitionerDynamicChunking(int from, int count, int rangeSize)
         {
             int to = from + count;
 
@@ -557,7 +517,7 @@ namespace System.Collections.Concurrent.Tests
             // Verifying that all items are there
             Assert.Equal(count, actualCount);
         }
-        
+
         /// <summary>
         /// Ensure that the range partitioner doesn't exceed the exclusive bound
         /// </summary>

--- a/src/libraries/System.Collections.Concurrent/tests/LongRangePartitionerTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/LongRangePartitionerTests.cs
@@ -49,19 +49,15 @@ namespace System.Collections.Concurrent.Tests
         /// We unroll the tuples and flatten them to a single sequence
         /// The single sequence is compared to the original range for verification
         /// </summary>
-        [Fact]
-        public static void CheckGetPartitions()
-        {
-            CheckGetPartitions(0, 1, 1);
-            CheckGetPartitions(1, 1999, 3);
-            CheckGetPartitions(2147473647, 9999, 4);
-            CheckGetPartitions(2147484647, 1000, 8);
-            CheckGetPartitions(-2147484647, 1000, 16);
-            CheckGetPartitions(-1999, 5000, 63);
-            CheckGetPartitions(9223372036854774807, 999, 13); // close to Int64.Max
-        }
-
-        private static void CheckGetPartitions(long from, long count, int dop)
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(1, 1999, 3)]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(2147484647, 1000, 8)]
+        [InlineData(-2147484647, 1000, 16)]
+        [InlineData(-1999, 5000, 63)]
+        [InlineData(9223372036854774807, 999, 13)] // close to Int64.Max
+        public static void CheckGetPartitions(long from, long count, int dop)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -81,19 +77,15 @@ namespace System.Collections.Concurrent.Tests
         /// We unroll the tuples and flatten them to a single sequence
         /// The single sequence is compared to the original range for verification
         /// </summary>
-        [Fact]
-        public static void CheckGetDynamicPartitions()
-        {
-            CheckGetDynamicPartitions(0, 1);
-            CheckGetDynamicPartitions(1, 1999);
-            CheckGetDynamicPartitions(2147473647, 9999);
-            CheckGetDynamicPartitions(2147484647, 1000);
-            CheckGetDynamicPartitions(-2147484647, 1000);
-            CheckGetDynamicPartitions(-1999, 5000);
-            CheckGetDynamicPartitions(9223372036854774807, 999); // close to Int64.Max
-        }
-
-        private static void CheckGetDynamicPartitions(long from, long count)
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1999)]
+        [InlineData(2147473647, 9999)]
+        [InlineData(2147484647, 1000)]
+        [InlineData(-2147484647, 1000)]
+        [InlineData(-1999, 5000)]
+        [InlineData(9223372036854774807, 999)] // close to Int64.Max
+        public static void CheckGetDynamicPartitions(long from, long count)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -114,19 +106,15 @@ namespace System.Collections.Concurrent.Tests
         /// The single sequence is compared to the original range for verification
         /// Also the indices are extracted to ensure that they are ordered & normalized
         /// </summary>
-        [Fact]
-        public static void CheckGetOrderablePartitions()
-        {
-            CheckGetOrderablePartitions(0, 1, 1);
-            CheckGetOrderablePartitions(1, 1999, 3);
-            CheckGetOrderablePartitions(2147473647, 9999, 4);
-            CheckGetOrderablePartitions(2147484647, 1000, 8);
-            CheckGetOrderablePartitions(-2147484647, 1000, 16);
-            CheckGetOrderablePartitions(-1999, 5000, 63);
-            CheckGetOrderablePartitions(9223372036854774807, 999, 13); // close to Int64.Max
-        }
-
-        private static void CheckGetOrderablePartitions(long from, long count, int dop)
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(1, 1999, 3)]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(2147484647, 1000, 8)]
+        [InlineData(-2147484647, 1000, 16)]
+        [InlineData(-1999, 5000, 63)]
+        [InlineData(9223372036854774807, 999, 13)] // close to Int64.Max
+        public static void CheckGetOrderablePartitions(long from, long count, int dop)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -159,19 +147,15 @@ namespace System.Collections.Concurrent.Tests
         /// </summary>
         /// <param name="from"></param>
         /// <param name="count"></param>
-        [Fact]
-        public static void GetOrderableDynamicPartitions()
-        {
-            GetOrderableDynamicPartitions(0, 1);
-            GetOrderableDynamicPartitions(1, 1999);
-            GetOrderableDynamicPartitions(2147473647, 9999);
-            GetOrderableDynamicPartitions(2147484647, 1000);
-            GetOrderableDynamicPartitions(-2147484647, 1000);
-            GetOrderableDynamicPartitions(-1999, 5000);
-            GetOrderableDynamicPartitions(9223372036854774807, 999); // close to Int64.Max
-        }
-
-        private static void GetOrderableDynamicPartitions(long from, long count)
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1999)]
+        [InlineData(2147473647, 9999)]
+        [InlineData(2147484647, 1000)]
+        [InlineData(-2147484647, 1000)]
+        [InlineData(-1999, 5000)]
+        [InlineData(9223372036854774807, 999)] // close to Int64.Max
+        public static void GetOrderableDynamicPartitions(long from, long count)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to);
@@ -202,17 +186,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetPartitionsWithRange()
-        {
-            CheckGetPartitionsWithRange(1999, 1000, 20, 1);
-            CheckGetPartitionsWithRange(-1999, 1000, 100, 2);
-            CheckGetPartitionsWithRange(1999, 1, 2000, 3);
-            CheckGetPartitionsWithRange(9223372036854774807, 999, 600, 4);
-            CheckGetPartitionsWithRange(-9223372036854774807, 1000, 19, 63);
-        }
-
-        private static void CheckGetPartitionsWithRange(long from, long count, long desiredRangeSize, int dop)
+        [Theory]
+        [InlineData(1999, 1000, 20, 1)]
+        [InlineData(-1999, 1000, 100, 2)]
+        [InlineData(1999, 1, 2000, 3)]
+        [InlineData(9223372036854774807, 999, 600, 4)]
+        [InlineData(-9223372036854774807, 1000, 19, 63)]
+        public static void CheckGetPartitionsWithRange(long from, long count, long desiredRangeSize, int dop)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -244,17 +224,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetDynamicPartitionsWithRange()
-        {
-            CheckGetDynamicPartitionsWithRange(1999, 1000, 20);
-            CheckGetDynamicPartitionsWithRange(-1999, 1000, 100);
-            CheckGetDynamicPartitionsWithRange(1999, 1, 2000);
-            CheckGetDynamicPartitionsWithRange(9223372036854774807, 999, 600);
-            CheckGetDynamicPartitionsWithRange(-9223372036854774807, 1000, 19);
-        }
-
-        private static void CheckGetDynamicPartitionsWithRange(long from, long count, long desiredRangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 20)]
+        [InlineData(-1999, 1000, 100)]
+        [InlineData(1999, 1, 2000)]
+        [InlineData(9223372036854774807, 999, 600)]
+        [InlineData(-9223372036854774807, 1000, 19)]
+        public static void CheckGetDynamicPartitionsWithRange(long from, long count, long desiredRangeSize)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -286,17 +262,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void CheckGetOrderablePartitionsWithRange()
-        {
-            CheckGetOrderablePartitionsWithRange(1999, 1000, 20, 1);
-            CheckGetOrderablePartitionsWithRange(-1999, 1000, 100, 2);
-            CheckGetOrderablePartitionsWithRange(1999, 1, 2000, 3);
-            CheckGetOrderablePartitionsWithRange(9223372036854774807, 999, 600, 4);
-            CheckGetOrderablePartitionsWithRange(-9223372036854774807, 1000, 19, 63);
-        }
-
-        private static void CheckGetOrderablePartitionsWithRange(long from, long count, long desiredRangeSize, int dop)
+        [Theory]
+        [InlineData(1999, 1000, 20, 1)]
+        [InlineData(-1999, 1000, 100, 2)]
+        [InlineData(1999, 1, 2000, 3)]
+        [InlineData(9223372036854774807, 999, 600, 4)]
+        [InlineData(-9223372036854774807, 1000, 19, 63)]
+        public static void CheckGetOrderablePartitionsWithRange(long from, long count, long desiredRangeSize, int dop)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -339,17 +311,13 @@ namespace System.Collections.Concurrent.Tests
         /// The range sizes for individual ranges are checked to see if they are equal to
         /// desiredRangeSize. The last range may have less than or equal to desiredRangeSize.
         /// </summary>
-        [Fact]
-        public static void GetOrderableDynamicPartitionsWithRange()
-        {
-            GetOrderableDynamicPartitionsWithRange(1999, 1000, 20);
-            GetOrderableDynamicPartitionsWithRange(-1999, 1000, 100);
-            GetOrderableDynamicPartitionsWithRange(1999, 1, 2000);
-            GetOrderableDynamicPartitionsWithRange(9223372036854774807, 999, 600);
-            GetOrderableDynamicPartitionsWithRange(-9223372036854774807, 1000, 19);
-        }
-
-        private static void GetOrderableDynamicPartitionsWithRange(long from, long count, long desiredRangeSize)
+        [Theory]
+        [InlineData(1999, 1000, 20)]
+        [InlineData(-1999, 1000, 100)]
+        [InlineData(1999, 1, 2000)]
+        [InlineData(9223372036854774807, 999, 600)]
+        [InlineData(-9223372036854774807, 1000, 19)]
+        public static void GetOrderableDynamicPartitionsWithRange(long from, long count, long desiredRangeSize)
         {
             long to = from + count;
             var partitioner = Partitioner.Create(from, to, desiredRangeSize);
@@ -408,14 +376,10 @@ namespace System.Collections.Concurrent.Tests
         /// <summary>
         /// Ensure that the range partitioner doesn't chunk up elements i.e. uses chunk size = 1
         /// </summary>
-        [Fact]
-        public static void RangePartitionerChunking()
-        {
-            RangePartitionerChunking(2147473647, 9999, 4);
-            RangePartitionerChunking(2147484647, 1000, -1);
-        }
-
-        private static void RangePartitionerChunking(long from, long count, long rangeSize)
+        [Theory]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(2147484647, 1000, -1)]
+        public static void RangePartitionerChunking(long from, long count, long rangeSize)
         {
             long to = from + count;
 
@@ -481,14 +445,10 @@ namespace System.Collections.Concurrent.Tests
         /// <summary>
         /// Ensure that the range partitioner doesn't chunk up elements i.e. uses chunk size = 1
         /// </summary>
-        [Fact]
-        public static void RangePartitionerDynamicChunking()
-        {
-            RangePartitionerDynamicChunking(2147473647, 9999, 4);
-            RangePartitionerDynamicChunking(2147484647, 1000, -1);
-        }
-
-        private static void RangePartitionerDynamicChunking(long from, long count, long rangeSize)
+        [Theory]
+        [InlineData(2147473647, 9999, 4)]
+        [InlineData(2147484647, 1000, -1)]
+        public static void RangePartitionerDynamicChunking(long from, long count, long rangeSize)
         {
             long to = from + count;
 
@@ -552,7 +512,7 @@ namespace System.Collections.Concurrent.Tests
             // Verifying that all items are there
             Assert.Equal(count, actualCount);
         }
-        
+
         /// <summary>
         /// Ensure that the range partitioner doesn't exceed the exclusive bound
         /// </summary>

--- a/src/libraries/System.Collections.Concurrent/tests/RangePartitionerNegativeTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/RangePartitionerNegativeTests.cs
@@ -25,15 +25,11 @@ namespace System.Collections.Concurrent.Tests
         /// <summary>
         /// Test passing invalid range, 'to' is smaller or equal than 'from'
         /// </summary>
-        [Fact]
-        public static void IntFromNotGreaterThanTo()
-        {
-            IntFromNotGreaterThanTo(1000, 0, 100);
-            IntFromNotGreaterThanTo(899, 899, 100);
-            IntFromNotGreaterThanTo(-19999, -299999, 100);
-        }
-
-        private static void IntFromNotGreaterThanTo(int from, int to, int rangesize)
+        [Theory]
+        [InlineData(1000, 0, 100)]
+        [InlineData(899, 899, 100)]
+        [InlineData(-19999, -299999, 100)]
+        public static void IntFromNotGreaterThanTo(int from, int to, int rangesize)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to));
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to, rangesize));
@@ -41,15 +37,11 @@ namespace System.Collections.Concurrent.Tests
 
         /// <summary>
         /// Test passing invalid range, 'to' is smaller or equal than 'from', on long overload
-        [Fact]
-        public static void LongFromNotGreaterThanTo()
-        {
-            LongFromNotGreaterThanTo(1000, 0, 100);
-            LongFromNotGreaterThanTo(899, 899, 100);
-            LongFromNotGreaterThanTo(-19999, -299999, 100);
-        }
-
-        private static void LongFromNotGreaterThanTo(long from, long to, int rangesize)
+        [Theory]
+        [InlineData(1000, 0, 100)]
+        [InlineData(899, 899, 100)]
+        [InlineData(-19999, -299999, 100)]
+        public static void LongFromNotGreaterThanTo(long from, long to, int rangesize)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to));
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to, rangesize));
@@ -58,14 +50,10 @@ namespace System.Collections.Concurrent.Tests
         /// <summary>
         /// Test passing invalid range size, less than or equal to 0
         /// </summary>
-        [Fact]
-        public static void InvalidIntRangeSize()
-        {
-            InvalidIntRangeSize(0, 1000, 0);
-            InvalidIntRangeSize(899, 9000, -10);
-        }
-
-        private static void InvalidIntRangeSize(int from, int to, int rangesize)
+        [Theory]
+        [InlineData(0, 1000, 0)]
+        [InlineData(899, 9000, -10)]
+        public static void InvalidIntRangeSize(int from, int to, int rangesize)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to, rangesize));
         }
@@ -73,14 +61,10 @@ namespace System.Collections.Concurrent.Tests
         /// <summary>
         /// Test passing invalid range size, less than or equal to 0, on long overload
         /// </summary>
-        [Fact]
-        public static void ATestMethod()
-        {
-            InvalidLongRangeSize(0, 1000, 0);
-            InvalidLongRangeSize(899, 9000, -10);
-        }
-
-        private static void InvalidLongRangeSize(long from, long to, long rangesize)
+        [Theory]
+        [InlineData(0, 1000, 0)]
+        [InlineData(899, 9000, -10)]
+        public static void InvalidLongRangeSize(long from, long to, long rangesize)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => Partitioner.Create(from, to, rangesize));
         }

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -838,7 +838,7 @@ namespace System.Collections.Immutable.Tests
 
         [Theory]
         [MemberData(nameof(EqualsData))]
-        public void Equals(ImmutableArray<int> first, ImmutableArray<int> second, bool expected)
+        public void EqualsBaseTest(ImmutableArray<int> first, ImmutableArray<int> second, bool expected)
         {
             Assert.Equal(expected, first == second);
             Assert.NotEqual(expected, first != second);
@@ -944,7 +944,7 @@ namespace System.Collections.Immutable.Tests
         [Theory]
         [MemberData(nameof(Int32EnumerableData))]
         [MemberData(nameof(SpecialInt32ImmutableArrayData))]
-        public void GetHashCode(IEnumerable<int> source)
+        public void GetHashCodeTest(IEnumerable<int> source)
         {
             var array = source.ToImmutableArray();
 
@@ -2252,7 +2252,7 @@ namespace System.Collections.Immutable.Tests
 
         [Theory]
         [MemberData(nameof(Int32EnumerableData))]
-        public void DebuggerAttributesValid(IEnumerable<int> source)
+        public void DebuggerAttributesValid_AdditionalCases(IEnumerable<int> source)
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(source.ToImmutableArray());
         }

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -838,7 +838,7 @@ namespace System.Collections.Immutable.Tests
 
         [Theory]
         [MemberData(nameof(EqualsData))]
-        public void EqualsBaseTest(ImmutableArray<int> first, ImmutableArray<int> second, bool expected)
+        public void EqualsTest(ImmutableArray<int> first, ImmutableArray<int> second, bool expected)
         {
             Assert.Equal(expected, first == second);
             Assert.NotEqual(expected, first != second);

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -40,7 +40,23 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void RemoveNonExistingTest()
         {
-            this.RemoveNonExistingTest(this.Empty<int>());
+            var emptySet = this.Empty<int>();
+            Assert.Same(emptySet, emptySet.Remove(5));
+
+            // Also fill up a set with many elements to build up the tree, then remove from various places in the tree.
+            const int Size = 200;
+            var set = emptySet;
+            for (int i = 0; i < Size; i += 2)
+            { // only even numbers!
+                set = set.Add(i);
+            }
+
+            // Verify that removing odd numbers doesn't change anything.
+            for (int i = 1; i < Size; i += 2)
+            {
+                var setAfterRemoval = set.Remove(i);
+                Assert.Same(set, setAfterRemoval);
+            }
         }
 
         [Fact]
@@ -379,26 +395,6 @@ namespace System.Collections.Immutable.Tests
             }
 
             Assert.Equal(initialCount - removedCount, set.Count);
-        }
-
-        private void RemoveNonExistingTest(IImmutableSet<int> emptySet)
-        {
-            Assert.Same(emptySet, emptySet.Remove(5));
-
-            // Also fill up a set with many elements to build up the tree, then remove from various places in the tree.
-            const int Size = 200;
-            var set = emptySet;
-            for (int i = 0; i < Size; i += 2)
-            { // only even numbers!
-                set = set.Add(i);
-            }
-
-            // Verify that removing odd numbers doesn't change anything.
-            for (int i = 1; i < Size; i += 2)
-            {
-                var setAfterRemoval = set.Remove(i);
-                Assert.Same(set, setAfterRemoval);
-            }
         }
 
         private void AddRemoveLoadTestHelper<T>(IImmutableSet<T> set, T[] data)

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -40,7 +40,7 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void RemoveNonExistingTest()
         {
-            var emptySet = this.Empty<int>();
+            IImmutableSet<int> emptySet = this.Empty<int>();
             Assert.Same(emptySet, emptySet.Remove(5));
 
             // Also fill up a set with many elements to build up the tree, then remove from various places in the tree.

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.KeysTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.KeysTests.cs
@@ -106,7 +106,7 @@ namespace System.Collections.Specialized.Tests
         public void Keys_CopyTo(int count, int index)
         {
             MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(count);
-            Keys_CopyTo(nameObjectCollection, index);
+            Keys_CopyTo_Helper(nameObjectCollection, index);
         }
 
         [Fact]
@@ -118,10 +118,10 @@ namespace System.Collections.Specialized.Tests
             nameObjectCollection.Add(null, null);
             nameObjectCollection.Add(null, new Foo("3"));
 
-            Keys_CopyTo(nameObjectCollection, 0);
+            Keys_CopyTo_Helper(nameObjectCollection, 0);
         }
 
-        private static void Keys_CopyTo(MyNameObjectCollection nameObjectCollection, int index)
+        private static void Keys_CopyTo_Helper(MyNameObjectCollection nameObjectCollection, int index)
         {
             ICollection keys = nameObjectCollection.Keys;
             string[] keysArray = new string[index + keys.Count + index];

--- a/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Tests.cs
@@ -37,7 +37,7 @@ namespace System.Collections.Generic.Tests
         [MemberData(nameof(Int64EnumData))]
         [MemberData(nameof(NonEquatableValueTypeData))]
         [MemberData(nameof(ObjectData))]
-        public void Equals<T>(T left, T right, bool expected)
+        public void EqualsTest<T>(T left, T right, bool expected)
         {
             var comparer = EqualityComparer<T>.Default;
             IEqualityComparer nonGenericComparer = comparer;
@@ -305,7 +305,7 @@ namespace System.Collections.Generic.Tests
         [MemberData(nameof(Int64EnumHashData))]
         [MemberData(nameof(NonEquatableValueTypeHashData))]
         [MemberData(nameof(ObjectHashData))]
-        public void GetHashCode<T>(T value, int expected)
+        public void GetHashCodeTest<T>(T value, int expected)
         {
             var comparer = EqualityComparer<T>.Default;
             IEqualityComparer nonGenericComparer = comparer;

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/FilterUIHintAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/FilterUIHintAttributeTests.cs
@@ -78,7 +78,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(FilterUIHintAttribute attribute, object obj, bool expected)
+        public void EqualsTest(FilterUIHintAttribute attribute, object obj, bool expected)
         {
             Assert.Equal(expected, attribute.Equals(obj));
             Assert.Equal(attribute.GetHashCode(), attribute.GetHashCode());

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/UIHintAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/UIHintAttributeTests.cs
@@ -77,7 +77,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UIHintAttribute attribute, object obj, bool expected)
+        public void EqualsTest(UIHintAttribute attribute, object obj, bool expected)
         {
             Assert.Equal(expected, attribute.Equals(obj));
             Assert.Equal(attribute.GetHashCode(), attribute.GetHashCode());

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignerTransactionTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/DesignerTransactionTests.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel.Design.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("Description")]
-        public void Ctor_Default(string description)
+        public void Ctor_Description(string description)
         {
             using (var transaction = new TestDesignerTransaction(description))
             {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/DesignerSerializerAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/DesignerSerializerAttributeTests.cs
@@ -45,7 +45,7 @@ namespace System.ComponentModel.Design.Serialization.Tests
         [Theory]
         [InlineData(null, null)]
         [InlineData("SerializerTypeName", "BaseSerializerTypeName")]
-        public void Ctor_SerializerTypeName_BaseSerializerType(string serializerTypeName, string baseSerializerTypeName)
+        public void Ctor_SerializerTypeName_BaseSerializerTypeName(string serializerTypeName, string baseSerializerTypeName)
         {
             var attribute = new DesignerSerializerAttribute(serializerTypeName, baseSerializerTypeName);
             Assert.Equal(serializerTypeName, attribute.SerializerTypeName);

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/RootDesignerSerializerAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/RootDesignerSerializerAttributeTests.cs
@@ -48,7 +48,7 @@ namespace System.ComponentModel.Design.Serialization.Tests
         [Theory]
         [InlineData(null, null, true)]
         [InlineData("SerializerTypeName", "BaseSerializerTypeName", false)]
-        public void Ctor_SerializerTypeName_BaseSerializerType(string serializerTypeName, string baseSerializerTypeName, bool reloadable)
+        public void Ctor_SerializerTypeName_BaseSerializerTypeName(string serializerTypeName, string baseSerializerTypeName, bool reloadable)
         {
             var attribute = new RootDesignerSerializerAttribute(serializerTypeName, baseSerializerTypeName, reloadable);
             Assert.Equal(serializerTypeName, attribute.SerializerTypeName);

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Tests
         private static EnumConverter s_someFlagsEnumConverter = new EnumConverter(typeof(SomeFlagsEnum));
 
         [Fact]
-        public static void CanConvertFrom_WithContext()
+        public static void CanConvertFrom_WithContext_EnumConverter()
         {
             CanConvertFrom_WithContext(new object[2, 2]
                 {
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void CanConvertTo_WithContext()
+        public static void CanConvertTo_WithContext_EnumConverter()
         {
             CanConvertTo_WithContext(new object[2, 2]
                 {
@@ -37,7 +37,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertFrom_WithContext()
+        public static void ConvertFrom_WithContext_EnumConverter()
         {
             ConvertFrom_WithContext(new object[2, 3]
                 {
@@ -62,7 +62,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        public static void ConvertTo_WithContext_EnumConverter()
         {
             ConvertTo_WithContext(new object[1, 3]
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/MultilineStringConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/MultilineStringConverterTests.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel.Tests
     public class MultilineStringConverterTests : ConverterTestBase
     {
         [Fact]
-        public static void ConvertTo_WithContext()
+        public static void ConvertTo_WithContext_MultilineStringConverter()
         {
             using (new ThreadCultureChange(null, CultureInfo.InvariantCulture))
             {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/NullableConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/NullableConverterTests.cs
@@ -43,7 +43,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void CanConvertFrom_WithContext()
+        public static void CanConvertFrom_WithContext_NullableConverter()
         {
             CanConvertFrom_WithContext(new object[2, 2]
                 {
@@ -54,7 +54,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void CanConvertTo_WithContext()
+        public static void CanConvertTo_WithContext_NullableConverter()
         {
             CanConvertTo_WithContext(new object[3, 2]
                 {
@@ -66,7 +66,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertFrom_WithContext()
+        public static void ConvertFrom_WithContext_NullableConverter()
         {
             ConvertFrom_WithContext(new object[3, 3]
                 {
@@ -78,7 +78,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        public static void ConvertTo_WithContext_NullableConverter()
         {
             ConvertTo_WithContext(new object[4, 3]
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TypeDescriptionProviderTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TypeDescriptionProviderTests.cs
@@ -202,7 +202,7 @@ namespace System.ComponentModel.Tests
         {
             yield return new object[] { new object() };
             yield return new object[] { new Component() };
-            
+
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
                 .Setup(s => s.Container)
@@ -230,7 +230,7 @@ namespace System.ComponentModel.Tests
             {
                 yield return new object[] { new object(), result };
                 yield return new object[] { new Component(), result };
-                
+
                 var mockSite = new Mock<ISite>(MockBehavior.Strict);
                 mockSite
                     .Setup(s => s.Container)
@@ -341,7 +341,7 @@ namespace System.ComponentModel.Tests
         [Theory]
         [InlineData(null)]
         [InlineData(typeof(int))]
-        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload(Type objectType)
+        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload_ByType(Type objectType)
         {
             var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
             mockProvider
@@ -396,7 +396,7 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [InlineData(1, typeof(int))]
-        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload(object instance, Type expected)
+        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload_ByObjectAndType(object instance, Type expected)
         {
             var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
             mockProvider
@@ -499,7 +499,7 @@ namespace System.ComponentModel.Tests
             // Call again.
             Assert.Same(reflectionType, provider.GetRuntimeType(reflectionType));
         }
-        
+
         [Theory]
         [InlineData(null)]
         [InlineData(typeof(int))]
@@ -571,7 +571,7 @@ namespace System.ComponentModel.Tests
         [Theory]
         [InlineData(null)]
         [InlineData(typeof(int))]
-        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload(Type objectType)
+        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload_Type(Type objectType)
         {
             var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
             mockProvider
@@ -630,7 +630,7 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [InlineData(1)]
-        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload(object instance)
+        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload_Object(object instance)
         {
             var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
             mockProvider
@@ -783,7 +783,7 @@ namespace System.ComponentModel.Tests
             public SubTypeDescriptionProvider() : base()
             {
             }
-            
+
             public SubTypeDescriptionProvider(TypeDescriptionProvider parent) : base(parent)
             {
             }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TypeListConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TypeListConverterTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Tests
         private static TypeListConverter s_converter = new MyTypeListConverter(new Type[] { typeof(bool), typeof(int) });
 
         [Fact]
-        public static void CanConvertFrom_WithContext()
+        public static void CanConvertFrom_WithContext_TypeListConverter()
         {
             CanConvertFrom_WithContext(new object[2, 2]
                 {
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertFrom_WithContext()
+        public static void ConvertFrom_WithContext_TypeListConverter()
         {
             ConvertFrom_WithContext(new object[1, 3]
                 {
@@ -36,7 +36,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        public static void ConvertTo_WithContext_TypeListConverter()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.Tests
         private static UriTypeConverter s_converter = new UriTypeConverter();
 
         [Fact]
-        public static void CanConvertFrom_WithContext()
+        public static void CanConvertFrom_WithContext_UriTypeConverter()
         {
             CanConvertFrom_WithContext(new object[3, 2]
                 {
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void CanConvertTo_WithContext()
+        public static void CanConvertTo_WithContext_UriTypeConverter()
         {
             CanConvertTo_WithContext(new object[3, 2]
                 {
@@ -38,7 +38,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertFrom_WithContext()
+        public static void ConvertFrom_WithContext_UriTypeConverter()
         {
             ConvertFrom_WithContext(new object[5, 3]
                 {
@@ -52,7 +52,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertTo_WithContext()
+        public static void ConvertTo_WithContext_UriTypeConverter()
         {
             ConvertTo_WithContext(new object[3, 3]
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/VersionConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/VersionConverterTests.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel.Tests
         private static VersionConverter s_converter = new VersionConverter();
 
         [Fact]
-        public static void CanConvertFrom_WithContext()
+        public static void CanConvertFrom_WithContext_VersionConverter()
         {
             CanConvertFrom_WithContext(new object[3, 2]
                 {
@@ -24,7 +24,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void ConvertFrom_WithContext()
+        public static void ConvertFrom_WithContext_VersionConverter()
         {
             ConvertFrom_WithContext(new object[4, 3]
                 {
@@ -37,7 +37,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public static void CanConvertTo_WithContext()
+        public static void CanConvertTo_WithContext_VersionConverter()
         {
             CanConvertTo_WithContext(new object[3, 2]
                 {

--- a/src/libraries/System.Composition.AttributedModel/tests/ExportAttributeTests.cs
+++ b/src/libraries/System.Composition.AttributedModel/tests/ExportAttributeTests.cs
@@ -29,7 +29,7 @@ namespace System.Composition.AttributeModel.Tests
         [Theory]
         [InlineData(null)]
         [InlineData(typeof(string))]
-        public void Ctor_ContractName(Type contractType)
+        public void Ctor_ContractType(Type contractType)
         {
             var attribute = new ExportAttribute(contractType);
             Assert.Null(attribute.ContractName);

--- a/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
+++ b/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
@@ -25,7 +25,7 @@ namespace System.Composition.Runtime.Tests
         [Theory]
         [InlineData(typeof(int), null)]
         [InlineData(typeof(object), "contractName")]
-        public void Ctor_ContractType(Type contractType, string contractName)
+        public void Ctor_ContractType_ContractName(Type contractType, string contractName)
         {
             var contract = new CompositionContract(contractType, contractName);
             Assert.Equal(contractType, contract.ContractType);

--- a/src/libraries/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
@@ -436,7 +436,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataTable table = new DataTable("test_table");
             DataTable table2 = new DataTable("test_table");

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
@@ -207,7 +207,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataRelationCollection drcol = _dataset.Relations;
             drcol.Add("CustOrder"

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRelationTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRelationTest2.cs
@@ -155,7 +155,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void ToString()
+        public void ToStringTest()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -441,7 +441,7 @@ namespace System.Data.Tests
             PropertyCollection pc;
             pc = dRel.ExtendedProperties;
 
-            // Checking ExtendedProperties default 
+            // Checking ExtendedProperties default
             Assert.NotNull(pc);
 
             // Checking ExtendedProperties count

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
@@ -366,7 +366,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             _tbl.Columns.Add();
             _tbl.Columns.Add();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -134,7 +134,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataTable myTable = new DataTable("myTable");
             DataRow dr1, dr2;
@@ -389,7 +389,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void GetHashCode()
+        public void GetHashCodeTest()
         {
             int iHashCode;
             DataRow dr;

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
@@ -223,7 +223,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             DataView dv = new DataView(dt);

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
@@ -262,7 +262,7 @@ namespace System.Data.Tests
             Assert.Equal("Table4", array1[5].TableName);
         }
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataTableCollection tbcol1 = _dataset[0].Tables;
             DataTableCollection tbcol2 = _dataset[1].Tables;

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -1846,13 +1846,13 @@ Assert.False(true);
             Assert.False(col2.Unique);
         }
 
-        private void RowChanging(object o, DataRowChangeEventArgs e)
+        private void RowChangingEventHandler(object o, DataRowChangeEventArgs e)
         {
             Assert.Equal(_rowChangingExpectedAction, e.Action);
             _rowChangingRowChanging = true;
         }
 
-        private void RowChanged(object o, DataRowChangeEventArgs e)
+        private void RowChangedEventHandler(object o, DataRowChangeEventArgs e)
         {
             Assert.Equal(_rowChangingExpectedAction, e.Action);
             _rowChangingRowChanged = true;
@@ -1867,8 +1867,8 @@ Assert.False(true);
             DataTable dt = new DataTable("table");
             dt.Columns.Add("col1");
             dt.Columns.Add("col2");
-            dt.RowChanging += new DataRowChangeEventHandler(RowChanging);
-            dt.RowChanged += new DataRowChangeEventHandler(RowChanged);
+            dt.RowChanging += new DataRowChangeEventHandler(RowChangingEventHandler);
+            dt.RowChanged += new DataRowChangeEventHandler(RowChangedEventHandler);
             _rowChangingExpectedAction = DataRowAction.Add;
             dt.Rows.Add(new object[] { 1, 2 });
             Assert.True(_rowChangingRowChanging);

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -690,7 +690,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void GetHashCode()
+        public void GetHashCodeTest()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             int iHashCode;
@@ -1431,7 +1431,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void ToString()
+        public void ToStringTest()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             dt.DisplayExpression = dt.Columns[0].ColumnName;

--- a/src/libraries/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
@@ -51,7 +51,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             var ds = new DataSet();
             DataTable dtParent = DataProvider.CreateParentDataTable();
@@ -120,7 +120,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void ToString()
+        public void ToStringTest()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateChildDataTable();

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
@@ -236,7 +236,7 @@ namespace System.Data.Tests.SqlTypes
 
         // Equals
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             SqlBoolean sqlTrue2 = new SqlBoolean(true);
             SqlBoolean sqlFalse2 = new SqlBoolean(false);

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
@@ -104,7 +104,7 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             SqlInt32 x;
             SqlInt32 y;

--- a/src/libraries/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
@@ -99,7 +99,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void ToString()
+        public void ToStringTest()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
 

--- a/src/libraries/System.Data.DataSetExtensions/tests/Mono/DataRowComparerTest.cs
+++ b/src/libraries/System.Data.DataSetExtensions/tests/Mono/DataRowComparerTest.cs
@@ -46,7 +46,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
-        public void Equals()
+        public void EqualsTest()
         {
             DataRowComparer<DataRow> c = DataRowComparer.Default;
 

--- a/src/libraries/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/libraries/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -22,7 +22,7 @@ namespace System.Data.OleDb.Tests
         [ConditionalTheory(Helpers.IsDriverAvailable)]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.TableDirect)]
-        public void DeriveParameters_NullCommand_Throws(CommandType commandType)
+        public void DeriveParameters_InvalidCommandType_Throws(CommandType commandType)
         {
             using (var cmd = (OleDbCommand)OleDbFactory.Instance.CreateCommand())
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -402,7 +402,7 @@ namespace System.Diagnostics.Tests
             MemberData(nameof(StartOSXProcessWithArgumentList))]
         [PlatformSpecific(TestPlatforms.OSX)]
         [OuterLoop("Opens browser")]
-        public void ProcessStart_UseShellExecuteTrue_OpenUrl_SuccessfullyReadsArgument(string[] argumentList)
+        public void ProcessStart_UseShellExecuteTrue_OpenUrl_SuccessfullyReadsArgumentArray(string[] argumentList)
         {
             var startInfo = new ProcessStartInfo { UseShellExecute = true, FileName = "https://github.com/dotnet/corefx"};
 

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -125,7 +125,7 @@ namespace System.Diagnostics.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Ctor_ThrownException_GetFramesReturnsExpected_2(bool fNeedFileInfo)
+        public void Ctor_Bool_ThrownException_GetFramesReturnsExpected(bool fNeedFileInfo)
         {
             var stackTrace = new StackTrace(InvokeException(), fNeedFileInfo);
             VerifyFrames(stackTrace, fNeedFileInfo);

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -107,6 +107,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void Ctor_ThrownException_GetFramesReturnsExpected()
         {
+            // TODO: is this test redundant? See Ctor_ThrownException_GetFramesReturnsExpected_2 below
             var stackTrace = new StackTrace(InvokeException());
             VerifyFrames(stackTrace, false);
         }
@@ -124,7 +125,7 @@ namespace System.Diagnostics.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Ctor_ThrownException_GetFramesReturnsExpected(bool fNeedFileInfo)
+        public void Ctor_ThrownException_GetFramesReturnsExpected_2(bool fNeedFileInfo)
         {
             var stackTrace = new StackTrace(InvokeException(), fNeedFileInfo);
             VerifyFrames(stackTrace, fNeedFileInfo);

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -107,7 +107,6 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void Ctor_ThrownException_GetFramesReturnsExpected()
         {
-            // TODO: is this test redundant? See Ctor_ThrownException_GetFramesReturnsExpected_2 below
             var stackTrace = new StackTrace(InvokeException());
             VerifyFrames(stackTrace, false);
         }

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalContextTests.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/PrincipalContextTests.cs
@@ -55,7 +55,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
         [InlineData(ContextType.Machine, "", null)]
         [InlineData(ContextType.Machine, "\0", null)]
         [InlineData(ContextType.Machine, "name", null)]
-        public void Ctor_ContextType_Name(ContextType contextType, string name, string container)
+        public void Ctor_ContextType_Name_Container(ContextType contextType, string name, string container)
         {
             var context = new PrincipalContext(contextType, name, container);
             Assert.Equal(contextType, context.ContextType);

--- a/src/libraries/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
@@ -58,7 +58,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_Identifier_NetworkCredential_TestData))]
-        public void Ctor_Identifier_AuthType(LdapDirectoryIdentifier identifier, NetworkCredential credential)
+        public void Ctor_Identifier_Credential(LdapDirectoryIdentifier identifier, NetworkCredential credential)
         {
             var connection = new LdapConnection(identifier, credential);
             Assert.Equal(AuthType.Negotiate, connection.AuthType);
@@ -76,7 +76,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_Identifier_NetworkCredential_AuthType_TestData))]
-        public void Ctor_Identifier_AuthType(LdapDirectoryIdentifier identifier, NetworkCredential credential, AuthType authType)
+        public void Ctor_Identifier_Credential_AuthType(LdapDirectoryIdentifier identifier, NetworkCredential credential, AuthType authType)
         {
             var connection = new LdapConnection(identifier, credential, authType);
             Assert.Equal(authType, connection.AuthType);

--- a/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/QuotaControlTests.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_QuerySid_TestData))]
-        public void Ctor_QuerySid_TestData(SecurityIdentifier querySid, byte[] expectedValue)
+        public void Ctor_QuerySid_Test(SecurityIdentifier querySid, byte[] expectedValue)
         {
             var control = new QuotaControl(querySid);
             Assert.True(control.IsCritical);

--- a/src/libraries/System.DirectoryServices.Protocols/tests/SortKeyTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/SortKeyTests.cs
@@ -20,7 +20,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [Theory]
         [InlineData("", null, false)]
         [InlineData("AttributeName", null, false)]
-        public void Ctor_Default(string attributeName, string matchingRule, bool reverseOrder)
+        public void Ctor_AttributeName_MatchingRule_ReverseOrder(string attributeName, string matchingRule, bool reverseOrder)
         {
             var sortKey = new SortKey(attributeName, matchingRule, reverseOrder);
             Assert.Equal(attributeName, sortKey.AttributeName);

--- a/src/libraries/System.Drawing.Common/tests/IconTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/IconTests.cs
@@ -397,7 +397,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ExtractAssociatedIcon_FilePath_Success()
         {
-            ExtractAssociatedIcon_FilePath_Success(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
+            ExtractAssociatedIcon_FilePath_Success_Helper(Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico"));
         }
 
         [PlatformSpecific(TestPlatforms.Windows)] // UNC
@@ -422,10 +422,10 @@ namespace System.Drawing.Tests
 
             Assert.True(new Uri(bitmapUncPath).IsUnc);
 
-            ExtractAssociatedIcon_FilePath_Success(bitmapUncPath);
+            ExtractAssociatedIcon_FilePath_Success_Helper(bitmapUncPath);
         }
 
-        private void ExtractAssociatedIcon_FilePath_Success(string filePath)
+        private void ExtractAssociatedIcon_FilePath_Success_Helper(string filePath)
         {
             using (Icon icon = Icon.ExtractAssociatedIcon(filePath))
             {

--- a/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -404,7 +404,7 @@ namespace System.Drawing.Imaging.Tests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Description_TestData))]
-        public void Ctor_StringIntPtrEmfType_Success(string description)
+        public void Ctor_StringIntPtrEmfTypeDescription_Success(string description)
         {
             string fileName = GetPath("newTestImage.wmf");
             using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format32bppArgb))
@@ -677,7 +677,7 @@ namespace System.Drawing.Imaging.Tests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(MetafileFrameUnit_Invalid_TestData))]
-        public void Ctor_InvalidEmfTypeII_ThrowsArgumentException(MetafileFrameUnit frameUnit)
+        public void Ctor_InvalidFrameUnit_ThrowsArgumentException(MetafileFrameUnit frameUnit)
         {
             string fileName = GetPath("newTestImage.wmf");
             using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format32bppArgb))
@@ -861,7 +861,7 @@ namespace System.Drawing.Imaging.Tests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(MetafileFrameUnit_Invalid_TestData))]
-        public void Ctor_InvalidEmfTypeIII_ThrowsArgumentException(MetafileFrameUnit frameUnit)
+        public void Ctor_InvalidFrameUnitIII_ThrowsArgumentException(MetafileFrameUnit frameUnit)
         {
             using (var stream = new MemoryStream())
             using (Bitmap bmp = new Bitmap(10, 10, PixelFormat.Format32bppArgb))

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -2106,7 +2106,7 @@ namespace MonoTests.System.Drawing
                     new CharacterRange (2, 1)
                 };
 
-        Region[] Measure(Graphics gfx, RectangleF rect)
+        Region[] Measure_Helper(Graphics gfx, RectangleF rect)
         {
             using (StringFormat format = StringFormat.GenericTypographic)
             {
@@ -2124,10 +2124,10 @@ namespace MonoTests.System.Drawing
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
             {
-                Region[] zero = Measure(gfx, new RectangleF(0, 0, 0, 0));
+                Region[] zero = Measure_Helper(gfx, new RectangleF(0, 0, 0, 0));
                 Assert.Equal(3, zero.Length);
 
-                Region[] small = Measure(gfx, new RectangleF(0, 0, 100, 100));
+                Region[] small = Measure_Helper(gfx, new RectangleF(0, 0, 100, 100));
                 Assert.Equal(3, small.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2139,7 +2139,7 @@ namespace MonoTests.System.Drawing
                     Assert.Equal(sb.Height, zb.Height);
                 }
 
-                Region[] max = Measure(gfx, new RectangleF(0, 0, float.MaxValue, float.MaxValue));
+                Region[] max = Measure_Helper(gfx, new RectangleF(0, 0, float.MaxValue, float.MaxValue));
                 Assert.Equal(3, max.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2158,7 +2158,7 @@ namespace MonoTests.System.Drawing
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
             {
-                Region[] min = Measure(gfx, new RectangleF(0, 0, float.MinValue, float.MinValue));
+                Region[] min = Measure_Helper(gfx, new RectangleF(0, 0, float.MinValue, float.MinValue));
                 Assert.Equal(3, min.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2169,7 +2169,7 @@ namespace MonoTests.System.Drawing
                     Assert.Equal(8388608.0f, mb.Height);
                 }
 
-                Region[] neg = Measure(gfx, new RectangleF(0, 0, -20, -20));
+                Region[] neg = Measure_Helper(gfx, new RectangleF(0, 0, -20, -20));
                 Assert.Equal(3, neg.Length);
                 for (int i = 0; i < 3; i++)
                 {

--- a/src/libraries/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/libraries/System.Drawing.Primitives/tests/ColorTests.cs
@@ -250,7 +250,7 @@ namespace System.Drawing.Primitives.Tests
 
         [Theory]
         [MemberData(nameof(ColorNamePairs))]
-        public void GetHashCode(string name1, string name2)
+        public void GetHashCodeTest(string name1, string name2)
         {
             Assert.NotEqual(name1, name2);
             Color c1 = GetColorByProperty(name1) ?? Color.FromName(name1);

--- a/src/libraries/System.Globalization.Extensions/tests/GetStringComparerTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/GetStringComparerTests.cs
@@ -60,7 +60,7 @@ namespace System.Globalization.Tests
         [InlineData("en-US", CompareOptions.IgnoreCase, "en-US", CompareOptions.IgnoreSymbols, false)]
         [InlineData("en-US", CompareOptions.IgnoreCase, "fr-FR", CompareOptions.IgnoreCase, false)]
         [InlineData("en-US", CompareOptions.IgnoreCase, "fr-FR", CompareOptions.Ordinal, false)]
-        public void Equals(string cultureName1, CompareOptions options1, string cultureName2, CompareOptions options2, bool expected)
+        public void EqualsTest(string cultureName1, CompareOptions options1, string cultureName2, CompareOptions options2, bool expected)
         {
             StringComparer comparer1 = new CultureInfo(cultureName1).CompareInfo.GetStringComparer(options1);
             StringComparer comparer2 = new CultureInfo(cultureName2).CompareInfo.GetStringComparer(options2);

--- a/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
@@ -164,21 +164,21 @@ namespace System.Globalization.Tests
         [MemberData(nameof(GetAscii_Invalid_TestData))]
         public void GetAscii_Invalid(string unicode, int index, int count, Type exceptionType)
         {
-            GetAscii_Invalid(new IdnMapping() { UseStd3AsciiRules = false }, unicode, index, count, exceptionType);
-            GetAscii_Invalid(new IdnMapping() { UseStd3AsciiRules = true }, unicode, index, count, exceptionType);
-        }
-
-        private static void GetAscii_Invalid(IdnMapping idnMapping, string unicode, int index, int count, Type exceptionType)
-        {
-            if (unicode == null || index + count == unicode.Length)
+            static void getAscii_Invalid(IdnMapping idnMapping, string unicode, int index, int count, Type exceptionType)
             {
-                if (unicode == null || index == 0)
+                if (unicode == null || index + count == unicode.Length)
                 {
-                    Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode));
+                    if (unicode == null || index == 0)
+                    {
+                        Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode));
+                    }
+                    Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode, index));
                 }
-                Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode, index));
+                Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode, index, count));
             }
-            Assert.Throws(exceptionType, () => idnMapping.GetAscii(unicode, index, count));
+
+            getAscii_Invalid(new IdnMapping() { UseStd3AsciiRules = false }, unicode, index, count, exceptionType);
+            getAscii_Invalid(new IdnMapping() { UseStd3AsciiRules = true }, unicode, index, count, exceptionType);
         }
 
         [Fact]

--- a/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetUnicodeTests.cs
@@ -107,21 +107,21 @@ namespace System.Globalization.Tests
         [MemberData(nameof(GetUnicode_Invalid_TestData))]
         public void GetUnicode_Invalid(string ascii, int index, int count, Type exceptionType)
         {
-            GetUnicode_Invalid(new IdnMapping() { UseStd3AsciiRules = false }, ascii, index, count, exceptionType);
-            GetUnicode_Invalid(new IdnMapping() { UseStd3AsciiRules = true }, ascii, index, count, exceptionType);
-        }
-
-        private static void GetUnicode_Invalid(IdnMapping idnMapping, string ascii, int index, int count, Type exceptionType)
-        {
-            if (ascii == null || index + count == ascii.Length)
+            static void getUnicode_Invalid(IdnMapping idnMapping, string ascii, int index, int count, Type exceptionType)
             {
-                if (ascii == null || index == 0)
+                if (ascii == null || index + count == ascii.Length)
                 {
-                    Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii));
+                    if (ascii == null || index == 0)
+                    {
+                        Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii));
+                    }
+                    Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii, index));
                 }
-                Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii, index));
+                Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii, index, count));
             }
-            Assert.Throws(exceptionType, () => idnMapping.GetUnicode(ascii, index, count));
+
+            getUnicode_Invalid(new IdnMapping() { UseStd3AsciiRules = false }, ascii, index, count, exceptionType);
+            getUnicode_Invalid(new IdnMapping() { UseStd3AsciiRules = true }, ascii, index, count, exceptionType);
         }
     }
 }

--- a/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
@@ -129,7 +129,7 @@ namespace System.Globalization.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
-        public static void Equals(bool allowUnassigned, bool useStd3AsciiRules)
+        public static void EqualsTest(bool allowUnassigned, bool useStd3AsciiRules)
         {
             // first check for equals
             IdnMapping original = new IdnMapping() { AllowUnassigned = allowUnassigned, UseStd3AsciiRules = useStd3AsciiRules };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -267,14 +267,14 @@ namespace System.Globalization.Tests
         [MemberData(nameof(Compare_Kana_TestData))]
         public void CompareWithKana(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
-            Compare(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);
+            Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);
         }
 
         [Theory]
         [MemberData(nameof(Compare_TestData))]
         public void Compare(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
-            Compare(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);
+            Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);
         }
 
         public static IEnumerable<object[]> Compare_Advanced_TestData()
@@ -326,7 +326,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Compare_Advanced_TestData))]
-        public void Compare(CompareInfo compareInfo, string string1, int offset1, int length1, string string2, int offset2, int length2, CompareOptions options, int expected)
+        public void Compare_Advanced(CompareInfo compareInfo, string string1, int offset1, int length1, string string2, int offset2, int length2, CompareOptions options, int expected)
         {
             if (offset1 + length1 == (string1?.Length ?? 0) && offset2 + length2 == (string2?.Length ?? 0))
             {

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -40,7 +40,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(CompareInfo compare1, object value, bool expected)
+        public void EqualsTest(CompareInfo compare1, object value, bool expected)
         {
             Assert.Equal(expected, compare1.Equals(value));
             if (value is CompareInfo)
@@ -60,7 +60,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCodeTestData))]
-        public void GetHashCode(string source1, CompareOptions options1, string source2, CompareOptions options2, bool expected)
+        public void GetHashCodeTest(string source1, CompareOptions options1, string source2, CompareOptions options2, bool expected)
         {
             CompareInfo invariantCompare = CultureInfo.InvariantCulture.CompareInfo;
             Assert.Equal(expected, invariantCompare.GetHashCode(source1, options1).Equals(invariantCompare.GetHashCode(source2, options2)));
@@ -80,7 +80,7 @@ namespace System.Globalization.Tests
         [InlineData("", "CompareInfo - ")]
         [InlineData("en-US", "CompareInfo - en-US")]
         [InlineData("EN-US", "CompareInfo - en-US")]
-        public void ToString(string name, string expected)
+        public void ToStringTest(string name, string expected)
         {
             Assert.Equal(expected, new CultureInfo(name).CompareInfo.ToString());
         }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEquals.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEquals.cs
@@ -26,7 +26,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(CultureInfo culture, object value, bool expected)
+        public void EqualsTest(CultureInfo culture, object value, bool expected)
         {
             Assert.Equal(expected, culture.Equals(value));
         }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoGetHashCode.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoGetHashCode.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         [InlineData("en-US")]
         [InlineData("en")]
         [InlineData("")]
-        public void GetHashCode(string name)
+        public void GetHashCodeTest(string name)
         {
             // The only guarantee that can be made about HashCodes is that they will be the same across calls
             CultureInfo culture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
@@ -65,7 +65,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(AbbreviatedMonthGenitiveNames_SetInvalidLength_TestData))]
-        public void AbbreviatedMonthGenitiveNames_SetNullValueInValues_ThrowsArgumentNullException(string[] value)
+        public void AbbreviatedMonthGenitiveNames_SetNullValueInValues_ThrowsArgumentException(string[] value)
         {
             var format = new DateTimeFormatInfo();
             AssertExtensions.Throws<ArgumentException>("value", () => format.AbbreviatedMonthGenitiveNames = value);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
@@ -65,7 +65,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(AbbreviatedMonthNames_SetInvalidLength_TestData))]
-        public void AbbreviatedMonthNames_SetNullValueInValues_ThrowsArgumentNullException(string[] value)
+        public void AbbreviatedMonthNames_SetNullValueInValues_ThrowsArgumentException(string[] value)
         {
             var format = new DateTimeFormatInfo();
             AssertExtensions.Throws<ArgumentException>("value", () => format.AbbreviatedMonthNames = value);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
@@ -91,7 +91,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(MonthGenitiveNames_SetInvalidLength_TestData))]
-        public void MonthGenitiveNames_SetNullValueInValues_ThrowsArgumentNullException(string[] value)
+        public void MonthGenitiveNames_SetNullValueInValues_ThrowsArgumentException(string[] value)
         {
             var format = new DateTimeFormatInfo();
             AssertExtensions.Throws<ArgumentException>("value", () => format.MonthGenitiveNames = value);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthNames.cs
@@ -65,7 +65,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(MonthNames_SetInvalidLength_TestData))]
-        public void MonthNames_SetNullValueInValues_ThrowsArgumentNullException(string[] value)
+        public void MonthNames_SetNullValueInValues_ThrowsArgumentException(string[] value)
         {
             var format = new DateTimeFormatInfo();
             AssertExtensions.Throws<ArgumentException>("value", () => format.MonthNames = value);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -31,7 +31,7 @@ namespace System.Globalization.Tests
         [InlineData("as")]
         [InlineData("es-BO")]
         [InlineData("fr-CA")]
-        public void CurrencyNegativePattern_Get_ReturnsExpected(string locale)
+        public void CurrencyNegativePattern_Get_ReturnsExpected_ByLocale(string locale)
         {
             CultureInfo culture;
             try

--- a/src/libraries/System.Globalization/tests/System/Globalization/CharUnicodeInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/CharUnicodeInfoTests.cs
@@ -18,17 +18,17 @@ namespace System.Globalization.Tests
                 if (testCase.Utf32CodeValue.Length == 1)
                 {
                     // Test the char overload for a single char
-                    GetUnicodeCategory(testCase.Utf32CodeValue[0], testCase.GeneralCategory);
+                    GetUnicodeCategoryTest_Char(testCase.Utf32CodeValue[0], testCase.GeneralCategory);
                 }
                 // Test the string overload for a surrogate pair or a single char
-                GetUnicodeCategory(testCase.Utf32CodeValue, new UnicodeCategory[] { testCase.GeneralCategory });
+                GetUnicodeCategoryTest_String(testCase.Utf32CodeValue, new UnicodeCategory[] { testCase.GeneralCategory });
                 Assert.Equal(testCase.GeneralCategory, CharUnicodeInfo.GetUnicodeCategory(testCase.CodePoint));
             }
         }
 
         [Theory]
         [InlineData('\uFFFF', UnicodeCategory.OtherNotAssigned)]
-        public void GetUnicodeCategory(char ch, UnicodeCategory expected)
+        public void GetUnicodeCategoryTest_Char(char ch, UnicodeCategory expected)
         {
             UnicodeCategory actual = CharUnicodeInfo.GetUnicodeCategory(ch);
             Assert.True(actual == expected, ErrorMessage(ch, expected, actual));
@@ -38,7 +38,7 @@ namespace System.Globalization.Tests
         [InlineData("aA1!", new UnicodeCategory[] { UnicodeCategory.LowercaseLetter, UnicodeCategory.UppercaseLetter, UnicodeCategory.DecimalDigitNumber, UnicodeCategory.OtherPunctuation })]
         [InlineData("\uD808\uDF6C", new UnicodeCategory[] { UnicodeCategory.OtherLetter, UnicodeCategory.Surrogate })]
         [InlineData("a\uD808\uDF6Ca", new UnicodeCategory[] { UnicodeCategory.LowercaseLetter, UnicodeCategory.OtherLetter, UnicodeCategory.Surrogate, UnicodeCategory.LowercaseLetter })]
-        public void GetUnicodeCategory(string s, UnicodeCategory[] expected)
+        public void GetUnicodeCategoryTest_String(string s, UnicodeCategory[] expected)
         {
             for (int i = 0; i < expected.Length; i++)
             {
@@ -50,13 +50,13 @@ namespace System.Globalization.Tests
         public void GetUnicodeCategory_String_InvalidSurrogatePairs()
         {
             // High, high surrogate pair
-            GetUnicodeCategory("\uD808\uD808", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
+            GetUnicodeCategoryTest_String("\uD808\uD808", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
 
             // Low, low surrogate pair
-            GetUnicodeCategory("\uDF6C\uDF6C", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
+            GetUnicodeCategoryTest_String("\uDF6C\uDF6C", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
 
             // Low, high surrogate pair
-            GetUnicodeCategory("\uDF6C\uD808", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
+            GetUnicodeCategoryTest_String("\uDF6C\uD808", new UnicodeCategory[] { UnicodeCategory.Surrogate, UnicodeCategory.Surrogate });
         }
 
         [Fact]
@@ -76,16 +76,16 @@ namespace System.Globalization.Tests
                 if (testCase.Utf32CodeValue.Length == 1)
                 {
                     // Test the char overload for a single char
-                    GetNumericValue(testCase.Utf32CodeValue[0], testCase.NumericValue);
+                    GetNumericValueTest_Char(testCase.Utf32CodeValue[0], testCase.NumericValue);
                 }
                 // Test the string overload for a surrogate pair
-                GetNumericValue(testCase.Utf32CodeValue, new double[] { testCase.NumericValue });
+                GetNumericValueTest_String(testCase.Utf32CodeValue, new double[] { testCase.NumericValue });
             }
         }
 
         [Theory]
         [InlineData('\uFFFF', -1)]
-        public void GetNumericValue(char ch, double expected)
+        public void GetNumericValueTest_Char(char ch, double expected)
         {
             double actual = CharUnicodeInfo.GetNumericValue(ch);
             Assert.True(expected == actual, ErrorMessage(ch, expected, actual));
@@ -93,7 +93,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(s_GetNumericValueData))]
-        public void GetNumericValue(string s, double[] expected)
+        public void GetNumericValueTest_String(string s, double[] expected)
         {
             for (int i = 0; i < expected.Length; i++)
             {

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -184,7 +184,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(RegionInfo regionInfo1, object obj, bool expected)
+        public void EqualsTest(RegionInfo regionInfo1, object obj, bool expected)
         {
             Assert.Equal(expected, regionInfo1.Equals(obj));
             Assert.Equal(regionInfo1.GetHashCode(), regionInfo1.GetHashCode());

--- a/src/libraries/System.Globalization/tests/System/Globalization/StringInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/StringInfoTests.cs
@@ -111,7 +111,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(StringInfo stringInfo, object value, bool expected)
+        public void EqualsTest(StringInfo stringInfo, object value, bool expected)
         {
             Assert.Equal(expected, stringInfo.Equals(value));
             if (value is StringInfo)
@@ -240,7 +240,7 @@ namespace System.Globalization.Tests
             //                            ,-- Extend (U+20D1 COMBINING RIGHT HARPOON ABOVE)
             //                            |       ,-- Extend (U+FE22 COMBINING DOUBLE TILDE LEFT HALF)
             //                            |       |     ,-- Extend (U+20D1 COMBINING RIGHT HARPOON ABOVE)
-            //                            |       |     |     ,-- Extend (U+20EB COMBINING LONG DOUBLE SOLIDUS OVERLAY) 
+            //                            |       |     |     ,-- Extend (U+20EB COMBINING LONG DOUBLE SOLIDUS OVERLAY)
             yield return new object[] { "!\u20D1bo\uFE22\u20D1\u20EB|", new int[] { 0, 2, 3, 7 } };
 
             //                            ,-- Other (U+10FFFF <Unassigned>)

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -163,7 +163,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(TextInfo textInfo, object obj, bool expected)
+        public void EqualsTest(TextInfo textInfo, object obj, bool expected)
         {
             Assert.Equal(expected, textInfo.Equals(obj));
             if (obj is TextInfo)
@@ -416,7 +416,7 @@ namespace System.Globalization.Tests
         [InlineData("en-US", "TextInfo - en-US")]
         [InlineData("fr-FR", "TextInfo - fr-FR")]
         [InlineData("", "TextInfo - ")]
-        public void ToString(string name, string expected)
+        public void ToStringTest(string name, string expected)
         {
             Assert.Equal(expected, new CultureInfo(name).TextInfo.ToString());
         }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -47,7 +47,7 @@ namespace System.IO.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        public void File_Move_From_Watched_To_Unwatched(int filesCount)
+        public void File_Move_Multiple_From_Watched_To_Unwatched(int filesCount)
         {
             FileMove_Multiple_FromWatchedToUnwatched(filesCount, skipOldEvents: false);
         }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
@@ -192,22 +192,6 @@ namespace System.IO.Tests
         /// <summary>
         /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
         /// </summary>
-        [Fact]
-        public void EndInit_ResumesPausedEnableRaisingEvents()
-        {
-            using (var testDirectory = new TempDirectory(GetTestFilePath()))
-            using (var watcher = new TestFileSystemWatcher(testDirectory.Path, "*"))
-            {
-                watcher.BeginInit();
-                watcher.EnableRaisingEvents = true;
-                watcher.EndInit();
-                ExpectEvent(watcher, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted, () => new TempFile(Path.Combine(testDirectory.Path, GetTestFileName())).Dispose(), null);
-            }
-        }
-
-        /// <summary>
-        /// EndInit will begin EnableRaisingEvents if we previously set EnableRaisingEvents=true
-        /// </summary>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -109,7 +109,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(CopyFileWithData_MemberData))]
-        public void CopyFileWithData_MemberData(char[] data, bool readOnly)
+        public void CopyFileWithData(char[] data, bool readOnly)
         {
             string testFileSource = GetTestFilePath();
             string testFileDest = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -279,10 +279,10 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public Task ManyConcurrentWriteAsyncs_BaseTest()
+        public Task ManyConcurrentWriteAsyncs()
         {
             // For inner loop, just test one case
-            return ManyConcurrentWriteAsyncs(
+            return ManyConcurrentWriteAsyncs_OuterLoop(
                 useAsync: RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
                 presize: false,
                 exposeHandle: false,
@@ -295,7 +295,7 @@ namespace System.IO.Tests
         [Theory]
         [MemberData(nameof(MemberData_FileStreamAsyncWriting))]
         [OuterLoop] // many combinations: we test just one in inner loop and the rest outer
-        public async Task ManyConcurrentWriteAsyncs(
+        public async Task ManyConcurrentWriteAsyncs_OuterLoop(
             bool useAsync, bool presize, bool exposeHandle, bool cancelable, int bufferSize, int writeSize, int numWrites)
         {
             long totalLength = writeSize * numWrites;

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -279,7 +279,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public Task ManyConcurrentWriteAsyncs()
+        public Task ManyConcurrentWriteAsyncs_BaseTest()
         {
             // For inner loop, just test one case
             return ManyConcurrentWriteAsyncs(

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/DirectoryExistsTests.cs
@@ -72,7 +72,7 @@ namespace System.IO.IsolatedStorage
 
         [Theory]
         [MemberData(nameof(ValidStores))]
-        public void DirectoryExists_Existance(PresetScopes scope)
+        public void DirectoryExists_Existance_WithScope(PresetScopes scope)
         {
             using (var isf = GetPresetScope(scope))
             {

--- a/src/libraries/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.cs
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/tests/UmsReadWrite.cs
@@ -245,7 +245,7 @@ namespace System.IO.Tests
 
 
         [Fact]
-        public void Write()
+        public void WriteTest()
         {
             const int length = 1000;
             using (var manager = new UmsManager(FileAccess.Write, length))

--- a/src/libraries/System.Linq/tests/AnyTests.cs
+++ b/src/libraries/System.Linq/tests/AnyTests.cs
@@ -59,7 +59,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public void Any(IEnumerable<int> source, bool expected)
+        public void AnyTest(IEnumerable<int> source, bool expected)
         {
             Assert.Equal(expected, source.Any());
         }

--- a/src/libraries/System.Linq/tests/AnyTests.cs
+++ b/src/libraries/System.Linq/tests/AnyTests.cs
@@ -59,7 +59,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public void AnyTest(IEnumerable<int> source, bool expected)
+        public void Any(IEnumerable<int> source, bool expected)
         {
             Assert.Equal(expected, source.Any());
         }
@@ -87,7 +87,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(TestDataWithPredicate))]
-        public void Any(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
+        public void Any_Predicate(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {
             if (predicate == null)
             {

--- a/src/libraries/System.Linq/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq/tests/ConcatTests.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Tests
     {
         [Theory]
         [InlineData(new int[] { 2, 3, 2, 4, 5 }, new int[] { 1, 9, 4 })]
-        public void SameResultsWithQueryAndRepeatCalls(IEnumerable<int> first, IEnumerable<int> second)
+        public void SameResultsWithQueryAndRepeatCalls_Int(IEnumerable<int> first, IEnumerable<int> second)
         {
             // workaround: xUnit type inference doesn't work if the input type is not T (like IEnumerable<T>)
             SameResultsWithQueryAndRepeatCallsWorker(first, second);
@@ -21,7 +21,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [InlineData(new[] { "AAA", "", "q", "C", "#", "!@#$%^", "0987654321", "Calling Twice" }, new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS" })]
-        public void SameResultsWithQueryAndRepeatCalls(IEnumerable<string> first, IEnumerable<string> second)
+        public void SameResultsWithQueryAndRepeatCalls_String(IEnumerable<string> first, IEnumerable<string> second)
         {
             // workaround: xUnit type inference doesn't work if the input type is not T (like IEnumerable<T>)
             SameResultsWithQueryAndRepeatCallsWorker(first, second);

--- a/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
+++ b/src/libraries/System.Linq/tests/FirstOrDefaultTests.cs
@@ -82,13 +82,13 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.FirstOrDefault());
         }
 
-        private static IEnumerable<T> EmptySource<T>()
-        {
-            yield break;
-        }
-
         private static void TestEmptyNotIList<T>()
         {
+            static IEnumerable<T1> EmptySource<T1>()
+            {
+                yield break;
+            }
+
             var source = EmptySource<T>();
             T expected = default(T);
 

--- a/src/libraries/System.Linq/tests/FirstTests.cs
+++ b/src/libraries/System.Linq/tests/FirstTests.cs
@@ -81,13 +81,13 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.First());
         }
 
-        private static IEnumerable<T> EmptySource<T>()
-        {
-            yield break;
-        }
-
         private static void TestEmptyNotIList<T>()
         {
+            static IEnumerable<T1> EmptySource<T1>()
+            {
+                yield break;
+            }
+
             var source = EmptySource<T>();
 
             Assert.Null(source as IList<T>);

--- a/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
+++ b/src/libraries/System.Memory/tests/ArrayBufferWriter/ArrayBufferWriterTests.T.cs
@@ -156,7 +156,7 @@ namespace System.Buffers.Tests
 
         [Theory]
         [MemberData(nameof(SizeHints))]
-        public void GetSpan_DefaultCtor(int sizeHint)
+        public void GetSpan_DefaultCtor_WithSizeHint(int sizeHint)
         {
             var output = new ArrayBufferWriter<T>();
             Span<T> span = output.GetSpan(sizeHint);
@@ -173,7 +173,7 @@ namespace System.Buffers.Tests
 
         [Theory]
         [MemberData(nameof(SizeHints))]
-        public void GetSpan_InitSizeCtor(int sizeHint)
+        public void GetSpan_InitSizeCtor_WithSizeHint(int sizeHint)
         {
             {
                 var output = new ArrayBufferWriter<T>(256);
@@ -198,7 +198,7 @@ namespace System.Buffers.Tests
 
         [Theory]
         [MemberData(nameof(SizeHints))]
-        public void GetMemory_DefaultCtor(int sizeHint)
+        public void GetMemory_DefaultCtor_WithSizeHint(int sizeHint)
         {
             var output = new ArrayBufferWriter<T>();
             Memory<T> memory = output.GetMemory(sizeHint);
@@ -222,7 +222,7 @@ namespace System.Buffers.Tests
 
         [Theory]
         [MemberData(nameof(SizeHints))]
-        public void GetMemory_InitSizeCtor(int sizeHint)
+        public void GetMemory_InitSizeCtor_WithSizeHint(int sizeHint)
         {
             {
                 var output = new ArrayBufferWriter<T>(256);

--- a/src/libraries/System.Memory/tests/MemoryMarshal/AsMemory.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/AsMemory.cs
@@ -39,15 +39,15 @@ namespace System.MemoryTests
 
         [Theory]
         [MemberData(nameof(ReadOnlyMemoryInt32Instances))]
-        public static void AsMemory_Roundtrips(ReadOnlyMemory<int> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory, true);
+        public static void AsMemory_Roundtrips_Int(ReadOnlyMemory<int> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory, true);
 
         [Theory]
         [MemberData(nameof(ReadOnlyMemoryObjectInstances))]
-        public static void AsMemory_Roundtrips(ReadOnlyMemory<object> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory, false);
+        public static void AsMemory_Roundtrips_Object(ReadOnlyMemory<object> readOnlyMemory) => AsMemory_Roundtrips_Core(readOnlyMemory, false);
 
         [Theory]
         [MemberData(nameof(ReadOnlyMemoryCharInstances))]
-        public static void AsMemory_Roundtrips(ReadOnlyMemory<char> readOnlyMemory)
+        public static void AsMemory_Roundtrips_Char(ReadOnlyMemory<char> readOnlyMemory)
         {
             AsMemory_Roundtrips_Core(readOnlyMemory, true);
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/EscapeUnescapeIriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/EscapeUnescapeIriTests.cs
@@ -5,7 +5,7 @@ namespace System.PrivateUri.Tests
 {
     public class EscapeUnescapeIriTests
     {
-        public static IEnumerable<object[]> ReplacesStandaloneSurrogatesWithReplacementChar()
+        public static IEnumerable<object[]> ReplacesStandaloneSurrogatesWithReplacementChar_Data()
         {
             const string UrlEncodedReplacementChar = "%EF%BF%BD";
             const string HighSurrogate = "\ud83f";
@@ -21,7 +21,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ReplacesStandaloneSurrogatesWithReplacementChar))]
+        [MemberData(nameof(ReplacesStandaloneSurrogatesWithReplacementChar_Data))]
         public static void ReplacesStandaloneSurrogatesWithReplacementChar(string input, string expected)
         {
             const string Prefix = "scheme:";

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriBuilderTests.cs
@@ -339,7 +339,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UriBuilder uriBuilder1, UriBuilder uriBuilder2, bool expected)
+        public void EqualsTest(UriBuilder uriBuilder1, UriBuilder uriBuilder2, bool expected)
         {
             Assert.Equal(expected, uriBuilder1.Equals(uriBuilder2));
             if (uriBuilder2 != null)
@@ -374,7 +374,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public void ToString(UriBuilder uriBuilder, string expected)
+        public void ToStringTest(UriBuilder uriBuilder, string expected)
         {
             Assert.Equal(expected, uriBuilder.ToString());
         }

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.Internal.cs
@@ -21,8 +21,8 @@ public static partial class XmlSerializerTests
             mappings[i] = importer.ImportTypeMapping(types[i]);
         }
         var serializers = XmlSerializer.FromMappings(mappings, typeof(object));
-        Xml_GuidAsRoot(serializers[0]);
-        Xml_ListGenericRoot(serializers[1]);
+        Xml_GuidAsRoot_Helper(serializers[0]);
+        Xml_ListGenericRoot_Helper(serializers[1]);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public static partial class XmlSerializerTests
 
         mapping = new XmlReflectionImporter(null, null).ImportTypeMapping(typeof(List<string>));
         serializer = new XmlSerializer(mapping);
-        Xml_ListGenericRoot(serializer);
+        Xml_ListGenericRoot_Helper(serializer);
     }
 
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -161,11 +161,13 @@ public static partial class XmlSerializerTests
     [Fact]
     public static void Xml_GuidAsRoot()
     {
-        Xml_GuidAsRoot(new XmlSerializer(typeof(Guid)));
+        Xml_GuidAsRoot_Helper(new XmlSerializer(typeof(Guid)));
     }
 
-    private static void Xml_GuidAsRoot(XmlSerializer serializer)
+    private static void Xml_GuidAsRoot_Helper(XmlSerializer serializer)
     {
+        // TODO: the 'serializer' parameter is not used, this test might have issues
+
         foreach (Guid value in new Guid[] { Guid.NewGuid(), Guid.Empty })
         {
             Assert.StrictEqual(SerializeAndDeserialize<Guid>(value, string.Format(@"<?xml version=""1.0""?>
@@ -314,10 +316,10 @@ public static partial class XmlSerializerTests
     [Fact]
     public static void Xml_ListGenericRoot()
     {
-        Xml_ListGenericRoot(new XmlSerializer(typeof(List<string>)));
+        Xml_ListGenericRoot_Helper(new XmlSerializer(typeof(List<string>)));
     }
 
-    private static void Xml_ListGenericRoot(XmlSerializer serializer)
+    private static void Xml_ListGenericRoot_Helper(XmlSerializer serializer)
     {
         List<string> x = new List<string>();
         x.Add("zero");
@@ -963,8 +965,8 @@ public static partial class XmlSerializerTests
     public static void Xml_FromTypes()
     {
         var serializers = XmlSerializer.FromTypes(new Type[] { typeof(Guid), typeof(List<string>) });
-        Xml_GuidAsRoot(serializers[0]);
-        Xml_ListGenericRoot(serializers[1]);
+        Xml_GuidAsRoot_Helper(serializers[0]);
+        Xml_ListGenericRoot_Helper(serializers[1]);
 
         serializers = XmlSerializer.FromTypes(null);
         Assert.Equal(0, serializers.Length);

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/SignatureHelper/SignatureHelperEquals.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/SignatureHelper/SignatureHelperEquals.cs
@@ -28,7 +28,7 @@ namespace System.Reflection.Emit.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(SignatureHelper helper, object obj, bool expected)
+        public void EqualsTest(SignatureHelper helper, object obj, bool expected)
         {
             Assert.Equal(expected, helper.Equals(obj));
             if (obj is SignatureHelper && expected == true)

--- a/src/libraries/System.Reflection.Emit/tests/AssemblyBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/AssemblyBuilderTests.cs
@@ -287,7 +287,7 @@ namespace System.Reflection.Emit.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(AssemblyBuilder assembly, object obj, bool expected)
+        public void EqualsTest(AssemblyBuilder assembly, object obj, bool expected)
         {
             Assert.Equal(expected, assembly.Equals(obj));
             if (obj is AssemblyBuilder)

--- a/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderEquals.cs
+++ b/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderEquals.cs
@@ -74,7 +74,7 @@ namespace System.Reflection.Emit.Tests
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2389", TestRuntimes.Mono)]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(MethodBuilder builder, object obj, bool expected)
+        public void EqualsTest(MethodBuilder builder, object obj, bool expected)
         {
             Assert.Equal(expected, builder.Equals(obj));
         }

--- a/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetHashCode.cs
+++ b/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetHashCode.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.Emit.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCode_TestData))]
-        public void GetHashCode(MethodBuilder method1, MethodBuilder method2, bool expected)
+        public void GetHashCodeTest(MethodBuilder method1, MethodBuilder method2, bool expected)
         {
             Assert.Equal(expected, method1.GetHashCode().Equals(method2.GetHashCode()));
         }

--- a/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderToString.cs
+++ b/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderToString.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData("Test_Type")]
         [InlineData("Test Type")]
         [InlineData("   ")]
-        public void ToString(string typeName)
+        public void ToStringTest(string typeName)
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic, typeName: typeName);
             Assert.Equal(typeName, type.ToString());

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -576,7 +576,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData("Foo")]
         [InlineData("Hi There")]
-        public void ToString(string name)
+        public void ToStringTest(string name)
         {
             var assemblyName = new AssemblyName(name);
             Assert.StartsWith(name, assemblyName.ToString());

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -122,7 +122,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(Assembly assembly1, Assembly assembly2, bool expected)
+        public void EqualsTest(Assembly assembly1, Assembly assembly2, bool expected)
         {
             Assert.Equal(expected, assembly1.Equals(assembly2));
         }
@@ -179,7 +179,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCode_TestData))]
-        public void GetHashCode(Assembly assembly)
+        public void GetHashCodeTest(Assembly assembly)
         {
             int hashCode = assembly.GetHashCode();
             Assert.NotEqual(-1, hashCode);
@@ -193,7 +193,7 @@ namespace System.Reflection.Tests
         [InlineData("System.Reflection.Tests.PublicStruct", true)]
         [InlineData("AssemblyPublicClass", false)]
         [InlineData("NoSuchType", false)]
-        public void GetType(string name, bool exists)
+        public void GetTypeTest(string name, bool exists)
         {
             Type type = Helpers.ExecutingAssembly.GetType(name);
             if (exists)
@@ -352,7 +352,7 @@ namespace System.Reflection.Tests
         [InlineData(50)]
         [InlineData(100)]
         // Higher numbers hit some codepaths that currently don't include the path in the exception message
-        public void LoadFile_ValidPEBadIL_ThrowsBadImageFormatExceptionWithPath(int seek)
+        public void LoadFile_ValidPEBadIL_ThrowsBadImageFormatExceptionWithPath_ByInitialSeek(int seek)
         {
             ReadOnlySpan<byte> garbage = Encoding.UTF8.GetBytes(new string('X', 500));
             string path = GetTestFilePath();

--- a/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(ConstructorInfo constructorInfo1, ConstructorInfo constructorInfo2, bool expected)
+        public void EqualsTest(ConstructorInfo constructorInfo1, ConstructorInfo constructorInfo2, bool expected)
         {
             Assert.Equal(expected, constructorInfo1.Equals(constructorInfo2));
             Assert.NotEqual(expected, constructorInfo1 != constructorInfo2);

--- a/src/libraries/System.Reflection/tests/EventInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/EventInfoTests.cs
@@ -142,7 +142,7 @@ namespace System.Reflection.Tests
         [InlineData(typeof(BaseClass), nameof(BaseClass.PublicEvent), typeof(BaseClass), nameof(BaseClass.PublicEvent), true)]
         [InlineData(typeof(BaseClass), nameof(BaseClass.PublicEvent), typeof(SubClass), nameof(SubClass.PublicEvent), false)]
         [InlineData(typeof(BaseClass), nameof(BaseClass.PublicEvent), typeof(BaseClass), nameof(BaseClass.PublicStaticEvent), false)]
-        public void Equals(Type type1, string name1, Type type2, string name2, bool expected)
+        public void EqualsTest(Type type1, string name1, Type type2, string name2, bool expected)
         {
             EventInfo eventInfo1 = GetEventInfo(type1, name1);
             EventInfo eventInfo2 = GetEventInfo(type2, name2);

--- a/src/libraries/System.Reflection/tests/FieldInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/FieldInfoTests.cs
@@ -129,7 +129,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData(typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), true)]
         [InlineData(typeof(FieldInfoTests), nameof(FieldInfoTests.stringField), typeof(FieldInfoTests), nameof(FieldInfoTests.s_intField), false)]
-        public void Equals(Type type1, string name1, Type type2, string name2, bool expected)
+        public void EqualsTest(Type type1, string name1, Type type2, string name2, bool expected)
         {
             FieldInfo fieldInfo1 = GetField(type1, name1);
             FieldInfo fieldInfo2 = GetField(type2, name2);

--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -87,7 +87,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(GetType_TestData))]
-        public void GetType(string typeName, Type expectedResult)
+        public void GetTypeTest(string typeName, Type expectedResult)
         {
             Assembly a = typeof(GetTypeTests).GetTypeInfo().Assembly;
             Module m = a.ManifestModule;

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -146,7 +146,7 @@ namespace System.Reflection.Tests
         [InlineData(typeof(MI_SubClass), nameof(MI_SubClass.ObjectMethodReturningString), typeof(MI_SubClass), nameof(MI_SubClass.VoidMethodReturningInt), false)]
         [InlineData(typeof(MI_SubClass), nameof(MI_GenericClass<int>.GenericMethod1), typeof(MI_GenericClass<>), nameof(MI_GenericClass<int>.GenericMethod1), false)]
         [InlineData(typeof(MI_SubClass), nameof(MI_GenericClass<int>.GenericMethod2), typeof(MI_GenericClass<string>), nameof(MI_GenericClass<int>.GenericMethod2), false)]
-        public void Equals(Type type1, string name1, Type type2, string name2, bool expected)
+        public void EqualsTest(Type type1, string name1, Type type2, string name2, bool expected)
         {
             MethodInfo methodInfo1 = GetMethod(type1, name1);
             MethodInfo methodInfo2 = GetMethod(type2, name2);
@@ -543,7 +543,7 @@ namespace System.Reflection.Tests
         [InlineData(typeof(MI_GenericClass<>), nameof(MI_GenericClass<string>.GenericMethod2), "T GenericMethod2[S](S, T, System.String)")]
         [InlineData(typeof(MI_GenericClass<string>), nameof(MI_GenericClass<string>.GenericMethod1), "System.String GenericMethod1(System.String)")]
         [InlineData(typeof(MI_GenericClass<string>), nameof(MI_GenericClass<string>.GenericMethod2), "System.String GenericMethod2[S](S, System.String, System.String)")]
-        public void ToString(Type type, string name, string expected)
+        public void ToStringTest(Type type, string name, string expected)
         {
             MethodInfo methodInfo = GetMethod(type, name);
             Assert.Equal(expected, methodInfo.ToString());
@@ -557,7 +557,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public void ToString(MethodInfo methodInfo, string expected)
+        public void ToStringTest_ByMethodInfo(MethodInfo methodInfo, string expected)
         {
             Assert.Equal(expected, methodInfo.ToString());
         }

--- a/src/libraries/System.Reflection/tests/ModuleTests.cs
+++ b/src/libraries/System.Reflection/tests/ModuleTests.cs
@@ -69,7 +69,7 @@ namespace System.Reflection.Tests
         [InlineData("OutsideModuleTest[]", typeof(OutsideModuleTest[]))]
         [InlineData("OutsideModuleTest[,,]", typeof(OutsideModuleTest[,,]))]
         [InlineData("OutsideModuleTest[][]", typeof(OutsideModuleTest[][]))]
-        public void GetType(string className, Type expectedType)
+        public void GetTypeTest(string className, Type expectedType)
         {
             Module module = expectedType.GetTypeInfo().Module;
 

--- a/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/PropertyInfoTests.cs
@@ -245,7 +245,7 @@ namespace System.Reflection.Tests
         [Theory]
         [InlineData(typeof(BaseClass), nameof(BaseClass.ReadWriteProperty1), typeof(BaseClass), nameof(BaseClass.ReadWriteProperty1), true)]
         [InlineData(typeof(BaseClass), nameof(BaseClass.ReadWriteProperty1), typeof(BaseClass), nameof(BaseClass.ReadWriteProperty2), false)]
-        public void Equals(Type type1, string name1, Type type2, string name2, bool expected)
+        public void EqualsTest(Type type1, string name1, Type type2, string name2, bool expected)
         {
             PropertyInfo propertyInfo1 = GetProperty(type1, name1);
             PropertyInfo propertyInfo2 = GetProperty(type2, name2);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -192,7 +192,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(EnvironmentTests.EnvironmentVariableTargets), MemberType = typeof(EnvironmentTests))]
-        public void EnvironmentVariablesAreHashtable(EnvironmentVariableTarget target)
+        public void EnvironmentVariablesAreHashtable_SpecificTarget(EnvironmentVariableTarget target)
         {
             // On NetFX, the type returned was always Hashtable
             Assert.IsType<Hashtable>(Environment.GetEnvironmentVariables(target));
@@ -200,7 +200,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(EnvironmentTests.EnvironmentVariableTargets), MemberType = typeof(EnvironmentTests))]
-        public void EnumerateYieldsDictionaryEntryFromIEnumerable(EnvironmentVariableTarget target)
+        public void EnumerateYieldsDictionaryEntryFromIEnumerable_SpecificTarget(EnvironmentVariableTarget target)
         {
             // GetEnvironmentVariables has always yielded DictionaryEntry from IEnumerable
             IDictionary vars = Environment.GetEnvironmentVariables(target);
@@ -220,7 +220,7 @@ namespace System.Tests
         public void EnumerateEnvironmentVariables(EnvironmentVariableTarget target)
         {
             bool lookForSetValue = (target == EnvironmentVariableTarget.Process) || PlatformDetection.IsWindowsAndElevated;
-            
+
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/30566")]
             if (PlatformDetection.IsWindowsNanoServer && target == EnvironmentVariableTarget.User)
             {

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
@@ -204,7 +204,7 @@ namespace System.IO.Tests
             { @"C:\\foo2", @"C:\" },
         };
 
-        protected static void GetTempPath_SetEnvVar(string envVar, string expected, string newTempPath)
+        protected static void GetTempPath_SetEnvVar_Helper(string envVar, string expected, string newTempPath)
         {
             string original = Path.GetTempPath();
             Assert.NotNull(original);

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
@@ -54,7 +54,7 @@ namespace System.IO.Tests
             {
                 foreach (string[] tempPath in GetTempPath_SetEnvVar_Data())
                 {
-                    GetTempPath_SetEnvVar("TMPDIR", tempPath[0], tempPath[1]);
+                    GetTempPath_SetEnvVar_Helper("TMPDIR", tempPath[0], tempPath[1]);
                 }
             }).Dispose();
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
@@ -77,7 +77,7 @@ namespace System.IO.Tests
             {
                 foreach (string[] tempPath in GetTempPath_SetEnvVar_Data())
                 {
-                    GetTempPath_SetEnvVar("TMP", tempPath[0], tempPath[1]);
+                    GetTempPath_SetEnvVar_Helper("TMP", tempPath[0], tempPath[1]);
                 }
             }).Dispose();
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -1397,14 +1397,6 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Round_Decimal_Digits()
-        {
-            Assert.Equal(3.422m, Math.Round(3.42156m, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(-3.422m, Math.Round(-3.42156m, 3, MidpointRounding.AwayFromZero));
-            Assert.Equal(decimal.Zero, Math.Round(decimal.Zero, 3, MidpointRounding.AwayFromZero));
-        }
-
-        [Fact]
         public static void Round_Double()
         {
             Assert.Equal(0.0, Math.Round(0.0));
@@ -1418,7 +1410,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Round_Double_Digits()
+        public static void Round_Double_Digits_SpecificCases()
         {
             Assert.Equal(3.422, Math.Round(3.42156, 3, MidpointRounding.AwayFromZero), 10);
             Assert.Equal(-3.422, Math.Round(-3.42156, 3, MidpointRounding.AwayFromZero), 10);
@@ -2431,7 +2423,7 @@ namespace System.Tests
         [InlineData(MidpointRounding.ToZero)]
         [InlineData(MidpointRounding.ToNegativeInfinity)]
         [InlineData(MidpointRounding.ToPositiveInfinity)]
-        public static void Round_Double_Digits(MidpointRounding mode)
+        public static void Round_Double_Digits_ByMidpointRounding(MidpointRounding mode)
         {
             Assert.Equal(double.NaN, Math.Round(double.NaN, 3, mode));
             Assert.Equal(double.PositiveInfinity, Math.Round(double.PositiveInfinity, 3, mode));
@@ -2458,7 +2450,7 @@ namespace System.Tests
         [InlineData(MidpointRounding.ToZero)]
         [InlineData(MidpointRounding.ToNegativeInfinity)]
         [InlineData(MidpointRounding.ToPositiveInfinity)]
-        public static void Round_Decimal_Digits(MidpointRounding mode)
+        public static void Round_Decimal_Digits_ByMidpointRounding(MidpointRounding mode)
         {
             Assert.Equal(decimal.Zero, Math.Round(decimal.Zero, 3, mode));
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -1463,7 +1463,7 @@ namespace System.Tests
         [InlineData(MidpointRounding.AwayFromZero)]
         [InlineData(MidpointRounding.ToNegativeInfinity)]
         [InlineData(MidpointRounding.ToPositiveInfinity)]
-        public static void Round_Digits(MidpointRounding mode)
+        public static void Round_Digits_ByMidpointRounding(MidpointRounding mode)
         {
             Assert.Equal(float.PositiveInfinity, MathF.Round(float.PositiveInfinity, 3, mode));
             Assert.Equal(float.NegativeInfinity, MathF.Round(float.NegativeInfinity, 3, mode));

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
@@ -297,7 +297,7 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        public static IEnumerable<object[]> GetObjectForNativeVariant_CantMap_ThrowsArgumentException()
+        public static IEnumerable<object[]> GetObjectForNativeVariant_CantMap_ThrowsArgumentException_Data()
         {
             yield return new object[] { CreateVariant(VT_VARIANT, new UnionTypes()) };
             yield return new object[] { CreateVariant(15, new UnionTypes()) };
@@ -331,7 +331,7 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GetObjectForNativeVariant_CantMap_ThrowsArgumentException))]
+        [MemberData(nameof(GetObjectForNativeVariant_CantMap_ThrowsArgumentException_Data))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetObjectForNativeVariant_CantMap_ThrowsArgumentException(Variant variant)
         {
@@ -339,7 +339,7 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GetObjectForNativeVariant_CantMap_ThrowsArgumentException))]
+        [MemberData(nameof(GetObjectForNativeVariant_CantMap_ThrowsArgumentException_Data))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetObjectForNativeVariant_CantMapByRef_ThrowsArgumentException(Variant variant)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(2, 2, 1)]
         [InlineData(2, 1, 2)]
         [InlineData(2, 0, 3)]
-        public void ReadWriteArray_NegativeCount_ThrowsArgumentOutOfRangeException(int arrayLength, int index, int count)
+        public void ReadWriteArray_NegativeCount_ThrowsArgumentException(int arrayLength, int index, int count)
         {
             var wrapper = new SubBuffer(true);
             AssertExtensions.Throws<ArgumentException>(null, () => wrapper.ReadArray(0, new int[arrayLength], index, count));

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -90,93 +90,93 @@ namespace System.Numerics.Tests
             string format;
 
             // Currency
-            RunStandardFormatToStringTests(s_random, "C", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "c0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "C1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "c2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "C5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "c33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, CurrencyFormatter);
-            RunStandardFormatToStringTests(s_random, "C99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "C", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "c0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "C1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "c2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "C5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "c33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, CurrencyFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "C99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, CurrencyFormatter);
 
             // Decimal
-            RunStandardFormatToStringTests(s_random, "D", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "d0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D0000001", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "d2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "d33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D\0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D4\0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 4, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "D4\0Z", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 4, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "d0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D0000001", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "d2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "d33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D\0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D4\0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 4, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "D4\0Z", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 4, DecimalFormatter);
 
             // Exponential (note: negative precision means lower case e)
-            RunStandardFormatToStringTests(s_random, "E", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 6, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "E0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "E1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "e2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -2, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "E5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "e33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -33, ExponentialFormatter);
-            RunStandardFormatToStringTests(s_random, "E99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "E", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 6, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "E0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "E1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "e2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -2, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "E5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "e33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -33, ExponentialFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "E99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, ExponentialFormatter);
 
             // Test exponent of 4 digits
             test = GetDigitSequence(2000, 2000, s_random);
             VerifyToString(test, "E", ExponentialFormatter(test, 6, CultureInfo.CurrentCulture.NumberFormat));
 
             // Fixed-Point
-            RunStandardFormatToStringTests(s_random, "f", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.NumberDecimalDigits, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "F0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "f1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "F2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "f5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "F33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, FixedFormatter);
-            RunStandardFormatToStringTests(s_random, "f99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "f", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.NumberDecimalDigits, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "F0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "f1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "F2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "f5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "F33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, FixedFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "f99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, FixedFormatter);
 
             // General
-            RunStandardFormatToStringTests(s_random, "g", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "G0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "G1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "G2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "g5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "G33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "g99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "g", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "G0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "G1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "G2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "g5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "G33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "g99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
             // Number
-            RunStandardFormatToStringTests(s_random, "n", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.NumberDecimalDigits, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "N0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "N1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "N2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "n5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "N33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, NumberFormatter);
-            RunStandardFormatToStringTests(s_random, "n99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "n", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.NumberDecimalDigits, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "N0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "N1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "N2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "n5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "N33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, NumberFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "n99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, NumberFormatter);
 
             // Percent
-            RunStandardFormatToStringTests(s_random, "p", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.PercentDecimalDigits, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "P0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "P1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "P2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "p5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "P33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, PercentFormatter);
-            RunStandardFormatToStringTests(s_random, "p99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "p", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, CultureInfo.CurrentCulture.NumberFormat.PercentDecimalDigits, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "P0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "P1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "P2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "p5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "P33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, PercentFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "p99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, PercentFormatter);
 
             // Hex
-            RunStandardFormatToStringTests(s_random, "X", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "X0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "x1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -1, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "X2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "x5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -5, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "X33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, HexFormatter);
-            RunStandardFormatToStringTests(s_random, "x99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -99, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "X", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "X0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "x1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -1, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "X2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "x5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -5, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "X33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, HexFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "x99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, -99, HexFormatter);
 
             // RoundTrip
-            RunStandardFormatToStringTests(s_random, "R", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "R0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "r1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "R2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "r5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "R33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-            RunStandardFormatToStringTests(s_random, "r99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "R", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "R0", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "r1", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "R2", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "r5", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "R33", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+            RunStandardFormatToStringTests_Helper(s_random, "r99", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
             // Other - invalid format characters
             for (int i = 0; i < s_samples; i++)
@@ -200,85 +200,85 @@ namespace System.Numerics.Tests
                 using (new ThreadCultureChange(culture))
                 {
                     // Currency
-                    RunStandardFormatToStringTests(s_random, "C", culture.NumberFormat.NegativeSign, culture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "c0", culture.NumberFormat.NegativeSign, 0, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "C1", culture.NumberFormat.NegativeSign, 1, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "c2", culture.NumberFormat.NegativeSign, 2, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "C5", culture.NumberFormat.NegativeSign, 5, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "c33", culture.NumberFormat.NegativeSign, 33, CurrencyFormatter);
-                    RunStandardFormatToStringTests(s_random, "C99", culture.NumberFormat.NegativeSign, 99, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "C", culture.NumberFormat.NegativeSign, culture.NumberFormat.CurrencyDecimalDigits, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "c0", culture.NumberFormat.NegativeSign, 0, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "C1", culture.NumberFormat.NegativeSign, 1, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "c2", culture.NumberFormat.NegativeSign, 2, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "C5", culture.NumberFormat.NegativeSign, 5, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "c33", culture.NumberFormat.NegativeSign, 33, CurrencyFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "C99", culture.NumberFormat.NegativeSign, 99, CurrencyFormatter);
 
                     // Decimal
-                    RunStandardFormatToStringTests(s_random, "D", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "d0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "D1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "d2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "D5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "d33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "D99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "D", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "d0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "D1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "d2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "D5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "d33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "D99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
                     // Exponential (note: negative precision means lower case e)
-                    RunStandardFormatToStringTests(s_random, "E", culture.NumberFormat.NegativeSign, 6, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "E0", culture.NumberFormat.NegativeSign, 0, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "E1", culture.NumberFormat.NegativeSign, 1, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "e2", culture.NumberFormat.NegativeSign, -2, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "E5", culture.NumberFormat.NegativeSign, 5, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "e33", culture.NumberFormat.NegativeSign, -33, ExponentialFormatter);
-                    RunStandardFormatToStringTests(s_random, "E99", culture.NumberFormat.NegativeSign, 99, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "E", culture.NumberFormat.NegativeSign, 6, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "E0", culture.NumberFormat.NegativeSign, 0, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "E1", culture.NumberFormat.NegativeSign, 1, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "e2", culture.NumberFormat.NegativeSign, -2, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "E5", culture.NumberFormat.NegativeSign, 5, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "e33", culture.NumberFormat.NegativeSign, -33, ExponentialFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "E99", culture.NumberFormat.NegativeSign, 99, ExponentialFormatter);
 
                     // Fixed-Point
-                    RunStandardFormatToStringTests(s_random, "f", culture.NumberFormat.NegativeSign, culture.NumberFormat.NumberDecimalDigits, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "F0", culture.NumberFormat.NegativeSign, 0, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "f1", culture.NumberFormat.NegativeSign, 1, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "F2", culture.NumberFormat.NegativeSign, 2, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "f5", culture.NumberFormat.NegativeSign, 5, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "F33", culture.NumberFormat.NegativeSign, 33, FixedFormatter);
-                    RunStandardFormatToStringTests(s_random, "f99", culture.NumberFormat.NegativeSign, 99, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "f", culture.NumberFormat.NegativeSign, culture.NumberFormat.NumberDecimalDigits, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "F0", culture.NumberFormat.NegativeSign, 0, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "f1", culture.NumberFormat.NegativeSign, 1, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "F2", culture.NumberFormat.NegativeSign, 2, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "f5", culture.NumberFormat.NegativeSign, 5, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "F33", culture.NumberFormat.NegativeSign, 33, FixedFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "f99", culture.NumberFormat.NegativeSign, 99, FixedFormatter);
 
                     // General
-                    RunStandardFormatToStringTests(s_random, "g", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "G0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "G1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "G2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "g5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "G33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "g99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "g", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "G0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "G1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "G2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "g5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "G33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "g99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
 
                     // Number
-                    RunStandardFormatToStringTests(s_random, "n", culture.NumberFormat.NegativeSign, culture.NumberFormat.NumberDecimalDigits, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "N0", culture.NumberFormat.NegativeSign, 0, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "N1", culture.NumberFormat.NegativeSign, 1, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "N2", culture.NumberFormat.NegativeSign, 2, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "n5", culture.NumberFormat.NegativeSign, 5, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "N33", culture.NumberFormat.NegativeSign, 33, NumberFormatter);
-                    RunStandardFormatToStringTests(s_random, "n99", culture.NumberFormat.NegativeSign, 99, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "n", culture.NumberFormat.NegativeSign, culture.NumberFormat.NumberDecimalDigits, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "N0", culture.NumberFormat.NegativeSign, 0, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "N1", culture.NumberFormat.NegativeSign, 1, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "N2", culture.NumberFormat.NegativeSign, 2, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "n5", culture.NumberFormat.NegativeSign, 5, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "N33", culture.NumberFormat.NegativeSign, 33, NumberFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "n99", culture.NumberFormat.NegativeSign, 99, NumberFormatter);
 
                     // Percent
-                    RunStandardFormatToStringTests(s_random, "p", culture.NumberFormat.NegativeSign, culture.NumberFormat.PercentDecimalDigits, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "P0", culture.NumberFormat.NegativeSign, 0, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "P1", culture.NumberFormat.NegativeSign, 1, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "P2", culture.NumberFormat.NegativeSign, 2, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "p5", culture.NumberFormat.NegativeSign, 5, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "P33", culture.NumberFormat.NegativeSign, 33, PercentFormatter);
-                    RunStandardFormatToStringTests(s_random, "p99", culture.NumberFormat.NegativeSign, 99, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "p", culture.NumberFormat.NegativeSign, culture.NumberFormat.PercentDecimalDigits, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "P0", culture.NumberFormat.NegativeSign, 0, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "P1", culture.NumberFormat.NegativeSign, 1, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "P2", culture.NumberFormat.NegativeSign, 2, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "p5", culture.NumberFormat.NegativeSign, 5, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "P33", culture.NumberFormat.NegativeSign, 33, PercentFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "p99", culture.NumberFormat.NegativeSign, 99, PercentFormatter);
 
                     // Hex
-                    RunStandardFormatToStringTests(s_random, "X", culture.NumberFormat.NegativeSign, 0, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "X0", culture.NumberFormat.NegativeSign, 0, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "x1", culture.NumberFormat.NegativeSign, -1, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "X2", culture.NumberFormat.NegativeSign, 2, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "x5", culture.NumberFormat.NegativeSign, -5, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "X33", culture.NumberFormat.NegativeSign, 33, HexFormatter);
-                    RunStandardFormatToStringTests(s_random, "x99", culture.NumberFormat.NegativeSign, -99, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "X", culture.NumberFormat.NegativeSign, 0, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "X0", culture.NumberFormat.NegativeSign, 0, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "x1", culture.NumberFormat.NegativeSign, -1, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "X2", culture.NumberFormat.NegativeSign, 2, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "x5", culture.NumberFormat.NegativeSign, -5, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "X33", culture.NumberFormat.NegativeSign, 33, HexFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "x99", culture.NumberFormat.NegativeSign, -99, HexFormatter);
 
                     // RoundTrip
-                    RunStandardFormatToStringTests(s_random, "R", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "R0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "r1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "R2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "r5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "R33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
-                    RunStandardFormatToStringTests(s_random, "r99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "R", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "R0", culture.NumberFormat.NegativeSign, 0, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "r1", culture.NumberFormat.NegativeSign, 1, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "R2", culture.NumberFormat.NegativeSign, 2, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "r5", culture.NumberFormat.NegativeSign, 5, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "R33", culture.NumberFormat.NegativeSign, 33, DecimalFormatter);
+                    RunStandardFormatToStringTests_Helper(s_random, "r99", culture.NumberFormat.NegativeSign, 99, DecimalFormatter);
                 }
             }
         }
@@ -444,7 +444,7 @@ namespace System.Numerics.Tests
             VerifyToString(Int64.MaxValue.ToString("d", provider), format, provider, false, formatter(Int64.MaxValue.ToString("d", provider), precision, provider));
         }
 
-        private static void RunStandardFormatToStringTests(Random random, string format, string negativeSign, int precision, StringFormatter formatter)
+        private static void RunStandardFormatToStringTests_Helper(Random random, string format, string negativeSign, int precision, StringFormatter formatter)
         {
             string test;
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/ToByteArray.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/ToByteArray.cs
@@ -130,7 +130,7 @@ namespace System.Numerics.Tests
 
         [Theory]
         [MemberData(nameof(FromIntTests_MemberData))]
-        public void ToByteArray_FromIntTests(int i, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
+        public void ToByteArray_FromIntTests_Advanced(int i, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
         {
             BigInteger bi = new BigInteger(i);
 
@@ -151,7 +151,7 @@ namespace System.Numerics.Tests
 
         [Theory]
         [MemberData(nameof(FromLongTests_MemberData))]
-        public void ToByteArray_FromLongTests(long l, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
+        public void ToByteArray_FromLongTests_Advanced(long l, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
         {
             BigInteger bi = new BigInteger(l);
 
@@ -172,7 +172,7 @@ namespace System.Numerics.Tests
 
         [Theory]
         [MemberData(nameof(FromStringTests_MemberData))]
-        public void ToByteArray_FromStringTests(string str, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
+        public void ToByteArray_FromStringTests_Advanced(string str, bool isUnsigned, bool isBigEndian, byte[] expectedBytes)
         {
             BigInteger bi = BigInteger.Parse(str);
 

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -783,70 +783,70 @@ namespace System.Numerics.Tests
             foreach (double invalidReal in s_invalidDoubleValues)
             {
                 invalidComplex = new Complex(invalidReal, 1);
-                Equals(invalidComplex, complex, false, false);
-                Equals(invalidComplex, invalidComplex, !double.IsNaN(invalidReal), true); // Handle double.NaN != double.NaN
+                Equals_Helper(invalidComplex, complex, false, false);
+                Equals_Helper(invalidComplex, invalidComplex, !double.IsNaN(invalidReal), true); // Handle double.NaN != double.NaN
                 foreach (double invalidImaginary in s_invalidDoubleValues)
                 {
                     invalidComplex = new Complex(1, invalidImaginary);
-                    Equals(invalidComplex, complex, false, false);
-                    Equals(invalidComplex, invalidComplex, !double.IsNaN(invalidImaginary), true); // Handle double.NaN != double.NaN
+                    Equals_Helper(invalidComplex, complex, false, false);
+                    Equals_Helper(invalidComplex, invalidComplex, !double.IsNaN(invalidImaginary), true); // Handle double.NaN != double.NaN
 
                     invalidComplex = new Complex(invalidReal, invalidImaginary);
-                    Equals(invalidComplex, complex, false, false);
-                    Equals(invalidComplex, invalidComplex, !double.IsNaN(invalidReal) && !double.IsNaN(invalidImaginary), true); // Handle double.NaN != double.NaN
+                    Equals_Helper(invalidComplex, complex, false, false);
+                    Equals_Helper(invalidComplex, invalidComplex, !double.IsNaN(invalidReal) && !double.IsNaN(invalidImaginary), true); // Handle double.NaN != double.NaN
                 }
             }
         }
 
         [Fact]
-        public static void Equals()
+        public static void EqualsTest()
         {
             // This is not InlineData, to workaround a niche bug, that mainly occurs on non Windows platforms.
             // This bug moves test values around to different intermediate memory locations, causing true assertions to be false.
             // Moving these methods into a method, not an iterator fixes this.
-            Equals(Complex.Zero, Complex.Zero, true, true);
-            Equals(Complex.Zero, Complex.One, false, false);
-            Equals(Complex.Zero, -Complex.One, false, false);
-            Equals(Complex.Zero, Complex.ImaginaryOne, false, false);
-            Equals(Complex.Zero, -Complex.ImaginaryOne, false, false);
+            Equals_Helper(Complex.Zero, Complex.Zero, true, true);
+            Equals_Helper(Complex.Zero, Complex.One, false, false);
+            Equals_Helper(Complex.Zero, -Complex.One, false, false);
+            Equals_Helper(Complex.Zero, Complex.ImaginaryOne, false, false);
+            Equals_Helper(Complex.Zero, -Complex.ImaginaryOne, false, false);
 
-            Equals(Complex.One, Complex.One, true, true);
-            Equals(Complex.One, -Complex.One, false, false);
-            Equals(Complex.One, Complex.ImaginaryOne, false, false);
-            Equals(Complex.One, -Complex.ImaginaryOne, false, false);
+            Equals_Helper(Complex.One, Complex.One, true, true);
+            Equals_Helper(Complex.One, -Complex.One, false, false);
+            Equals_Helper(Complex.One, Complex.ImaginaryOne, false, false);
+            Equals_Helper(Complex.One, -Complex.ImaginaryOne, false, false);
 
-            Equals(-Complex.One, -Complex.One, true, true);
-            Equals(-Complex.One, Complex.ImaginaryOne, false, false);
-            Equals(-Complex.One, -Complex.ImaginaryOne, false, false);
+            Equals_Helper(-Complex.One, -Complex.One, true, true);
+            Equals_Helper(-Complex.One, Complex.ImaginaryOne, false, false);
+            Equals_Helper(-Complex.One, -Complex.ImaginaryOne, false, false);
 
-            Equals(Complex.ImaginaryOne, Complex.ImaginaryOne, true, true);
-            Equals(Complex.ImaginaryOne, -Complex.ImaginaryOne, false, false);
+            Equals_Helper(Complex.ImaginaryOne, Complex.ImaginaryOne, true, true);
+            Equals_Helper(Complex.ImaginaryOne, -Complex.ImaginaryOne, false, false);
 
-            Equals(-Complex.ImaginaryOne, -Complex.ImaginaryOne, true, true);
+            Equals_Helper(-Complex.ImaginaryOne, -Complex.ImaginaryOne, true, true);
 
-            Equals(Complex.Zero, new Complex(0, 0), true, true);
-            Equals(Complex.Zero, new Complex(1, 0), false, false);
-            Equals(Complex.Zero, new Complex(0, 1), false, false);
+            Equals_Helper(Complex.Zero, new Complex(0, 0), true, true);
+            Equals_Helper(Complex.Zero, new Complex(1, 0), false, false);
+            Equals_Helper(Complex.Zero, new Complex(0, 1), false, false);
 
-            Equals(Complex.One, new Complex(1, 0), true, true);
-            Equals(Complex.One, new Complex(1, 1), false, false);
-            Equals(Complex.One, new Complex(0, 1), false, false);
+            Equals_Helper(Complex.One, new Complex(1, 0), true, true);
+            Equals_Helper(Complex.One, new Complex(1, 1), false, false);
+            Equals_Helper(Complex.One, new Complex(0, 1), false, false);
 
-            Equals(-Complex.One, new Complex(-1, 0), true, true);
-            Equals(-Complex.One, new Complex(-1, -1), false, false);
-            Equals(-Complex.One, new Complex(0, -1), false, false);
+            Equals_Helper(-Complex.One, new Complex(-1, 0), true, true);
+            Equals_Helper(-Complex.One, new Complex(-1, -1), false, false);
+            Equals_Helper(-Complex.One, new Complex(0, -1), false, false);
 
-            Equals(Complex.ImaginaryOne, new Complex(0, 1), true, true);
-            Equals(Complex.ImaginaryOne, new Complex(1, 1), false, false);
-            Equals(Complex.ImaginaryOne, new Complex(0, -1), false, false);
+            Equals_Helper(Complex.ImaginaryOne, new Complex(0, 1), true, true);
+            Equals_Helper(Complex.ImaginaryOne, new Complex(1, 1), false, false);
+            Equals_Helper(Complex.ImaginaryOne, new Complex(0, -1), false, false);
 
-            Equals(-Complex.ImaginaryOne, new Complex(0, -1), true, true);
-            Equals(-Complex.ImaginaryOne, new Complex(-1, -1), false, false);
-            Equals(-Complex.ImaginaryOne, new Complex(0, 1), false, false);
+            Equals_Helper(-Complex.ImaginaryOne, new Complex(0, -1), true, true);
+            Equals_Helper(-Complex.ImaginaryOne, new Complex(-1, -1), false, false);
+            Equals_Helper(-Complex.ImaginaryOne, new Complex(0, 1), false, false);
 
-            Equals(new Complex(0.5, 0.5), new Complex(0.5, 0.5), true, true);
-            Equals(new Complex(0.5, 0.5), new Complex(0.5, 1.5), false, false);
-            Equals(new Complex(0.5, 0.5), new Complex(1.5, 0.5), false, false);
+            Equals_Helper(new Complex(0.5, 0.5), new Complex(0.5, 0.5), true, true);
+            Equals_Helper(new Complex(0.5, 0.5), new Complex(0.5, 1.5), false, false);
+            Equals_Helper(new Complex(0.5, 0.5), new Complex(1.5, 0.5), false, false);
 
             // Boundary values
             Complex maxMax = new Complex(double.MaxValue, double.MaxValue);
@@ -854,33 +854,33 @@ namespace System.Numerics.Tests
             Complex minMax = new Complex(double.MinValue, double.MaxValue);
             Complex minMin = new Complex(double.MinValue, double.MinValue);
 
-            Equals(maxMax, maxMax, true, true);
-            Equals(maxMax, maxMin, false, false);
-            Equals(maxMax, minMax, false, false);
-            Equals(maxMax, minMin, false, false);
-            Equals(maxMax, new Complex(1, 2), false, false);
+            Equals_Helper(maxMax, maxMax, true, true);
+            Equals_Helper(maxMax, maxMin, false, false);
+            Equals_Helper(maxMax, minMax, false, false);
+            Equals_Helper(maxMax, minMin, false, false);
+            Equals_Helper(maxMax, new Complex(1, 2), false, false);
 
-            Equals(maxMin, maxMin, true, true);
-            Equals(maxMin, minMax, false, false);
-            Equals(maxMin, minMin, false, false);
-            Equals(maxMin, new Complex(1, 2), false, false);
+            Equals_Helper(maxMin, maxMin, true, true);
+            Equals_Helper(maxMin, minMax, false, false);
+            Equals_Helper(maxMin, minMin, false, false);
+            Equals_Helper(maxMin, new Complex(1, 2), false, false);
 
-            Equals(minMax, minMax, true, true);
-            Equals(minMax, minMin, false, false);
-            Equals(minMax, new Complex(1, 2), false, false);
+            Equals_Helper(minMax, minMax, true, true);
+            Equals_Helper(minMax, minMin, false, false);
+            Equals_Helper(minMax, new Complex(1, 2), false, false);
 
-            Equals(minMin, minMin, true, true);
-            Equals(minMin, new Complex(1, 2), false, false);
+            Equals_Helper(minMin, minMin, true, true);
+            Equals_Helper(minMin, new Complex(1, 2), false, false);
 
-            Equals(new Complex(100.5, 0), 100.5, false, false);
-            Equals(new Complex(0, 100.5), 100.5, false, false);
-            Equals(new Complex(100.5, 0), 0, false, false);
-            Equals(new Complex(0, 100.5), 0, false, false);
-            Equals(new Complex(0, 100.5), "0", false, false);
-            Equals(new Complex(0, 100.5), null, false, false);
+            Equals_Helper(new Complex(100.5, 0), 100.5, false, false);
+            Equals_Helper(new Complex(0, 100.5), 100.5, false, false);
+            Equals_Helper(new Complex(100.5, 0), 0, false, false);
+            Equals_Helper(new Complex(0, 100.5), 0, false, false);
+            Equals_Helper(new Complex(0, 100.5), "0", false, false);
+            Equals_Helper(new Complex(0, 100.5), null, false, false);
         }
 
-        private static void Equals(Complex complex1, object obj, bool expected, bool expectedEquals)
+        private static void Equals_Helper(Complex complex1, object obj, bool expected, bool expectedEquals)
         {
             if (obj is Complex)
             {
@@ -1728,7 +1728,7 @@ namespace System.Numerics.Tests
         [MemberData(nameof(Random_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]
         [MemberData(nameof(Invalid_2_TestData))]
-        public static void ToString(double real, double imaginary)
+        public static void ToStringTest(double real, double imaginary)
         {
             var complex = new Complex(real, imaginary);
 

--- a/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/DurationTests.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/DurationTests.cs
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Tests
             Assert.Equal(expected, duration1 - duration2);
         }
 
-        public static IEnumerable<object[]> Compare_TestData()
+        public static IEnumerable<object[]> Compare_TestData_Data()
         {
             yield return new object[] { new Duration(TimeSpan.FromSeconds(1)), new Duration(TimeSpan.FromSeconds(2)), -1 };
             yield return new object[] { new Duration(TimeSpan.FromSeconds(2)), new Duration(TimeSpan.FromSeconds(1)), 1 };
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Compare_TestData))]
+        [MemberData(nameof(Compare_TestData_Data))]
         public void Compare_TestData(Duration duration1, Duration duration2, int expected)
         {
             bool bothOrNoneAutomatic = (duration1 == Duration.Automatic) == (duration2 == Duration.Automatic);
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        [MemberData(nameof(Compare_TestData))]
+        [MemberData(nameof(Compare_TestData_Data))]
         public void Equals_Object_ReturnsExpected(Duration duration, object other, int expected)
         {
             Assert.Equal(expected == 0, duration.Equals(other));

--- a/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/ThicknessTests.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime.UI.Xaml/tests/Windows/UI/Xaml/ThicknessTests.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Tests
 
         [Theory]
         [MemberData(nameof(Values_TestData))]
-        public void Ctor_Default(double uniformLength)
+        public void Ctor_WithLengthParameter(double uniformLength)
         {
             var thickness = new Thickness(uniformLength);
             Assert.Equal(uniformLength, thickness.Left);

--- a/src/libraries/System.Runtime/tests/System/ArraySegmentTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArraySegmentTests.cs
@@ -245,7 +245,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(ArraySegment<int> segment1, object obj, bool expected)
+        public static void EqualsTest(ArraySegment<int> segment1, object obj, bool expected)
         {
             if (obj is ArraySegment<int>)
             {

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -1770,10 +1770,10 @@ namespace System.Tests
         [MemberData(nameof(CreateInstance_TestData))]
         public static void CreateInstance(Type elementType, object repeatedValue)
         {
-            CreateInstance(elementType, new int[] { 10 }, new int[1], repeatedValue);
-            CreateInstance(elementType, new int[] { 0 }, new int[1], repeatedValue);
-            CreateInstance(elementType, new int[] { 1, 2 }, new int[] { 1, 2 }, repeatedValue);
-            CreateInstance(elementType, new int[] { 5, 6 }, new int[] { int.MinValue, 0 }, repeatedValue);
+            CreateInstance_Advanced(elementType, new int[] { 10 }, new int[1], repeatedValue);
+            CreateInstance_Advanced(elementType, new int[] { 0 }, new int[1], repeatedValue);
+            CreateInstance_Advanced(elementType, new int[] { 1, 2 }, new int[] { 1, 2 }, repeatedValue);
+            CreateInstance_Advanced(elementType, new int[] { 5, 6 }, new int[] { int.MinValue, 0 }, repeatedValue);
         }
 
         [Theory]
@@ -1785,7 +1785,7 @@ namespace System.Tests
         [InlineData(typeof(int), new int[] { 7 }, new int[] { 1 }, default(int))]
         [InlineData(typeof(int), new int[] { 7, 8 }, new int[] { 1, 2 }, default(int))]
         [InlineData(typeof(int), new int[] { 7, 8, 9 }, new int[] { 1, 2, 3 }, default(int))]
-        public static void CreateInstance(Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)
+        public static void CreateInstance_Advanced(Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)
         {
             bool lowerBoundsAreAllZero = lowerBounds.All(lowerBound => lowerBound == 0);
             if ((!lowerBoundsAreAllZero) && !PlatformDetection.IsNonZeroLowerBoundArraySupported)
@@ -3577,7 +3577,7 @@ namespace System.Tests
         [InlineData(10, 1)]
         [InlineData(9, 2)]
         [InlineData(0, 11)]
-        public void Store_NegativeLength_ThrowsArgumentOutOfRangeException(int index, int length)
+        public void Store_NegativeLength_ThrowsArgumentException(int index, int length)
         {
             AssertExtensions.Throws<ArgumentException>(null, () => Array.Sort((Array)new int[10], index, length));
             AssertExtensions.Throws<ArgumentException>(null, () => Array.Sort((Array)new int[10], index, length, null));

--- a/src/libraries/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/AttributeTests.cs
@@ -187,7 +187,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(Attribute attr1, object obj, bool expected, bool hashEqualityExpected)
+        public static void EqualsTest(Attribute attr1, object obj, bool expected, bool hashEqualityExpected)
         {
             Assert.Equal(expected, attr1.Equals(obj));
 

--- a/src/libraries/System.Runtime/tests/System/ByteTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.cs
@@ -68,7 +68,7 @@ namespace System.Tests
         [InlineData((byte)78, null, false)]
         [InlineData((byte)78, "78", false)]
         [InlineData((byte)78, 78, false)]
-        public static void Equals(byte b, object obj, bool expected)
+        public static void EqualsTest(byte b, object obj, bool expected)
         {
             if (obj is byte b2)
             {
@@ -120,7 +120,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(byte b, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(byte b, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/CharTests.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.cs
@@ -155,7 +155,7 @@ namespace System.Tests
         [InlineData('a', (int)'a', false)]
         [InlineData('a', "a", false)]
         [InlineData('a', null, false)]
-        public static void Equals(char c, object obj, bool expected)
+        public static void EqualsTest(char c, object obj, bool expected)
         {
             if (obj is char)
             {
@@ -826,7 +826,7 @@ namespace System.Tests
         [Theory]
         [InlineData('a', "a")]
         [InlineData('\uabcd', "\uabcd")]
-        public static void ToString(char c, string expected)
+        public static void ToStringTest(char c, string expected)
         {
             Assert.Equal(expected, c.ToString());
             Assert.Equal(expected, char.ToString(c));

--- a/src/libraries/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ComponentModel/DefaultValueAttributeTests.cs
@@ -122,7 +122,7 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(DefaultValueAttribute attr1, object obj, bool expected)
+        public static void EqualsTest(DefaultValueAttribute attr1, object obj, bool expected)
         {
             Assert.Equal(expected, attr1.Equals(obj));
 

--- a/src/libraries/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ComponentModel/EditorBrowsableAttributeTests.cs
@@ -25,7 +25,7 @@ namespace System.ComponentModel.Tests
         [InlineData((EditorBrowsableState)12345, (EditorBrowsableState)12345, true)]
         [InlineData(EditorBrowsableState.Advanced, EditorBrowsableState.Always, false)]
         [InlineData(EditorBrowsableState.Advanced, EditorBrowsableState.Never, false)]
-        public static void Equals(EditorBrowsableState state1, EditorBrowsableState state2, bool equal)
+        public static void EqualsTest(EditorBrowsableState state1, EditorBrowsableState state2, bool equal)
         {
             var attr1 = new EditorBrowsableAttribute(state1);
             var attr2 = new EditorBrowsableAttribute(state2);

--- a/src/libraries/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -721,7 +721,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(DateTimeOffset dateTimeOffset1, object obj, bool expectedEquals, bool expectedEqualsExact)
+        public static void EqualsTest(DateTimeOffset dateTimeOffset1, object obj, bool expectedEquals, bool expectedEqualsExact)
         {
             Assert.Equal(expectedEquals, dateTimeOffset1.Equals(obj));
             if (obj is DateTimeOffset)

--- a/src/libraries/System.Runtime/tests/System/DecimalTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DecimalTests.cs
@@ -535,7 +535,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(object obj1, object obj2, bool expected)
+        public static void EqualsTest(object obj1, object obj2, bool expected)
         {
             if (obj1 is decimal d1)
             {
@@ -1858,7 +1858,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static new void GetHashCode()
+        public static void GetHashCodeTest()
         {
             var dict = new Dictionary<string, (int hash, string value)>();
             foreach (decimal d in GetRandomData(out _, hash: true))

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -112,7 +112,7 @@ namespace System.Tests
         [InlineData(double.NaN, -double.NaN, true)]
         [InlineData(789.0, 789.0f, false)]
         [InlineData(789.0, "789", false)]
-        public static void Equals(double d1, object value, bool expected)
+        public static void EqualsTest(double d1, object value, bool expected)
         {
             if (value is double d2)
             {

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -944,7 +944,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(Enum e, object obj, bool expected)
+        public static void EqualsTest(Enum e, object obj, bool expected)
         {
             Assert.Equal(expected, e.Equals(obj));
             Assert.Equal(e.GetHashCode(), e.GetHashCode());

--- a/src/libraries/System.Runtime/tests/System/GuidTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GuidTests.cs
@@ -310,7 +310,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(Guid guid1, object obj, bool expected)
+        public static void EqualsTest(Guid guid1, object obj, bool expected)
         {
             if (obj is Guid)
             {
@@ -343,7 +343,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(Guid guid, string format, string expected)
+        public static void ToStringTest(Guid guid, string format, string expected)
         {
             IFormattable formattable = guid;
             if (string.IsNullOrEmpty(format) || format == "D")

--- a/src/libraries/System.Runtime/tests/System/Int16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int16Tests.cs
@@ -81,7 +81,7 @@ namespace System.Tests
         [InlineData((short)789, null, false)]
         [InlineData((short)789, "789", false)]
         [InlineData((short)789, 789, false)]
-        public static void Equals(short i1, object obj, bool expected)
+        public static void EqualsTest(short i1, object obj, bool expected)
         {
             if (obj is short)
             {
@@ -142,7 +142,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(short i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(short i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/Int32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int32Tests.cs
@@ -81,7 +81,7 @@ namespace System.Tests
         [InlineData(789, null, false)]
         [InlineData(789, "789", false)]
         [InlineData(789, (long)789, false)]
-        public static void Equals(int i1, object obj, bool expected)
+        public static void EqualsTest(int i1, object obj, bool expected)
         {
             if (obj is int)
             {
@@ -142,7 +142,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(int i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(int i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.cs
@@ -82,7 +82,7 @@ namespace System.Tests
         [InlineData((long)789, null, false)]
         [InlineData((long)789, "789", false)]
         [InlineData((long)789, 789, false)]
-        public static void Equals(long i1, object obj, bool expected)
+        public static void EqualsTest(long i1, object obj, bool expected)
         {
             if (obj is long)
             {
@@ -143,7 +143,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(long i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(long i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.cs
@@ -108,7 +108,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(IntPtr ptr1, object obj, bool expected)
+        public static void EqualsTest(IntPtr ptr1, object obj, bool expected)
         {
             if (obj is IntPtr)
             {

--- a/src/libraries/System.Runtime/tests/System/MulticastDelegateTests.cs
+++ b/src/libraries/System.Runtime/tests/System/MulticastDelegateTests.cs
@@ -19,7 +19,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Equals()
+        public static void EqualsTest()
         {
             C c = new C();
             DFoo d1 = c.Foo;

--- a/src/libraries/System.Runtime/tests/System/ObjectTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ObjectTests.cs
@@ -25,7 +25,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(object obj1, object obj2, bool expected)
+        public static void EqualsTest(object obj1, object obj2, bool expected)
         {
             if (obj1 != null)
             {
@@ -41,7 +41,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ReferenceEquals()
+        public static void ReferenceEqualsTest()
         {
             var e1 = new EOverrider(7);
             var e2 = new EOverrider(8);
@@ -82,7 +82,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetType_TestData))]
-        public static void GetType(object obj, Type expected)
+        public static void GetTypeTest(object obj, Type expected)
         {
             Assert.Equal(expected, obj.GetType());
         }

--- a/src/libraries/System.Runtime/tests/System/SByteTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SByteTests.cs
@@ -77,7 +77,7 @@ namespace System.Tests
         [InlineData((sbyte)78, null, false)]
         [InlineData((sbyte)78, "78", false)]
         [InlineData((sbyte)78, 78, false)]
-        public static void Equals(sbyte i1, object obj, bool expected)
+        public static void EqualsTest(sbyte i1, object obj, bool expected)
         {
             if (obj is sbyte)
             {
@@ -138,7 +138,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(sbyte i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(sbyte i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -113,7 +113,7 @@ namespace System.Tests
         [InlineData(float.NaN, -float.NaN, true)]
         [InlineData(789.0f, 789.0, false)]
         [InlineData(789.0f, "789", false)]
-        public static void Equals(float f1, object value, bool expected)
+        public static void EqualsTest(float f1, object value, bool expected)
         {
             if (value is float f2)
             {
@@ -456,12 +456,12 @@ namespace System.Tests
             {
                 foreach (object[] testdata in ToString_TestData_NotNetFramework())
                 {
-                    ToString((float)testdata[0], (string)testdata[1], (IFormatProvider)testdata[2], (string)testdata[3]);
+                    ToStringTest((float)testdata[0], (string)testdata[1], (IFormatProvider)testdata[2], (string)testdata[3]);
                 }
             }
         }
 
-        private static void ToString(float f, string format, IFormatProvider provider, string expected)
+        private static void ToStringTest(float f, string format, IFormatProvider provider, string expected)
         {
             bool isDefaultProvider = provider == null;
             if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -200,7 +200,7 @@ namespace System.Tests
         [InlineData("Hello", 'e', StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("Hello", 'E', StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", 'H', StringComparison.OrdinalIgnoreCase, false)]
-        public static void Contains_Char_ExplicitComparisonType(string s, char value, StringComparison comparisionType, bool expected)
+        public static void Contains_Char_StringComparison(string s, char value, StringComparison comparisionType, bool expected)
         {
             Assert.Equal(expected, s.Contains(value, comparisionType));
         }
@@ -272,7 +272,7 @@ namespace System.Tests
         [InlineData("Hello", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("Hello", "ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("Hello", "Ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
-        public static void Contains_String_ExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
+        public static void Contains_String_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             Assert.Equal(expected, s.Contains(value, comparisonType));
             Assert.Equal(expected, s.AsSpan().Contains(value, comparisonType));
@@ -964,7 +964,7 @@ namespace System.Tests
         [InlineData("_____________\u807f\u007f_", '\u007f', StringComparison.OrdinalIgnoreCase, 14)]
         [InlineData("__\u807f_______________", '\u007f', StringComparison.OrdinalIgnoreCase, -1)]
         [InlineData("__\u807f___\u007f___________", '\u007f', StringComparison.OrdinalIgnoreCase, 6)]
-        public static void IndexOf_SingleLetter_WithExplicitComparisonType(string s, char target, StringComparison stringComparison, int expected)
+        public static void IndexOf_SingleLetter_StringComparison(string s, char target, StringComparison stringComparison, int expected)
         {
             Assert.Equal(expected, s.IndexOf(target, stringComparison));
             var charArray = new char[1];

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -155,7 +155,7 @@ namespace System.Tests
         [InlineData("Hello", 'e', true)]
         [InlineData("Hello", 'E', false)]
         [InlineData("", 'H', false)]
-        public static void Contains(string s, char value, bool expected)
+        public static void Contains_Char(string s, char value, bool expected)
         {
             Assert.Equal(expected, s.Contains(value));
 
@@ -200,7 +200,7 @@ namespace System.Tests
         [InlineData("Hello", 'e', StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("Hello", 'E', StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", 'H', StringComparison.OrdinalIgnoreCase, false)]
-        public static void Contains(string s, char value, StringComparison comparisionType, bool expected)
+        public static void Contains_Char_ExplicitComparisonType(string s, char value, StringComparison comparisionType, bool expected)
         {
             Assert.Equal(expected, s.Contains(value, comparisionType));
         }
@@ -272,7 +272,7 @@ namespace System.Tests
         [InlineData("Hello", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("Hello", "ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("Hello", "Ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
-        public static void Contains(string s, string value, StringComparison comparisonType, bool expected)
+        public static void Contains_String_ExplicitComparisonType(string s, string value, StringComparison comparisonType, bool expected)
         {
             Assert.Equal(expected, s.Contains(value, comparisonType));
             Assert.Equal(expected, s.AsSpan().Contains(value, comparisonType));
@@ -426,7 +426,7 @@ namespace System.Tests
         [InlineData(StringComparison.InvariantCultureIgnoreCase)]
         [InlineData(StringComparison.Ordinal)]
         [InlineData(StringComparison.OrdinalIgnoreCase)]
-        public static void Contains_NullValue_ThrowsArgumentNullException(StringComparison comparisonType)
+        public static void Contains_NullValue_WithComparisonType_ThrowsArgumentNullException(StringComparison comparisonType)
         {
             AssertExtensions.Throws<ArgumentNullException>("value", () => "foo".Contains(null, comparisonType));
         }
@@ -964,7 +964,7 @@ namespace System.Tests
         [InlineData("_____________\u807f\u007f_", '\u007f', StringComparison.OrdinalIgnoreCase, 14)]
         [InlineData("__\u807f_______________", '\u007f', StringComparison.OrdinalIgnoreCase, -1)]
         [InlineData("__\u807f___\u007f___________", '\u007f', StringComparison.OrdinalIgnoreCase, 6)]
-        public static void IndexOf_SingleLetter(string s, char target, StringComparison stringComparison, int expected)
+        public static void IndexOf_SingleLetter_WithExplicitComparisonType(string s, char target, StringComparison stringComparison, int expected)
         {
             Assert.Equal(expected, s.IndexOf(target, stringComparison));
             var charArray = new char[1];

--- a/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
@@ -139,7 +139,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(SurrogatePairTestData_InvalidOnly))]
-        public static void Ctor_SurrogatePair_Valid(char highSurrogate, char lowSurrogate)
+        public static void Ctor_SurrogatePair_Invalid(char highSurrogate, char lowSurrogate)
         {
             string expectedParamName = !char.IsHighSurrogate(highSurrogate) ? nameof(highSurrogate) : nameof(lowSurrogate);
             Assert.Throws<ArgumentOutOfRangeException>(expectedParamName, () => new Rune(highSurrogate, lowSurrogate));

--- a/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -1105,7 +1105,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(StringBuilder sb1, StringBuilder sb2, bool expected)
+        public static void EqualsTest(StringBuilder sb1, StringBuilder sb2, bool expected)
         {
             Assert.Equal(expected, sb1.Equals(sb2));
         }
@@ -1746,7 +1746,7 @@ namespace System.Text.Tests
         [InlineData("Hello", 4, 0, "")]
         [InlineData("Hello", 0, 0, "")]
         [InlineData("", 0, 0, "")]
-        public static void ToString(string value, int startIndex, int length, string expected)
+        public static void ToStringTest(string value, int startIndex, int length, string expected)
         {
             var builder = new StringBuilder(value);
             if (startIndex == 0 && length == value.Length)
@@ -2170,7 +2170,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_String_TestData))]
-        public static void Equals(StringBuilder sb1, string value, bool expected)
+        public static void Equals_String(StringBuilder sb1, string value, bool expected)
         {
             Assert.Equal(expected, sb1.Equals(value.AsSpan()));
         }

--- a/src/libraries/System.Runtime/tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeSpanTests.cs
@@ -293,7 +293,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(TimeSpan timeSpan1, object obj, bool expected)
+        public static void EqualsTest(TimeSpan timeSpan1, object obj, bool expected)
         {
             if (obj is TimeSpan)
             {
@@ -1111,7 +1111,7 @@ namespace System.Tests
         }
 
         [Theory, MemberData(nameof(ParseDifferentLengthFractionWithLeadingZerosData))]
-        public static void Multiplication(string input, TimeSpan expected)
+        public static void ParseDifferentLengthFractionWithLeadingZeros(string input, TimeSpan expected)
         {
             Assert.Equal(expected, TimeSpan.Parse(input, CultureInfo.InvariantCulture));
             Assert.Equal(expected, TimeSpan.ParseExact(input, "g", CultureInfo.InvariantCulture));

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -1891,7 +1891,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(TimeZoneInfo timeZoneInfo, object obj, bool expected)
+        public static void EqualsTest(TimeZoneInfo timeZoneInfo, object obj, bool expected)
         {
             Assert.Equal(expected, timeZoneInfo.Equals(obj));
             if (obj is TimeZoneInfo)

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.cs
@@ -68,7 +68,7 @@ namespace System.Tests
         [InlineData((ushort)789, null, false)]
         [InlineData((ushort)789, "789", false)]
         [InlineData((ushort)789, 789, false)]
-        public static void Equals(ushort i1, object obj, bool expected)
+        public static void EqualsTest(ushort i1, object obj, bool expected)
         {
             if (obj is ushort)
             {
@@ -123,7 +123,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(ushort i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(ushort i, string format, IFormatProvider provider, string expected)
         {
             // Format should be case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.cs
@@ -69,7 +69,7 @@ namespace System.Tests
         [InlineData((uint)789, null, false)]
         [InlineData((uint)789, "789", false)]
         [InlineData((uint)789, 789, false)]
-        public static void Equals(uint i1, object obj, bool expected)
+        public static void EqualsTest(uint i1, object obj, bool expected)
         {
             if (obj is uint)
             {
@@ -125,7 +125,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(uint i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(uint i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.cs
@@ -69,7 +69,7 @@ namespace System.Tests
         [InlineData((ulong)789, null, false)]
         [InlineData((ulong)789, "789", false)]
         [InlineData((ulong)789, 789, false)]
-        public static void Equals(ulong i1, object obj, bool expected)
+        public static void EqualsTest(ulong i1, object obj, bool expected)
         {
             if (obj is ulong i2)
             {
@@ -124,7 +124,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        public static void ToString(ulong i, string format, IFormatProvider provider, string expected)
+        public static void ToStringTest(ulong i, string format, IFormatProvider provider, string expected)
         {
             // Format is case insensitive
             string upperFormat = format.ToUpperInvariant();

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.cs
@@ -105,7 +105,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public static void Equals(UIntPtr ptr1, object obj, bool expected)
+        public static void EqualsTest(UIntPtr ptr1, object obj, bool expected)
         {
             if (obj is UIntPtr)
             {

--- a/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -386,7 +386,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(Uri uri1, object obj, bool expected)
+        public void EqualsTest(Uri uri1, object obj, bool expected)
         {
             Uri uri2 = obj as Uri;
             if (uri1 != null)
@@ -599,9 +599,9 @@ namespace System.Tests
         [MemberData(nameof(GetComponents_Basic_TestData))]
         public void GetComponents(Uri uri, UriComponents components, string expected)
         {
-            GetComponents(uri, components, UriFormat.SafeUnescaped, expected);
-            GetComponents(uri, components, UriFormat.Unescaped, expected);
-            GetComponents(uri, components, UriFormat.UriEscaped, expected);
+            GetComponents_Advanced(uri, components, UriFormat.SafeUnescaped, expected);
+            GetComponents_Advanced(uri, components, UriFormat.Unescaped, expected);
+            GetComponents_Advanced(uri, components, UriFormat.UriEscaped, expected);
         }
 
         public static IEnumerable<object[]> GetComponents_Advanced_TestData()
@@ -667,7 +667,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetComponents_Advanced_TestData))]
-        public void GetComponents(Uri uri, UriComponents components, UriFormat format, string expected)
+        public void GetComponents_Advanced(Uri uri, UriComponents components, UriFormat format, string expected)
         {
             Assert.Equal(expected, uri.GetComponents(components, format));
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DSASignatureFormatterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DSASignatureFormatterTests.cs
@@ -10,13 +10,13 @@ namespace System.Security.Cryptography.Dsa.Tests
     public partial class DSASignatureFormatterTests : AsymmetricSignatureFormatterTests
     {
         [Fact]
-        public static void InvalidFormatterArguments()
+        public static void InvalidFormatterArguments_DSA()
         {
             InvalidFormatterArguments(new DSASignatureFormatter());
         }
 
         [Fact]
-        public static void InvalidDeformatterArguments()
+        public static void InvalidDeformatterArguments_DSA()
         {
             InvalidDeformatterArguments(new DSASignatureDeformatter());
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RSASignatureFormatterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RSASignatureFormatterTests.cs
@@ -10,13 +10,13 @@ namespace System.Security.Cryptography.Rsa.Tests
     public partial class RSASignatureFormatterTests : AsymmetricSignatureFormatterTests
     {
         [Fact]
-        public static void InvalidFormatterArguments()
+        public static void InvalidFormatterArguments_RSA()
         {
             InvalidFormatterArguments(new RSAPKCS1SignatureFormatter());
         }
 
         [Fact]
-        public static void InvalidDeformatterArguments()
+        public static void InvalidDeformatterArguments_RSA()
         {
             InvalidDeformatterArguments(new RSAPKCS1SignatureDeformatter());
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.RNG.Tests
             using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
             {
                 AssertExtensions.Throws<ArgumentNullException>("data", () => rng.GetNonZeroBytes(null));
-                GetBytes_InvalidArgs(rng);
+                GetBytes_InvalidArgs_Helper(rng);
             }
         }
 
@@ -226,7 +226,7 @@ namespace System.Security.Cryptography.RNG.Tests
             using (var rng = new RandomNumberGeneratorMininal())
             {
                 Assert.Throws<NotImplementedException>(() => rng.GetNonZeroBytes(null));
-                GetBytes_InvalidArgs(rng);
+                GetBytes_InvalidArgs_Helper(rng);
             }
         }
 
@@ -504,7 +504,7 @@ namespace System.Security.Cryptography.RNG.Tests
             }
         }
 
-        private static void GetBytes_InvalidArgs(RandomNumberGenerator rng)
+        private static void GetBytes_InvalidArgs_Helper(RandomNumberGenerator rng)
         {
             AssertExtensions.Throws<ArgumentNullException>("data", () => rng.GetBytes(null, 0, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => rng.GetBytes(Array.Empty<byte>(), -1, 0));

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -19,36 +19,36 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         [Fact]
         public static void VerifyDefaults()
         {
+            static void verifyDefaults(Rijndael alg)
+            {
+                // The block size differs from the base
+                Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
+                Assert.Equal(128, alg.LegalBlockSizes[0].MaxSize);
+                Assert.Equal(128, alg.BlockSize);
+
+                // Different exception since we have different supported BlockSizes than desktop
+                Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 192);
+                Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 256);
+
+                // Normal exception for rest
+                Assert.Throws<CryptographicException>(() => alg.BlockSize = 111);
+
+                Assert.Equal(CipherMode.CBC, alg.Mode);
+                Assert.Equal(PaddingMode.PKCS7, alg.Padding);
+            }
+
             using (var alg = Rijndael.Create())
             {
                 // We use an internal class for the implementation, not the public RijndaelManaged
                 Assert.IsNotType<RijndaelManaged>(alg);
 
-                VerifyDefaults(alg);
+                verifyDefaults(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                VerifyDefaults(alg);
+                verifyDefaults(alg);
             }
-        }
-
-        private static void VerifyDefaults(Rijndael alg)
-        {
-            // The block size differs from the base
-            Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
-            Assert.Equal(128, alg.LegalBlockSizes[0].MaxSize);
-            Assert.Equal(128, alg.BlockSize);
-
-            // Different exception since we have different supported BlockSizes than desktop
-            Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 192);
-            Assert.Throws<PlatformNotSupportedException>(() => alg.BlockSize = 256);
-
-            // Normal exception for rest
-            Assert.Throws<CryptographicException>(() => alg.BlockSize = 111);
-
-            Assert.Equal(CipherMode.CBC, alg.Mode);
-            Assert.Equal(PaddingMode.PKCS7, alg.Padding);
         }
 
         [Fact]
@@ -90,96 +90,96 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         [Fact]
         public static void EncryptDecryptKnownECB192()
         {
+            static void encryptDecryptKnownECB192(Rijndael alg)
+            {
+                byte[] plainTextBytes =
+                    new ASCIIEncoding().GetBytes("This is a sentence that is longer than a block, it ensures that multi-block functions work.");
+
+                byte[] encryptedBytesExpected = new byte[]
+                {
+                    0xC9, 0x7F, 0xA5, 0x5B, 0xC3, 0x92, 0xDC, 0xA6,
+                    0xE4, 0x9F, 0x2D, 0x1A, 0xEF, 0x7A, 0x27, 0x03,
+                    0x04, 0x9C, 0xFB, 0x56, 0x63, 0x38, 0xAE, 0x4F,
+                    0xDC, 0xF6, 0x36, 0x98, 0x28, 0x05, 0x32, 0xE9,
+                    0xF2, 0x6E, 0xEC, 0x0C, 0x04, 0x9D, 0x12, 0x17,
+                    0x18, 0x35, 0xD4, 0x29, 0xFC, 0x01, 0xB1, 0x20,
+                    0xFA, 0x30, 0xAE, 0x00, 0x53, 0xD4, 0x26, 0x25,
+                    0xA4, 0xFD, 0xD5, 0xE6, 0xED, 0x79, 0x35, 0x2A,
+                    0xE2, 0xBB, 0x95, 0x0D, 0xEF, 0x09, 0xBB, 0x6D,
+                    0xC5, 0xC4, 0xDB, 0x28, 0xC6, 0xF4, 0x31, 0x33,
+                    0x9A, 0x90, 0x12, 0x36, 0x50, 0xA0, 0xB7, 0xD1,
+                    0x35, 0xC4, 0xCE, 0x81, 0xE5, 0x2B, 0x85, 0x6B,
+                };
+
+                byte[] aes192Key = new byte[]
+                {
+                    0xA6, 0x1E, 0xC7, 0x54, 0x37, 0x4D, 0x8C, 0xA5,
+                    0xA4, 0xBB, 0x99, 0x50, 0x35, 0x4B, 0x30, 0x4D,
+                    0x6C, 0xFE, 0x3B, 0x59, 0x65, 0xCB, 0x93, 0xE3,
+                };
+
+                // The CipherMode and KeySize are different than the default values; this ensures the type
+                // forwards the state properly to Aes.
+                alg.Mode = CipherMode.ECB;
+                alg.Key = aes192Key;
+
+                byte[] encryptedBytes = alg.Encrypt(plainTextBytes);
+                Assert.Equal(encryptedBytesExpected, encryptedBytes);
+
+                byte[] decryptedBytes = alg.Decrypt(encryptedBytes);
+                Assert.Equal(plainTextBytes, decryptedBytes);
+            }
+
             using (var alg = Rijndael.Create())
             {
-                EncryptDecryptKnownECB192(alg);
+                encryptDecryptKnownECB192(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                EncryptDecryptKnownECB192(alg);
+                encryptDecryptKnownECB192(alg);
             }
-        }
-
-        private static void EncryptDecryptKnownECB192(Rijndael alg)
-        {
-            byte[] plainTextBytes =
-                new ASCIIEncoding().GetBytes("This is a sentence that is longer than a block, it ensures that multi-block functions work.");
-
-            byte[] encryptedBytesExpected = new byte[]
-            {
-                0xC9, 0x7F, 0xA5, 0x5B, 0xC3, 0x92, 0xDC, 0xA6,
-                0xE4, 0x9F, 0x2D, 0x1A, 0xEF, 0x7A, 0x27, 0x03,
-                0x04, 0x9C, 0xFB, 0x56, 0x63, 0x38, 0xAE, 0x4F,
-                0xDC, 0xF6, 0x36, 0x98, 0x28, 0x05, 0x32, 0xE9,
-                0xF2, 0x6E, 0xEC, 0x0C, 0x04, 0x9D, 0x12, 0x17,
-                0x18, 0x35, 0xD4, 0x29, 0xFC, 0x01, 0xB1, 0x20,
-                0xFA, 0x30, 0xAE, 0x00, 0x53, 0xD4, 0x26, 0x25,
-                0xA4, 0xFD, 0xD5, 0xE6, 0xED, 0x79, 0x35, 0x2A,
-                0xE2, 0xBB, 0x95, 0x0D, 0xEF, 0x09, 0xBB, 0x6D,
-                0xC5, 0xC4, 0xDB, 0x28, 0xC6, 0xF4, 0x31, 0x33,
-                0x9A, 0x90, 0x12, 0x36, 0x50, 0xA0, 0xB7, 0xD1,
-                0x35, 0xC4, 0xCE, 0x81, 0xE5, 0x2B, 0x85, 0x6B,
-            };
-
-            byte[] aes192Key = new byte[]
-            {
-                0xA6, 0x1E, 0xC7, 0x54, 0x37, 0x4D, 0x8C, 0xA5,
-                0xA4, 0xBB, 0x99, 0x50, 0x35, 0x4B, 0x30, 0x4D,
-                0x6C, 0xFE, 0x3B, 0x59, 0x65, 0xCB, 0x93, 0xE3,
-            };
-
-            // The CipherMode and KeySize are different than the default values; this ensures the type
-            // forwards the state properly to Aes.
-            alg.Mode = CipherMode.ECB;
-            alg.Key = aes192Key;
-
-            byte[] encryptedBytes = alg.Encrypt(plainTextBytes);
-            Assert.Equal(encryptedBytesExpected, encryptedBytes);
-
-            byte[] decryptedBytes = alg.Decrypt(encryptedBytes);
-            Assert.Equal(plainTextBytes, decryptedBytes);
         }
 
         [Fact]
         public static void TestShims()
         {
+            static void testShims(Rijndael alg)
+            {
+                alg.BlockSize = 128;
+                Assert.Equal(128, alg.BlockSize);
+
+                var emptyIV = new byte[alg.BlockSize / 8];
+                alg.IV = emptyIV;
+                Assert.Equal(emptyIV, alg.IV);
+                alg.GenerateIV();
+                Assert.NotEqual(emptyIV, alg.IV);
+
+                var emptyKey = new byte[alg.KeySize / 8];
+                alg.Key = emptyKey;
+                Assert.Equal(emptyKey, alg.Key);
+                alg.GenerateKey();
+                Assert.NotEqual(emptyKey, alg.Key);
+
+                alg.KeySize = 128;
+                Assert.Equal(128, alg.KeySize);
+
+                alg.Mode = CipherMode.ECB;
+                Assert.Equal(CipherMode.ECB, alg.Mode);
+
+                alg.Padding = PaddingMode.PKCS7;
+                Assert.Equal(PaddingMode.PKCS7, alg.Padding);
+            }
+
             using (var alg = Rijndael.Create())
             {
-                TestShims(alg);
+                testShims(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                TestShims(alg);
+                testShims(alg);
             }
-        }
-
-        private static void TestShims(Rijndael alg)
-        {
-            alg.BlockSize = 128;
-            Assert.Equal(128, alg.BlockSize);
-
-            var emptyIV = new byte[alg.BlockSize / 8];
-            alg.IV = emptyIV;
-            Assert.Equal(emptyIV, alg.IV);
-            alg.GenerateIV();
-            Assert.NotEqual(emptyIV, alg.IV);
-
-            var emptyKey = new byte[alg.KeySize / 8];
-            alg.Key = emptyKey;
-            Assert.Equal(emptyKey, alg.Key);
-            alg.GenerateKey();
-            Assert.NotEqual(emptyKey, alg.Key);
-
-            alg.KeySize = 128;
-            Assert.Equal(128, alg.KeySize);
-
-            alg.Mode = CipherMode.ECB;
-            Assert.Equal(CipherMode.ECB, alg.Mode);
-
-            alg.Padding = PaddingMode.PKCS7;
-            Assert.Equal(PaddingMode.PKCS7, alg.Padding);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RijndaelTests.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         [Fact]
         public static void VerifyDefaults()
         {
-            static void verifyDefaults(Rijndael alg)
+            static void test(Rijndael alg)
             {
                 // The block size differs from the base
                 Assert.Equal(128, alg.LegalBlockSizes[0].MinSize);
@@ -42,12 +42,12 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
                 // We use an internal class for the implementation, not the public RijndaelManaged
                 Assert.IsNotType<RijndaelManaged>(alg);
 
-                verifyDefaults(alg);
+                test(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                verifyDefaults(alg);
+                test(alg);
             }
         }
 
@@ -90,7 +90,7 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
         [Fact]
         public static void EncryptDecryptKnownECB192()
         {
-            static void encryptDecryptKnownECB192(Rijndael alg)
+            static void test(Rijndael alg)
             {
                 byte[] plainTextBytes =
                     new ASCIIEncoding().GetBytes("This is a sentence that is longer than a block, it ensures that multi-block functions work.");
@@ -132,19 +132,19 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 
             using (var alg = Rijndael.Create())
             {
-                encryptDecryptKnownECB192(alg);
+                test(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                encryptDecryptKnownECB192(alg);
+                test(alg);
             }
         }
 
         [Fact]
         public static void TestShims()
         {
-            static void testShims(Rijndael alg)
+            static void test(Rijndael alg)
             {
                 alg.BlockSize = 128;
                 Assert.Equal(128, alg.BlockSize);
@@ -173,12 +173,12 @@ namespace System.Security.Cryptography.Encryption.Rijndael.Tests
 
             using (var alg = Rijndael.Create())
             {
-                testShims(alg);
+                test(alg);
             }
 
             using (var alg = new RijndaelManaged())
             {
-                testShims(alg);
+                test(alg);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
@@ -337,7 +337,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyBMPString_Throws(PublicEncodingRules ruleSet, byte[] inputData)
+        private static void TryCopyBMPString_Throws_Helper(PublicEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
@@ -446,7 +446,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            TryCopyBMPString_Throws(ruleSet, inputData);
+            TryCopyBMPString_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
@@ -475,7 +475,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[5] = 0xE9;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyBMPString_Throws(PublicEncodingRules.CER, input);
+            TryCopyBMPString_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -513,7 +513,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[1011] = 0x02;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyBMPString_Throws(PublicEncodingRules.CER, input);
+            TryCopyBMPString_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
@@ -252,7 +252,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
         }
 
-        private static void TryCopyBitStringBytes_Throws(
+        private static void TryCopyBitStringBytes_Throws_Helper(
             PublicEncodingRules ruleSet,
             byte[] input)
         {
@@ -330,7 +330,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            TryCopyBitStringBytes_Throws(ruleSet, inputData);
+            TryCopyBitStringBytes_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
@@ -348,7 +348,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[2] = 0x03;
             input[3] = 0xE9;
 
-            TryCopyBitStringBytes_Throws(PublicEncodingRules.CER, input);
+            TryCopyBitStringBytes_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -377,7 +377,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[5] = 0xE9;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyBitStringBytes_Throws(PublicEncodingRules.CER, input);
+            TryCopyBitStringBytes_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -416,7 +416,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[1011] = 0x02;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyBitStringBytes_Throws(PublicEncodingRules.CER, input);
+            TryCopyBitStringBytes_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
@@ -324,7 +324,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyIA5String_Throws(PublicEncodingRules ruleSet, byte[] inputData)
+        private static void TryCopyIA5String_Throws_Helper(PublicEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
@@ -408,7 +408,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            TryCopyIA5String_Throws(ruleSet, inputData);
+            TryCopyIA5String_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
@@ -437,7 +437,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[5] = 0xE9;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyIA5String_Throws(PublicEncodingRules.CER, input);
+            TryCopyIA5String_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -475,7 +475,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[1011] = 0x02;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyIA5String_Throws(PublicEncodingRules.CER, input);
+            TryCopyIA5String_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
@@ -209,7 +209,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
         }
 
-        private static void TryCopyOctetStringBytes_Throws(
+        private static void TryCopyOctetStringBytes_Throws_Helper(
             PublicEncodingRules ruleSet,
             byte[] input)
         {
@@ -259,7 +259,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            TryCopyOctetStringBytes_Throws(ruleSet, inputData);
+            TryCopyOctetStringBytes_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
@@ -288,7 +288,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[5] = 0xE9;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyOctetStringBytes_Throws(PublicEncodingRules.CER, input);
+            TryCopyOctetStringBytes_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[1011] = 0x02;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyOctetStringBytes_Throws(PublicEncodingRules.CER, input);
+            TryCopyOctetStringBytes_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
@@ -338,7 +338,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyUTF8String_Throws(PublicEncodingRules ruleSet, byte[] inputData)
+        private static void TryCopyUTF8String_Throws_Helper(PublicEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
@@ -422,7 +422,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            TryCopyUTF8String_Throws(ruleSet, inputData);
+            TryCopyUTF8String_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
@@ -451,7 +451,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[5] = 0xE9;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyUTF8String_Throws(PublicEncodingRules.CER, input);
+            TryCopyUTF8String_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]
@@ -489,7 +489,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             input[1011] = 0x02;
             // EOC implicit since the byte[] initializes to zeros
 
-            TryCopyUTF8String_Throws(PublicEncodingRules.CER, input);
+            TryCopyUTF8String_Throws_Helper(PublicEncodingRules.CER, input);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteBMPString.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteBMPString.cs
@@ -80,227 +80,227 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        [MemberData(nameof(LongValidCases))]
+        public void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null(ruleSet);
+        public void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null_CustomTag(ruleSet);
+        public void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_CustomTag_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_String(ruleSet);
+        public void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_String_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_Span(ruleSet);
+        public void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_Span_Helper(ruleSet);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(InvalidInputs))]
-        public new void VerifyWrite_String_NonEncodable(string input) =>
-            base.VerifyWrite_String_NonEncodable(input);
+        public void VerifyWrite_String_NonEncodable(string input) =>
+            base.VerifyWrite_String_NonEncodable_Helper(input);
 
         [Theory]
         [MemberData(nameof(InvalidInputs))]
-        public new void VerifyWrite_Span_NonEncodable(string input) =>
-            base.VerifyWrite_Span_NonEncodable(input);
+        public void VerifyWrite_Span_NonEncodable(string input) =>
+            base.VerifyWrite_Span_NonEncodable_Helper(input);
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_Span(bool empty) =>
-            base.WriteAfterDispose_Span(empty);
+        public void WriteAfterDispose_Span(bool empty) =>
+            base.WriteAfterDispose_Span_Helper(empty);
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_String(bool empty) =>
-            base.WriteAfterDispose_String(empty);
+        public void WriteAfterDispose_String(bool empty) =>
+            base.WriteAfterDispose_String_Helper(empty);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteCharacterString.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             "not have died in vain-that this nation, under God, shall have a new birth of freedom-and " +
             "that government of the people, by the people, for the people, shall not perish from the earth.";
 
-        protected void VerifyWrite_BER_String(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_String_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_String_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_String(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_String_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -71,7 +71,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_String_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -82,7 +82,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_String(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_String_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_String_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -103,7 +103,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_Span(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_Span_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_Span_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -124,7 +124,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_Span(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_Span_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_Span_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_Span(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_Span_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_Span_CustomTag_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -166,7 +166,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_String_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -178,7 +178,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_String_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -190,7 +190,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_Span_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -202,7 +202,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_BER_Span_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -214,7 +214,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_String_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -226,7 +226,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_String_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -238,7 +238,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_Span_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -250,7 +250,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_CER_Span_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -262,7 +262,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_String_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -274,7 +274,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_String_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -286,7 +286,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_Span_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -298,7 +298,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex)
+        protected void VerifyWrite_DER_Span_CustomTag_ClearsConstructed_Helper(string input, string expectedPayloadHex)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -310,7 +310,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_String_Null(PublicEncodingRules ruleSet)
+        protected void VerifyWrite_String_Null_Helper(PublicEncodingRules ruleSet)
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
@@ -320,7 +320,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet)
+        protected void VerifyWrite_String_Null_CustomTag_Helper(PublicEncodingRules ruleSet)
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
@@ -330,7 +330,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet)
+        protected void VerifyWrite_EndOfContents_String_Helper(PublicEncodingRules ruleSet)
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
@@ -340,7 +340,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet)
+        protected void VerifyWrite_EndOfContents_Span_Helper(PublicEncodingRules ruleSet)
         {
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
@@ -377,7 +377,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             Assert.Equal(encodedSize, encoded.Length);
         }
 
-        protected void VerifyWrite_CERSegmented_String(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_String_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -390,7 +390,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_String_CustomTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -402,7 +402,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_String_ConstructedTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -415,7 +415,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_String_CustomPrimitiveTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -428,7 +428,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_Span(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_Span_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -441,7 +441,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_Span_CustomTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -453,7 +453,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_Span_ConstructedTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -466,7 +466,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount)
+        protected void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag_Helper(string input, int contentByteCount)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.CER))
             {
@@ -479,7 +479,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_String_NonEncodable(string input)
+        protected void VerifyWrite_String_NonEncodable_Helper(string input)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -487,7 +487,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void VerifyWrite_Span_NonEncodable(string input)
+        protected void VerifyWrite_Span_NonEncodable_Helper(string input)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.BER))
             {
@@ -495,7 +495,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void WriteAfterDispose_Span(bool empty)
+        protected void WriteAfterDispose_Span_Helper(bool empty)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {
@@ -520,7 +520,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             }
         }
 
-        protected void WriteAfterDispose_String(bool empty)
+        protected void WriteAfterDispose_String_Helper(bool empty)
         {
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteIA5String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteIA5String.cs
@@ -74,227 +74,227 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        [MemberData(nameof(LongValidCases))]
+        public void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null(ruleSet);
+        public void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null_CustomTag(ruleSet);
+        public void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_CustomTag_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_String(ruleSet);
+        public void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_String_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_Span(ruleSet);
+        public void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_Span_Helper(ruleSet);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(InvalidInputs))]
-        public new void VerifyWrite_String_NonEncodable(string input) =>
-            base.VerifyWrite_String_NonEncodable(input);
+        public void VerifyWrite_String_NonEncodable(string input) =>
+            base.VerifyWrite_String_NonEncodable_Helper(input);
 
         [Theory]
         [MemberData(nameof(InvalidInputs))]
-        public new void VerifyWrite_Span_NonEncodable(string input) =>
-            base.VerifyWrite_Span_NonEncodable(input);
+        public void VerifyWrite_Span_NonEncodable(string input) =>
+            base.VerifyWrite_Span_NonEncodable_Helper(input);
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_Span(bool empty) =>
-            base.WriteAfterDispose_Span(empty);
+        public void WriteAfterDispose_Span(bool empty) =>
+            base.WriteAfterDispose_Span_Helper(empty);
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_String(bool empty) =>
-            base.WriteAfterDispose_String(empty);
+        public void WriteAfterDispose_String(bool empty) =>
+            base.WriteAfterDispose_String_Helper(empty);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtf8String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtf8String.cs
@@ -73,219 +73,219 @@ namespace System.Security.Cryptography.Tests.Asn1
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String(input, expectedPayloadHex);
+        public void VerifyWrite_CER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_CustomTag(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_ClearsConstructed(input, expectedPayloadHex);
-
-        [Theory]
-        [MemberData(nameof(ShortValidCases))]
-        public new void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_BER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_BER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        public void VerifyWrite_CER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_CER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_String_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_String_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [MemberData(nameof(ShortValidCases))]
         [MemberData(nameof(LongValidCases))]
-        public new void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
-            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed(input, expectedPayloadHex);
+        public void VerifyWrite_DER_Span_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_ClearsConstructed_Helper(input, expectedPayloadHex);
+
+        [Theory]
+        [MemberData(nameof(ShortValidCases))]
+        [MemberData(nameof(LongValidCases))]
+        public void VerifyWrite_DER_Span_CustomTag_ClearsConstructed(string input, string expectedPayloadHex) =>
+            base.VerifyWrite_DER_Span_CustomTag_ClearsConstructed_Helper(input, expectedPayloadHex);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null(ruleSet);
+        public void VerifyWrite_String_Null(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_String_Null_CustomTag(ruleSet);
+        public void VerifyWrite_String_Null_CustomTag(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_String_Null_CustomTag_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_String(ruleSet);
+        public void VerifyWrite_EndOfContents_String(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_String_Helper(ruleSet);
 
         [Theory]
         [InlineData(PublicEncodingRules.BER)]
         [InlineData(PublicEncodingRules.CER)]
         [InlineData(PublicEncodingRules.DER)]
-        public new void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
-            base.VerifyWrite_EndOfContents_Span(ruleSet);
+        public void VerifyWrite_EndOfContents_Span(PublicEncodingRules ruleSet) =>
+            base.VerifyWrite_EndOfContents_Span_Helper(ruleSet);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_String_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_String_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_ConstructedTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_ConstructedTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_ConstructedTag_Helper(input, contentByteCount);
 
         [Theory]
         [MemberData(nameof(CERSegmentedCases))]
-        public new void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
-            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(input, contentByteCount);
+        public void VerifyWrite_CERSegmented_Span_CustomPrimitiveTag(string input, int contentByteCount) =>
+            base.VerifyWrite_CERSegmented_Span_CustomPrimitiveTag_Helper(input, contentByteCount);
 
         // UTF8 has no non-encodable values.
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_Span(bool empty) =>
-            base.WriteAfterDispose_Span(empty);
+        public void WriteAfterDispose_Span(bool empty) =>
+            base.WriteAfterDispose_Span_Helper(empty);
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public new void WriteAfterDispose_String(bool empty) =>
-            base.WriteAfterDispose_String(empty);
+        public void WriteAfterDispose_String(bool empty) =>
+            base.WriteAfterDispose_String_Helper(empty);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Primitives/tests/SimpleHashAlgorithmTest.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/tests/SimpleHashAlgorithmTest.cs
@@ -51,20 +51,20 @@ namespace System.Security.Cryptography.Hashing.Tests
         [Fact]
         public void EmptyStreamHash()
         {
-            StreamHash(0);
+            StreamHashHelper(0);
         }
 
         [Fact]
         public void StreamHash()
         {
             // This value is a completely arbitrary non-power-of-two.
-            StreamHash(82);
+            StreamHashHelper(82);
         }
 
         [Fact]
         public void LargeStreamHash()
         {
-            StreamHash(1048576);
+            StreamHashHelper(1048576);
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace System.Security.Cryptography.Hashing.Tests
             AssertCorrectAnswer((uint)count, result);
         }
 
-        private void StreamHash(int byteCount)
+        private void StreamHashHelper(int byteCount)
         {
             byte[] result;
 

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataTests.cs
@@ -15,14 +15,10 @@ namespace System.Security.Cryptography.ProtectedDataTests
     [PlatformSpecific(TestPlatforms.Windows)]
     public static class ProtectedDataTests
     {
-        [Fact]
-        public static void RoundTrip()
-        {
-            RoundTrip(null);
-            RoundTrip(new byte[] { 4, 5, 6 });
-        }
-
-        private static void RoundTrip(byte[] entropy)
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new byte[] { 4, 5, 6 })]
+        public static void RoundTrip(byte[] entropy)
         {
             foreach (DataProtectionScope scope in new DataProtectionScope[] { DataProtectionScope.CurrentUser, DataProtectionScope.LocalMachine })
             {
@@ -74,18 +70,12 @@ namespace System.Security.Cryptography.ProtectedDataTests
             Assert.Equal<byte>(plain, recovered);
         }
 
-        [Fact]
-        public static void WrongEntropy()
-        {
-            // Passing a zero-length array as entropy is equivalent to passing null as entropy.
-            byte[] entropy1 = { 4, 5, 6 };
-            byte[] entropy2 = { 4, 5, 7 };
-            WrongEntropy(null, entropy1);
-            WrongEntropy(entropy1, null);
-            WrongEntropy(entropy1, entropy2);
-        }
-
-        private static void WrongEntropy(byte[] entropy1, byte[] entropy2)
+        [Theory]
+        // Passing a zero-length array as entropy is equivalent to passing null as entropy.
+        [InlineData(null, new byte[] { 4, 5, 6 })]
+        [InlineData(new byte[] { 4, 5, 6 }, null)]
+        [InlineData(new byte[] { 4, 5, 6 }, new byte[] { 4, 5, 7 })]
+        public static void WrongEntropy(byte[] entropy1, byte[] entropy2)
         {
             foreach (DataProtectionScope scope in new DataProtectionScope[] { DataProtectionScope.CurrentUser, DataProtectionScope.LocalMachine })
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("SHA384", true)]
         [InlineData("SHA512", false)]
         [InlineData("SHA512", true)]
-        public static void TestThumbprint(string hashAlgName, bool viaSpan)
+        public static void TestThumbprint_ByHashAlgorithm(string hashAlgName, bool viaSpan)
         {
             string expectedThumbprintHex;
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -80,13 +80,13 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Fact]
         public void AsymmetricEncryptionRoundtripUseOAEP() =>
-            AsymmetricEncryptionRoundtrip(useOAEP: true); // OAEP is recommended
+            AsymmetricEncryptionRoundtrip_Helper(useOAEP: true); // OAEP is recommended
 
         [Fact]
         public void AsymmetricEncryptionRoundtrip() =>
-            AsymmetricEncryptionRoundtrip(useOAEP: false);
+            AsymmetricEncryptionRoundtrip_Helper(useOAEP: false);
 
-        private void AsymmetricEncryptionRoundtrip(bool useOAEP)
+        private void AsymmetricEncryptionRoundtrip_Helper(bool useOAEP)
         {
             const string testString = "some text node";
             const string exampleXmlRootElement = "example";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1413,9 +1413,12 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
-        private void HmacMustBeMultipleOfEightBits(int bits)
+        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        public void HmacMustBeMultipleOfEightBits()
         {
-            string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            static void hmacMustBeMultipleOfEightBits(int bits)
+            {
+                string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <Signature xmlns=""http://www.w3.org/2000/09/xmldsig#"">
   <SignedInfo>
     <CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315"" />
@@ -1433,20 +1436,17 @@ namespace System.Security.Cryptography.Xml.Tests
   <Object Id=""object"">some other text</Object>
 </Signature>
 ";
-            SignedXml sign = GetSignedXml(string.Format(xml, bits));
-            // only multiple of 8 bits are supported
-            sign.CheckSignature(new HMACSHA1(Encoding.ASCII.GetBytes("secret")));
-        }
+                SignedXml sign = GetSignedXml(string.Format(xml, bits));
+                // only multiple of 8 bits are supported
+                sign.CheckSignature(new HMACSHA1(Encoding.ASCII.GetBytes("secret")));
+            }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
-        public void HmacMustBeMultipleOfEightBits()
-        {
             for (int i = 1; i < 160; i++)
             {
                 // The .NET framework only supports multiple of 8 bits
                 if (i % 8 != 0)
                 {
-                    Assert.Throws<CryptographicException>(() => HmacMustBeMultipleOfEightBits(i));
+                    Assert.Throws<CryptographicException>(() => hmacMustBeMultipleOfEightBits(i));
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1413,7 +1413,8 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void HmacMustBeMultipleOfEightBits()
         {
             static void hmacMustBeMultipleOfEightBits(int bits)

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.cs
@@ -254,18 +254,6 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Equal("Atom10", formatter.Version);
         }
 
-        [Fact]
-        public void GetRss20Formatter_Invoke_ReturnsExpected()
-        {
-            var feed = new SyndicationFeed();
-            Rss20FeedFormatter formatter = Assert.IsType<Rss20FeedFormatter>(feed.GetRss20Formatter());
-            Assert.Same(feed, formatter.Feed);
-            Assert.True(formatter.PreserveAttributeExtensions);
-            Assert.True(formatter.PreserveElementExtensions);
-            Assert.True(formatter.SerializeExtensionsAsAtom);
-            Assert.Equal("Rss20", formatter.Version);
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationItemTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationItemTests.cs
@@ -446,18 +446,6 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Equal("Atom10", formatter.Version);
         }
 
-        [Fact]
-        public void GetRss20Formatter_Invoke_ReturnsExpected()
-        {
-            var item = new SyndicationItem();
-            Rss20ItemFormatter formatter = Assert.IsType<Rss20ItemFormatter>(item.GetRss20Formatter());
-            Assert.Same(item, formatter.Item);
-            Assert.True(formatter.PreserveAttributeExtensions);
-            Assert.True(formatter.PreserveElementExtensions);
-            Assert.True(formatter.SerializeExtensionsAsAtom);
-            Assert.Equal("Rss20", formatter.Version);
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/WorkspaceTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/WorkspaceTests.cs
@@ -24,7 +24,7 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Null(workspace.Title);
         }
 
-        public static IEnumerable<object[]> Ctor_String_Collections()
+        public static IEnumerable<object[]> Ctor_String_Collections_Data()
         {
             yield return new object[] { null, null };
             yield return new object[] { "", new ResourceCollectionInfo[0] };
@@ -32,7 +32,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Ctor_String_Collections))]
+        [MemberData(nameof(Ctor_String_Collections_Data))]
         public void Ctor_String_Collections(string title, ResourceCollectionInfo[] collections)
         {
             var workspace = new Workspace(title, collections);
@@ -51,7 +51,7 @@ namespace System.ServiceModel.Syndication.Tests
             }
         }
 
-        public static IEnumerable<object[]> Ctor_TextSyndicationContent_Collections()
+        public static IEnumerable<object[]> Ctor_TextSyndicationContent_Collections_Data()
         {
             yield return new object[] { null, null };
             yield return new object[] { new TextSyndicationContent("", TextSyndicationContentKind.Html), new ResourceCollectionInfo[0] };
@@ -59,7 +59,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Ctor_TextSyndicationContent_Collections))]
+        [MemberData(nameof(Ctor_TextSyndicationContent_Collections_Data))]
         public void Ctor_TextSyndicationContent_Collections(TextSyndicationContent title, ResourceCollectionInfo[] collections)
         {
             var workspace = new Workspace(title, collections);

--- a/src/libraries/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/ASCIIEncoding/ASCIIEncodingTests.cs
@@ -75,7 +75,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(ASCIIEncoding encoding, object value, bool expected)
+        public void EqualsTest(ASCIIEncoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             Assert.Equal(expected, encoding.GetHashCode().Equals(value?.GetHashCode()));

--- a/src/libraries/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoder/EncoderGetBytes2.cs
@@ -110,14 +110,28 @@ namespace System.Text.Tests
         [MemberData(nameof(Encoders_MixedInput))]
         public void EncoderGetBytesMixedInput(Encoder encoder, int asciiSize, int unicodeSize0, int unicodeSize1)
         {
+            static void encoderGetBytesMixedInput(Encoder encoder, char[] chars, int length, int asciiSize, int unicodeSize0, int unicodeSize1)
+            {
+                int byteLength = asciiSize
+                    + Clamp(length - 1, 0, 1) * unicodeSize0
+                    + Clamp(length - 2, 0, 1) * unicodeSize1
+                    + Math.Max(length - 3, 0) * asciiSize;
+                byte[] b = new byte[byteLength];
+                Assert.Equal(byteLength, encoder.GetBytes(chars, 0, length, new byte[byteLength], 0, flush: true));
+
+                // Fixed buffer so make larger
+                b = new byte[20];
+                VerificationFixedEncodingHelper(encoder, chars, length, b, byteLength);
+            }
+
             // Bytes does not have enough capacity to accomodate result
             string s = "T\uD83D\uDE01est";
             char[] c = s.ToCharArray();
 
-            EncoderGetBytesMixedInput(encoder, c, 2, asciiSize, unicodeSize0, unicodeSize1);
-            EncoderGetBytesMixedInput(encoder, c, 3, asciiSize, unicodeSize0, unicodeSize1);
-            EncoderGetBytesMixedInput(encoder, c, 4, asciiSize, unicodeSize0, unicodeSize1);
-            EncoderGetBytesMixedInput(encoder, c, 5, asciiSize, unicodeSize0, unicodeSize1);
+            encoderGetBytesMixedInput(encoder, c, 2, asciiSize, unicodeSize0, unicodeSize1);
+            encoderGetBytesMixedInput(encoder, c, 3, asciiSize, unicodeSize0, unicodeSize1);
+            encoderGetBytesMixedInput(encoder, c, 4, asciiSize, unicodeSize0, unicodeSize1);
+            encoderGetBytesMixedInput(encoder, c, 5, asciiSize, unicodeSize0, unicodeSize1);
         }
 
         // Call GetBytes to convert an ASCIIUnicode character array by different encoders
@@ -133,20 +147,6 @@ namespace System.Text.Tests
             EncoderGetBytesMixedInputThrows(encoder, c, 3, asciiSize, unicodeSize0, unicodeSize1);
             EncoderGetBytesMixedInputThrows(encoder, c, 4, asciiSize, unicodeSize0, unicodeSize1);
             EncoderGetBytesMixedInputThrows(encoder, c, 5, asciiSize, unicodeSize0, unicodeSize1);
-        }
-
-        private void EncoderGetBytesMixedInput(Encoder encoder, char[] chars, int length, int asciiSize, int unicodeSize0, int unicodeSize1)
-        {
-            int byteLength = asciiSize
-                + Clamp(length - 1, 0, 1) * unicodeSize0
-                + Clamp(length - 2, 0, 1) * unicodeSize1
-                + Math.Max(length - 3, 0) * asciiSize;
-            byte[] b = new byte[byteLength];
-            Assert.Equal(byteLength, encoder.GetBytes(chars, 0, length, new byte[byteLength], 0, flush: true));
-
-            // Fixed buffer so make larger
-            b = new byte[20];
-            VerificationFixedEncodingHelper(encoder, chars, length, b, byteLength);
         }
 
         private void EncoderGetBytesMixedInputThrows(Encoder encoder, char[] chars, int length, int asciiSize, int unicodeSize0, int unicodeSize1)

--- a/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/Encoding.cs
@@ -67,7 +67,7 @@ namespace System.Text.Encodings.Tests
 
         [Theory]
         [MemberData(nameof(Encoding_TestData))]
-        public static void NormalizationTest(int codepage, string name, string bodyName, string headerName, bool isBrowserDisplay,
+        public static void VerifyCodePageAttributes(int codepage, string name, string bodyName, string headerName, bool isBrowserDisplay,
                                             bool isBrowserSave, bool isMailNewsDisplay, bool isMailNewsSave, int windowsCodePage)
         {
             Encoding encoding = Encoding.GetEncoding(codepage);

--- a/src/libraries/System.Text.Encoding/tests/Encoding/EncodingConvertTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Encoding/EncodingConvertTests.cs
@@ -16,25 +16,25 @@ namespace System.Text.Tests
         [InlineData("\uD800\uDC00")]
         public void Convert(string source)
         {
+            static void convert(Encoding srcEncoding, Encoding dstEncoding, byte[] bytes, int index, int count, byte[] expected)
+            {
+                if (index == 0 && count == bytes.Length)
+                {
+                    Assert.Equal(expected, Encoding.Convert(srcEncoding, dstEncoding, bytes));
+                }
+                Assert.Equal(expected, Encoding.Convert(srcEncoding, dstEncoding, bytes, index, count));
+            }
+
             Encoding[] encodings = new Encoding[] { Encoding.UTF8, Encoding.Unicode, Encoding.BigEndianUnicode };
             foreach (Encoding srcEncoding in encodings)
             {
                 foreach (Encoding dstEncoding in encodings)
                 {
                     byte[] bytes = srcEncoding.GetBytes(source);
-                    Convert(srcEncoding, dstEncoding, bytes, 0, bytes.Length, dstEncoding.GetBytes(source));
-                    Convert(srcEncoding, dstEncoding, bytes, 0, 0, new byte[0]);
+                    convert(srcEncoding, dstEncoding, bytes, 0, bytes.Length, dstEncoding.GetBytes(source));
+                    convert(srcEncoding, dstEncoding, bytes, 0, 0, new byte[0]);
                 }
             }
-        }
-
-        private static void Convert(Encoding srcEncoding, Encoding dstEncoding, byte[] bytes, int index, int count, byte[] expected)
-        {
-            if (index == 0 && count == bytes.Length)
-            {
-                Assert.Equal(expected, Encoding.Convert(srcEncoding, dstEncoding, bytes));
-            }
-            Assert.Equal(expected, Encoding.Convert(srcEncoding, dstEncoding, bytes, index, count));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Encoding/tests/Fallback/DecoderExceptionFallbackTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Fallback/DecoderExceptionFallbackTests.cs
@@ -26,7 +26,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(DecoderExceptionFallback fallback, object value, bool expected)
+        public void EqualsTest(DecoderExceptionFallback fallback, object value, bool expected)
         {
             Assert.Equal(expected, fallback.Equals(value));
         }

--- a/src/libraries/System.Text.Encoding/tests/Fallback/DecoderReplacementFallbackTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Fallback/DecoderReplacementFallbackTests.cs
@@ -59,7 +59,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(DecoderReplacementFallback fallback, object value, bool expected)
+        public void EqualsTest(DecoderReplacementFallback fallback, object value, bool expected)
         {
             Assert.Equal(expected, fallback.Equals(value));
         }

--- a/src/libraries/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Fallback/EncoderExceptionFallbackTests.cs
@@ -26,7 +26,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(EncoderExceptionFallback fallback, object value, bool expected)
+        public void EqualsTest(EncoderExceptionFallback fallback, object value, bool expected)
         {
             Assert.Equal(expected, fallback.Equals(value));
         }

--- a/src/libraries/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Fallback/EncoderReplacementFallbackTests.cs
@@ -59,7 +59,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(EncoderReplacementFallback fallback, object value, bool expected)
+        public void EqualsTest(EncoderReplacementFallback fallback, object value, bool expected)
         {
             Assert.Equal(expected, fallback.Equals(value));
         }

--- a/src/libraries/System.Text.Encoding/tests/Latin1Encoding/Latin1EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Latin1Encoding/Latin1EncodingTests.cs
@@ -73,7 +73,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(Encoding encoding, object value, bool expected)
+        public void EqualsTest(Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             Assert.Equal(expected, encoding.GetHashCode().Equals(value?.GetHashCode()));

--- a/src/libraries/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingTests.cs
@@ -145,7 +145,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UTF32Encoding encoding, object value, bool expected)
+        public void EqualsTest(UTF32Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             Assert.Equal(expected, encoding.GetHashCode().Equals(value?.GetHashCode()));

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingEncode.cs
@@ -61,10 +61,10 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encode_Basic_TestData))]
-        public void Encode(string source, int index, int count, byte[] expected)
+        public void Encode_Basic(string source, int index, int count, byte[] expected)
         {
-            Encode(true, source, index, count, expected);
-            Encode(false, source, index, count, expected);
+            Encode_Advanced(true, source, index, count, expected);
+            Encode_Advanced(false, source, index, count, expected);
 
             // UTF7Encoding performs no error checking, so even encoding invalid chars with
             // a custom fallback should never throw
@@ -108,7 +108,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encode_Advanced_TestData))]
-        public void Encode(bool allowOptionals, string source, int index, int count, byte[] expected)
+        public void Encode_Advanced(bool allowOptionals, string source, int index, int count, byte[] expected)
         {
             EncodingHelpers.Encode(new UTF7Encoding(allowOptionals), source, index, count, expected);
         }

--- a/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF7Encoding/UTF7EncodingTests.cs
@@ -115,7 +115,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UTF7Encoding encoding, object value, bool expected)
+        public void EqualsTest(UTF7Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             Assert.Equal(value is UTF7Encoding, encoding.GetHashCode().Equals(value?.GetHashCode()));

--- a/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UTF8Encoding/UTF8EncodingTests.cs
@@ -162,7 +162,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UTF8Encoding encoding, object value, bool expected)
+        public void EqualsTest(UTF8Encoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             if (value is UTF8Encoding)

--- a/src/libraries/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingTests.cs
@@ -147,7 +147,7 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        public void Equals(UnicodeEncoding encoding, object value, bool expected)
+        public void EqualsTest(UnicodeEncoding encoding, object value, bool expected)
         {
             Assert.Equal(expected, encoding.Equals(value));
             Assert.Equal(expected, encoding.GetHashCode().Equals(value?.GetHashCode()));

--- a/src/libraries/System.Text.Json/tests/JsonEncodedTextTests.cs
+++ b/src/libraries/System.Text.Json/tests/JsonEncodedTextTests.cs
@@ -111,7 +111,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        public static void Equals()
+        public static void EqualsTest()
         {
             string message = "message";
 

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(Parse_WithinRange_Signed))]
-        public static void Parse_WithinRange_ReturnsExpected(object expected, long value, string name)
+        public static void Parse_WithinRange_Signed_ReturnsExpected(object expected, long value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
             SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);
@@ -90,7 +90,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(Parse_WithinRange_Unsigned))]
-        public static void Parse_WithinRange_ReturnsExpected(object expected, ulong value, string name)
+        public static void Parse_WithinRange_Unsigned_ReturnsExpected(object expected, ulong value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
             SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);

--- a/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -997,16 +997,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(3, input.Value[2]);
         }
 
-        [Fact]
-        public static void ReadKeyValuePairOfKeyValuePair()
-        {
-            KeyValuePair<string, KeyValuePair<int, int>> input = JsonSerializer.Deserialize<KeyValuePair<string, KeyValuePair<int, int>>>(@"{""Key"":""Key"", ""Value"":{""Key"":1, ""Value"":2}}");
-
-            Assert.Equal("Key", input.Key);
-            Assert.Equal(1, input.Value.Key);
-            Assert.Equal(2, input.Value.Value);
-        }
-
         [Theory]
         [InlineData(@"{""Key"":""Key"", ""Value"":{""Key"":1, ""Value"":2}}")]
         [InlineData(@"{""Key"":""Key"", ""Value"":{""Value"":2, ""Key"":1}}")]

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -1336,27 +1336,27 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonGuidTestData.ValidGuidTests), MemberType = typeof(JsonGuidTestData))]
         public static void TryGetGuid_HasValueSequence_RetrievesGuid(string testString, string expectedString)
         {
-            TryGetGuid_HasValueSequence_RetrievesGuid_Helper(testString, expectedString, isFinalBlock: true);
-            TryGetGuid_HasValueSequence_RetrievesGuid_Helper(testString, expectedString, isFinalBlock: false);
-        }
+            static void test(string testString, string expectedString, bool isFinalBlock)
+            {
+                byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
+                var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
 
-        private static void TryGetGuid_HasValueSequence_RetrievesGuid_Helper(string testString, string expectedString, bool isFinalBlock)
-        {
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
-            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
-            var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
+                Guid expected = new Guid(expectedString);
 
-            Guid expected = new Guid(expectedString);
+                Assert.True(json.Read(), "json.Read()");
+                Assert.Equal(JsonTokenType.String, json.TokenType);
 
-            Assert.True(json.Read(), "json.Read()");
-            Assert.Equal(JsonTokenType.String, json.TokenType);
+                Assert.True(json.HasValueSequence, "json.HasValueSequence");
+                Assert.False(json.ValueSequence.IsEmpty, "json.ValueSequence.IsEmpty");
+                Assert.True(json.ValueSpan.IsEmpty, "json.ValueSpan.IsEmpty");
+                Assert.True(json.TryGetGuid(out Guid actual), "TryGetGuid");
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected, json.GetGuid());
+            }
 
-            Assert.True(json.HasValueSequence, "json.HasValueSequence");
-            Assert.False(json.ValueSequence.IsEmpty, "json.ValueSequence.IsEmpty");
-            Assert.True(json.ValueSpan.IsEmpty, "json.ValueSpan.IsEmpty");
-            Assert.True(json.TryGetGuid(out Guid actual), "TryGetGuid");
-            Assert.Equal(expected, actual);
-            Assert.Equal(expected, json.GetGuid());
+            test(testString, expectedString, isFinalBlock: true);
+            test(testString, expectedString, isFinalBlock: false);
         }
 
         [Theory]
@@ -1379,25 +1379,25 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonGuidTestData.InvalidGuidTests), MemberType = typeof(JsonGuidTestData))]
         public static void TryGetGuid_HasValueSequence_False(string testString)
         {
-            TryGetGuid_HasValueSequence_False_Helper(testString, isFinalBlock: true);
-            TryGetGuid_HasValueSequence_False_Helper(testString, isFinalBlock: false);
-        }
+            static void test(string testString, bool isFinalBlock)
+            {
+                byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
+                var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
 
-        private static void TryGetGuid_HasValueSequence_False_Helper(string testString, bool isFinalBlock)
-        {
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
-            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
-            var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
+                Assert.True(json.Read(), "json.Read()");
+                Assert.Equal(JsonTokenType.String, json.TokenType);
+                Assert.True(json.HasValueSequence, "json.HasValueSequence");
+                // If the string is empty, the ValueSequence is empty, because it contains all 0 bytes between the two characters
+                Assert.Equal(string.IsNullOrEmpty(testString), json.ValueSequence.IsEmpty);
+                Assert.False(json.TryGetGuid(out Guid actual), "json.TryGetGuid(out Guid actual)");
+                Assert.Equal(Guid.Empty, actual);
 
-            Assert.True(json.Read(), "json.Read()");
-            Assert.Equal(JsonTokenType.String, json.TokenType);
-            Assert.True(json.HasValueSequence, "json.HasValueSequence");
-            // If the string is empty, the ValueSequence is empty, because it contains all 0 bytes between the two characters
-            Assert.Equal(string.IsNullOrEmpty(testString), json.ValueSequence.IsEmpty);
-            Assert.False(json.TryGetGuid(out Guid actual), "json.TryGetGuid(out Guid actual)");
-            Assert.Equal(Guid.Empty, actual);
+                JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetGuid());
+            }
 
-            JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetGuid());
+            test(testString, isFinalBlock: true);
+            test(testString, isFinalBlock: false);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -1336,11 +1336,11 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonGuidTestData.ValidGuidTests), MemberType = typeof(JsonGuidTestData))]
         public static void TryGetGuid_HasValueSequence_RetrievesGuid(string testString, string expectedString)
         {
-            TryGetGuid_HasValueSequence_RetrievesGuid(testString, expectedString, isFinalBlock: true);
-            TryGetGuid_HasValueSequence_RetrievesGuid(testString, expectedString, isFinalBlock: false);
+            TryGetGuid_HasValueSequence_RetrievesGuid_Helper(testString, expectedString, isFinalBlock: true);
+            TryGetGuid_HasValueSequence_RetrievesGuid_Helper(testString, expectedString, isFinalBlock: false);
         }
 
-        private static void TryGetGuid_HasValueSequence_RetrievesGuid(string testString, string expectedString, bool isFinalBlock)
+        private static void TryGetGuid_HasValueSequence_RetrievesGuid_Helper(string testString, string expectedString, bool isFinalBlock)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
@@ -1379,11 +1379,11 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonGuidTestData.InvalidGuidTests), MemberType = typeof(JsonGuidTestData))]
         public static void TryGetGuid_HasValueSequence_False(string testString)
         {
-            TryGetGuid_HasValueSequence_False(testString, isFinalBlock: true);
-            TryGetGuid_HasValueSequence_False(testString, isFinalBlock: false);
+            TryGetGuid_HasValueSequence_False_Helper(testString, isFinalBlock: true);
+            TryGetGuid_HasValueSequence_False_Helper(testString, isFinalBlock: false);
         }
 
-        private static void TryGetGuid_HasValueSequence_False(string testString, bool isFinalBlock)
+        private static void TryGetGuid_HasValueSequence_False_Helper(string testString, bool isFinalBlock)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);

--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -4159,7 +4159,7 @@ namespace System.Text.Json.Tests
         [InlineData(true, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>mess\nage", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Hello, \nWorld!")]
         [InlineData(false, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>mess\nage", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Hello, \nWorld!")]
         [InlineData(false, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>mess\nage", ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Hello, \nWorld!")]
-        public void WriteHelloWorldEscaped(bool formatted, bool skipValidation, string key, string value)
+        public void WriteHelloWorldEscaped_AdditionalCases(bool formatted, bool skipValidation, string key, string value)
         {
             string expectedStr = GetEscapedExpectedString(prettyPrint: formatted, key, value, StringEscapeHandling.EscapeHtml);
 
@@ -4666,7 +4666,7 @@ namespace System.Text.Json.Tests
         public void OutputConsistentWithJsonEncodedText()
         {
             string jsonEncodedText = $"{{\"{JsonEncodedText.Encode("propertyName+1")}\":\"{JsonEncodedText.Encode("value+1")}\"}}";
-            
+
             var output = new ArrayBufferWriter<byte>(1024);
 
             using (var writer = new Utf8JsonWriter(output))
@@ -4880,7 +4880,7 @@ namespace System.Text.Json.Tests
         [InlineData(true, false, 100)]
         [InlineData(false, true, 100)]
         [InlineData(false, false, 100)]
-        public void WriteStartEndWithPropertyNameArray(bool formatted, bool skipValidation, int keyLength)
+        public void WriteStartEndWithPropertyNameArrayDifferentKeyLengths(bool formatted, bool skipValidation, int keyLength)
         {
             var keyChars = new char[keyLength];
             for (int i = 0; i < keyChars.Length; i++)
@@ -4969,7 +4969,7 @@ namespace System.Text.Json.Tests
         [InlineData(true, false, 100)]
         [InlineData(false, true, 100)]
         [InlineData(false, false, 100)]
-        public void WriteStartEndWithPropertyNameObject(bool formatted, bool skipValidation, int keyLength)
+        public void WriteStartEndWithPropertyNameObjectDifferentKeyLengths(bool formatted, bool skipValidation, int keyLength)
         {
             var keyChars = new char[keyLength];
             for (int i = 0; i < keyChars.Length; i++)

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -799,7 +799,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [MemberData(nameof(Match_Advanced_TestData))]
         [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Match_Advanced_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
-        public void Match(string pattern, string input, RegexOptions options, int beginning, int length, CaptureData[] expected)
+        public void Match_Advanced(string pattern, string input, RegexOptions options, int beginning, int length, CaptureData[] expected)
         {
             Regex r;
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -178,7 +178,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [MemberData(nameof(Replace_MatchEvaluator_TestData))]
         [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Replace_MatchEvaluator_TestData), 3, MemberType = typeof(RegexCompilationHelper))]
-        public void Replace(string pattern, string input, MatchEvaluator evaluator, RegexOptions options, int count, int start, string expected)
+        public void Replace_MatchEvaluator_Test(string pattern, string input, MatchEvaluator evaluator, RegexOptions options, int count, int start, string expected)
         {
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, start);
             bool isDefaultCount = RegexHelpers.IsDefaultCount(input, options, count);

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
@@ -39,60 +39,61 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void OneMoveNext()
         {
+            static void oneMoveNext(int length, bool isOrderable)
+            {
+                Debug.WriteLine("Length: {0} IsOrderable: {1}", length, isOrderable);
+                List<int> ds = new List<int>();
+                for (int i = 0; i < length; i++)
+                    ds.Add(i);
+                int dataSourceMoveNextCalls = 0;
+
+                //this is an enumerable that will execute user actions on move next, current and dispose
+                //in this case we will set it to wait on MoveNext for the even indexes
+                UserActionEnumerable<int> customEnumerable = new UserActionEnumerable<int>(ds);
+                Action<int> moveNextUserAction = (currentElement) =>
+                {
+                    //keep track how many times the move next of the data source was called
+                    //it is expected as
+                    //every call of MoveNext on partitioner>GetDynamicPartions.GetEnumerator
+                    //to result in only one call of datasource Move Next
+                    //there is not need to guard for concurrency issues because this scenario is single threaded
+                    dataSourceMoveNextCalls++;
+                };
+
+                customEnumerable.MoveNextAction = moveNextUserAction;
+
+                var partitioner = Partitioner.Create<int>(customEnumerable, EnumerablePartitionerOptions.NoBuffering);
+                //get the dynamic partitions - enumerator
+                if (isOrderable)
+                {
+                    IEnumerator<KeyValuePair<long, int>> enumerator = partitioner.GetOrderableDynamicPartitions().GetEnumerator();
+                    while (enumerator.MoveNext())
+                    {
+                        Assert.Equal(1, dataSourceMoveNextCalls);
+                        //reset the count - for the next moveNext call
+                        dataSourceMoveNextCalls = 0;
+                    }
+                }
+                else
+                {
+                    IEnumerator<int> enumerator = partitioner.GetDynamicPartitions().GetEnumerator();
+
+                    while (enumerator.MoveNext())
+                    {
+                        Assert.Equal(1, dataSourceMoveNextCalls);
+                        //reset the count - for the next moveNext call
+                        dataSourceMoveNextCalls = 0;
+                    }
+                }
+            }
+
             int[] lengthsArray = new[] { 1, 8, 16, 32, 64, 1024 };
             bool[] isOrderableArray = new[] { true, false };
 
             foreach (var length in lengthsArray)
             {
                 foreach (var order in isOrderableArray)
-                    OneMoveNext(length, order);
-            }
-        }
-        private static void OneMoveNext(int length, bool isOrderable)
-        {
-            Debug.WriteLine("Length: {0} IsOrderable: {1}", length, isOrderable);
-            List<int> ds = new List<int>();
-            for (int i = 0; i < length; i++)
-                ds.Add(i);
-            int dataSourceMoveNextCalls = 0;
-
-            //this is an enumerable that will execute user actions on move next, current and dispose
-            //in this case we will set it to wait on MoveNext for the even indexes
-            UserActionEnumerable<int> customEnumerable = new UserActionEnumerable<int>(ds);
-            Action<int> moveNextUserAction = (currentElement) =>
-            {
-                //keep track how many times the move next of the data source was called
-                //it is expected as
-                //every call of MoveNext on partitioner>GetDynamicPartions.GetEnumerator
-                //to result in only one call of datasource Move Next
-                //there is not need to guard for concurrency issues because this scenario is single threaded
-                dataSourceMoveNextCalls++;
-            };
-
-            customEnumerable.MoveNextAction = moveNextUserAction;
-
-            var partitioner = Partitioner.Create<int>(customEnumerable, EnumerablePartitionerOptions.NoBuffering);
-            //get the dynamic partitions - enumerator
-            if (isOrderable)
-            {
-                IEnumerator<KeyValuePair<long, int>> enumerator = partitioner.GetOrderableDynamicPartitions().GetEnumerator();
-                while (enumerator.MoveNext())
-                {
-                    Assert.Equal(1, dataSourceMoveNextCalls);
-                    //reset the count - for the next moveNext call
-                    dataSourceMoveNextCalls = 0;
-                }
-            }
-            else
-            {
-                IEnumerator<int> enumerator = partitioner.GetDynamicPartitions().GetEnumerator();
-
-                while (enumerator.MoveNext())
-                {
-                    Assert.Equal(1, dataSourceMoveNextCalls);
-                    //reset the count - for the next moveNext call
-                    dataSourceMoveNextCalls = 0;
-                }
+                    oneMoveNext(length, order);
             }
         }
 
@@ -103,36 +104,37 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void IterationsWithDependency()
         {
-            IterationsWithDependency(128, 126);
-            IterationsWithDependency(128, 65);
-        }
-        private static void IterationsWithDependency(int length, int dependencyIndex)
-        {
-            List<int> ds = new List<int>();
-            for (int i = 0; i < length; i++)
-                ds.Add(i);
-            var partitioner = Partitioner.Create<int>(ds, EnumerablePartitionerOptions.NoBuffering);
-            ManualResetEvent mre = new ManualResetEvent(false);
-            ConcurrentQueue<int> savedDS = new ConcurrentQueue<int>();
+            static void iterationsWithDependency(int length, int dependencyIndex)
+            {
+                List<int> ds = new List<int>();
+                for (int i = 0; i < length; i++)
+                    ds.Add(i);
+                var partitioner = Partitioner.Create<int>(ds, EnumerablePartitionerOptions.NoBuffering);
+                ManualResetEvent mre = new ManualResetEvent(false);
+                ConcurrentQueue<int> savedDS = new ConcurrentQueue<int>();
 
-            Parallel.ForEach(partitioner, (index) =>
-                {
-                    if (index == dependencyIndex + 1)
+                Parallel.ForEach(partitioner, (index) =>
                     {
-                        mre.Set();
-                    }
-                    if (index == dependencyIndex)
-                    {
-                        //if the chunk size will not be one,
-                        //this iteration and the next one will not be processed by the same thread
-                        //waiting here will lead to a deadlock
-                        mre.WaitOne();
-                    }
-                    savedDS.Enqueue(index);
-                });
-            //if the PForEach ends this means pass
-            //verify the collection
-            Assert.True(CompareCollections(savedDS, ds));
+                        if (index == dependencyIndex + 1)
+                        {
+                            mre.Set();
+                        }
+                        if (index == dependencyIndex)
+                        {
+                            //if the chunk size will not be one,
+                            //this iteration and the next one will not be processed by the same thread
+                            //waiting here will lead to a deadlock
+                            mre.WaitOne();
+                        }
+                        savedDS.Enqueue(index);
+                    });
+                //if the PForEach ends this means pass
+                //verify the collection
+                Assert.True(CompareCollections(savedDS, ds));
+            }
+
+            iterationsWithDependency(128, 126);
+            iterationsWithDependency(128, 65);
         }
 
         /// <summary>
@@ -142,12 +144,8 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void PFEDisposeEnum()
         {
-            PFEDisposeEnum(1204);
-        }
-        private static void PFEDisposeEnum(int length)
-        {
             List<int> ds = new List<int>();
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < 1024; i++)
                 ds.Add(i);
             //this is an enumerable that will execute user actions on move next, current and dispose
             //in this case we will set it to wait on MoveNext for the even indexes
@@ -171,33 +169,34 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void ExceptionOnMoveNext()
         {
-            ExceptionOnMoveNext(128, 65, true);
-            ExceptionOnMoveNext(128, 65, false);
-        }
-        private static void ExceptionOnMoveNext(int length, int indexToThrow, bool isOrderable)
-        {
-            List<int> ds = new List<int>();
-            for (int i = 0; i < length; i++)
-                ds.Add(i);
+            static void exceptionOnMoveNext(int length, int indexToThrow, bool isOrderable)
+            {
+                List<int> ds = new List<int>();
+                for (int i = 0; i < length; i++)
+                    ds.Add(i);
 
-            Exception userEx = new InvalidOperationException("UserException");
-            //this is an enumerable that will execute user actions on move next, current and dispose
-            //in this case we will set it to throw on MoveNext for specified index
-            UserActionEnumerable<int> customEnumerable = new UserActionEnumerable<int>(ds);
-            Action<int> moveNextUserAction = (currentElement) =>
-                                                            {
-                                                                if (currentElement == indexToThrow)
+                Exception userEx = new InvalidOperationException("UserException");
+                //this is an enumerable that will execute user actions on move next, current and dispose
+                //in this case we will set it to throw on MoveNext for specified index
+                UserActionEnumerable<int> customEnumerable = new UserActionEnumerable<int>(ds);
+                Action<int> moveNextUserAction = (currentElement) =>
                                                                 {
-                                                                    throw userEx;
+                                                                    if (currentElement == indexToThrow)
+                                                                    {
+                                                                        throw userEx;
+                                                                    };
                                                                 };
-                                                            };
 
 
-            customEnumerable.MoveNextAction = moveNextUserAction;
-            var partitioner = Partitioner.Create<int>(customEnumerable, EnumerablePartitionerOptions.NoBuffering);
-            var exception = Assert.Throws<AggregateException>(() => Parallel.ForEach(partitioner, (index) => { }));
-            VerifyAggregateException(exception, userEx);
-            Assert.True(customEnumerable.AreEnumeratorsDisposed());
+                customEnumerable.MoveNextAction = moveNextUserAction;
+                var partitioner = Partitioner.Create<int>(customEnumerable, EnumerablePartitionerOptions.NoBuffering);
+                var exception = Assert.Throws<AggregateException>(() => Parallel.ForEach(partitioner, (index) => { }));
+                VerifyAggregateException(exception, userEx);
+                Assert.True(customEnumerable.AreEnumeratorsDisposed());
+            }
+
+            exceptionOnMoveNext(128, 65, true);
+            exceptionOnMoveNext(128, 65, false);
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
@@ -44,66 +44,66 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void RangePartitionerCoverageTest()
         {
-            RangePartitionerCoverageTest(0, 1, -1);
-            RangePartitionerCoverageTest(-15, -14, -1);
-            RangePartitionerCoverageTest(14, 15, -1);
-            RangePartitionerCoverageTest(0, 1, 1);
-            RangePartitionerCoverageTest(-15, -14, 1);
-            RangePartitionerCoverageTest(14, 15, 1);
-            RangePartitionerCoverageTest(0, 1, 20);
-            RangePartitionerCoverageTest(-15, -14, 20);
-            RangePartitionerCoverageTest(14, 15, 20);
-            RangePartitionerCoverageTest(0, 7, -1);
-            RangePartitionerCoverageTest(-21, -14, -1);
-            RangePartitionerCoverageTest(14, 21, -1);
-            RangePartitionerCoverageTest(0, 7, 1);
-            RangePartitionerCoverageTest(-21, -14, 1);
-            RangePartitionerCoverageTest(14, 21, 1);
-            RangePartitionerCoverageTest(0, 7, 2);
-            RangePartitionerCoverageTest(-21, -14, 2);
-            RangePartitionerCoverageTest(14, 21, 2);
-            RangePartitionerCoverageTest(0, 7, 20);
-            RangePartitionerCoverageTest(-21, -14, 20);
-            RangePartitionerCoverageTest(14, 21, 20);
-            RangePartitionerCoverageTest(0, 1000, -1);
-            RangePartitionerCoverageTest(-2000, -1000, -1);
-            RangePartitionerCoverageTest(1000, 2000, -1);
-            RangePartitionerCoverageTest(0, 1000, 1);
-            RangePartitionerCoverageTest(-2000, -1000, 1);
-            RangePartitionerCoverageTest(1000, 2000, 1);
-            RangePartitionerCoverageTest(0, 1000, 27);
-            RangePartitionerCoverageTest(-2000, -1000, 27);
-            RangePartitionerCoverageTest(1000, 2000, 27);
-            RangePartitionerCoverageTest(0, 1000, 250);
-            RangePartitionerCoverageTest(-2000, -1000, 250);
-            RangePartitionerCoverageTest(1000, 2000, 250);
-            RangePartitionerCoverageTest(0, 1000, 750);
-            RangePartitionerCoverageTest(-2000, -1000, 750);
-            RangePartitionerCoverageTest(1000, 2000, 750);
+            RangePartitionerCoverageTest_HelperInt(0, 1, -1);
+            RangePartitionerCoverageTest_HelperInt(-15, -14, -1);
+            RangePartitionerCoverageTest_HelperInt(14, 15, -1);
+            RangePartitionerCoverageTest_HelperInt(0, 1, 1);
+            RangePartitionerCoverageTest_HelperInt(-15, -14, 1);
+            RangePartitionerCoverageTest_HelperInt(14, 15, 1);
+            RangePartitionerCoverageTest_HelperInt(0, 1, 20);
+            RangePartitionerCoverageTest_HelperInt(-15, -14, 20);
+            RangePartitionerCoverageTest_HelperInt(14, 15, 20);
+            RangePartitionerCoverageTest_HelperInt(0, 7, -1);
+            RangePartitionerCoverageTest_HelperInt(-21, -14, -1);
+            RangePartitionerCoverageTest_HelperInt(14, 21, -1);
+            RangePartitionerCoverageTest_HelperInt(0, 7, 1);
+            RangePartitionerCoverageTest_HelperInt(-21, -14, 1);
+            RangePartitionerCoverageTest_HelperInt(14, 21, 1);
+            RangePartitionerCoverageTest_HelperInt(0, 7, 2);
+            RangePartitionerCoverageTest_HelperInt(-21, -14, 2);
+            RangePartitionerCoverageTest_HelperInt(14, 21, 2);
+            RangePartitionerCoverageTest_HelperInt(0, 7, 20);
+            RangePartitionerCoverageTest_HelperInt(-21, -14, 20);
+            RangePartitionerCoverageTest_HelperInt(14, 21, 20);
+            RangePartitionerCoverageTest_HelperInt(0, 1000, -1);
+            RangePartitionerCoverageTest_HelperInt(-2000, -1000, -1);
+            RangePartitionerCoverageTest_HelperInt(1000, 2000, -1);
+            RangePartitionerCoverageTest_HelperInt(0, 1000, 1);
+            RangePartitionerCoverageTest_HelperInt(-2000, -1000, 1);
+            RangePartitionerCoverageTest_HelperInt(1000, 2000, 1);
+            RangePartitionerCoverageTest_HelperInt(0, 1000, 27);
+            RangePartitionerCoverageTest_HelperInt(-2000, -1000, 27);
+            RangePartitionerCoverageTest_HelperInt(1000, 2000, 27);
+            RangePartitionerCoverageTest_HelperInt(0, 1000, 250);
+            RangePartitionerCoverageTest_HelperInt(-2000, -1000, 250);
+            RangePartitionerCoverageTest_HelperInt(1000, 2000, 250);
+            RangePartitionerCoverageTest_HelperInt(0, 1000, 750);
+            RangePartitionerCoverageTest_HelperInt(-2000, -1000, 750);
+            RangePartitionerCoverageTest_HelperInt(1000, 2000, 750);
         }
 
         // Test that chunk sizes are being honored
         [Fact]
         public static void RangePartitionerChunkTest()
         {
-            RangePartitionerChunkTest(0, 10, 1);
-            RangePartitionerChunkTest(-20, -10, 1);
-            RangePartitionerChunkTest(10, 20, 1);
-            RangePartitionerChunkTest(0, 10, 3);
-            RangePartitionerChunkTest(-20, -10, 3);
-            RangePartitionerChunkTest(10, 20, 3);
-            RangePartitionerChunkTest(0, 10, 5);
-            RangePartitionerChunkTest(-20, -10, 5);
-            RangePartitionerChunkTest(10, 20, 5);
-            RangePartitionerChunkTest(0, 10, 7);
-            RangePartitionerChunkTest(-20, -10, 7);
-            RangePartitionerChunkTest(10, 20, 7);
-            RangePartitionerChunkTest(0, 1000000, 32768);
-            RangePartitionerChunkTest(-2000000, -1000000, 32768);
-            RangePartitionerChunkTest(1000000, 2000000, 32768);
+            RangePartitionerChunkTest_HelperInt(0, 10, 1);
+            RangePartitionerChunkTest_HelperInt(-20, -10, 1);
+            RangePartitionerChunkTest_HelperInt(10, 20, 1);
+            RangePartitionerChunkTest_HelperInt(0, 10, 3);
+            RangePartitionerChunkTest_HelperInt(-20, -10, 3);
+            RangePartitionerChunkTest_HelperInt(10, 20, 3);
+            RangePartitionerChunkTest_HelperInt(0, 10, 5);
+            RangePartitionerChunkTest_HelperInt(-20, -10, 5);
+            RangePartitionerChunkTest_HelperInt(10, 20, 5);
+            RangePartitionerChunkTest_HelperInt(0, 10, 7);
+            RangePartitionerChunkTest_HelperInt(-20, -10, 7);
+            RangePartitionerChunkTest_HelperInt(10, 20, 7);
+            RangePartitionerChunkTest_HelperInt(0, 1000000, 32768);
+            RangePartitionerChunkTest_HelperInt(-2000000, -1000000, 32768);
+            RangePartitionerChunkTest_HelperInt(1000000, 2000000, 32768);
         }
 
-        private static void RangePartitionerChunkTest(int from, int to, int rangeSize)
+        private static void RangePartitionerChunkTest_HelperInt(int from, int to, int rangeSize)
         {
             Debug.WriteLine("    RangePartitionChunkTest[int]({0},{1},{2})", from, to, rangeSize);
             int numLess = 0;
@@ -125,10 +125,10 @@ namespace System.Threading.Tasks.Tests
 
             Assert.False(numLess > 1, string.Format("    > FAILED.  {0} chunks smaller than desired range size.", numLess));
 
-            RangePartitionerChunkTest((long)from, (long)to, (long)rangeSize);
+            RangePartitionerChunkTest_HelperLong((long)from, (long)to, (long)rangeSize);
         }
 
-        private static void RangePartitionerChunkTest(long from, long to, long rangeSize)
+        private static void RangePartitionerChunkTest_HelperLong(long from, long to, long rangeSize)
         {
             Debug.WriteLine("    RangePartitionChunkTest[long]({0},{1},{2})", from, to, rangeSize);
             int numLess = 0;
@@ -150,7 +150,7 @@ namespace System.Threading.Tasks.Tests
             Assert.False(numLess > 1, string.Format("    > FAILED.  {0} chunks smaller than desired range size.", numLess));
         }
 
-        private static void RangePartitionerCoverageTest(int from, int to, int rangeSize)
+        private static void RangePartitionerCoverageTest_HelperInt(int from, int to, int rangeSize)
         {
             Debug.WriteLine("    RangePartitionCoverageTest[int]({0},{1},{2})", from, to, rangeSize);
 
@@ -172,10 +172,10 @@ namespace System.Threading.Tasks.Tests
                 Assert.False(visits[i] != 1, string.Format("    > FAILED.  Visits[{0}] = {1}", i, visits[i]));
             }
 
-            RangePartitionerCoverageTest((long)from, (long)to, (long)rangeSize);
+            RangePartitionerCoverageTest_HelperLong((long)from, (long)to, (long)rangeSize);
         }
 
-        private static void RangePartitionerCoverageTest(long from, long to, long rangeSize)
+        private static void RangePartitionerCoverageTest_HelperLong(long from, long to, long rangeSize)
         {
             Debug.WriteLine("    RangePartitionCoverageTest[long]({0},{1},{2})", from, to, rangeSize);
 

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
@@ -25,161 +25,161 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public static void RunContinueWithTaskTask_State()
         {
-            RunContinueWithTaskTask_State(TaskContinuationOptions.None);
-            RunContinueWithTaskTask_State(s_onlyOnRanToCompletion);
+            RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.None);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion);
 
-            RunContinueWithTaskTask_State(TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithTaskTask_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithTaskFuture_State()
         {
-            RunContinueWithTaskFuture_State(TaskContinuationOptions.None);
-            RunContinueWithTaskFuture_State(s_onlyOnRanToCompletion);
+            RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.None);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion);
 
-            RunContinueWithTaskFuture_State(TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithTaskFuture_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithFutureTask_State()
         {
-            RunContinueWithFutureTask_State(TaskContinuationOptions.None);
-            RunContinueWithFutureTask_State(s_onlyOnRanToCompletion);
+            RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.None);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion);
 
-            RunContinueWithFutureTask_State(TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithFutureTask_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithFutureFuture_State()
         {
-            RunContinueWithFutureFuture_State(TaskContinuationOptions.None);
-            RunContinueWithFutureFuture_State(s_onlyOnRanToCompletion);
+            RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.None);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion);
 
-            RunContinueWithFutureFuture_State(TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithFutureFuture_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithTaskTask_State_FaultedCanceled()
         {
-            RunContinueWithTaskTask_State(s_onlyOnCanceled);
-            RunContinueWithTaskTask_State(s_onlyOnFaulted);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted);
 
-            RunContinueWithTaskTask_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithTaskTask_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithTaskFuture_State_FaultedCanceled()
         {
-            RunContinueWithTaskFuture_State(s_onlyOnCanceled);
-            RunContinueWithTaskFuture_State(s_onlyOnFaulted);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted);
 
-            RunContinueWithTaskFuture_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithTaskFuture_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithFutureTask_State_FaultedCanceled()
         {
-            RunContinueWithFutureTask_State(s_onlyOnCanceled);
-            RunContinueWithFutureTask_State(s_onlyOnFaulted);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted);
 
-            RunContinueWithFutureTask_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithFutureTask_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithFutureFuture_State_FaultedCanceled()
         {
-            RunContinueWithFutureFuture_State(s_onlyOnCanceled);
-            RunContinueWithFutureFuture_State(s_onlyOnFaulted);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted);
 
-            RunContinueWithFutureFuture_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
-            RunContinueWithFutureFuture_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         [Fact]
         public static void RunContinueWithTaskTask_State_OnException()
         {
-            RunContinueWithTaskTask_State(TaskContinuationOptions.None, true);
-            RunContinueWithTaskTask_State(s_onlyOnRanToCompletion, true);
+            RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.None, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion, true);
 
-            RunContinueWithTaskTask_State(TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithTaskTask_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithTaskFuture_State_OnException()
         {
-            RunContinueWithTaskFuture_State(TaskContinuationOptions.None, true);
-            RunContinueWithTaskFuture_State(s_onlyOnRanToCompletion, true);
+            RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.None, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion, true);
 
-            RunContinueWithTaskFuture_State(TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithTaskFuture_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithFutureTask_State_OnException()
         {
-            RunContinueWithFutureTask_State(TaskContinuationOptions.None, true);
-            RunContinueWithFutureTask_State(s_onlyOnRanToCompletion, true);
+            RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.None, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion, true);
 
-            RunContinueWithFutureTask_State(TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithFutureTask_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithFutureFuture_State_OnException()
         {
-            RunContinueWithFutureFuture_State(TaskContinuationOptions.None, true);
-            RunContinueWithFutureFuture_State(s_onlyOnRanToCompletion, true);
+            RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.None, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion, true);
 
-            RunContinueWithFutureFuture_State(TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithFutureFuture_State(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithTaskTask_State_FaultedCanceled_OnException()
         {
-            RunContinueWithTaskTask_State(s_onlyOnCanceled, true);
-            RunContinueWithTaskTask_State(s_onlyOnFaulted, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted, true);
 
-            RunContinueWithTaskTask_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithTaskTask_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithTaskFuture_State_FaultedCanceled_OnException()
         {
-            RunContinueWithTaskFuture_State(s_onlyOnCanceled, true);
-            RunContinueWithTaskFuture_State(s_onlyOnFaulted, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted, true);
 
-            RunContinueWithTaskFuture_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithTaskFuture_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithFutureTask_State_FaultedCanceled_OnException()
         {
-            RunContinueWithFutureTask_State(s_onlyOnCanceled, true);
-            RunContinueWithFutureTask_State(s_onlyOnFaulted, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted, true);
 
-            RunContinueWithFutureTask_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithFutureTask_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
         public static void RunContinueWithFutureFuture_State_FaultedCanceled_OnException()
         {
-            RunContinueWithFutureFuture_State(s_onlyOnCanceled, true);
-            RunContinueWithFutureFuture_State(s_onlyOnFaulted, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted, true);
 
-            RunContinueWithFutureFuture_State(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
-            RunContinueWithFutureFuture_State(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
+            RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace System.Threading.Tasks.Tests
         #region Helper Methods
 
         // Chains a Task continuation to a Task.
-        private static void RunContinueWithTaskTask_State(TaskContinuationOptions options, bool runNegativeCases = false)
+        private static void RunContinueWithTaskTask_State_Helper(TaskContinuationOptions options, bool runNegativeCases = false)
         {
             bool ran = false;
 
@@ -447,7 +447,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Chains a Task<T> continuation to a Task, with a Func<Task, T>.
-        private static void RunContinueWithTaskFuture_State(TaskContinuationOptions options, bool runNegativeCases = false)
+        private static void RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions options, bool runNegativeCases = false)
         {
             bool ran = false;
 
@@ -481,7 +481,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Chains a Task continuation to a Task<T>.
-        private static void RunContinueWithFutureTask_State(TaskContinuationOptions options, bool runNegativeCases = false)
+        private static void RunContinueWithFutureTask_State_Helper(TaskContinuationOptions options, bool runNegativeCases = false)
         {
             bool ran = false;
 
@@ -515,7 +515,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Chains a Task<U> continuation to a Task<T>, with a Func<Task<T>, U>.
-        private static void RunContinueWithFutureFuture_State(TaskContinuationOptions options, bool runNegativeCases = false)
+        private static void RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions options, bool runNegativeCases = false)
         {
             bool ran = false;
 

--- a/src/libraries/System.Threading/tests/CountdownEventTests.cs
+++ b/src/libraries/System.Threading/tests/CountdownEventTests.cs
@@ -9,34 +9,24 @@ namespace System.Threading.Tests
 {
     public class CountdownEventTests
     {
-        [Fact]
-        public static void RunCountdownEventTest0_StateTrans()
+        [Theory]
+        [InlineData(0, 0, false)]
+        [InlineData(1, 0, false)]
+        [InlineData(128, 0, false)]
+        [InlineData(1024 * 1024, 0, false)]
+        [InlineData(1, 1024, false)]
+        [InlineData(128, 1024, false)]
+        [InlineData(1024 * 1024, 1024, false)]
+        [InlineData(1, 0, true)]
+        [InlineData(128, 0, true)]
+        [InlineData(1024 * 1024, 0, true)]
+        [InlineData(1, 1024, true)]
+        [InlineData(128, 1024, true)]
+        [InlineData(1024 * 1024, 1024, true)]
+        public static void RunCountdownEventTest0_StateTrans(int initCount, int increms, bool takeAllAtOnce)
         {
-            RunCountdownEventTest0_StateTrans(0, 0, false);
-            RunCountdownEventTest0_StateTrans(1, 0, false);
-            RunCountdownEventTest0_StateTrans(128, 0, false);
-            RunCountdownEventTest0_StateTrans(1024 * 1024, 0, false);
-            RunCountdownEventTest0_StateTrans(1, 1024, false);
-            RunCountdownEventTest0_StateTrans(128, 1024, false);
-            RunCountdownEventTest0_StateTrans(1024 * 1024, 1024, false);
-            RunCountdownEventTest0_StateTrans(1, 0, true);
-            RunCountdownEventTest0_StateTrans(128, 0, true);
-            RunCountdownEventTest0_StateTrans(1024 * 1024, 0, true);
-            RunCountdownEventTest0_StateTrans(1, 1024, true);
-            RunCountdownEventTest0_StateTrans(128, 1024, true);
-            RunCountdownEventTest0_StateTrans(1024 * 1024, 1024, true);
-        }
+            // Validates init, set, reset state transitions.
 
-        [Fact]
-        public static void RunCountdownEventTest1_SimpleTimeout()
-        {
-            RunCountdownEventTest1_SimpleTimeout(0);
-            RunCountdownEventTest1_SimpleTimeout(100);
-        }
-
-        // Validates init, set, reset state transitions.
-        private static void RunCountdownEventTest0_StateTrans(int initCount, int increms, bool takeAllAtOnce)
-        {
             CountdownEvent ev = new CountdownEvent(initCount);
 
             Assert.Equal(initCount, ev.InitialCount);
@@ -70,15 +60,17 @@ namespace System.Threading.Tests
             Assert.Equal(ev.InitialCount, ev.CurrentCount);
         }
 
-        // Tries some simple timeout cases.
-        private static void RunCountdownEventTest1_SimpleTimeout(int ms)
+        [Theory]
+        [InlineData(0)]
+        [InlineData(100)]
+        public static void RunCountdownEventTest1_SimpleTimeout(int ms)
         {
-            // Wait on the event.
             CountdownEvent ev = new CountdownEvent(999);
             Assert.False(ev.Wait(ms));
             Assert.False(ev.IsSet);
             Assert.False(ev.WaitHandle.WaitOne(ms));
         }
+
         [Fact]
         public static void RunCountdownEventTest2_Exceptions()
         {

--- a/src/libraries/System.Threading/tests/ManualResetEventSlimTests.cs
+++ b/src/libraries/System.Threading/tests/ManualResetEventSlimTests.cs
@@ -10,15 +10,11 @@ namespace System.Threading.Tests
 {
     public class ManualResetEventSlimTests
     {
-        [Fact]
-        public static void RunManualResetEventSlimTest0_StateTrans()
-        {
-            RunManualResetEventSlimTest0_StateTrans(false);
-            RunManualResetEventSlimTest0_StateTrans(true);
-        }
-
         // Validates init, set, reset state transitions.
-        private static void RunManualResetEventSlimTest0_StateTrans(bool init)
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void RunManualResetEventSlimTest0_StateTrans(bool init)
         {
             ManualResetEventSlim ev = new ManualResetEventSlim(init);
             Assert.Equal(init, ev.IsSet);

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -30,43 +30,43 @@ namespace System.Threading.Tests
         [Fact]
         public static void RunSemaphoreSlimTest0_Ctor()
         {
-            RunSemaphoreSlimTest0_Ctor(0, 10, null);
-            RunSemaphoreSlimTest0_Ctor(5, 10, null);
-            RunSemaphoreSlimTest0_Ctor(10, 10, null);
+            RunSemaphoreSlimTest0_Helper(0, 10, null);
+            RunSemaphoreSlimTest0_Helper(5, 10, null);
+            RunSemaphoreSlimTest0_Helper(10, 10, null);
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest0_Ctor_Negative()
         {
-            RunSemaphoreSlimTest0_Ctor(10, 0, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest0_Ctor(10, -1, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest0_Ctor(-1, 10, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest0_Helper(10, 0, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest0_Helper(10, -1, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest0_Helper(-1, 10, typeof(ArgumentOutOfRangeException));
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest1_Wait()
         {
             // Infinite timeout
-            RunSemaphoreSlimTest1_Wait(10, 10, -1, true, null);
-            RunSemaphoreSlimTest1_Wait(1, 10, -1, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(10, 10, -1, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, -1, true, null);
 
             // Zero timeout
-            RunSemaphoreSlimTest1_Wait(10, 10, 0, true, null);
-            RunSemaphoreSlimTest1_Wait(1, 10, 0, true, null);
-            RunSemaphoreSlimTest1_Wait(0, 10, 0, false, null);
+            RunSemaphoreSlimTest1_Wait_Helper(10, 10, 0, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, 0, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(0, 10, 0, false, null);
 
             // Positive timeout
-            RunSemaphoreSlimTest1_Wait(10, 10, 10, true, null);
-            RunSemaphoreSlimTest1_Wait(1, 10, 10, true, null);
-            RunSemaphoreSlimTest1_Wait(0, 10, 10, false, null);
+            RunSemaphoreSlimTest1_Wait_Helper(10, 10, 10, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, 10, true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(0, 10, 10, false, null);
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest1_Wait_NegativeCases()
         {
             // Invalid timeout
-            RunSemaphoreSlimTest1_Wait(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest1_Wait
+            RunSemaphoreSlimTest1_Wait_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest1_Wait_Helper
                (10, 10, new TimeSpan(0, 0, int.MaxValue), true, typeof(ArgumentOutOfRangeException));
         }
 
@@ -74,26 +74,26 @@ namespace System.Threading.Tests
         public static void RunSemaphoreSlimTest1_WaitAsync()
         {
             // Infinite timeout
-            RunSemaphoreSlimTest1_WaitAsync(10, 10, -1, true, null);
-            RunSemaphoreSlimTest1_WaitAsync(1, 10, -1, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -1, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, -1, true, null);
 
             // Zero timeout
-            RunSemaphoreSlimTest1_WaitAsync(10, 10, 0, true, null);
-            RunSemaphoreSlimTest1_WaitAsync(1, 10, 0, true, null);
-            RunSemaphoreSlimTest1_WaitAsync(0, 10, 0, false, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 0, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 0, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 0, false, null);
 
             // Positive timeout
-            RunSemaphoreSlimTest1_WaitAsync(10, 10, 10, true, null);
-            RunSemaphoreSlimTest1_WaitAsync(1, 10, 10, true, null);
-            RunSemaphoreSlimTest1_WaitAsync(0, 10, 10, false, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 10, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest1_WaitAsync_NegativeCases()
         {
             // Invalid timeout
-            RunSemaphoreSlimTest1_WaitAsync(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest1_WaitAsync
+            RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest1_WaitAsync_Helper
                (10, 10, new TimeSpan(0, 0, int.MaxValue), true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync2();
         }
@@ -102,62 +102,62 @@ namespace System.Threading.Tests
         public static void RunSemaphoreSlimTest2_Release()
         {
             // Valid release count
-            RunSemaphoreSlimTest2_Release(5, 10, 1, null);
-            RunSemaphoreSlimTest2_Release(0, 10, 1, null);
-            RunSemaphoreSlimTest2_Release(5, 10, 5, null);
+            RunSemaphoreSlimTest2_Release_Helper(5, 10, 1, null);
+            RunSemaphoreSlimTest2_Release_Helper(0, 10, 1, null);
+            RunSemaphoreSlimTest2_Release_Helper(5, 10, 5, null);
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest2_Release_NegativeCases()
         {
             // Invalid release count
-            RunSemaphoreSlimTest2_Release(5, 10, 0, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest2_Release(5, 10, -1, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest2_Release_Helper(5, 10, 0, typeof(ArgumentOutOfRangeException));
+            RunSemaphoreSlimTest2_Release_Helper(5, 10, -1, typeof(ArgumentOutOfRangeException));
 
             // Semaphore Full
-            RunSemaphoreSlimTest2_Release(10, 10, 1, typeof(SemaphoreFullException));
-            RunSemaphoreSlimTest2_Release(5, 10, 6, typeof(SemaphoreFullException));
-            RunSemaphoreSlimTest2_Release(int.MaxValue - 1, int.MaxValue, 10, typeof(SemaphoreFullException));
+            RunSemaphoreSlimTest2_Release_Helper(10, 10, 1, typeof(SemaphoreFullException));
+            RunSemaphoreSlimTest2_Release_Helper(5, 10, 6, typeof(SemaphoreFullException));
+            RunSemaphoreSlimTest2_Release_Helper(int.MaxValue - 1, int.MaxValue, 10, typeof(SemaphoreFullException));
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest4_Dispose()
         {
-            RunSemaphoreSlimTest4_Dispose(5, 10, null, null);
-            RunSemaphoreSlimTest4_Dispose(5, 10, SemaphoreSlimActions.CurrentCount, null);
-            RunSemaphoreSlimTest4_Dispose
+            RunSemaphoreSlimTest4_Dispose_Helper(5, 10, null, null);
+            RunSemaphoreSlimTest4_Dispose_Helper(5, 10, SemaphoreSlimActions.CurrentCount, null);
+            RunSemaphoreSlimTest4_Dispose_Helper
                (5, 10, SemaphoreSlimActions.Wait, typeof(ObjectDisposedException));
-            RunSemaphoreSlimTest4_Dispose
+            RunSemaphoreSlimTest4_Dispose_Helper
                (5, 10, SemaphoreSlimActions.WaitAsync, typeof(ObjectDisposedException));
-            RunSemaphoreSlimTest4_Dispose
+            RunSemaphoreSlimTest4_Dispose_Helper
               (5, 10, SemaphoreSlimActions.Release, typeof(ObjectDisposedException));
-            RunSemaphoreSlimTest4_Dispose
+            RunSemaphoreSlimTest4_Dispose_Helper
               (5, 10, SemaphoreSlimActions.AvailableWaitHandle, typeof(ObjectDisposedException));
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest5_CurrentCount()
         {
-            RunSemaphoreSlimTest5_CurrentCount(5, 10, null);
-            RunSemaphoreSlimTest5_CurrentCount(5, 10, SemaphoreSlimActions.Wait);
-            RunSemaphoreSlimTest5_CurrentCount(5, 10, SemaphoreSlimActions.WaitAsync);
-            RunSemaphoreSlimTest5_CurrentCount(5, 10, SemaphoreSlimActions.Release);
+            RunSemaphoreSlimTest5_CurrentCount_Helper(5, 10, null);
+            RunSemaphoreSlimTest5_CurrentCount_Helper(5, 10, SemaphoreSlimActions.Wait);
+            RunSemaphoreSlimTest5_CurrentCount_Helper(5, 10, SemaphoreSlimActions.WaitAsync);
+            RunSemaphoreSlimTest5_CurrentCount_Helper(5, 10, SemaphoreSlimActions.Release);
         }
 
         [Fact]
         public static void RunSemaphoreSlimTest7_AvailableWaitHandle()
         {
-            RunSemaphoreSlimTest7_AvailableWaitHandle(5, 10, null, true);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(0, 10, null, false);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(5, 10, null, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(0, 10, null, false);
 
-            RunSemaphoreSlimTest7_AvailableWaitHandle(5, 10, SemaphoreSlimActions.Wait, true);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(1, 10, SemaphoreSlimActions.Wait, false);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(5, 10, SemaphoreSlimActions.Wait, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(5, 10, SemaphoreSlimActions.Wait, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(1, 10, SemaphoreSlimActions.Wait, false);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(5, 10, SemaphoreSlimActions.Wait, true);
 
-            RunSemaphoreSlimTest7_AvailableWaitHandle(5, 10, SemaphoreSlimActions.WaitAsync, true);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(1, 10, SemaphoreSlimActions.WaitAsync, false);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(5, 10, SemaphoreSlimActions.WaitAsync, true);
-            RunSemaphoreSlimTest7_AvailableWaitHandle(0, 10, SemaphoreSlimActions.Release, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(5, 10, SemaphoreSlimActions.WaitAsync, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(1, 10, SemaphoreSlimActions.WaitAsync, false);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(5, 10, SemaphoreSlimActions.WaitAsync, true);
+            RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(0, 10, SemaphoreSlimActions.Release, true);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace System.Threading.Tests
         /// <param name="exceptionType">The type of the thrown exception in case of invalid cases,
         /// null for valid cases</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest0_Ctor(int initial, int maximum, Type exceptionType)
+        private static void RunSemaphoreSlimTest0_Helper(int initial, int maximum, Type exceptionType)
         {
             string methodFailed = "RunSemaphoreSlimTest0_Ctor(" + initial + "," + maximum + "):  FAILED.  ";
             Exception exception = null;
@@ -195,7 +195,7 @@ namespace System.Threading.Tests
         /// <param name="exceptionType">The type of the thrown exception in case of invalid cases,
         /// null for valid cases</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest1_Wait
+        private static void RunSemaphoreSlimTest1_Wait_Helper
             (int initial, int maximum, object timeout, bool returnValue, Type exceptionType)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
@@ -233,7 +233,7 @@ namespace System.Threading.Tests
         /// <param name="exceptionType">The type of the thrown exception in case of invalid cases,
         /// null for valid cases</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest1_WaitAsync
+        private static void RunSemaphoreSlimTest1_WaitAsync_Helper
             (int initial, int maximum, object timeout, bool returnValue, Type exceptionType)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
@@ -308,7 +308,7 @@ namespace System.Threading.Tests
         /// <param name="exceptionType">The type of the thrown exception in case of invalid cases,
         /// null for valid cases</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest2_Release
+        private static void RunSemaphoreSlimTest2_Release_Helper
            (int initial, int maximum, int releaseCount, Type exceptionType)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
@@ -395,7 +395,7 @@ namespace System.Threading.Tests
         /// <param name="exceptionType">The type of the thrown exception in case of invalid cases,
         /// null for valid cases</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest4_Dispose(int initial, int maximum, SemaphoreSlimActions? action, Type exceptionType)
+        private static void RunSemaphoreSlimTest4_Dispose_Helper(int initial, int maximum, SemaphoreSlimActions? action, Type exceptionType)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
             try
@@ -417,7 +417,7 @@ namespace System.Threading.Tests
         /// <param name="maximum">The maximum semaphore count</param>
         /// <param name="action">SemaphoreSlim action to be called before CurrentCount</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest5_CurrentCount(int initial, int maximum, SemaphoreSlimActions? action)
+        private static void RunSemaphoreSlimTest5_CurrentCount_Helper(int initial, int maximum, SemaphoreSlimActions? action)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
 
@@ -440,7 +440,7 @@ namespace System.Threading.Tests
         /// <param name="action">SemaphoreSlim action to be called before WaitHandle</param>
         /// <param name="state">The expected wait handle state</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        private static void RunSemaphoreSlimTest7_AvailableWaitHandle(int initial, int maximum, SemaphoreSlimActions? action, bool state)
+        private static void RunSemaphoreSlimTest7_AvailableWaitHandle_Helper(int initial, int maximum, SemaphoreSlimActions? action, bool state)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(initial, maximum);
 

--- a/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -639,7 +639,7 @@ namespace System.Web.Tests
         [Theory]
         [InlineData(" abc defgh", "abc+def", 1, 7)]
         [InlineData(" abc defgh", "", 1, 0)]
-        public void UrlEncodeToBytesExplicitSize(string decoded, string encoded, int offset, int count)
+        public void UrlEncodeToBytesExplicitSize_WithOffsetAndCount(string decoded, string encoded, int offset, int count)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(decoded);
             Assert.Equal(encoded, Encoding.UTF8.GetString(HttpUtility.UrlEncodeToBytes(bytes, offset, count)));


### PR DESCRIPTION
There's a couple of recurring patterns in this PR:
- A simple rename of a test method (e.g. add a suffix; If there are conventions around that that I'm not aware of, I'm happy to adjust the renames).
- Replace a `Fact` that does nothing but call a helper method with different parameter values, with a `Theory` that uses `InlineData` (or just "inline" the redundant method, if there was only one call).
- Replace a helper method with the same name as a `Fact`/`Theory` method, with a local function.


I'll make particular notes about changes that do not fall in one of the above patterns, or other comments, for easier review:
- `src/libraries/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs`
  - Removed `ReadKeyValuePairOfKeyValuePair` `Fact` since the `Theory` right after it already covers that case. The code is identical, and the inline data for the `Theory` already includes the value that the `Fact` used.
- `src/libraries/System.Private.Xml/tests/XmlSerialize/XmlSerializerTests.RuntimeOnly.cs`
  - `Xml_GuidAsRoot_Helper` and `Xml_ListGenericRoot_Helper` were just renames, but I noticed that they don't use their only parameter so maybe there's a problem there. To be handled in a separate issue if they actually are.
- `src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs`
  - `Ctor_ThrownException_GetFramesReturnsExpected` might be redundant? Depending on the default value that `fNeedFileInfo` gets when instantiating a `StackTrace`, but I couldn't easily find where to check that.

Will fix https://github.com/dotnet/runtime/issues/34503