### PR TITLE
Fix memory leak in SuperPMI

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1588,12 +1588,12 @@ void MyICJI::allocMem(ULONG              hotCodeSize,   /* IN */
 {
     jitInstance->mc->cr->AddCall("allocMem");
     // TODO-Cleanup: investigate if we need to check roDataBlock as well. Could hot block size be ever 0?
-    *hotCodeBlock = new BYTE[hotCodeSize];
+    *hotCodeBlock = jitInstance->mc->cr->allocateMemory(hotCodeSize);
     if (coldCodeSize > 0)
-        *coldCodeBlock = new BYTE[coldCodeSize];
+        *coldCodeBlock = jitInstance->mc->cr->allocateMemory(coldCodeSize);
     else
         *coldCodeBlock = nullptr;
-    *roDataBlock       = new BYTE[roDataSize];
+    *roDataBlock       = jitInstance->mc->cr->allocateMemory(roDataSize);
     jitInstance->mc->cr->recAllocMem(hotCodeSize, coldCodeSize, roDataSize, xcptnsCount, flag, hotCodeBlock,
                                      coldCodeBlock, roDataBlock);
 }
@@ -1657,7 +1657,7 @@ void* MyICJI::allocGCInfo(size_t size /* IN */
                           )
 {
     jitInstance->mc->cr->AddCall("allocGCInfo");
-    void* temp = (unsigned char*)new BYTE[size];
+    void* temp = jitInstance->mc->cr->allocateMemory(size);
     jitInstance->mc->cr->recAllocGCInfo(size, temp);
 
     return temp;

--- a/src/coreclr/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -427,7 +427,7 @@ const WCHAR* JitInstance::getOption(const WCHAR* key, LightWeightMap<DWORD, DWOR
 void* JitInstance::allocateArray(size_t cBytes)
 {
     mc->cr->AddCall("allocateArray");
-    return new BYTE[cBytes];
+    return mc->cr->allocateMemory(cBytes);
 }
 
 // Used to allocate memory that needs to live as long as the jit
@@ -444,7 +444,7 @@ void* JitInstance::allocateLongLivedArray(size_t cBytes)
 void JitInstance::freeArray(void* array)
 {
     mc->cr->AddCall("freeArray");
-    delete [] (BYTE*)array;
+    // We don't bother freeing this until the mc->cr itself gets freed.
 }
 
 // Used to free memory allocated by JitInstance::allocateLongLivedArray.


### PR DESCRIPTION
Introduced on Windows by change to Heap APIs (https://github.com/dotnet/runtime/pull/34289).

Also fixes a long-existing memory leak on Linux where we never had `HeapDestroy()`.
