### PR TITLE
[meta] Mono ALC embedding primer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -12,8 +12,10 @@ using System.Threading;
 
 namespace System.Runtime.Loader
 {
+    [StructLayout(LayoutKind.Sequential)]
     public partial class AssemblyLoadContext
     {
+        // Keep in sync with MonoManagedAssemblyLoadContextInternalState in object-internals.h
         private enum InternalState
         {
             /// <summary>
@@ -34,6 +36,7 @@ namespace System.Runtime.Loader
 #region private data members
         // If you modify any of these fields, you must also update the
         // AssemblyLoadContextBaseObject structure in object.h
+        // and MonoManagedAssemblyLoadContext in object-internals.h
 
         // synchronization primitive to protect against usage of this instance while unloading
         private readonly object _unloadLock;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -12,7 +12,6 @@ using System.Threading;
 
 namespace System.Runtime.Loader
 {
-    [StructLayout(LayoutKind.Sequential)]
     public partial class AssemblyLoadContext
     {
         // Keep in sync with MonoManagedAssemblyLoadContextInternalState in object-internals.h

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -172,6 +172,14 @@ mono_alc_is_default (MonoAssemblyLoadContext *alc)
 	return alc == mono_alc_domain (alc)->default_alc;
 }
 
+MonoAssemblyLoadContext *
+mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
+{
+	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
+	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
+	return alc;
+}
+
 static MonoAssembly*
 invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, MonoError *error)
 {

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2290,7 +2290,8 @@ mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer 
 	}
 }
 
-void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append)
+void
+mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append)
 {
 	AssemblyPreLoadHook *hook;
 
@@ -2311,7 +2312,6 @@ void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpoi
 		assembly_preload_hook = hook;
 	}
 }
-
 
 static void
 free_assembly_preload_hooks (void)
@@ -4859,7 +4859,7 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 }
 
 MonoAssembly *
-mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoGCHandle alc_gchandle)
+mono_assembly_load_full_alc (MonoGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status)
 {
 	MonoAssembly *res;
 	MONO_ENTER_GC_UNSAFE;

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2286,7 +2286,7 @@ mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer 
 	}
 }
 
-void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data)
+void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append)
 {
 	AssemblyPreLoadHook *hook;
 
@@ -2296,9 +2296,16 @@ void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpoi
 	hook->version = 3;
 	hook->func.v3 = func;
 	hook->user_data = user_data;
-	hook->next = assembly_preload_hook;
 
-	assembly_preload_hook = hook;
+	if (append && assembly_preload_hook != NULL) {
+		AssemblyPreLoadHook *old = assembly_preload_hook;
+		while (old->next != NULL)
+			old = old->next;
+		old->next = hook;
+	} else {
+		hook->next = assembly_preload_hook;
+		assembly_preload_hook = hook;
+	}
 }
 
 

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -45,6 +45,7 @@
 #include <mono/utils/mono-io-portability.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/mono-os-mutex.h>
+#include <mono/metadata/mono-private-unstable.h>
 
 #ifndef HOST_WIN32
 #include <sys/types.h>
@@ -4821,6 +4822,21 @@ mono_assembly_request_byname (MonoAssemblyName *aname, const MonoAssemblyByNameR
 	}
 #endif
 	return result;
+}
+
+MonoAssembly *
+mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoGCHandle alc_gchandle)
+{
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	MonoAssemblyByNameRequest req;
+	MonoAssemblyLoadContext *alc = mono_alc_from_gchandle (alc_gchandle);
+	mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, alc);
+	req.requesting_assembly = NULL;
+	req.basedir = basedir;
+	res = mono_assembly_request_byname (aname, &req, status);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -103,6 +103,9 @@ mono_alc_invoke_resolve_using_resolving_event_nofail (MonoAssemblyLoadContext *a
 MonoAssembly*
 mono_alc_invoke_resolve_using_resolve_satellite_nofail (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname);
 
+MonoAssemblyLoadContext *
+mono_alc_from_gchandle (MonoGCHandle alc_gchandle);
+
 #endif /* ENABLE_NETCORE */
 
 static inline MonoDomain *

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -20,6 +20,6 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoAssemblyLoadContextGCHandle alc_gchandle);
 
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle *alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
-void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data);
+void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);
 
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -17,7 +17,7 @@
 typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 
 MONO_API MONO_RT_EXTERNAL_ONLY
-MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoAssemblyLoadContextGCHandle alc_gchandle);
+MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status);
 
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle *alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
 void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -14,6 +14,9 @@
 
 #include <mono/utils/mono-publib.h>
 
+typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoAssemblyLoadContextGCHandle alc_gchandle);
 
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -19,4 +19,7 @@ typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, MonoAssemblyLoadContextGCHandle alc_gchandle);
 
+typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle *alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
+void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data);
+
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1647,6 +1647,30 @@ typedef struct {
 	MonoProperty *prop;
 } CattrNamedArg;
 
+#ifdef ENABLE_NETCORE
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext.InternalState
+typedef enum {
+	ALIVE = 0,
+	UNLOADING = 1
+} MonoManagedAssemblyLoadContextInternalState;
+
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext
+typedef struct {
+	MonoObject object;
+	MonoObject *unload_lock;
+	MonoEvent *resolving_unmaned_dll;
+	MonoEvent *resolving;
+	MonoEvent *unloading;
+	MonoString *name;
+	gpointer *native_assembly_load_context;
+	gint64 id;
+	gint32 internal_state;
+	MonoBoolean is_collectible;
+} MonoManagedAssemblyLoadContext;
+
+TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
+#endif
+
 /* All MonoInternalThread instances should be pinned, so it's safe to use the raw ptr.  However
  * for uniformity, icall wrapping will make handles anyway.  So this is the method for getting the payload.
  */

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
@@ -10,6 +10,7 @@ using System.Threading;
 
 namespace System.Runtime.Loader
 {
+    [StructLayout(LayoutKind.Sequential)]
     public partial class AssemblyLoadContext
     {
         internal IntPtr NativeALC


### PR DESCRIPTION
After talking with @lambdageek , we decided we wanted the public API for ALCs to just use gchandles instead of a native struct and to handle conversion within the runtime.

This PR takes that approach, exposing the managed ALC fields to the runtime for cheap conversion and adding `mono_assembly_load_full_alc` and preload hook V3 to the unstable headers.

I considered trying to do something fancier with conversion for the preload hook but decided against it in the end; making a V3 that's intended for embedder usage is straightforward and should work fine. When invoking it, we create a new strong gchandle to keep the managed ALC pinned and then free it after the call is done.

I went with `MonoManagedAssemblyLoadContext` instead of `MonoReflectionAssemblyLoadContext` since ALCs aren't really part of reflection, but I have no strong attachment to the name and can change it if preferred to maintain consistency.

cc: @vargaz @mdh1418 @garuma 