### PR TITLE
[metadata] Handle MONO_TYPE_FNPTR case in collect_type_images

### DIFF
--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -3054,8 +3054,8 @@ retry:
 		type = m_class_get_byval_arg (type->data.array->eklass);
 		goto retry;
 	case MONO_TYPE_FNPTR:
-		//return signature_in_image (type->data.method, image);
-		g_assert_not_reached ();
+		collect_signature_images (type->data.method, data);
+		break;
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 	{


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19434,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes abort when PTR-FNPTR field signature is encountered.

I do not have a deep understanding of how the code in this area works,
but I have called the function that appears most consistent with how
other signatures are being handled.

Fixes mono/mono#12098
Fixes mono/mono#17113
Fixes mono/mono#19433