### PR TITLE
Fix IsBlittable flag bug on types.

### DIFF
--- a/src/coreclr/src/vm/classlayoutinfo.cpp
+++ b/src/coreclr/src/vm/classlayoutinfo.cpp
@@ -611,7 +611,6 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     // Set some defaults based on the parent type of this type (if one exists).
     _ASSERTE(!(fHasNonTrivialParent && !(pParentMT->HasLayout())));
 
-    pEEClassLayoutInfoOut->SetIsBlittable(fHasNonTrivialParent ? pParentMT->IsBlittable() : TRUE);
     pEEClassLayoutInfoOut->SetIsZeroSized(FALSE);
     pEEClassLayoutInfoOut->SetHasExplicitSize(FALSE);
     pEEClassLayoutInfoOut->m_cbPackingSize = packingSize;
@@ -663,6 +662,8 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
         DEBUGARG(szName)
         );
 
+    // Type is blittable only if parent is also blittable
+    isBlittable = isBlittable && (fHasNonTrivialParent ? pParentMT->IsBlittable() : TRUE);
     pEEClassLayoutInfoOut->SetIsBlittable(isBlittable);
 
     S_UINT32 cbSortArraySize = S_UINT32(cTotalFields) * S_UINT32(sizeof(LayoutRawFieldInfo*));


### PR DESCRIPTION
The issue is that we are automatically assuming that types are blittable until proven otherwise while traversing the list of fields declared on the type. In the case of a type with no fields, we have to also check if the parent type is blittable, before blindly setting the flag to true (Ex: what if the base type has non-blittable fields?)

Fixes https://github.com/dotnet/runtime/issues/33366