### PR TITLE
Fix unsupported instruction set handling in crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2951,7 +2951,7 @@ namespace Internal.JitInterface
                 if (!isMethodDefinedInCoreLib())
 #endif
                 {
-                    _actualInstructionSetSupported.AddInstructionSet(instructionSet);
+                    _actualInstructionSetUnsupported.AddInstructionSet(instructionSet);
                 }
             }
         }


### PR DESCRIPTION
- A refactoring during crossgen2 production in the recent pr broke the unsupported instruction set mode for crossgen
- Tested via manual inspection of the JIT\HardwareIntrinsics\X86\Avx\Sqrt_r test.