### PR TITLE
Adds tests for missing object and collection properties in S.T.J.S

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -82,6 +82,26 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(obj.Class);
         }
 
+        [Fact]
+        public static void MissingObjectProperty()
+        {
+            ClassWithMissingObjectProperty obj
+                = JsonSerializer.Deserialize<ClassWithMissingObjectProperty>(@"{ ""Object"": {} }");
+
+            Assert.NotNull(obj);
+            Assert.Null(obj.Collection);
+        }
+
+        [Fact]
+        public static void MissingCollectionProperty()
+        {
+            ClassWithMissingCollectionProperty obj
+                = JsonSerializer.Deserialize<ClassWithMissingCollectionProperty>(@"{ ""Collection"": [] }");
+
+            Assert.NotNull(obj);
+            Assert.Null(obj.Object);
+        }
+
         private class ClassWithPublicGetterAndPrivateSetter
         {
             public NestedClass Class { get; private set; }
@@ -271,7 +291,15 @@ namespace System.Text.Json.Serialization.Tests
             public ClassWithIgnoredUnsupportedBigInteger MyClass { get; set; }
         }
 
-        // Todo: https://github.com/dotnet/runtime/issues/32348
+        public class ClassWithMissingObjectProperty
+        {
+            public object[] Collection { get; set; }
+        }
+
+        public class ClassWithMissingCollectionProperty
+        {
+            public object Object { get; set; }
+        }
 
         public class ClassWithPrivateSetterAndGetter
         {

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -88,7 +88,6 @@ namespace System.Text.Json.Serialization.Tests
             ClassWithMissingObjectProperty obj
                 = JsonSerializer.Deserialize<ClassWithMissingObjectProperty>(@"{ ""Object"": {} }");
 
-            Assert.NotNull(obj);
             Assert.Null(obj.Collection);
         }
 
@@ -98,7 +97,6 @@ namespace System.Text.Json.Serialization.Tests
             ClassWithMissingCollectionProperty obj
                 = JsonSerializer.Deserialize<ClassWithMissingCollectionProperty>(@"{ ""Collection"": [] }");
 
-            Assert.NotNull(obj);
             Assert.Null(obj.Object);
         }
 


### PR DESCRIPTION
Adds two tests to ensure a missing object and a missing collection property are ignored when deserializing - the expected behaviour.

Not sure if this is what you wanted, let me know.

Fixes #32348