### PR TITLE
Don't test ANSI any mapping on non en-US locales.

### DIFF
--- a/src/coreclr/tests/src/Interop/PInvoke/AsAny/AsAnyTest.cs
+++ b/src/coreclr/tests/src/Interop/PInvoke/AsAny/AsAnyTest.cs
@@ -339,6 +339,13 @@ class AsAnyTests
 
     private static void RunBestFitMappingTests()
     {
+        if (System.Globalization.CultureInfo.CurrentCulture.Name != "en-US")
+        {
+            Console.WriteLine("Non english platforms are not supported");
+            Console.WriteLine("passing without running tests");
+            return;
+        }
+
         TestAnsiStringBestFitMapping();
         TestAnsiStringBuilder();
         TestAnsiStringArrayBestFitMapping();


### PR DESCRIPTION
Fixes #33925 
/cc @jkoritzinsky @elinor-fung 