### PR TITLE
[WIP] Fixed IndentedTextWriter Behavior

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -45,7 +45,11 @@ namespace System.CodeDom.Compiler
         public int Indent
         {
             get { return _indentLevel; }
-            set { _indentLevel = Math.Max(value, 0); }
+            set
+            {
+                _indentLevel = Math.Max(value, 0);
+                _tabsPending = _indentLevel != 0;
+            }
         }
 
         public TextWriter InnerWriter => _writer;

--- a/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -6,6 +6,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.CodeDom.Compiler
 {
@@ -252,6 +254,48 @@ namespace System.CodeDom.Compiler
         {
             OutputTabs();
             _writer.WriteLine(value);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync()
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync().ConfigureAwait(false);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync(char value)
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync(value).ConfigureAwait(false);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync(string? value)
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync(value).ConfigureAwait(false);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = default)
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync(value, cancellationToken).ConfigureAwait(false);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync(char[] buffer, int index, int count)
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync(buffer, index, count).ConfigureAwait(false);
+            _tabsPending = true;
+        }
+
+        public override async Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            OutputTabs();
+            await _writer.WriteLineAsync(buffer, cancellationToken).ConfigureAwait(false);
             _tabsPending = true;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -45,11 +45,7 @@ namespace System.CodeDom.Compiler
         public int Indent
         {
             get { return _indentLevel; }
-            set
-            {
-                _indentLevel = Math.Max(value, 0);
-                _tabsPending = _indentLevel != 0;
-            }
+            set { _indentLevel = Math.Max(value, 0); }
         }
 
         public TextWriter InnerWriter => _writer;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -693,7 +693,8 @@ namespace System.IO
 
         public virtual Task WriteLineAsync()
         {
-            return WriteAsync(CoreNewLine);
+            return Task.Factory.StartNew(state => ((TextWriter) state!).WriteLine(), this,
+                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public virtual Task FlushAsync()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -693,8 +693,7 @@ namespace System.IO
 
         public virtual Task WriteLineAsync()
         {
-            return Task.Factory.StartNew(state => ((TextWriter) state!).WriteLine(), this,
-                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            return WriteAsync(CoreNewLine);
         }
 
         public virtual Task FlushAsync()


### PR DESCRIPTION
1. implementation of `TextWriter.WriteLineAsync()` corrected The previous implementation differed from the other `TextWriter.*Async` implementations, so that a malfunction with overwritten synchronous methods occurred. As described in #30351.

2. adjustment of the `IndentedTextWriter.Indent` setter, This did not take into account the adjustment of the indent level after executing `writer.Indent++' for example.

Fix #30351