### PR TITLE
Optimize newline handling for RegexOptions.Multiline

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexAssemblyCompiler.cs
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions
             _strings = code.Strings;
             _leadingCharClasses = code.LeadingCharClasses;
             _boyerMoorePrefix = code.BoyerMoorePrefix;
-            _anchors = code.Anchors;
+            _leadingAnchor = code.LeadingAnchor;
             _trackcount = code.TrackCount;
 
             // Pick a name for the class.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -103,14 +103,14 @@ namespace System.Text.RegularExpressions
         public readonly (string CharClass, bool CaseInsensitive)[]? LeadingCharClasses; // the set of candidate first characters, if available.  Each entry corresponds to the next char in the input.
         public int[]? LeadingCharClassAsciiLookup;                                      // the ASCII lookup table optimization for LeadingCharClasses[0], if it exists; only used by the interpreter
         public readonly RegexBoyerMoore? BoyerMoorePrefix;                              // the fixed prefix string as a Boyer-Moore machine, if available
-        public readonly int Anchors;                                                    // the set of zero-length start anchors (RegexPrefixAnalyzer.Bol, etc)
+        public readonly int LeadingAnchor;                                              // the leading anchor, if one exists (RegexPrefixAnalyzer.Bol, etc)
         public readonly bool RightToLeft;                                               // true if right to left
 
         public RegexCode(RegexTree tree, int[] codes, string[] strings, int trackcount,
                          Hashtable? caps, int capsize,
                          RegexBoyerMoore? boyerMoorePrefix,
                          (string CharClass, bool CaseInsensitive)[]? leadingCharClasses,
-                         int anchors, bool rightToLeft)
+                         int leadingAnchor, bool rightToLeft)
         {
             Debug.Assert(boyerMoorePrefix is null || leadingCharClasses is null);
 
@@ -123,7 +123,7 @@ namespace System.Text.RegularExpressions
             CapSize = capsize;
             BoyerMoorePrefix = boyerMoorePrefix;
             LeadingCharClasses = leadingCharClasses;
-            Anchors = anchors;
+            LeadingAnchor = leadingAnchor;
             RightToLeft = rightToLeft;
         }
 
@@ -402,7 +402,7 @@ namespace System.Text.RegularExpressions
             var sb = new StringBuilder();
 
             sb.AppendLine("Direction:  " + (RightToLeft ? "right-to-left" : "left-to-right"));
-            sb.AppendLine("Anchors:    " + RegexPrefixAnalyzer.AnchorDescription(Anchors));
+            sb.AppendLine("Anchor:     " + RegexPrefixAnalyzer.AnchorDescription(LeadingAnchor));
             sb.AppendLine("");
 
             if (BoyerMoorePrefix != null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -100,7 +100,7 @@ namespace System.Text.RegularExpressions
         protected string[]? _strings;                                              // the stringtable associated with the RegexCodes
         protected (string CharClass, bool CaseInsensitive)[]? _leadingCharClasses; // the possible first chars computed by RegexPrefixAnalyzer
         protected RegexBoyerMoore? _boyerMoorePrefix;                              // a prefix as a boyer-moore machine
-        protected int _leadingAnchor;                                                    // the set of anchors
+        protected int _leadingAnchor;                                              // the set of anchors
         protected bool _hasTimeout;                                                // whether the regex has a non-infinite timeout
 
         private Label[]? _labels;             // a label for every operation in _codes
@@ -1031,48 +1031,42 @@ namespace System.Text.RegularExpressions
                 switch (_leadingAnchor)
                 {
                     case RegexPrefixAnalyzer.Beginning:
-                        if (!_code.RightToLeft)
                         {
                             Label l1 = DefineLabel();
                             Ldloc(_runtextposLocal);
-                            Ldthisfld(s_runtextbegField);
-                            Ble(l1);
-                            Br(returnFalse);
+                            if (!_code.RightToLeft)
+                            {
+                                Ldthisfld(s_runtextbegField);
+                                Ble(l1);
+                                Br(returnFalse);
+                            }
+                            else
+                            {
+                                Ldloc(_runtextbegLocal!);
+                                Ble(l1);
+                                Ldthis();
+                                Ldloc(_runtextbegLocal!);
+                                Stfld(s_runtextposField);
+                            }
                             MarkLabel(l1);
-                        }
-                        else
-                        {
-                            Label l1 = DefineLabel();
-                            Ldloc(_runtextposLocal);
-                            Ldloc(_runtextbegLocal!);
-                            Ble(l1);
-                            Ldthis();
-                            Ldloc(_runtextbegLocal!);
-                            Stfld(s_runtextposField);
-                            MarkLabel(l1);
-                            Ldc(1);
-                            Ret();
                         }
                         Ldc(1);
                         Ret();
                         return;
 
                     case RegexPrefixAnalyzer.Start:
-                        if (!_code.RightToLeft)
                         {
                             Label l1 = DefineLabel();
                             Ldloc(_runtextposLocal);
                             Ldthisfld(s_runtextstartField);
-                            Ble(l1);
-                            Br(returnFalse);
-                            MarkLabel(l1);
-                        }
-                        else
-                        {
-                            Label l1 = DefineLabel();
-                            Ldloc(_runtextposLocal);
-                            Ldthisfld(s_runtextstartField);
-                            Bge(l1);
+                            if (!_code.RightToLeft)
+                            {
+                                Ble(l1);
+                            }
+                            else
+                            {
+                                Bge(l1);
+                            }
                             Br(returnFalse);
                             MarkLabel(l1);
                         }
@@ -1081,65 +1075,64 @@ namespace System.Text.RegularExpressions
                         return;
 
                     case RegexPrefixAnalyzer.EndZ:
-                        if (!_code.RightToLeft)
                         {
                             Label l1 = DefineLabel();
-                            Ldloc(_runtextposLocal);
-                            Ldloc(_runtextendLocal);
-                            Ldc(1);
-                            Sub();
-                            Bge(l1);
-                            Ldthis();
-                            Ldloc(_runtextendLocal);
-                            Ldc(1);
-                            Sub();
-                            Stfld(s_runtextposField);
-                            MarkLabel(l1);
-                        }
-                        else
-                        {
-                            Label l1 = DefineLabel();
-                            Label l2 = DefineLabel();
-                            Ldloc(_runtextposLocal);
-                            Ldloc(_runtextendLocal);
-                            Ldc(1);
-                            Sub();
-                            Blt(l1);
-                            Ldloc(_runtextposLocal);
-                            Ldloc(_runtextendLocal);
-                            Beq(l2);
-                            Ldthisfld(s_runtextField);
-                            Ldloc(_runtextposLocal);
-                            Callvirt(s_stringGetCharsMethod);
-                            Ldc('\n');
-                            Beq(l2);
-                            MarkLabel(l1);
-                            BrFar(returnFalse);
-                            MarkLabel(l2);
+                            if (!_code.RightToLeft)
+                            {
+                                Ldloc(_runtextposLocal);
+                                Ldloc(_runtextendLocal);
+                                Ldc(1);
+                                Sub();
+                                Bge(l1);
+                                Ldthis();
+                                Ldloc(_runtextendLocal);
+                                Ldc(1);
+                                Sub();
+                                Stfld(s_runtextposField);
+                                MarkLabel(l1);
+                            }
+                            else
+                            {
+                                Label l2 = DefineLabel();
+                                Ldloc(_runtextposLocal);
+                                Ldloc(_runtextendLocal);
+                                Ldc(1);
+                                Sub();
+                                Blt(l1);
+                                Ldloc(_runtextposLocal);
+                                Ldloc(_runtextendLocal);
+                                Beq(l2);
+                                Ldthisfld(s_runtextField);
+                                Ldloc(_runtextposLocal);
+                                Callvirt(s_stringGetCharsMethod);
+                                Ldc('\n');
+                                Beq(l2);
+                                MarkLabel(l1);
+                                BrFar(returnFalse);
+                                MarkLabel(l2);
+                            }
                         }
                         Ldc(1);
                         Ret();
                         return;
 
                     case RegexPrefixAnalyzer.End when minRequiredLength == 0:  // if it's > 0, we already output a more stringent check
-                        if (!_code.RightToLeft)
                         {
                             Label l1 = DefineLabel();
                             Ldloc(_runtextposLocal);
                             Ldloc(_runtextendLocal);
-                            Bge(l1);
-                            Ldthis();
-                            Ldloc(_runtextendLocal);
-                            Stfld(s_runtextposField);
-                            MarkLabel(l1);
-                        }
-                        else
-                        {
-                            Label l1 = DefineLabel();
-                            Ldloc(_runtextposLocal);
-                            Ldloc(_runtextendLocal);
-                            Bge(l1);
-                            Br(returnFalse);
+                            if (!_code.RightToLeft)
+                            {
+                                Bge(l1);
+                                Ldthis();
+                                Ldloc(_runtextendLocal);
+                                Stfld(s_runtextposField);
+                            }
+                            else
+                            {
+                                Bge(l1);
+                                Br(returnFalse);
+                            }
                             MarkLabel(l1);
                         }
                         Ldc(1);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -67,6 +67,7 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_stringAsSpanMethod = typeof(MemoryExtensions).GetMethod("AsSpan", new Type[] { typeof(string) })!;
         private static readonly MethodInfo s_stringAsSpanIntIntMethod = typeof(MemoryExtensions).GetMethod("AsSpan", new Type[] { typeof(string), typeof(int), typeof(int) })!;
         private static readonly MethodInfo s_stringGetCharsMethod = typeof(string).GetMethod("get_Chars", new Type[] { typeof(int) })!;
+        private static readonly MethodInfo s_stringIndexOfCharInt = typeof(string).GetMethod("IndexOf", new Type[] { typeof(char), typeof(int) })!;
 
         /// <summary>
         /// The max recursion depth used for computations that can recover for not walking the entire node tree.
@@ -99,7 +100,7 @@ namespace System.Text.RegularExpressions
         protected string[]? _strings;                                              // the stringtable associated with the RegexCodes
         protected (string CharClass, bool CaseInsensitive)[]? _leadingCharClasses; // the possible first chars computed by RegexPrefixAnalyzer
         protected RegexBoyerMoore? _boyerMoorePrefix;                              // a prefix as a boyer-moore machine
-        protected int _anchors;                                                    // the set of anchors
+        protected int _leadingAnchor;                                                    // the set of anchors
         protected bool _hasTimeout;                                                // whether the regex has a non-infinite timeout
 
         private Label[]? _labels;             // a label for every operation in _codes
@@ -1025,49 +1026,103 @@ namespace System.Text.RegularExpressions
             MarkLabel(finishedLengthCheck);
 
             // Generate anchor checks.
-            if ((_anchors & (RegexPrefixAnalyzer.Beginning | RegexPrefixAnalyzer.Start | RegexPrefixAnalyzer.EndZ | RegexPrefixAnalyzer.End)) != 0)
+            if ((_leadingAnchor & (RegexPrefixAnalyzer.Beginning | RegexPrefixAnalyzer.Start | RegexPrefixAnalyzer.EndZ | RegexPrefixAnalyzer.End | RegexPrefixAnalyzer.Bol)) != 0)
             {
-                if (!_code.RightToLeft)
+                switch (_leadingAnchor)
                 {
-                    if ((_anchors & RegexPrefixAnalyzer.Beginning) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldthisfld(s_runtextbegField);
-                        Ble(l1);
-                        Br(returnFalse);
-                        MarkLabel(l1);
-                    }
-
-                    if ((_anchors & RegexPrefixAnalyzer.Start) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldthisfld(s_runtextstartField);
-                        Ble(l1);
-                        BrFar(returnFalse);
-                        MarkLabel(l1);
-                    }
-
-                    if ((_anchors & RegexPrefixAnalyzer.EndZ) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldloc(_runtextendLocal);
+                    case RegexPrefixAnalyzer.Beginning:
+                        if (!_code.RightToLeft)
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldthisfld(s_runtextbegField);
+                            Ble(l1);
+                            Br(returnFalse);
+                            MarkLabel(l1);
+                        }
+                        else
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldloc(_runtextbegLocal!);
+                            Ble(l1);
+                            Ldthis();
+                            Ldloc(_runtextbegLocal!);
+                            Stfld(s_runtextposField);
+                            MarkLabel(l1);
+                            Ldc(1);
+                            Ret();
+                        }
                         Ldc(1);
-                        Sub();
-                        Bge(l1);
-                        Ldthis();
-                        Ldloc(_runtextendLocal);
-                        Ldc(1);
-                        Sub();
-                        Stfld(s_runtextposField);
-                        MarkLabel(l1);
-                    }
+                        Ret();
+                        return;
 
-                    if ((_anchors & RegexPrefixAnalyzer.End) != 0)
-                    {
-                        if (minRequiredLength == 0) // if it's > 0, we already output a more stringent check
+                    case RegexPrefixAnalyzer.Start:
+                        if (!_code.RightToLeft)
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldthisfld(s_runtextstartField);
+                            Ble(l1);
+                            Br(returnFalse);
+                            MarkLabel(l1);
+                        }
+                        else
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldthisfld(s_runtextstartField);
+                            Bge(l1);
+                            Br(returnFalse);
+                            MarkLabel(l1);
+                        }
+                        Ldc(1);
+                        Ret();
+                        return;
+
+                    case RegexPrefixAnalyzer.EndZ:
+                        if (!_code.RightToLeft)
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldloc(_runtextendLocal);
+                            Ldc(1);
+                            Sub();
+                            Bge(l1);
+                            Ldthis();
+                            Ldloc(_runtextendLocal);
+                            Ldc(1);
+                            Sub();
+                            Stfld(s_runtextposField);
+                            MarkLabel(l1);
+                        }
+                        else
+                        {
+                            Label l1 = DefineLabel();
+                            Label l2 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldloc(_runtextendLocal);
+                            Ldc(1);
+                            Sub();
+                            Blt(l1);
+                            Ldloc(_runtextposLocal);
+                            Ldloc(_runtextendLocal);
+                            Beq(l2);
+                            Ldthisfld(s_runtextField);
+                            Ldloc(_runtextposLocal);
+                            Callvirt(s_stringGetCharsMethod);
+                            Ldc('\n');
+                            Beq(l2);
+                            MarkLabel(l1);
+                            BrFar(returnFalse);
+                            MarkLabel(l2);
+                        }
+                        Ldc(1);
+                        Ret();
+                        return;
+
+                    case RegexPrefixAnalyzer.End when minRequiredLength == 0:  // if it's > 0, we already output a more stringent check
+                        if (!_code.RightToLeft)
                         {
                             Label l1 = DefineLabel();
                             Ldloc(_runtextposLocal);
@@ -1078,69 +1133,74 @@ namespace System.Text.RegularExpressions
                             Stfld(s_runtextposField);
                             MarkLabel(l1);
                         }
-                    }
-                }
-                else
-                {
-                    if ((_anchors & RegexPrefixAnalyzer.End) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldloc(_runtextendLocal);
-                        Bge(l1);
-                        Br(returnFalse);
-                        MarkLabel(l1);
-                    }
-
-                    if ((_anchors & RegexPrefixAnalyzer.EndZ) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Label l2 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldloc(_runtextendLocal);
+                        else
+                        {
+                            Label l1 = DefineLabel();
+                            Ldloc(_runtextposLocal);
+                            Ldloc(_runtextendLocal);
+                            Bge(l1);
+                            Br(returnFalse);
+                            MarkLabel(l1);
+                        }
                         Ldc(1);
-                        Sub();
-                        Blt(l1);
-                        Ldloc(_runtextposLocal);
-                        Ldloc(_runtextendLocal);
-                        Beq(l2);
-                        Ldthisfld(s_runtextField);
-                        Ldloc(_runtextposLocal);
-                        Callvirt(s_stringGetCharsMethod);
-                        Ldc('\n');
-                        Beq(l2);
-                        MarkLabel(l1);
-                        BrFar(returnFalse);
-                        MarkLabel(l2);
-                    }
+                        Ret();
+                        return;
 
-                    if ((_anchors & RegexPrefixAnalyzer.Start) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldthisfld(s_runtextstartField);
-                        Bge(l1);
-                        BrFar(returnFalse);
-                        MarkLabel(l1);
-                    }
+                    case RegexPrefixAnalyzer.Bol when !_code.RightToLeft: // don't bother optimizing for the niche case of RegexOptions.RightToLeft | RegexOptions.Multiline
+                        {
+                            // Optimize the handling of a Beginning-Of-Line (BOL) anchor.  BOL is special, in that unlike
+                            // other anchors like Beginning, there are potentially multiple places a BOL can match.  So unlike
+                            // the other anchors, which all skip all subsequent processing if found, with BOL we just use it
+                            // to boost our position to the next line, and then continue normally with any Boyer-Moore or
+                            // leading char class searches.
 
-                    if ((_anchors & RegexPrefixAnalyzer.Beginning) != 0)
-                    {
-                        Label l1 = DefineLabel();
-                        Ldloc(_runtextposLocal);
-                        Ldloc(_runtextbegLocal!);
-                        Ble(l1);
-                        Ldthis();
-                        Ldloc(_runtextbegLocal!);
-                        Stfld(s_runtextposField);
-                        MarkLabel(l1);
-                    }
+                            Label atBeginningOfLine = DefineLabel();
+
+                            // if (runtextpos > runtextbeg...
+                            Ldloc(_runtextposLocal!);
+                            Ldthisfld(s_runtextbegField);
+                            BleFar(atBeginningOfLine);
+
+                            // ... && runtext[runtextpos - 1] != '\n') { ... }
+                            Ldthisfld(s_runtextField);
+                            Ldloc(_runtextposLocal);
+                            Ldc(1);
+                            Sub();
+                            Callvirt(s_stringGetCharsMethod);
+                            Ldc('\n');
+                            BeqFar(atBeginningOfLine);
+
+                            // int tmp = runtext.IndexOf('\n', runtextpos);
+                            Ldthisfld(s_runtextField);
+                            Ldc('\n');
+                            Ldloc(_runtextposLocal);
+                            Call(s_stringIndexOfCharInt);
+                            Dup();
+
+                            // if (tmp == -1)
+                            // {
+                            //     runtextpos = runtextend;
+                            //     return false;
+                            // }
+                            Label foundNextLine = DefineLabel();
+                            Ldc(-1);
+                            BneFar(foundNextLine);
+                            Pop();
+                            BrFar(returnFalse);
+
+                            // runtextpos = tmp + 1;
+                            MarkLabel(foundNextLine);
+                            Ldc(1);
+                            Add();
+                            Stloc(_runtextposLocal);
+
+                            MarkLabel(atBeginningOfLine);
+                        }
+                        break;
                 }
-
-                Ldc(1);
-                Ret();
             }
-            else if (_boyerMoorePrefix != null && _boyerMoorePrefix.NegativeUnicode == null)
+
+            if (_boyerMoorePrefix != null && _boyerMoorePrefix.NegativeUnicode == null)
             {
                 // Compiled Boyer-Moore string matching
                 LocalBuilder chLocal = _temp1Local;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexLWCGCompiler.cs
@@ -42,7 +42,7 @@ namespace System.Text.RegularExpressions
             _strings = code.Strings;
             _leadingCharClasses = code.LeadingCharClasses;
             _boyerMoorePrefix = code.BoyerMoorePrefix;
-            _anchors = code.Anchors;
+            _leadingAnchor = code.LeadingAnchor;
             _trackcount = code.TrackCount;
             _options = options;
             _hasTimeout = hasTimeout;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -290,7 +290,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Takes a RegexTree and computes the leading anchor that it encounters.</summary>
-        public static int FindLeadingAnchors(RegexTree tree)
+        public static int FindLeadingAnchor(RegexTree tree)
         {
             RegexNode curNode = tree.Root;
             RegexNode? concatNode = null;
@@ -300,6 +300,30 @@ namespace System.Text.RegularExpressions
             {
                 switch (curNode.Type)
                 {
+                    case RegexNode.Bol:
+                        return Bol;
+
+                    case RegexNode.Eol:
+                        return Eol;
+
+                    case RegexNode.Boundary:
+                        return Boundary;
+
+                    case RegexNode.ECMABoundary:
+                        return ECMABoundary;
+
+                    case RegexNode.Beginning:
+                        return Beginning;
+
+                    case RegexNode.Start:
+                        return Start;
+
+                    case RegexNode.EndZ:
+                        return EndZ;
+
+                    case RegexNode.End:
+                        return End;
+
                     case RegexNode.Concatenate:
                         if (curNode.ChildCount() > 0)
                         {
@@ -313,27 +337,6 @@ namespace System.Text.RegularExpressions
                         curNode = curNode.Child(0);
                         concatNode = null;
                         continue;
-
-                    case RegexNode.Bol:
-                    case RegexNode.Eol:
-                    case RegexNode.Boundary:
-                    case RegexNode.ECMABoundary:
-                    case RegexNode.Beginning:
-                    case RegexNode.Start:
-                    case RegexNode.EndZ:
-                    case RegexNode.End:
-                        return curNode.Type switch
-                        {
-                            RegexNode.Bol => Bol,
-                            RegexNode.Eol => Eol,
-                            RegexNode.Boundary => Boundary,
-                            RegexNode.ECMABoundary => ECMABoundary,
-                            RegexNode.Beginning => Beginning,
-                            RegexNode.Start => Start,
-                            RegexNode.EndZ => EndZ,
-                            RegexNode.End => End,
-                            _ => 0,
-                        };
 
                     case RegexNode.Empty:
                     case RegexNode.Require:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -170,7 +170,7 @@ namespace System.Text.RegularExpressions
             }
 
             // Compute any anchors starting the expression.
-            int anchors = RegexPrefixAnalyzer.FindLeadingAnchors(tree);
+            int leadingAnchor = RegexPrefixAnalyzer.FindLeadingAnchor(tree);
 
             // Convert the string table into an ordered string array.
             var strings = new string[_stringTable.Count];
@@ -180,7 +180,7 @@ namespace System.Text.RegularExpressions
             }
 
             // Return all that in a RegexCode object.
-            return new RegexCode(tree, emitted, strings, _trackCount, _caps, capsize, boyerMoorePrefix, leadingCharClasses, anchors, rtl);
+            return new RegexCode(tree, emitted, strings, _trackCount, _caps, capsize, boyerMoorePrefix, leadingCharClasses, leadingAnchor, rtl);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -192,6 +192,66 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
+            // Using ^ with multiline
+            yield return new object[]
+            {
+                "^", "", RegexOptions.Multiline,
+                new[] { new CaptureData("", 0, 0) }
+            };
+            yield return new object[]
+            {
+                "^", "\n\n\n", RegexOptions.Multiline,
+                new[]
+                {
+                    new CaptureData("", 0, 0),
+                    new CaptureData("", 1, 0),
+                    new CaptureData("", 2, 0),
+                    new CaptureData("", 3, 0)
+                }
+            };
+            yield return new object[]
+            {
+                "^abc", "abc\nabc \ndef abc \nab\nabc", RegexOptions.Multiline,
+                new[]
+                {
+                    new CaptureData("abc", 0, 3),
+                    new CaptureData("abc", 4, 3),
+                    new CaptureData("abc", 21, 3),
+                }
+            };
+            yield return new object[]
+            {
+                @"^\w{5}", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline,
+                new[]
+                {
+                    new CaptureData("hijkl", 10, 5),
+                }
+            };
+            yield return new object[]
+            {
+                @"^.*$", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline,
+                new[]
+                {
+                    new CaptureData("abc", 0, 3),
+                    new CaptureData("defg", 4, 4),
+                    new CaptureData("", 9, 0),
+                    new CaptureData("hijkl", 10, 5),
+                    new CaptureData("", 16, 0),
+                }
+            };
+            yield return new object[]
+            {
+                @"^.*$", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline | RegexOptions.RightToLeft,
+                new[]
+                {
+                    new CaptureData("", 16, 0),
+                    new CaptureData("hijkl", 10, 5),
+                    new CaptureData("", 9, 0),
+                    new CaptureData("defg", 4, 4),
+                    new CaptureData("abc", 0, 3),
+                }
+            };
+
             if (!PlatformDetection.IsNetFramework)
             {
                 // .NET Framework missing fix in https://github.com/dotnet/runtime/pull/1075


### PR DESCRIPTION
We previously didn't do any special handling of beginning-of-line anchors (`^` when `RegexOptions.Multiline` is specified).  This PR adds special handling for the anchor so that `FindFirstChar` will jump to the next newline as part of its processing.

As part of this, I also cleaned up some of the anchor handling code.  The `RegexPrefixAnalyzer` only ever returns a single anchor, but the rest of the code was written such that it was expecting multiple anchors.

Example:
Finding all lines in Romeo and Juliet that contain the word "love":
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO;
using System.Text.RegularExpressions;

public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly string _input = File.ReadAllText(@"C:\romeojuliet.txt");
    private Regex _regex;

    [Params(false, true)]
    public bool Compiled { get; set; }

    [GlobalSetup]
    public void Setup() => _regex = new Regex(@"^.*\blove\b.*$", RegexOptions.Multiline | (Compiled ? RegexOptions.Compiled : RegexOptions.None));

    [Benchmark]
    public int Count() => _regex.Matches(_input).Count;
}
```

| Method |              Toolchain | Compiled |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|------- |----------------------- |--------- |----------:|----------:|----------:|----------:|------:|--------:|
|  Count | \netcore31\corerun.exe |    False | 21.184 ms | 0.1938 ms | 0.1619 ms | 21.179 ms |  2.15 |    0.05 |
|  Count |    \master\corerun.exe |    False |  9.868 ms | 0.2870 ms | 0.2545 ms |  9.784 ms |  1.00 |    0.00 |
|  Count |        \pr\corerun.exe |    False |  4.436 ms | 0.0482 ms | 0.0428 ms |  4.445 ms |  0.45 |    0.01 |
|        |                        |          |           |           |           |           |       |         |
|  Count | \netcore31\corerun.exe |     True | 16.929 ms | 0.3705 ms | 1.0630 ms | 16.122 ms |  3.96 |    0.23 |
|  Count |    \master\corerun.exe |     True |  4.292 ms | 0.0415 ms | 0.0388 ms |  4.272 ms |  1.00 |    0.00 |
|  Count |        \pr\corerun.exe |     True |  2.167 ms | 0.0045 ms | 0.0040 ms |  2.166 ms |  0.50 |    0.00 |

Contributes to https://github.com/dotnet/runtime/issues/1349
cc: @pgovind, @eerhardt, @ViktorHofer, @danmosemsft 