### PR TITLE
Fix building WinRT tests on new Windows SDK (with new cppwinrt).

### DIFF
--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -4,6 +4,8 @@ include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 include_directories("../Contracts")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+add_compile_definitions(WINRT_NO_MAKE_DETECTION)
+
 set(SOURCES
   Component.Contracts.ArrayTesting.cpp
   Component.Contracts.BindingProjectionsTesting.cpp

--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.BindingViewModel.h
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.BindingViewModel.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "Component/Contracts/BindingViewModel.g.h"
+#include "winrt/Windows.Foundation.Collections.h"
+#include "winrt/Windows.UI.Xaml.Interop.h"
 #include <vector>
 
 template<typename T>

--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.KeyValuePairTesting.cpp
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.KeyValuePairTesting.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.KeyValuePairTesting.h"
+#include "winrt/Windows.Foundation.Collections.h"
 #include <utility>
 #include <vector>
 

--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.NullableTesting.cpp
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.NullableTesting.cpp
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.NullableTesting.h"
+#include "winrt/Windows.Foundation.h"
+
 
 namespace winrt::Component::Contracts::implementation
 {

--- a/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.UriTesting.cpp
+++ b/src/coreclr/tests/src/Interop/WinRT/NativeComponent/Component.Contracts.UriTesting.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 #include "pch.h"
 #include "Component.Contracts.UriTesting.h"
+#include "winrt/Windows.Foundation.h"
 
 namespace winrt::Component::Contracts::implementation
 {


### PR DESCRIPTION
Fixes the CoreCLR test build on the new VS 16.5.1 build queue.