### PR TITLE
Enable RuntimeIdentifierTests

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -117,8 +117,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             if (osd.Contains("Linux"))
             {
-                // Dump several procfs files
-                foreach (string path in new string[] { "/proc/self/mountinfo", "/proc/self/cgroup", "/proc/self/limits" })
+                // Dump several procfs files and /etc/os-release
+                foreach (string path in new string[] { "/proc/self/mountinfo", "/proc/self/cgroup", "/proc/self/limits", "/etc/os-release" })
                 {
                     Console.WriteLine($"### CONTENTS OF \"{path}\":");
                     try

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -72,7 +72,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             string expectedOSName = File.ReadAllLines("/etc/os-release")
                 .First(line => line.StartsWith("ID=", StringComparison.OrdinalIgnoreCase))
                 .Substring("ID=".Length)
-                .Trim();
+                .Trim('\"', '\'');
 
             Assert.StartsWith(expectedOSName, RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -12,7 +12,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class RuntimeIdentifierTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyOSRid()
         {
             Assert.NotNull(RuntimeInformation.RuntimeIdentifier);
@@ -21,7 +20,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyEnvironmentVariable()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
@@ -63,14 +61,12 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         }
 
         [Fact, PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyWindowsRid()
         {
             Assert.StartsWith("win", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact, PlatformSpecific(TestPlatforms.Linux)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyLinuxRid()
         {
             string expectedOSName = File.ReadAllLines("/etc/os-release")
@@ -82,14 +78,12 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         }
 
         [Fact, PlatformSpecific(TestPlatforms.FreeBSD)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyFreeBSDRid()
         {
             Assert.StartsWith("freebsd", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact, PlatformSpecific(TestPlatforms.OSX)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26780")] // need a new testhost
         public void VerifyOSXRid()
         {
             Assert.StartsWith("osx", RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Now that we have an updated test host, we can enable the RuntimeInformation.RuntimeIdentifier tests that are disabled.

Fix #26780