### PR TITLE
Use valid instructions in StubPrecode and NDirectImportPrecode on x64

### DIFF
--- a/src/coreclr/src/vm/i386/stublinkerx86.h
+++ b/src/coreclr/src/vm/i386/stublinkerx86.h
@@ -511,9 +511,9 @@ struct InvalidPrecode {
 struct StubPrecode {
 
 #ifdef HOST_64BIT
-    static const BYTE Type = 0x40;
+    static const BYTE Type = 0xF8;
     // mov r10,pMethodDesc
-    // inc eax
+    // clc
     // jmp Stub
 #else
     static const BYTE Type = 0xED;
@@ -584,9 +584,9 @@ typedef DPTR(StubPrecode) PTR_StubPrecode;
 struct NDirectImportPrecode : StubPrecode {
 
 #ifdef HOST_64BIT
-    static const int Type = 0x48;
+    static const int Type = 0xF9;
     // mov r10,pMethodDesc
-    // dec eax
+    // stc
     // jmp NDirectImportThunk
 #else
     static const int Type = 0xC0;


### PR DESCRIPTION
StubPrecode and NDirectImportPrecode precoded used undefined instruction
encodings on x64 due to copy&paste from x86. Change them to use valid
instructions.