### PR TITLE
Make NativeLibrary Load/TryLoad use ALC extension points for the specified assembly

### DIFF
--- a/src/coreclr/src/pal/inc/pal.h
+++ b/src/coreclr/src/pal/inc/pal.h
@@ -72,7 +72,6 @@ extern "C" {
 
 // Native system libray handle.
 // On Unix systems, NATIVE_LIBRARY_HANDLE type represents a library handle not registered with the PAL.
-// To get a HMODULE on Unix, call PAL_RegisterLibraryDirect() on a NATIVE_LIBRARY_HANDLE.
 typedef PVOID NATIVE_LIBRARY_HANDLE;
 
 /******************* Processor-specific glue  *****************************/

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -6975,6 +6975,11 @@ namespace
         return LoadLibraryModuleBySearch(pAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
     }
 
+    // This thread local and UseExtensionPoints class are used to guard against infinite recursion.
+    // The managed APIs (NativeLibarary.Load/TryLoad) that invoke managed extension points can also
+    // be called from within the extension points themselves. This class tracks whether or not the
+    // runtime is in a state where it should invoke those extension points (i.e. whether or not it
+    // is already in a load triggered by the managed APIs.
     thread_local bool t_shouldInvokeExtensionPoints = true;
     class UseExtensionPoints
     {

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -6431,117 +6431,6 @@ NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryFromPath(LPCWSTR libraryPath, BOOL thr
     return hmod;
 }
 
-namespace
-{
-    thread_local bool t_shouldInvokeExtensionPoints = true;
-    class UseExtensionPoints
-    {
-    public:
-        UseExtensionPoints()
-        {
-            ShouldInvoke = t_shouldInvokeExtensionPoints;
-            t_shouldInvokeExtensionPoints = false;
-        }
-
-        ~UseExtensionPoints()
-        {
-            if (ShouldInvoke)
-                t_shouldInvokeExtensionPoints = true;
-        }
-
-    public:
-        bool ShouldInvoke;
-    };
-}
-
-// static
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryByName(LPCWSTR libraryName, Assembly *callingAssembly,
-                                                 BOOL hasDllImportSearchFlags, DWORD dllImportSearchFlags,
-                                                 BOOL throwOnError)
-{
-    CONTRACTL
-    {
-        STANDARD_VM_CHECK;
-        PRECONDITION(CheckPointer(libraryName));
-        PRECONDITION(CheckPointer(callingAssembly));
-    }
-    CONTRACTL_END;
-
-    UseExtensionPoints useExtensionPoints;
-    bool invokeExtensionPoints = useExtensionPoints.ShouldInvoke;
-
-    // First checks if a default dllImportSearchPathFlags was passed in, if so, use that value.
-    // Otherwise checks if the assembly has the DefaultDllImportSearchPathsAttribute attribute.
-    // If so, use that value.
-    BOOL searchAssemblyDirectory;
-    if (hasDllImportSearchFlags)
-    {
-        searchAssemblyDirectory = dllImportSearchFlags & DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY;
-    }
-    else
-    {
-        hasDllImportSearchFlags = GetDllImportSearchPathFlags(callingAssembly->GetManifestModule(),
-                                                              &dllImportSearchFlags,
-                                                              &searchAssemblyDirectory);
-        dllImportSearchFlags |= searchAssemblyDirectory ? DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY : 0;
-    }
-
-    NATIVE_LIBRARY_HANDLE hmod = nullptr;
-
-    if (invokeExtensionPoints)
-    {
-        // Resolve using the registered DllImportResolver for the assembly
-        if (!callingAssembly->IsSystem())
-        {
-            hmod = LoadLibraryModuleViaCallback(callingAssembly, libraryName, hasDllImportSearchFlags, dllImportSearchFlags);
-            if (hmod != nullptr)
-                return hmod;
-        }
-
-        // Resolve using the AssemblyLoadContext.LoadUnmanagedDll implementation
-        hmod = LoadLibraryModuleViaAssemblyLoadContext(callingAssembly, libraryName);
-        if (hmod != nullptr)
-            return hmod;
-    }
-
-    LoadLibErrorTracker errorTracker;
-    DWORD dllImportSearchPathFlags = dllImportSearchFlags & ~DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY;
-
-    hmod = LoadLibraryModuleBySearch(callingAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
-    if (hmod != nullptr)
-        return hmod;
-
-    if (invokeExtensionPoints)
-    {
-        // Resolve using the AssemblyLoadContext.ResolvingUnmanagedDll event
-        hmod = LoadLibraryModuleViaAssemblyLoadContextEvent(callingAssembly, libraryName);
-        if (hmod != nullptr)
-            return hmod;
-    }
-
-    if (throwOnError)
-    {
-        SString libraryPathSString(libraryName);
-        errorTracker.Throw(libraryPathSString);
-    }
-
-    return hmod;
-}
-
-// static
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleBySearch(NDirectMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker, PCWSTR wszLibName)
-{
-    STANDARD_VM_CONTRACT;
-
-    BOOL searchAssemblyDirectory;
-    DWORD dllImportSearchPathFlags;
-
-    GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
-
-    Assembly* pAssembly = pMD->GetMethodTable()->GetAssembly();
-    return LoadLibraryModuleBySearch(pAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
-}
-
 // static
 void NDirect::FreeNativeLibrary(NATIVE_LIBRARY_HANDLE handle)
 {
@@ -6584,491 +6473,598 @@ INT_PTR NDirect::GetNativeLibraryExport(NATIVE_LIBRARY_HANDLE handle, LPCWSTR sy
     return address;
 }
 
-#ifndef TARGET_UNIX
-BOOL IsWindowsAPISet(PCWSTR wszLibName)
+namespace
 {
-    STANDARD_VM_CONTRACT;
-
-    // This is replicating quick check from the OS implementation of api sets.
-    return SString::_wcsnicmp(wszLibName, W("api-"), 4) == 0 ||
-           SString::_wcsnicmp(wszLibName, W("ext-"), 4) == 0;
-}
-#endif // !TARGET_UNIX
-
-// static
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleViaAssemblyLoadContext(Assembly * pAssembly, PCWSTR wszLibName)
-{
-    STANDARD_VM_CONTRACT;
-    //Dynamic Pinvoke Support:
-    //Check if we  need to provide the host a chance to provide the unmanaged dll
-
-    // AssemblyLoadContext is not supported in AppX mode
-    if (AppX::IsAppXProcess())
-        return NULL;
-
 #ifndef TARGET_UNIX
-    if (IsWindowsAPISet(wszLibName))
+    BOOL IsWindowsAPISet(PCWSTR wszLibName)
     {
-        // Prevent Overriding of Windows API sets.
-        return NULL;
+        STANDARD_VM_CONTRACT;
+
+        // This is replicating quick check from the OS implementation of api sets.
+        return SString::_wcsnicmp(wszLibName, W("api-"), 4) == 0 ||
+               SString::_wcsnicmp(wszLibName, W("ext-"), 4) == 0;
     }
 #endif // !TARGET_UNIX
 
-    NATIVE_LIBRARY_HANDLE hmod = NULL;
-    AppDomain* pDomain = GetAppDomain();
-    CLRPrivBinderCoreCLR *pTPABinder = pDomain->GetTPABinderContext();
-
-    PEFile *pManifestFile = pAssembly->GetManifestFile();
-    PTR_ICLRPrivBinder pBindingContext = pManifestFile->GetBindingContext();
-
-    //Step 0: Check if  the assembly was bound using TPA.
-    //        The Binding Context can be null or an overridden TPA context
-    if (pBindingContext == NULL)
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContext(Assembly * pAssembly, PCWSTR wszLibName)
     {
-        // If we do not have any binder associated, then return to the default resolution mechanism.
-        return NULL;
-    }
+        STANDARD_VM_CONTRACT;
+        //Dynamic Pinvoke Support:
+        //Check if we  need to provide the host a chance to provide the unmanaged dll
 
-    UINT_PTR assemblyBinderID = 0;
-    IfFailThrow(pBindingContext->GetBinderID(&assemblyBinderID));
+        // AssemblyLoadContext is not supported in AppX mode
+        if (AppX::IsAppXProcess())
+            return NULL;
 
-    ICLRPrivBinder *pCurrentBinder = reinterpret_cast<ICLRPrivBinder *>(assemblyBinderID);
-
-    // For assemblies bound via TPA binder, we should use the standard mechanism to make the pinvoke call.
-    if (AreSameBinderInstance(pCurrentBinder, pTPABinder))
-    {
-        return NULL;
-    }
-
-#ifdef FEATURE_COMINTEROP
-    CLRPrivBinderWinRT *pWinRTBinder = pDomain->GetWinRtBinder();
-    if (AreSameBinderInstance(pCurrentBinder, pWinRTBinder))
-    {
-        // We could be here when a non-WinRT assembly load is triggerred by a winmd (e.g. System.Runtime being loaded due to
-        // types being referenced from Windows.Foundation.Winmd) or when dealing with a winmd (which is bound using WinRT binder).
-        //
-        // For this, we should use the standard mechanism to make pinvoke call as well.
-        return NULL;
-    }
-#endif // FEATURE_COMINTEROP
-
-    //Step 1: If the assembly was not bound using TPA,
-    //        Call System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll to give
-    //        The custom assembly context a chance to load the unmanaged dll.
-
-    GCX_COOP();
-
-    STRINGREF pUnmanagedDllName;
-    pUnmanagedDllName = StringObject::NewString(wszLibName);
-
-    GCPROTECT_BEGIN(pUnmanagedDllName);
-
-    // Get the pointer to the managed assembly load context
-    INT_PTR ptrManagedAssemblyLoadContext = ((CLRPrivBinderAssemblyLoadContext *)pCurrentBinder)->GetManagedAssemblyLoadContext();
-
-    // Prepare to invoke  System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll method.
-    PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUNMANAGEDDLL);
-    DECLARE_ARGHOLDER_ARRAY(args, 2);
-    args[ARGNUM_0]  = STRINGREF_TO_ARGHOLDER(pUnmanagedDllName);
-    args[ARGNUM_1]  = PTR_TO_ARGHOLDER(ptrManagedAssemblyLoadContext);
-
-    // Make the call
-    CALL_MANAGED_METHOD(hmod, NATIVE_LIBRARY_HANDLE, args);
-
-    GCPROTECT_END();
-
-    return hmod;
-}
-
-// Return the AssemblyLoadContext for an assembly
-INT_PTR GetManagedAssemblyLoadContext(Assembly* pAssembly)
-{
-    STANDARD_VM_CONTRACT;
-
-    PTR_ICLRPrivBinder pBindingContext = pAssembly->GetManifestFile()->GetBindingContext();
-    if (pBindingContext == NULL)
-    {
-        // GetBindingContext() returns NULL for System.Private.CoreLib
-        return NULL;
-    }
-
-    UINT_PTR assemblyBinderID = 0;
-    IfFailThrow(pBindingContext->GetBinderID(&assemblyBinderID));
-
-    AppDomain *pDomain = GetAppDomain();
-    ICLRPrivBinder *pCurrentBinder = reinterpret_cast<ICLRPrivBinder *>(assemblyBinderID);
-
-#ifdef FEATURE_COMINTEROP
-    if (AreSameBinderInstance(pCurrentBinder, pDomain->GetWinRtBinder()))
-    {
-        // No ALC associated handle with WinRT Binders.
-        return NULL;
-    }
-#endif // FEATURE_COMINTEROP
-
-    // The code here deals with two implementations of ICLRPrivBinder interface:
-    //    - CLRPrivBinderCoreCLR for the TPA binder in the default ALC, and
-    //    - CLRPrivBinderAssemblyLoadContext for custom ALCs.
-    // in order obtain the associated ALC handle.
-    INT_PTR ptrManagedAssemblyLoadContext = AreSameBinderInstance(pCurrentBinder, pDomain->GetTPABinderContext())
-        ? ((CLRPrivBinderCoreCLR *)pCurrentBinder)->GetManagedAssemblyLoadContext()
-        : ((CLRPrivBinderAssemblyLoadContext *)pCurrentBinder)->GetManagedAssemblyLoadContext();
-
-    return ptrManagedAssemblyLoadContext;
-}
-
-// static
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleViaAssemblyLoadContextEvent(Assembly * pAssembly, PCWSTR wszLibName)
-{
-    STANDARD_VM_CONTRACT;
-
-    // AssemblyLoadContext is not supported in AppX mode
-    if (AppX::IsAppXProcess())
-        return NULL;
-
-    INT_PTR ptrManagedAssemblyLoadContext = GetManagedAssemblyLoadContext(pAssembly);
-    if (ptrManagedAssemblyLoadContext == NULL)
-    {
-        return NULL;
-    }
-
-    NATIVE_LIBRARY_HANDLE hmod = NULL;
-
-    GCX_COOP();
-
-    struct {
-        STRINGREF DllName;
-        OBJECTREF AssemblyRef;
-    } gc = { NULL, NULL };
-
-    GCPROTECT_BEGIN(gc);
-
-    gc.DllName = StringObject::NewString(wszLibName);
-    gc.AssemblyRef = pAssembly->GetExposedObject();
-
-    // Prepare to invoke  System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDllUsingEvent method
-    // While ResolveUnmanagedDllUsingEvent() could compute the AssemblyLoadContext using the AssemblyRef
-    // argument, it will involve another pInvoke to the runtime. So AssemblyLoadContext is passed in
-    // as an additional argument.
-    PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUNMANAGEDDLLUSINGEVENT);
-    DECLARE_ARGHOLDER_ARRAY(args, 3);
-    args[ARGNUM_0] = STRINGREF_TO_ARGHOLDER(gc.DllName);
-    args[ARGNUM_1] = OBJECTREF_TO_ARGHOLDER(gc.AssemblyRef);
-    args[ARGNUM_2] = PTR_TO_ARGHOLDER(ptrManagedAssemblyLoadContext);
-
-    // Make the call
-    CALL_MANAGED_METHOD(hmod, NATIVE_LIBRARY_HANDLE, args);
-
-    GCPROTECT_END();
-
-    return hmod;
-}
-
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleViaCallback(
-    Assembly * pAssembly,
-    LPCWSTR wszLibName,
-    BOOL hasDllImportSearchPathFlags,
-    DWORD dllImportSearchPathFlags)
-{
-    NATIVE_LIBRARY_HANDLE handle = NULL;
-
-    GCX_COOP();
-
-    struct {
-        STRINGREF libNameRef;
-        OBJECTREF assemblyRef;
-    } gc = { NULL, NULL };
-
-    GCPROTECT_BEGIN(gc);
-
-    gc.libNameRef = StringObject::NewString(wszLibName);
-    gc.assemblyRef = pAssembly->GetExposedObject();
-
-    PREPARE_NONVIRTUAL_CALLSITE(METHOD__NATIVELIBRARY__LOADLIBRARYCALLBACKSTUB);
-    DECLARE_ARGHOLDER_ARRAY(args, 4);
-    args[ARGNUM_0] = STRINGREF_TO_ARGHOLDER(gc.libNameRef);
-    args[ARGNUM_1] = OBJECTREF_TO_ARGHOLDER(gc.assemblyRef);
-    args[ARGNUM_2] = BOOL_TO_ARGHOLDER(hasDllImportSearchPathFlags);
-    args[ARGNUM_3] = DWORD_TO_ARGHOLDER(dllImportSearchPathFlags);
-
-     // Make the call
-    CALL_MANAGED_METHOD(handle, NATIVE_LIBRARY_HANDLE, args);
-    GCPROTECT_END();
-
-    return handle;
-}
-
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleViaCallback(NDirectMethodDesc * pMD, LPCWSTR wszLibName)
-{
-    STANDARD_VM_CONTRACT;
-
-    if (pMD->GetModule()->IsSystem())
-    {
-        // Don't attempt to callback on Corelib itself.
-        // The LoadLibrary callback stub is managed code that requires CoreLib
-        return NULL;
-    }
-
-    DWORD dllImportSearchPathFlags;
-    BOOL searchAssemblyDirectory;
-    BOOL hasDllImportSearchPathFlags = GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
-    dllImportSearchPathFlags |= searchAssemblyDirectory ? DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY : 0;
-
-    Assembly* pAssembly = pMD->GetMethodTable()->GetAssembly();
-    return LoadLibraryModuleViaCallback(pAssembly, wszLibName, hasDllImportSearchPathFlags, dllImportSearchPathFlags);
-}
-
-// Try to load the module alongside the assembly where the PInvoke was declared.
-NATIVE_LIBRARY_HANDLE NDirect::LoadFromPInvokeAssemblyDirectory(Assembly *pAssembly, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker)
-{
-    STANDARD_VM_CONTRACT;
-
-    NATIVE_LIBRARY_HANDLE hmod = NULL;
-
-    SString path = pAssembly->GetManifestFile()->GetPath();
-
-    SString::Iterator lastPathSeparatorIter = path.End();
-    if (PEAssembly::FindLastPathSeparator(path, lastPathSeparatorIter))
-    {
-        lastPathSeparatorIter++;
-        path.Truncate(lastPathSeparatorIter);
-
-        path.Append(libName);
-        hmod = LocalLoadLibraryHelper(path, flags, pErrorTracker);
-    }
-
-    return hmod;
-}
-
-// Try to load the module from the native DLL search directories
-NATIVE_LIBRARY_HANDLE NDirect::LoadFromNativeDllSearchDirectories(LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker)
-{
-    STANDARD_VM_CONTRACT;
-
-    NATIVE_LIBRARY_HANDLE hmod = NULL;
-    AppDomain* pDomain = GetAppDomain();
-
-    if (pDomain->HasNativeDllSearchDirectories())
-    {
-        AppDomain::PathIterator pathIter = pDomain->IterateNativeDllSearchDirectories();
-        while (hmod == NULL && pathIter.Next())
+#ifndef TARGET_UNIX
+        if (IsWindowsAPISet(wszLibName))
         {
-            SString qualifiedPath(*(pathIter.GetPath()));
-            qualifiedPath.Append(libName);
-            if (!Path::IsRelative(qualifiedPath))
+            // Prevent Overriding of Windows API sets.
+            return NULL;
+        }
+#endif // !TARGET_UNIX
+
+        NATIVE_LIBRARY_HANDLE hmod = NULL;
+        AppDomain* pDomain = GetAppDomain();
+        CLRPrivBinderCoreCLR *pTPABinder = pDomain->GetTPABinderContext();
+
+        PEFile *pManifestFile = pAssembly->GetManifestFile();
+        PTR_ICLRPrivBinder pBindingContext = pManifestFile->GetBindingContext();
+
+        //Step 0: Check if  the assembly was bound using TPA.
+        //        The Binding Context can be null or an overridden TPA context
+        if (pBindingContext == NULL)
+        {
+            // If we do not have any binder associated, then return to the default resolution mechanism.
+            return NULL;
+        }
+
+        UINT_PTR assemblyBinderID = 0;
+        IfFailThrow(pBindingContext->GetBinderID(&assemblyBinderID));
+
+        ICLRPrivBinder *pCurrentBinder = reinterpret_cast<ICLRPrivBinder *>(assemblyBinderID);
+
+        // For assemblies bound via TPA binder, we should use the standard mechanism to make the pinvoke call.
+        if (AreSameBinderInstance(pCurrentBinder, pTPABinder))
+        {
+            return NULL;
+        }
+
+#ifdef FEATURE_COMINTEROP
+        CLRPrivBinderWinRT *pWinRTBinder = pDomain->GetWinRtBinder();
+        if (AreSameBinderInstance(pCurrentBinder, pWinRTBinder))
+        {
+            // We could be here when a non-WinRT assembly load is triggerred by a winmd (e.g. System.Runtime being loaded due to
+            // types being referenced from Windows.Foundation.Winmd) or when dealing with a winmd (which is bound using WinRT binder).
+            //
+            // For this, we should use the standard mechanism to make pinvoke call as well.
+            return NULL;
+        }
+#endif // FEATURE_COMINTEROP
+
+        //Step 1: If the assembly was not bound using TPA,
+        //        Call System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll to give
+        //        The custom assembly context a chance to load the unmanaged dll.
+
+        GCX_COOP();
+
+        STRINGREF pUnmanagedDllName;
+        pUnmanagedDllName = StringObject::NewString(wszLibName);
+
+        GCPROTECT_BEGIN(pUnmanagedDllName);
+
+        // Get the pointer to the managed assembly load context
+        INT_PTR ptrManagedAssemblyLoadContext = ((CLRPrivBinderAssemblyLoadContext *)pCurrentBinder)->GetManagedAssemblyLoadContext();
+
+        // Prepare to invoke  System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll method.
+        PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUNMANAGEDDLL);
+        DECLARE_ARGHOLDER_ARRAY(args, 2);
+        args[ARGNUM_0]  = STRINGREF_TO_ARGHOLDER(pUnmanagedDllName);
+        args[ARGNUM_1]  = PTR_TO_ARGHOLDER(ptrManagedAssemblyLoadContext);
+
+        // Make the call
+        CALL_MANAGED_METHOD(hmod, NATIVE_LIBRARY_HANDLE, args);
+
+        GCPROTECT_END();
+
+        return hmod;
+    }
+
+    // Return the AssemblyLoadContext for an assembly
+    INT_PTR GetManagedAssemblyLoadContext(Assembly* pAssembly)
+    {
+        STANDARD_VM_CONTRACT;
+
+        PTR_ICLRPrivBinder pBindingContext = pAssembly->GetManifestFile()->GetBindingContext();
+        if (pBindingContext == NULL)
+        {
+            // GetBindingContext() returns NULL for System.Private.CoreLib
+            return NULL;
+        }
+
+        UINT_PTR assemblyBinderID = 0;
+        IfFailThrow(pBindingContext->GetBinderID(&assemblyBinderID));
+
+        AppDomain *pDomain = GetAppDomain();
+        ICLRPrivBinder *pCurrentBinder = reinterpret_cast<ICLRPrivBinder *>(assemblyBinderID);
+
+#ifdef FEATURE_COMINTEROP
+        if (AreSameBinderInstance(pCurrentBinder, pDomain->GetWinRtBinder()))
+        {
+            // No ALC associated handle with WinRT Binders.
+            return NULL;
+        }
+#endif // FEATURE_COMINTEROP
+
+        // The code here deals with two implementations of ICLRPrivBinder interface:
+        //    - CLRPrivBinderCoreCLR for the TPA binder in the default ALC, and
+        //    - CLRPrivBinderAssemblyLoadContext for custom ALCs.
+        // in order obtain the associated ALC handle.
+        INT_PTR ptrManagedAssemblyLoadContext = AreSameBinderInstance(pCurrentBinder, pDomain->GetTPABinderContext())
+            ? ((CLRPrivBinderCoreCLR *)pCurrentBinder)->GetManagedAssemblyLoadContext()
+            : ((CLRPrivBinderAssemblyLoadContext *)pCurrentBinder)->GetManagedAssemblyLoadContext();
+
+        return ptrManagedAssemblyLoadContext;
+    }
+
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContextEvent(Assembly * pAssembly, PCWSTR wszLibName)
+    {
+        STANDARD_VM_CONTRACT;
+
+        // AssemblyLoadContext is not supported in AppX mode
+        if (AppX::IsAppXProcess())
+            return NULL;
+
+        INT_PTR ptrManagedAssemblyLoadContext = GetManagedAssemblyLoadContext(pAssembly);
+        if (ptrManagedAssemblyLoadContext == NULL)
+        {
+            return NULL;
+        }
+
+        NATIVE_LIBRARY_HANDLE hmod = NULL;
+
+        GCX_COOP();
+
+        struct {
+            STRINGREF DllName;
+            OBJECTREF AssemblyRef;
+        } gc = { NULL, NULL };
+
+        GCPROTECT_BEGIN(gc);
+
+        gc.DllName = StringObject::NewString(wszLibName);
+        gc.AssemblyRef = pAssembly->GetExposedObject();
+
+        // Prepare to invoke  System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDllUsingEvent method
+        // While ResolveUnmanagedDllUsingEvent() could compute the AssemblyLoadContext using the AssemblyRef
+        // argument, it will involve another pInvoke to the runtime. So AssemblyLoadContext is passed in
+        // as an additional argument.
+        PREPARE_NONVIRTUAL_CALLSITE(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUNMANAGEDDLLUSINGEVENT);
+        DECLARE_ARGHOLDER_ARRAY(args, 3);
+        args[ARGNUM_0] = STRINGREF_TO_ARGHOLDER(gc.DllName);
+        args[ARGNUM_1] = OBJECTREF_TO_ARGHOLDER(gc.AssemblyRef);
+        args[ARGNUM_2] = PTR_TO_ARGHOLDER(ptrManagedAssemblyLoadContext);
+
+        // Make the call
+        CALL_MANAGED_METHOD(hmod, NATIVE_LIBRARY_HANDLE, args);
+
+        GCPROTECT_END();
+
+        return hmod;
+    }
+
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(
+        Assembly * pAssembly,
+        LPCWSTR wszLibName,
+        BOOL hasDllImportSearchPathFlags,
+        DWORD dllImportSearchPathFlags)
+    {
+        NATIVE_LIBRARY_HANDLE handle = NULL;
+
+        GCX_COOP();
+
+        struct {
+            STRINGREF libNameRef;
+            OBJECTREF assemblyRef;
+        } gc = { NULL, NULL };
+
+        GCPROTECT_BEGIN(gc);
+
+        gc.libNameRef = StringObject::NewString(wszLibName);
+        gc.assemblyRef = pAssembly->GetExposedObject();
+
+        PREPARE_NONVIRTUAL_CALLSITE(METHOD__NATIVELIBRARY__LOADLIBRARYCALLBACKSTUB);
+        DECLARE_ARGHOLDER_ARRAY(args, 4);
+        args[ARGNUM_0] = STRINGREF_TO_ARGHOLDER(gc.libNameRef);
+        args[ARGNUM_1] = OBJECTREF_TO_ARGHOLDER(gc.assemblyRef);
+        args[ARGNUM_2] = BOOL_TO_ARGHOLDER(hasDllImportSearchPathFlags);
+        args[ARGNUM_3] = DWORD_TO_ARGHOLDER(dllImportSearchPathFlags);
+
+         // Make the call
+        CALL_MANAGED_METHOD(handle, NATIVE_LIBRARY_HANDLE, args);
+        GCPROTECT_END();
+
+        return handle;
+    }
+
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(NDirectMethodDesc * pMD, LPCWSTR wszLibName)
+    {
+        STANDARD_VM_CONTRACT;
+
+        if (pMD->GetModule()->IsSystem())
+        {
+            // Don't attempt to callback on Corelib itself.
+            // The LoadLibrary callback stub is managed code that requires CoreLib
+            return NULL;
+        }
+
+        DWORD dllImportSearchPathFlags;
+        BOOL searchAssemblyDirectory;
+        BOOL hasDllImportSearchPathFlags = GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
+        dllImportSearchPathFlags |= searchAssemblyDirectory ? DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY : 0;
+
+        Assembly* pAssembly = pMD->GetMethodTable()->GetAssembly();
+        return LoadLibraryModuleViaCallback(pAssembly, wszLibName, hasDllImportSearchPathFlags, dllImportSearchPathFlags);
+    }
+
+    // Try to load the module alongside the assembly where the PInvoke was declared.
+    NATIVE_LIBRARY_HANDLE LoadFromPInvokeAssemblyDirectory(Assembly *pAssembly, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker)
+    {
+        STANDARD_VM_CONTRACT;
+
+        NATIVE_LIBRARY_HANDLE hmod = NULL;
+
+        SString path = pAssembly->GetManifestFile()->GetPath();
+
+        SString::Iterator lastPathSeparatorIter = path.End();
+        if (PEAssembly::FindLastPathSeparator(path, lastPathSeparatorIter))
+        {
+            lastPathSeparatorIter++;
+            path.Truncate(lastPathSeparatorIter);
+
+            path.Append(libName);
+            hmod = LocalLoadLibraryHelper(path, flags, pErrorTracker);
+        }
+
+        return hmod;
+    }
+
+    // Try to load the module from the native DLL search directories
+    NATIVE_LIBRARY_HANDLE LoadFromNativeDllSearchDirectories(LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker)
+    {
+        STANDARD_VM_CONTRACT;
+
+        NATIVE_LIBRARY_HANDLE hmod = NULL;
+        AppDomain* pDomain = GetAppDomain();
+
+        if (pDomain->HasNativeDllSearchDirectories())
+        {
+            AppDomain::PathIterator pathIter = pDomain->IterateNativeDllSearchDirectories();
+            while (hmod == NULL && pathIter.Next())
             {
-                hmod = LocalLoadLibraryHelper(qualifiedPath, flags, pErrorTracker);
+                SString qualifiedPath(*(pathIter.GetPath()));
+                qualifiedPath.Append(libName);
+                if (!Path::IsRelative(qualifiedPath))
+                {
+                    hmod = LocalLoadLibraryHelper(qualifiedPath, flags, pErrorTracker);
+                }
             }
         }
-    }
 
-    return hmod;
-}
+        return hmod;
+    }
 
 #ifdef TARGET_UNIX
-static const int MaxVariationCount = 4;
-static void DetermineLibNameVariations(const WCHAR** libNameVariations, int* numberOfVariations, const SString& libName, bool libNameIsRelativePath)
-{
-    // Supported lib name variations
-    static auto NameFmt = W("%.0s%s%.0s");
-    static auto PrefixNameFmt = W("%s%s%.0s");
-    static auto NameSuffixFmt = W("%.0s%s%s");
-    static auto PrefixNameSuffixFmt = W("%s%s%s");
-
-    _ASSERTE(*numberOfVariations >= MaxVariationCount);
-
-    int varCount = 0;
-    if (!libNameIsRelativePath)
+    const int MaxVariationCount = 4;
+    void DetermineLibNameVariations(const WCHAR** libNameVariations, int* numberOfVariations, const SString& libName, bool libNameIsRelativePath)
     {
-        libNameVariations[varCount++] = NameFmt;
-    }
-    else
-    {
-        // We check if the suffix is contained in the name, because on Linux it is common to append
-        // a version number to the library name (e.g. 'libicuuc.so.57').
-        bool containsSuffix = false;
-        SString::CIterator it = libName.Begin();
-        if (libName.Find(it, PLATFORM_SHARED_LIB_SUFFIX_W))
-        {
-            it += COUNTOF(PLATFORM_SHARED_LIB_SUFFIX_W);
-            containsSuffix = it == libName.End() || *it == (WCHAR)'.';
-        }
+        // Supported lib name variations
+        static auto NameFmt = W("%.0s%s%.0s");
+        static auto PrefixNameFmt = W("%s%s%.0s");
+        static auto NameSuffixFmt = W("%.0s%s%s");
+        static auto PrefixNameSuffixFmt = W("%s%s%s");
 
-        // If the path contains a path delimiter, we don't add a prefix
-        it = libName.Begin();
-        bool containsDelim = libName.Find(it, DIRECTORY_SEPARATOR_STR_W);
+        _ASSERTE(*numberOfVariations >= MaxVariationCount);
 
-        if (containsSuffix)
+        int varCount = 0;
+        if (!libNameIsRelativePath)
         {
             libNameVariations[varCount++] = NameFmt;
-
-            if (!containsDelim)
-                libNameVariations[varCount++] = PrefixNameFmt;
-
-            libNameVariations[varCount++] = NameSuffixFmt;
-
-            if (!containsDelim)
-                libNameVariations[varCount++] = PrefixNameSuffixFmt;
         }
         else
         {
-            libNameVariations[varCount++] = NameSuffixFmt;
+            // We check if the suffix is contained in the name, because on Linux it is common to append
+            // a version number to the library name (e.g. 'libicuuc.so.57').
+            bool containsSuffix = false;
+            SString::CIterator it = libName.Begin();
+            if (libName.Find(it, PLATFORM_SHARED_LIB_SUFFIX_W))
+            {
+                it += COUNTOF(PLATFORM_SHARED_LIB_SUFFIX_W);
+                containsSuffix = it == libName.End() || *it == (WCHAR)'.';
+            }
 
-            if (!containsDelim)
-                libNameVariations[varCount++] = PrefixNameSuffixFmt;
+            // If the path contains a path delimiter, we don't add a prefix
+            it = libName.Begin();
+            bool containsDelim = libName.Find(it, DIRECTORY_SEPARATOR_STR_W);
 
-            libNameVariations[varCount++] = NameFmt;
+            if (containsSuffix)
+            {
+                libNameVariations[varCount++] = NameFmt;
 
-            if (!containsDelim)
-                libNameVariations[varCount++] = PrefixNameFmt;
+                if (!containsDelim)
+                    libNameVariations[varCount++] = PrefixNameFmt;
+
+                libNameVariations[varCount++] = NameSuffixFmt;
+
+                if (!containsDelim)
+                    libNameVariations[varCount++] = PrefixNameSuffixFmt;
+            }
+            else
+            {
+                libNameVariations[varCount++] = NameSuffixFmt;
+
+                if (!containsDelim)
+                    libNameVariations[varCount++] = PrefixNameSuffixFmt;
+
+                libNameVariations[varCount++] = NameFmt;
+
+                if (!containsDelim)
+                    libNameVariations[varCount++] = PrefixNameFmt;
+            }
         }
+
+        *numberOfVariations = varCount;
+    }
+#else // TARGET_UNIX
+    const int MaxVariationCount = 2;
+    void DetermineLibNameVariations(const WCHAR** libNameVariations, int* numberOfVariations, const SString& libName, bool libNameIsRelativePath)
+    {
+        // Supported lib name variations
+        static auto NameFmt = W("%.0s%s%.0s");
+        static auto NameSuffixFmt = W("%.0s%s%s");
+
+        _ASSERTE(*numberOfVariations >= MaxVariationCount);
+
+        int varCount = 0;
+
+        // The purpose of following code is to workaround LoadLibrary limitation:
+        // LoadLibrary won't append extension if filename itself contains '.'. Thus it will break the following scenario:
+        // [DllImport("A.B")] // The full name for file is "A.B.dll". This is common code pattern for cross-platform PInvoke
+        // The workaround for above scenario is to call LoadLibrary with "A.B" first, if it fails, then call LoadLibrary with "A.B.dll"
+        auto it = libName.Begin();
+        if (!libNameIsRelativePath ||
+            !libName.Find(it, W('.')) ||
+            libName.EndsWith(W(".")) ||
+            libName.EndsWithCaseInsensitive(W(".dll")) ||
+            libName.EndsWithCaseInsensitive(W(".exe")))
+        {
+            // Follow LoadLibrary rules in MSDN doc: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx
+            // If the string specifies a full path, the function searches only that path for the module.
+            // If the string specifies a module name without a path and the file name extension is omitted, the function appends the default library extension .dll to the module name.
+            // To prevent the function from appending .dll to the module name, include a trailing point character (.) in the module name string.
+            libNameVariations[varCount++] = NameFmt;
+        }
+        else
+        {
+            libNameVariations[varCount++] = NameFmt;
+            libNameVariations[varCount++] = NameSuffixFmt;
+        }
+
+        *numberOfVariations = varCount;
+    }
+#endif // TARGET_UNIX
+
+    // Search for the library and variants of its name in probing directories.
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(Assembly *callingAssembly,
+                                                    BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags,
+                                                    LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName)
+    {
+        STANDARD_VM_CONTRACT;
+
+        NATIVE_LIBRARY_HANDLE hmod = NULL;
+
+#if defined(FEATURE_CORESYSTEM) && !defined(TARGET_UNIX)
+        // Try to go straight to System32 for Windows API sets. This is replicating quick check from
+        // the OS implementation of api sets.
+        if (IsWindowsAPISet(wszLibName))
+        {
+            hmod = LocalLoadLibraryHelper(wszLibName, LOAD_LIBRARY_SEARCH_SYSTEM32, pErrorTracker);
+            if (hmod != NULL)
+            {
+                return hmod;
+            }
+        }
+#endif // FEATURE_CORESYSTEM && !TARGET_UNIX
+
+        AppDomain* pDomain = GetAppDomain();
+        DWORD loadWithAlteredPathFlags = GetLoadWithAlteredSearchPathFlag();
+        bool libNameIsRelativePath = Path::IsRelative(wszLibName);
+
+        // P/Invokes are often declared with variations on the actual library name.
+        // For example, it's common to leave off the extension/suffix of the library
+        // even if it has one, or to leave off a prefix like "lib" even if it has one
+        // (both of these are typically done to smooth over cross-platform differences).
+        // We try to dlopen with such variations on the original.
+        const WCHAR* prefixSuffixCombinations[MaxVariationCount] = {};
+        int numberOfVariations = COUNTOF(prefixSuffixCombinations);
+        DetermineLibNameVariations(prefixSuffixCombinations, &numberOfVariations, wszLibName, libNameIsRelativePath);
+        for (int i = 0; i < numberOfVariations; i++)
+        {
+            SString currLibNameVariation;
+            currLibNameVariation.Printf(prefixSuffixCombinations[i], PLATFORM_SHARED_LIB_PREFIX_W, wszLibName, PLATFORM_SHARED_LIB_SUFFIX_W);
+
+            // NATIVE_DLL_SEARCH_DIRECTORIES set by host is considered well known path
+            hmod = LoadFromNativeDllSearchDirectories(currLibNameVariation, loadWithAlteredPathFlags, pErrorTracker);
+            if (hmod != NULL)
+            {
+                return hmod;
+            }
+
+            if (!libNameIsRelativePath)
+            {
+                DWORD flags = loadWithAlteredPathFlags;
+                if ((dllImportSearchPathFlags & LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR) != 0)
+                {
+                    // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR is the only flag affecting absolute path. Don't OR the flags
+                    // unconditionally as all absolute path P/Invokes could then lose LOAD_WITH_ALTERED_SEARCH_PATH.
+                    flags |= dllImportSearchPathFlags;
+                }
+
+                hmod = LocalLoadLibraryHelper(currLibNameVariation, flags, pErrorTracker);
+                if (hmod != NULL)
+                {
+                    return hmod;
+                }
+            }
+            else if ((callingAssembly != nullptr) && searchAssemblyDirectory)
+            {
+                hmod = LoadFromPInvokeAssemblyDirectory(callingAssembly, currLibNameVariation, loadWithAlteredPathFlags | dllImportSearchPathFlags, pErrorTracker);
+                if (hmod != NULL)
+                {
+                    return hmod;
+                }
+            }
+
+            hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
+            if (hmod != NULL)
+            {
+                return hmod;
+            }
+        }
+
+        // This may be an assembly name
+        // Format is "fileName, assemblyDisplayName"
+        MAKE_UTF8PTR_FROMWIDE(szLibName, wszLibName);
+        char *szComma = strchr(szLibName, ',');
+        if (szComma)
+        {
+            *szComma = '\0';
+            // Trim white spaces
+            while (COMCharacter::nativeIsWhiteSpace(*(++szComma)));
+
+            AssemblySpec spec;
+            if (SUCCEEDED(spec.Init(szComma)))
+            {
+                // Need to perform case insensitive hashing.
+                SString moduleName(SString::Utf8, szLibName);
+                moduleName.LowerCase();
+
+                StackScratchBuffer buffer;
+                szLibName = (LPSTR)moduleName.GetUTF8(buffer);
+
+                Assembly *pAssembly = spec.LoadAssembly(FILE_LOADED);
+                Module *pModule = pAssembly->FindModuleByName(szLibName);
+
+                hmod = LocalLoadLibraryHelper(pModule->GetPath(), loadWithAlteredPathFlags | dllImportSearchPathFlags, pErrorTracker);
+            }
+        }
+
+        return hmod;
     }
 
-    *numberOfVariations = varCount;
-}
-#else // TARGET_UNIX
-static const int MaxVariationCount = 2;
-static void DetermineLibNameVariations(const WCHAR** libNameVariations, int* numberOfVariations, const SString& libName, bool libNameIsRelativePath)
-{
-    // Supported lib name variations
-    static auto NameFmt = W("%.0s%s%.0s");
-    static auto NameSuffixFmt = W("%.0s%s%s");
-
-    _ASSERTE(*numberOfVariations >= MaxVariationCount);
-
-    int varCount = 0;
-
-    // The purpose of following code is to workaround LoadLibrary limitation:
-    // LoadLibrary won't append extension if filename itself contains '.'. Thus it will break the following scenario:
-    // [DllImport("A.B")] // The full name for file is "A.B.dll". This is common code pattern for cross-platform PInvoke
-    // The workaround for above scenario is to call LoadLibrary with "A.B" first, if it fails, then call LoadLibrary with "A.B.dll"
-    auto it = libName.Begin();
-    if (!libNameIsRelativePath ||
-        !libName.Find(it, W('.')) ||
-        libName.EndsWith(W(".")) ||
-        libName.EndsWithCaseInsensitive(W(".dll")) ||
-        libName.EndsWithCaseInsensitive(W(".exe")))
+    NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(NDirectMethodDesc *pMD, LoadLibErrorTracker *pErrorTracker, PCWSTR wszLibName)
     {
-        // Follow LoadLibrary rules in MSDN doc: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx
-        // If the string specifies a full path, the function searches only that path for the module.
-        // If the string specifies a module name without a path and the file name extension is omitted, the function appends the default library extension .dll to the module name.
-        // To prevent the function from appending .dll to the module name, include a trailing point character (.) in the module name string.
-        libNameVariations[varCount++] = NameFmt;
+        STANDARD_VM_CONTRACT;
+
+        BOOL searchAssemblyDirectory;
+        DWORD dllImportSearchPathFlags;
+
+        GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
+
+        Assembly *pAssembly = pMD->GetMethodTable()->GetAssembly();
+        return LoadLibraryModuleBySearch(pAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
+    }
+
+    thread_local bool t_shouldInvokeExtensionPoints = true;
+    class UseExtensionPoints
+    {
+    public:
+        UseExtensionPoints()
+        {
+            ShouldInvoke = t_shouldInvokeExtensionPoints;
+            t_shouldInvokeExtensionPoints = false;
+        }
+
+        ~UseExtensionPoints()
+        {
+            if (ShouldInvoke)
+                t_shouldInvokeExtensionPoints = true;
+        }
+
+    public:
+        bool ShouldInvoke;
+    };
+}
+
+// static
+NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryByName(LPCWSTR libraryName, Assembly *callingAssembly,
+    BOOL hasDllImportSearchFlags, DWORD dllImportSearchFlags,
+    BOOL throwOnError)
+{
+    CONTRACTL
+    {
+        STANDARD_VM_CHECK;
+        PRECONDITION(CheckPointer(libraryName));
+        PRECONDITION(CheckPointer(callingAssembly));
+    }
+    CONTRACTL_END;
+
+    UseExtensionPoints useExtensionPoints;
+    bool invokeExtensionPoints = useExtensionPoints.ShouldInvoke;
+
+    // First checks if a default dllImportSearchPathFlags was passed in, if so, use that value.
+    // Otherwise checks if the assembly has the DefaultDllImportSearchPathsAttribute attribute.
+    // If so, use that value.
+    BOOL searchAssemblyDirectory;
+    if (hasDllImportSearchFlags)
+    {
+        searchAssemblyDirectory = dllImportSearchFlags & DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY;
     }
     else
     {
-        libNameVariations[varCount++] = NameFmt;
-        libNameVariations[varCount++] = NameSuffixFmt;
+        hasDllImportSearchFlags = GetDllImportSearchPathFlags(callingAssembly->GetManifestModule(),
+            &dllImportSearchFlags,
+            &searchAssemblyDirectory);
+        dllImportSearchFlags |= searchAssemblyDirectory ? DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY : 0;
     }
 
-    *numberOfVariations = varCount;
-}
-#endif // TARGET_UNIX
+    NATIVE_LIBRARY_HANDLE hmod = nullptr;
 
-// Search for the library and variants of its name in probing directories.
-//static
-NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryModuleBySearch(Assembly *callingAssembly,
-                                                         BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags,
-                                                         LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName)
-{
-    STANDARD_VM_CONTRACT;
-
-    NATIVE_LIBRARY_HANDLE hmod = NULL;
-
-#if defined(FEATURE_CORESYSTEM) && !defined(TARGET_UNIX)
-    // Try to go straight to System32 for Windows API sets. This is replicating quick check from
-    // the OS implementation of api sets.
-    if (IsWindowsAPISet(wszLibName))
+    if (invokeExtensionPoints)
     {
-        hmod = LocalLoadLibraryHelper(wszLibName, LOAD_LIBRARY_SEARCH_SYSTEM32, pErrorTracker);
-        if (hmod != NULL)
+        // Resolve using the registered DllImportResolver for the assembly
+        if (!callingAssembly->IsSystem())
         {
-            return hmod;
-        }
-    }
-#endif // FEATURE_CORESYSTEM && !TARGET_UNIX
-
-    AppDomain* pDomain = GetAppDomain();
-    DWORD loadWithAlteredPathFlags = GetLoadWithAlteredSearchPathFlag();
-    bool libNameIsRelativePath = Path::IsRelative(wszLibName);
-
-    // P/Invokes are often declared with variations on the actual library name.
-    // For example, it's common to leave off the extension/suffix of the library
-    // even if it has one, or to leave off a prefix like "lib" even if it has one
-    // (both of these are typically done to smooth over cross-platform differences).
-    // We try to dlopen with such variations on the original.
-    const WCHAR* prefixSuffixCombinations[MaxVariationCount] = {};
-    int numberOfVariations = COUNTOF(prefixSuffixCombinations);
-    DetermineLibNameVariations(prefixSuffixCombinations, &numberOfVariations, wszLibName, libNameIsRelativePath);
-    for (int i = 0; i < numberOfVariations; i++)
-    {
-        SString currLibNameVariation;
-        currLibNameVariation.Printf(prefixSuffixCombinations[i], PLATFORM_SHARED_LIB_PREFIX_W, wszLibName, PLATFORM_SHARED_LIB_SUFFIX_W);
-
-        // NATIVE_DLL_SEARCH_DIRECTORIES set by host is considered well known path
-        hmod = LoadFromNativeDllSearchDirectories(currLibNameVariation, loadWithAlteredPathFlags, pErrorTracker);
-        if (hmod != NULL)
-        {
-            return hmod;
-        }
-
-        if (!libNameIsRelativePath)
-        {
-            DWORD flags = loadWithAlteredPathFlags;
-            if ((dllImportSearchPathFlags & LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR) != 0)
-            {
-                // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR is the only flag affecting absolute path. Don't OR the flags
-                // unconditionally as all absolute path P/Invokes could then lose LOAD_WITH_ALTERED_SEARCH_PATH.
-                flags |= dllImportSearchPathFlags;
-            }
-
-            hmod = LocalLoadLibraryHelper(currLibNameVariation, flags, pErrorTracker);
-            if (hmod != NULL)
-            {
+            hmod = LoadLibraryModuleViaCallback(callingAssembly, libraryName, hasDllImportSearchFlags, dllImportSearchFlags);
+            if (hmod != nullptr)
                 return hmod;
-            }
-        }
-        else if ((callingAssembly != nullptr) && searchAssemblyDirectory)
-        {
-            hmod = LoadFromPInvokeAssemblyDirectory(callingAssembly, currLibNameVariation, loadWithAlteredPathFlags | dllImportSearchPathFlags, pErrorTracker);
-            if (hmod != NULL)
-            {
-                return hmod;
-            }
         }
 
-        hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
-        if (hmod != NULL)
-        {
+        // Resolve using the AssemblyLoadContext.LoadUnmanagedDll implementation
+        hmod = LoadLibraryModuleViaAssemblyLoadContext(callingAssembly, libraryName);
+        if (hmod != nullptr)
             return hmod;
-        }
     }
 
-    // This may be an assembly name
-    // Format is "fileName, assemblyDisplayName"
-    MAKE_UTF8PTR_FROMWIDE(szLibName, wszLibName);
-    char *szComma = strchr(szLibName, ',');
-    if (szComma)
+    LoadLibErrorTracker errorTracker;
+    DWORD dllImportSearchPathFlags = dllImportSearchFlags & ~DLLIMPORTSEARCHPATH_ASSEMBLYDIRECTORY;
+
+    hmod = LoadLibraryModuleBySearch(callingAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
+    if (hmod != nullptr)
+        return hmod;
+
+    if (invokeExtensionPoints)
     {
-        *szComma = '\0';
-        // Trim white spaces
-        while (COMCharacter::nativeIsWhiteSpace(*(++szComma)));
+        // Resolve using the AssemblyLoadContext.ResolvingUnmanagedDll event
+        hmod = LoadLibraryModuleViaAssemblyLoadContextEvent(callingAssembly, libraryName);
+        if (hmod != nullptr)
+            return hmod;
+    }
 
-        AssemblySpec spec;
-        if (SUCCEEDED(spec.Init(szComma)))
-        {
-            // Need to perform case insensitive hashing.
-            SString moduleName(SString::Utf8, szLibName);
-            moduleName.LowerCase();
-
-            StackScratchBuffer buffer;
-            szLibName = (LPSTR)moduleName.GetUTF8(buffer);
-
-            Assembly *pAssembly = spec.LoadAssembly(FILE_LOADED);
-            Module *pModule = pAssembly->FindModuleByName(szLibName);
-
-            hmod = LocalLoadLibraryHelper(pModule->GetPath(), loadWithAlteredPathFlags | dllImportSearchPathFlags, pErrorTracker);
-        }
+    if (throwOnError)
+    {
+        SString libraryPathSString(libraryName);
+        errorTracker.Throw(libraryPathSString);
     }
 
     return hmod;

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -6306,9 +6306,7 @@ private:
     SString  m_message;
 };  // class LoadLibErrorTracker
 
-// Load the library directly. On Unix systems, don't register it yet with PAL.
-// * External callers like System.Runtime.InteropServices.NativeLibrary.Load() need the raw system handle
-// * Internal callers like LoadNativeLibrary() can convert this handle to a HMODULE via PAL APIs on Unix
+// Load the library directly and return the raw system handle
 static NATIVE_LIBRARY_HANDLE LocalLoadLibraryHelper( LPCWSTR name, DWORD flags, LoadLibErrorTracker *pErrorTracker )
 {
     STANDARD_VM_CONTRACT;
@@ -7013,7 +7011,6 @@ NATIVE_LIBRARY_HANDLE NDirect::LoadLibraryByName(LPCWSTR libraryName, Assembly *
     return hmod;
 }
 
-// This Method returns an instance of the PAL-Registered handle
 NATIVE_LIBRARY_HANDLE NDirect::LoadNativeLibrary(NDirectMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker)
 {
     CONTRACTL

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -76,7 +76,7 @@ public:
     static NATIVE_LIBRARY_HANDLE LoadLibraryByName(LPCWSTR name, Assembly *callingAssembly,
                                                    BOOL hasDllImportSearchPathFlags, DWORD dllImportSearchPathFlags,
                                                    BOOL throwOnError);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracker *pErrorTracker);
+    static NATIVE_LIBRARY_HANDLE LoadNativeLibrary(NDirectMethodDesc * pMD, LoadLibErrorTracker *pErrorTracker);
     static void FreeNativeLibrary(NATIVE_LIBRARY_HANDLE handle);
     static INT_PTR GetNativeLibraryExport(NATIVE_LIBRARY_HANDLE handle, LPCWSTR symbolName, BOOL throwOnError);
 

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -125,9 +125,10 @@ private:
 
     static NATIVE_LIBRARY_HANDLE LoadFromNativeDllSearchDirectories(LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
     static NATIVE_LIBRARY_HANDLE LoadFromPInvokeAssemblyDirectory(Assembly *pAssembly, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaHost(NDirectMethodDesc * pMD, LPCWSTR wszLibName);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaEvent(NDirectMethodDesc * pMD, LPCWSTR wszLibName);
+    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContext(Assembly * pAssembly, LPCWSTR wszLibName);
+    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContextEvent(Assembly * pAssembly, LPCWSTR wszLibName);
     static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(NDirectMethodDesc * pMD, LPCWSTR wszLibName);
+    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(Assembly * pAssembly, LPCWSTR wszLibName, BOOL hasDllImportSearchPathFlags, DWORD dllImportSearchPathFlags);
     static NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(NDirectMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName);
     static NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(Assembly *callingAssembly, BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags, LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName);
 };

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -122,15 +122,6 @@ public:
 
 private:
     NDirect() {LIMITED_METHOD_CONTRACT;};     // prevent "new"'s on this class
-
-    static NATIVE_LIBRARY_HANDLE LoadFromNativeDllSearchDirectories(LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
-    static NATIVE_LIBRARY_HANDLE LoadFromPInvokeAssemblyDirectory(Assembly *pAssembly, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContext(Assembly * pAssembly, LPCWSTR wszLibName);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaAssemblyLoadContextEvent(Assembly * pAssembly, LPCWSTR wszLibName);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(NDirectMethodDesc * pMD, LPCWSTR wszLibName);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleViaCallback(Assembly * pAssembly, LPCWSTR wszLibName, BOOL hasDllImportSearchPathFlags, DWORD dllImportSearchPathFlags);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(NDirectMethodDesc * pMD, LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName);
-    static NATIVE_LIBRARY_HANDLE LoadLibraryModuleBySearch(Assembly *callingAssembly, BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags, LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName);
 };
 
 //----------------------------------------------------------------

--- a/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackTests.cs
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackTests.cs
@@ -2,87 +2,161 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
+using TestLibrary;
+
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 public class CallbackTests
 {
+    private static readonly int seed = 123;
+    private static readonly Random rand = new Random(seed);
+
     public static int Main()
     {
         try
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
+            // The first test sets the resolver for the executing assembly
+            // Subsequents tests assume the resolver has already been set.
+            ValidateSetDllImportResolver();
 
-            DllImportResolver resolver =
-                (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
-                {
-                    if (dllImportSearchPath != DllImportSearchPath.System32)
-                    {
-                        Console.WriteLine($"Unexpected dllImportSearchPath: {dllImportSearchPath.ToString()}");
-                        throw new ArgumentException();
-                    }
-
-                    return NativeLibrary.Load(NativeLibraryToLoad.Name, asm, null);
-                };
-
-            DllImportResolver anotherResolver =
-                (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
-                    IntPtr.Zero;
-
-            try
-            {
-                NativeSum(10, 10);
-                Console.WriteLine("Exception expected: no callback registered yet");
-                return 101;
-            }
-            catch (DllNotFoundException) {}
-
-            try
-            {
-                NativeLibrary.SetDllImportResolver(null, resolver);
-
-                Console.WriteLine("Exception expected: assembly parameter null");
-                return 102;
-            }
-            catch (ArgumentNullException) { }
-
-            try
-            {
-                NativeLibrary.SetDllImportResolver(assembly, null);
-
-                Console.WriteLine("Exception expected: resolver parameter null");
-                return 103;
-            }
-            catch (ArgumentNullException) { }
-
-            // Set a resolver callback
-            NativeLibrary.SetDllImportResolver(assembly, resolver);
-
-            try
-            {
-                // Try to set another resolver on the same assembly.
-                NativeLibrary.SetDllImportResolver(assembly, anotherResolver);
-
-                Console.WriteLine("Exception expected: Trying to register second resolver");
-                return 104;
-            }
-            catch (InvalidOperationException) { }
-
-            if (NativeSum(10, 10) != 20)
-            {
-                Console.WriteLine("Unexpected ReturnValue from NativeSum()");
-                return 105;
-            }
+            ValidateExplicitLoad();
+            ValidatePInvoke();
         }
         catch (Exception e)
         {
-            Console.WriteLine($"Unexpected exception: {e.ToString()} {e.Message}");
-            return 106;
+            Console.WriteLine($"Test Failure: {e}");
+            return 101;
         }
 
         return 100;
+    }
+
+    public static void ValidateSetDllImportResolver()
+    {
+        Console.WriteLine($"Running {nameof(ValidateSetDllImportResolver)}...");
+        Assembly assembly = Assembly.GetExecutingAssembly();
+        DllImportResolver resolver = Resolver.Instance.Callback;
+
+        // Invalid arguments
+        Assert.Throws<ArgumentNullException>(() => NativeLibrary.SetDllImportResolver(null, resolver), "Exception expected for null assembly parameter");
+        Assert.Throws<ArgumentNullException>(() => NativeLibrary.SetDllImportResolver(assembly, null), "Exception expected for null resolver parameter");
+
+        // No callback registered yet
+        Assert.Throws<DllNotFoundException>(() => NativeSum(10, 10));
+        Assert.Throws<DllNotFoundException>(() => NativeLibrary.Load(FakeNativeLibrary.Name, assembly, null));
+        Assert.IsFalse(NativeLibrary.TryLoad(FakeNativeLibrary.Name, assembly, null, out IntPtr unused));
+
+        // Set a resolver callback
+        NativeLibrary.SetDllImportResolver(assembly, resolver);
+
+        // Try to set the resolver again on the same assembly
+        Assert.Throws<InvalidOperationException>(() => NativeLibrary.SetDllImportResolver(assembly, resolver), "Should not be able to re-register resolver");
+
+        // Try to set another resolver on the same assembly
+        DllImportResolver anotherResolver =
+            (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
+                IntPtr.Zero;
+        Assert.Throws<InvalidOperationException>(() => NativeLibrary.SetDllImportResolver(assembly, anotherResolver), "Should not be able to register another resolver");
+    }
+
+    public static void ValidatePInvoke()
+    {
+        Console.WriteLine($"Running {nameof(ValidatePInvoke)}...");
+        int addend1 = rand.Next(int.MaxValue / 2);
+        int addend2 = rand.Next(int.MaxValue / 2);
+        int expected = addend1 + addend2;
+
+        Resolver.Instance.Reset();
+        int value = NativeSum(addend1, addend2);
+        Resolver.Instance.Validate(NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.Name);
+        Assert.AreEqual(expected, value, $"Unexpected return value from {nameof(NativeSum)}");
+    }
+
+    public static void ValidateExplicitLoad()
+    {
+        Console.WriteLine($"Running {nameof(ValidateExplicitLoad)}...");
+        Assembly assembly = Assembly.GetExecutingAssembly();
+
+        Console.WriteLine($" -- Validate {nameof(NativeLibrary.Load)}...");
+        Resolver.Instance.Reset();
+        IntPtr ptr = NativeLibrary.Load(FakeNativeLibrary.Name, assembly, null);
+        Resolver.Instance.Validate(FakeNativeLibrary.Name);
+        Assert.AreEqual(FakeNativeLibrary.Handle, ptr, $"Unexpected return value for {nameof(NativeLibrary.Load)}");
+
+        Console.WriteLine($" -- Validate {nameof(NativeLibrary.TryLoad)}...");
+        ptr = IntPtr.Zero;
+        Resolver.Instance.Reset();
+        bool success = NativeLibrary.TryLoad(FakeNativeLibrary.Name, assembly, null, out ptr);
+        Assert.IsTrue(success, $"NativeLibrary.TryLoad should have succeeded");
+        Resolver.Instance.Validate(FakeNativeLibrary.Name);
+        Assert.AreEqual(FakeNativeLibrary.Handle, ptr, $"Unexpected return value for {nameof(NativeLibrary.Load)}");
+
+        Console.WriteLine($" -- Validate {nameof(NativeLibrary.Load)}: recurse...");
+        Resolver.Instance.Reset();
+        Resolver.Instance.UseNativeLoadAPI = true;
+        Assert.Throws<DllNotFoundException>(() => NativeLibrary.Load(FakeNativeLibrary.Name, assembly, null));
+        Resolver.Instance.Validate(FakeNativeLibrary.Name);
+
+        Console.WriteLine($" -- Validate {nameof(NativeLibrary.TryLoad)}: recurse...");
+        Resolver.Instance.Reset();
+        Resolver.Instance.UseNativeLoadAPI = true;
+        success = NativeLibrary.TryLoad(FakeNativeLibrary.Name, assembly, null, out ptr);
+        Assert.IsFalse(success, $"NativeLibrary.TryLoad should not have succeeded");
+        Resolver.Instance.Validate(FakeNativeLibrary.Name);
+    }
+
+    private class Resolver
+    {
+        public static Resolver Instance = new Resolver();
+
+        public DllImportResolver Callback => ResolveDllImport;
+        public bool UseNativeLoadAPI { get; set; }
+
+        private List<string> invocations = new List<string>();
+
+        public void Reset()
+        {
+            invocations.Clear();
+            UseNativeLoadAPI = false;
+        }
+
+        public void Validate(params string[] expectedNames)
+        {
+            Assert.AreEqual(expectedNames.Length, invocations.Count, $"Unexpected invocation count for registered {nameof(DllImportResolver)}.");
+            for (int i = 0; i < expectedNames.Length; i++)
+                Assert.AreEqual(expectedNames[i], invocations[i], $"Unexpected library name received by registered resolver.");
+        }
+
+        private IntPtr ResolveDllImport(string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath)
+        {
+            invocations.Add(libraryName);
+
+            if (string.Equals(libraryName, NativeLibraryToLoad.InvalidName))
+            {
+                Assert.AreEqual(DllImportSearchPath.System32, dllImportSearchPath, $"Unexpected {nameof(dllImportSearchPath)}: {dllImportSearchPath.ToString()}");
+                return NativeLibrary.Load(NativeLibraryToLoad.Name, asm, null);
+            }
+
+            if (string.Equals(libraryName, FakeNativeLibrary.Name))
+            {
+                if (UseNativeLoadAPI)
+                {
+                    IntPtr ptr;
+                    if (NativeLibrary.TryLoad(libraryName, asm, dllImportSearchPath, out ptr))
+                        return ptr;
+                }
+                else
+                {
+                    return FakeNativeLibrary.Handle;
+                }
+            }
+
+            return IntPtr.Zero;
+        }
     }
 
     [DllImport(NativeLibraryToLoad.InvalidName)]

--- a/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackTests.csproj
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackTests.csproj
@@ -9,5 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
@@ -33,3 +33,11 @@ public class NativeLibraryToLoad
         return Path.Combine(directory, GetFileName());
     }
 }
+
+public class FakeNativeLibrary
+{
+    public const string Name = "FakeNativeLibrary";
+
+    private static Random rand = new Random();
+    public static readonly IntPtr Handle = new IntPtr(rand.Next());
+}

--- a/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
@@ -33,11 +33,3 @@ public class NativeLibraryToLoad
         return Path.Combine(directory, GetFileName());
     }
 }
-
-public class FakeNativeLibrary
-{
-    public const string Name = "FakeNativeLibrary";
-
-    private static Random rand = new Random();
-    public static readonly IntPtr Handle = new IntPtr(rand.Next());
-}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -68,7 +68,8 @@ namespace System.Runtime.InteropServices
         /// If DllImportSearchPath parameter is non-null, the flags in this enumeration are used.
         /// Otherwise, the flags specified by the DefaultDllImportSearchPaths attribute on the
         /// calling assembly (if any) are used.
-        /// This LoadLibrary() method does not invoke the managed call-backs for native library resolution:
+        /// This method behaves as if DllImport was used in the specified <paramref name="assembly"/>.
+        /// It will invoke the managed call-backs for native library resolution:
         /// * The per-assembly registered callback
         /// * AssemblyLoadContext.LoadUnmanagedDll()
         /// * AssemblyLoadContext.ResolvingUnmanagedDllEvent
@@ -100,8 +101,8 @@ namespace System.Runtime.InteropServices
         /// NativeLibrary Loader: High-level API that doesn't throw.
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
-        /// <param name="searchPath">The search path</param>
         /// <param name="assembly">The assembly loading the native library</param>
+        /// <param name="searchPath">The search path</param>
         /// <param name="handle">The out-parameter for the loaded native library handle</param>
         /// <returns>True on successful load, false otherwise</returns>
         /// <exception cref="System.ArgumentNullException">If libraryPath or assembly is null</exception>
@@ -214,7 +215,7 @@ namespace System.Runtime.InteropServices
             }
             catch (ArgumentException)
             {
-                // ConditionalWealTable throws ArgumentException if the Key already exists
+                // ConditionalWeakTable throws ArgumentException if the Key already exists
                 throw new InvalidOperationException(SR.InvalidOperation_CannotRegisterSecondResolver);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -68,13 +68,12 @@ namespace System.Runtime.InteropServices
         /// If DllImportSearchPath parameter is non-null, the flags in this enumeration are used.
         /// Otherwise, the flags specified by the DefaultDllImportSearchPaths attribute on the
         /// calling assembly (if any) are used.
-        /// This method behaves as if DllImport was used in the specified <paramref name="assembly"/>.
-        /// It will invoke the managed extension points for native library resolution:
-        /// * The per-assembly registered callback
+        /// This method follows the native library resolution for the AssemblyLoadContext of the
+        /// specified assembly. It will invoke the managed extension points:
         /// * AssemblyLoadContext.LoadUnmanagedDll()
         /// * AssemblyLoadContext.ResolvingUnmanagedDllEvent
-        /// If this method is called from within one of the managed extension points, the extension
-        /// points will not be recursively called again.
+        /// It does not invoke extension points that are not tied to the AssemblyLoadContext:
+        /// * The per-assembly registered DllImportResolver callback
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
         /// <param name="assembly">The assembly loading the native library</param>
@@ -82,7 +81,7 @@ namespace System.Runtime.InteropServices
         /// <returns>The handle for the loaded library</returns>
         /// <exception cref="System.ArgumentNullException">If libraryPath or assembly is null</exception>
         /// <exception cref="System.ArgumentException">If assembly is not a RuntimeAssembly</exception>
-        /// <exception cref="System.DllNotFoundException ">If the library can't be found.</exception>
+        /// <exception cref="System.DllNotFoundException">If the library can't be found.</exception>
         /// <exception cref="System.BadImageFormatException">If the library is not valid.</exception>
         public static IntPtr Load(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
@@ -106,13 +105,12 @@ namespace System.Runtime.InteropServices
         /// If DllImportSearchPath parameter is non-null, the flags in this enumeration are used.
         /// Otherwise, the flags specified by the DefaultDllImportSearchPaths attribute on the
         /// calling assembly (if any) are used.
-        /// This method behaves as if DllImport was used in the specified <paramref name="assembly"/>.
-        /// It will invoke the managed extension points for native library resolution:
-        /// * The per-assembly registered callback
+        /// This method follows the native library resolution for the AssemblyLoadContext of the
+        /// specified assembly. It will invoke the managed extension points:
         /// * AssemblyLoadContext.LoadUnmanagedDll()
         /// * AssemblyLoadContext.ResolvingUnmanagedDllEvent
-        /// If this method is called from within one of the managed extension points, the extension
-        /// points will not be recursively called again.
+        /// It does not invoke extension points that are not tied to the AssemblyLoadContext:
+        /// * The per-assembly registered DllImportResolver callback
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
         /// <param name="assembly">The assembly loading the native library</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -69,10 +69,12 @@ namespace System.Runtime.InteropServices
         /// Otherwise, the flags specified by the DefaultDllImportSearchPaths attribute on the
         /// calling assembly (if any) are used.
         /// This method behaves as if DllImport was used in the specified <paramref name="assembly"/>.
-        /// It will invoke the managed call-backs for native library resolution:
+        /// It will invoke the managed extension points for native library resolution:
         /// * The per-assembly registered callback
         /// * AssemblyLoadContext.LoadUnmanagedDll()
         /// * AssemblyLoadContext.ResolvingUnmanagedDllEvent
+        /// If this method is called from within one of the managed extension points, the extension
+        /// points will not be recursively called again.
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
         /// <param name="assembly">The assembly loading the native library</param>
@@ -99,6 +101,18 @@ namespace System.Runtime.InteropServices
 
         /// <summary>
         /// NativeLibrary Loader: High-level API that doesn't throw.
+        /// Given a library name, this function searches specific paths based on the
+        /// runtime configuration, input parameters, and attributes of the calling assembly.
+        /// If DllImportSearchPath parameter is non-null, the flags in this enumeration are used.
+        /// Otherwise, the flags specified by the DefaultDllImportSearchPaths attribute on the
+        /// calling assembly (if any) are used.
+        /// This method behaves as if DllImport was used in the specified <paramref name="assembly"/>.
+        /// It will invoke the managed extension points for native library resolution:
+        /// * The per-assembly registered callback
+        /// * AssemblyLoadContext.LoadUnmanagedDll()
+        /// * AssemblyLoadContext.ResolvingUnmanagedDllEvent
+        /// If this method is called from within one of the managed extension points, the extension
+        /// points will not be recursively called again.
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
         /// <param name="assembly">The assembly loading the native library</param>


### PR DESCRIPTION
Make the `NativeLibrary.Load/TryLoad` overloads that take an `Assembly` mimic the logic of native assembly resolution for the `AssemblyLoadContext` of the specified assembly. They will go through the extension points for the `AssemblyLoadContext` of the specified assembly:
- Call the ALC's `LoadUnmanagedDll` function
- Fire the ALC's `ResolvingUnmanagedDll` event

They will no go through the extension points that are not tied to the `AssemblyLoadContext`:
- Invoke any registered per-assembly callback (`DllImportResolver` delegate)

Fix #13819