### PR TITLE
Rename ThirdPartyNotices.txt to THIRD-PARTY-NOTICES.txt

### DIFF
--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -90,7 +90,7 @@
           DestinationFolder="$(SharedHostPublishRoot)" />
 
     <Copy SourceFiles="$(RepoRoot)THIRD-PARTY-NOTICES.TXT"
-          DestinationFiles="$(SharedHostPublishRoot)ThirdPartyNotices.txt" />
+          DestinationFiles="$(SharedHostPublishRoot)THIRD-PARTY-NOTICES.txt" />
 
     <Copy SourceFiles="$(RepoRoot)LICENSE.TXT"
           DestinationFiles="$(SharedHostPublishRoot)LICENSE.txt"

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -28,7 +28,7 @@
           DestinationFolder="$(PublishRootDir)" />
 
     <Copy SourceFiles="$(RepoRoot)THIRD-PARTY-NOTICES.TXT"
-          DestinationFiles="$(PublishRootDir)ThirdPartyNotices.txt" />
+          DestinationFiles="$(PublishRootDir)THIRD-PARTY-NOTICES.txt" />
 
     <Copy SourceFiles="$(RepoRoot)LICENSE.TXT"
           DestinationFiles="$(PublishRootDir)LICENSE.txt"

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/host.wxs
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/host.wxs
@@ -34,7 +34,7 @@
         <File Id="fileLicenseTxt" KeyPath="yes" Source="$(var.HostSrc)\LICENSE.txt">
           <CopyFile Id="copyFileLicenseTxt" DestinationDirectory="PROGRAMFILES_DOTNET" />
         </File>
-        <File Id="fileThirdPartyNoticesTxt" Source="$(var.HostSrc)\ThirdPartyNotices.txt">
+        <File Id="fileThirdPartyNoticesTxt" Source="$(var.HostSrc)\THIRD-PARTY-NOTICES.txt">
           <CopyFile Id="copyFileThirdPartyNoticesTxt" DestinationDirectory="PROGRAMFILES_DOTNET" />
         </File>
       </Component>


### PR DESCRIPTION
Renamed instances where ThirdPartyNotices.txt was referenced to upper case naming.

Fixes https://github.com/dotnet/runtime/issues/2243

Please let me know if I've renamed something incorrectly, or if additional files need to be modified as well. 

Thank you