### PR TITLE
Disable test DnsGetHostEntry_LocalHost_ReturnsFqdnAndLoopbackIPs

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -186,6 +186,7 @@ namespace System.Net.NameResolution.Tests
             await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(() => Task.Factory.FromAsync(Dns.BeginGetHostEntry, Dns.EndGetHostEntry, hostNameOrAddress, null));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34317")]
         [Theory]
         [InlineData(0)]
         [InlineData(1)]


### PR DESCRIPTION
The test started affecting CI significantly (responsible for 3% CI run failures)
Disabled issue tracked in #34317