### PR TITLE
Fix various LastIndexOf bugs when dealing with zero-length target substrings

### DIFF
--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -3379,7 +3379,6 @@ namespace System.Tests
             Assert.Equal(2, index);
             Assert.Equal(index, s1.IndexOf(s2, StringComparison.Ordinal));
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.IndexOf(value);
@@ -3396,7 +3395,6 @@ namespace System.Tests
             Assert.Equal(5, index);
             Assert.Equal(index, s1.IndexOf(s2, StringComparison.Ordinal));
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.IndexOf(value);
@@ -3413,7 +3411,6 @@ namespace System.Tests
             Assert.Equal(-1, index);
             Assert.Equal(index, s1.IndexOf(s2, StringComparison.Ordinal));
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.IndexOf(value);
@@ -3887,18 +3884,23 @@ namespace System.Tests
 
             if (value.Length == 0)
             {
-                int expectedIndex = s.Length > 0 ? s.Length - 1 : 0;
-                int expectedStartIndex = startIndex == s.Length ? startIndex - 1 : startIndex;
+                int expectedStartIndex = startIndex;
                 if (s.Length == 0 && (startIndex == -1 || startIndex == 0))
-                    expectedStartIndex = (value.Length == 0) ? 0 : -1;
-                Assert.Equal(expectedIndex, s.LastIndexOf(value, comparison));
+                    expectedStartIndex = 0; // empty string occurs at beginning of search space
+                if (s.Length > 0 && startIndex < s.Length)
+                    expectedStartIndex = startIndex + 1; // empty string occurs just after the last char included in the search space
+
+                Assert.Equal(s.Length, s.LastIndexOf(value, comparison));
                 Assert.Equal(expectedStartIndex, s.LastIndexOf(value, startIndex, comparison));
-                Assert.Equal(expectedIndex, s.AsSpan().LastIndexOf(value.AsSpan(), comparison));
+                Assert.Equal(s.Length, s.AsSpan().LastIndexOf(value.AsSpan(), comparison));
                 return;
             }
 
             if (s.Length == 0)
             {
+                // unit test shouldn't have passed a weightless string to this routine
+                Assert.NotEqual(value, string.Empty, StringComparer.FromComparison(comparison));
+
                 Assert.Equal(-1, s.LastIndexOf(value, comparison));
                 Assert.Equal(-1, s.LastIndexOf(value, startIndex, comparison));
                 Assert.Equal(-1, s.AsSpan().LastIndexOf(value.AsSpan(), comparison));
@@ -4068,8 +4070,8 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData("foo", 2)]
-        [InlineData("hello", 4)]
+        [InlineData("foo", 3)]
+        [InlineData("hello", 5)]
         [InlineData("", 0)]
         public static void LastIndexOf_EmptyString(string s, int expected)
         {
@@ -4325,13 +4327,13 @@ namespace System.Tests
             string s1 = "0172377457778667789";
             string s2 = string.Empty;
             int index = s1.LastIndexOf(s2);
-            Assert.Equal(s1.Length - 1, index);
+            Assert.Equal(s1.Length, index);
 
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -4356,7 +4358,6 @@ namespace System.Tests
             int index = s1.LastIndexOf(s2);
             Assert.Equal(2, index);
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.LastIndexOf(value);
@@ -4371,7 +4372,6 @@ namespace System.Tests
             int index = s1.LastIndexOf(s2);
             Assert.Equal(5, index);
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.LastIndexOf(value);
@@ -4386,7 +4386,6 @@ namespace System.Tests
             int index = s1.LastIndexOf(s2);
             Assert.Equal(5, index);
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.LastIndexOf(value);
@@ -4401,7 +4400,6 @@ namespace System.Tests
             int index = s1.LastIndexOf(s2);
             Assert.Equal(-1, index);
 
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<char> span = s1.AsSpan();
             ReadOnlySpan<char> value = s2.AsSpan();
             index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/ReadOnlySpan/IndexOfSequence.T.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/IndexOfSequence.T.cs
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 2 });
             int index = span.IndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 5 });
             int index = span.IndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 5 });
             int index = span.IndexOf(value);
@@ -205,7 +202,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "2" });
             int index = span.IndexOf(value);
@@ -215,7 +211,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "5" });
             int index = span.IndexOf(value);
@@ -225,7 +220,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" }, 0, 5);
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "5" });
             int index = span.IndexOf(value);

--- a/src/libraries/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/IndexOfSequence.byte.cs
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2 });
             int index = span.IndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
             int index = span.IndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
             int index = span.IndexOf(value);

--- a/src/libraries/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.T.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.T.cs
@@ -74,11 +74,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(Array.Empty<int>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 2 });
             int index = span.LastIndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueMultipleTimes()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 5, 3, 4, 5 });
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -123,7 +120,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<int> span = new ReadOnlySpan<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<int> value = new ReadOnlySpan<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -196,11 +192,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "77", "2", "3", "77", "77", "4", "5", "77", "77", "77", "88", "6", "6", "77", "77", "88", "9" });
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(Array.Empty<string>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -215,7 +211,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "2" });
             int index = span.LastIndexOf(value);
@@ -225,7 +220,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "5" });
             int index = span.LastIndexOf(value);
@@ -235,7 +229,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<string> span = new ReadOnlySpan<string>(new string[] { "0", "1", "2", "3", "4", "5" }, 0, 5);
             ReadOnlySpan<string> value = new ReadOnlySpan<string>(new string[] { "5" });
             int index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.byte.cs
@@ -74,11 +74,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(Array.Empty<byte>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 2 });
             int index = span.LastIndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueMultipleTimes_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 5, 3, 4, 5 });
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);
@@ -123,7 +120,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             ReadOnlySpan<byte> value = new ReadOnlySpan<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/IndexOfSequence.T.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfSequence.T.cs
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             Span<int> value = new Span<int>(new int[] { 2 });
             int index = span.IndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             Span<int> value = new Span<int>(new int[] { 5 });
             int index = span.IndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<int> value = new Span<int>(new int[] { 5 });
             int index = span.IndexOf(value);
@@ -205,7 +202,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             Span<string> value = new Span<string>(new string[] { "2" });
             int index = span.IndexOf(value);
@@ -215,7 +211,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             Span<string> value = new Span<string>(new string[] { "5" });
             int index = span.IndexOf(value);
@@ -225,7 +220,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" }, 0, 5);
             Span<string> value = new Span<string>(new string[] { "5" });
             int index = span.IndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/IndexOfSequence.byte.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfSequence.byte.cs
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 2 });
             int index = span.IndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 5 });
             int index = span.IndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 5 });
             int index = span.IndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/IndexOfSequence.char.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfSequence.char.cs
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValue_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' });
             Span<char> value = new Span<char>(new char[] { '2' });
             int index = span.IndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueAtVeryEnd_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' });
             Span<char> value = new Span<char>(new char[] { '5' });
             int index = span.IndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void IndexOfSequenceLengthOneValueJustPasttVeryEnd_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' }, 0, 5);
             Span<char> value = new Span<char>(new char[] { '5' });
             int index = span.IndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.T.cs
+++ b/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.T.cs
@@ -74,11 +74,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<int> value = new Span<int>(Array.Empty<int>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             Span<int> value = new Span<int>(new int[] { 2 });
             int index = span.LastIndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 });
             Span<int> value = new Span<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueMultipleTimes()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 5, 3, 4, 5 });
             Span<int> value = new Span<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -123,7 +120,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<int> span = new Span<int>(new int[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<int> value = new Span<int>(new int[] { 5 });
             int index = span.LastIndexOf(value);
@@ -196,11 +192,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "77", "2", "3", "77", "77", "4", "5", "77", "77", "77", "88", "6", "6", "77", "77", "88", "9" });
             Span<string> value = new Span<string>(Array.Empty<string>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -215,7 +211,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             Span<string> value = new Span<string>(new string[] { "2" });
             int index = span.LastIndexOf(value);
@@ -225,7 +220,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" });
             Span<string> value = new Span<string>(new string[] { "5" });
             int index = span.LastIndexOf(value);
@@ -235,7 +229,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd_String()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<string> span = new Span<string>(new string[] { "0", "1", "2", "3", "4", "5" }, 0, 5);
             Span<string> value = new Span<string>(new string[] { "5" });
             int index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.byte.cs
+++ b/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.byte.cs
@@ -74,11 +74,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 77, 2, 3, 77, 77, 4, 5, 77, 77, 77, 88, 6, 6, 77, 77, 88, 9 });
             Span<byte> value = new Span<byte>(Array.Empty<byte>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 2 });
             int index = span.LastIndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueMultipleTimes_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 5, 3, 4, 5 });
             Span<byte> value = new Span<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);
@@ -123,7 +120,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd_Byte()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<byte> span = new Span<byte>(new byte[] { 0, 1, 2, 3, 4, 5 }, 0, 5);
             Span<byte> value = new Span<byte>(new byte[] { 5 });
             int index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.char.cs
+++ b/src/libraries/System.Memory/tests/Span/LastIndexOfSequence.char.cs
@@ -74,11 +74,11 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceZeroLengthValue_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
+            // A zero-length value is always "found" at the end of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '7', '2', '3', '7', '7', '4', '5', '7', '7', '7', '8', '6', '6', '7', '7', '8', '9' });
             Span<char> value = new Span<char>(Array.Empty<char>());
             int index = span.LastIndexOf(value);
-            Assert.Equal(0, index);
+            Assert.Equal(span.Length, index);
         }
 
         [Fact]
@@ -93,7 +93,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValue_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' });
             Span<char> value = new Span<char>(new char[] { '2' });
             int index = span.LastIndexOf(value);
@@ -103,7 +102,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueAtVeryEnd_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' });
             Span<char> value = new Span<char>(new char[] { '5' });
             int index = span.LastIndexOf(value);
@@ -113,7 +111,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueMultipleTimes_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '5', '3', '4', '5' });
             Span<char> value = new Span<char>(new char[] { '5' });
             int index = span.LastIndexOf(value);
@@ -123,7 +120,6 @@ namespace System.SpanTests
         [Fact]
         public static void LastIndexOfSequenceLengthOneValueJustPasttVeryEnd_Char()
         {
-            // A zero-length value is always "found" at the start of the span.
             Span<char> span = new Span<char>(new char[] { '0', '1', '2', '3', '4', '5' }, 0, 5);
             Span<char> value = new Span<char>(new char[] { '5' });
             int index = span.LastIndexOf(value);

--- a/src/libraries/System.Memory/tests/TestHelpers.cs
+++ b/src/libraries/System.Memory/tests/TestHelpers.cs
@@ -505,12 +505,12 @@ namespace System
         {
             { new string[] { "1", null, "2" }, new string[] { "1", null, "2" }, 0},
             { new string[] { "1", null, "2" }, new string[] { null }, 1},
-            { new string[] { "1", null, "2" }, (string[])null, 0},
+            { new string[] { "1", null, "2" }, (string[])null, 3},
 
             { new string[] { "1", "3", "1" }, new string[] { "1", null, "2" }, -1},
             { new string[] { "1", "3", "1" }, new string[] { "1" }, 2},
             { new string[] { "1", "3", "1" }, new string[] { null }, -1},
-            { new string[] { "1", "3", "1" }, (string[])null, 0},
+            { new string[] { "1", "3", "1" }, (string[])null, 3},
 
             { null, new string[] { "1", null, "2" }, -1},
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Invariant.cs
@@ -40,9 +40,9 @@ namespace System.Globalization
             }
         }
 
-        internal static unsafe int InvariantLastIndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
+        private static unsafe int InvariantLastIndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(value != null);
             Debug.Assert(startIndex >= 0 && startIndex < source.Length);
 
@@ -73,7 +73,7 @@ namespace System.Globalization
 
             if (valueCount == 0)
             {
-                return fromBeginning ? 0 : sourceCount - 1;
+                return fromBeginning ? 0 : sourceCount;
             }
 
             if (sourceCount < valueCount)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Unix.cs
@@ -465,9 +465,12 @@ namespace System.Globalization
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
 
+            // startIndex points to the final char to include in the search space.
+            // empty target strings trivially occur at the end of the search space.
+
             if (target.Length == 0)
             {
-                return startIndex;
+                return startIndex + 1;
             }
 
             if (options == CompareOptions.Ordinal)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Windows.cs
@@ -369,11 +369,15 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
+            Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
 
+            // startIndex points to the final char to include in the search space.
+            // empty target strings trivially occur at the end of the search space.
+
             if (target.Length == 0)
-                return startIndex;
+                return startIndex + 1;
 
             if ((options & CompareOptions.Ordinal) != 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -1336,10 +1336,10 @@ namespace System.Globalization
                     count--;
                 }
 
-                // If we are looking for nothing, just return 0
+                // empty substrings trivially occur at the end of the search space
                 if (value.Length == 0 && count >= 0 && startIndex - count + 1 >= 0)
                 {
-                    return startIndex;
+                    return startIndex + 1;
                 }
             }
 
@@ -1360,9 +1360,9 @@ namespace System.Globalization
             return LastIndexOfCore(source, value, startIndex, count, options);
         }
 
-        internal static int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
+        private static int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(value != null);
 
             if (GlobalizationMode.Invariant)
@@ -1377,7 +1377,7 @@ namespace System.Globalization
 
             if (value.Length == 0)
             {
-                return Math.Max(0, startIndex - count + 1);
+                return startIndex + 1; // startIndex is the index of the last char to include in the search space
             }
 
             if (count == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
@@ -142,7 +142,7 @@ namespace System
 
             if (value.Length == 0)
             {
-                return 0;
+                return 0; // empty substring trivially occurs at every index (including start) of search space
             }
 
             if (span.Length == 0)
@@ -192,7 +192,7 @@ namespace System
 
             if (value.Length == 0)
             {
-                return span.Length > 0 ? span.Length - 1 : 0;
+                return span.Length; // empty substring trivially occurs at every index (including end) of search space
             }
 
             if (span.Length == 0)
@@ -337,7 +337,7 @@ namespace System
 
             if (value.Length == 0)
             {
-                return true;
+                return true; // the empty string is trivially a suffix of every other string
             }
 
             if (comparisonType >= StringComparison.Ordinal || GlobalizationMode.Invariant)
@@ -370,7 +370,7 @@ namespace System
 
             if (value.Length == 0)
             {
-                return true;
+                return true; // the empty string is trivially a prefix of every other string
             }
 
             if (comparisonType >= StringComparison.Ordinal || GlobalizationMode.Invariant)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -430,7 +430,7 @@ namespace System
             Debug.Assert(valueLength >= 0);
 
             if (valueLength == 0)
-                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+                return searchSpaceLength;  // A zero-length sequence is always treated as "found" at the end of the search space.
 
             byte valueHead = value;
             ref byte valueTail = ref Unsafe.Add(ref value, 1);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -441,7 +441,7 @@ namespace System
             Debug.Assert(valueLength >= 0);
 
             if (valueLength == 0)
-                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+                return searchSpaceLength;  // A zero-length sequence is always treated as "found" at the end of the search space.
 
             T valueHead = value;
             ref T valueTail = ref Unsafe.Add(ref value, 1);

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -929,5 +929,16 @@ namespace System
 
             return (CompareOptions)((int)comparisonType & (int)CompareOptions.IgnoreCase);
         }
+
+        private static CompareOptions GetCompareOptionsFromOrdinalStringComparison(StringComparison comparisonType)
+        {
+            Debug.Assert(comparisonType == StringComparison.Ordinal || comparisonType == StringComparison.OrdinalIgnoreCase);
+
+            // StringComparison.Ordinal (0x04) --> CompareOptions.Ordinal (0x4000_0000)
+            // StringComparison.OrdinalIgnoreCase (0x05) -> CompareOptions.OrdinalIgnoreCase (0x1000_0000)
+
+            int ct = (int)comparisonType;
+            return (CompareOptions)((ct & -ct) << 28); // neg and shl
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -219,6 +219,85 @@ namespace System
             charMap[value & PROBABILISTICMAP_BLOCK_INDEX_MASK] |= 1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
         }
 
+       /*
+        * IndexOf, LastIndexOf, Contains, StartsWith, and EndsWith
+        * ========================================================
+        *
+        * Given a search string 'searchString', a target string 'value' to locate within the search string, and a comparer
+        * 'comparer', the comparer will return a set S of tuples '(startPos, endPos)' for which the below expression
+        * returns true:
+        *
+        * >> bool result = searchString.Substring(startPos, endPos - startPos).Equals(value, comparer);
+        *
+        * If the set S is empty (i.e., there is no combination of values 'startPos' and 'endPos' which makes the
+        * above expression evaluate to true), then we say "'searchString' does not contain 'value'", and the expression
+        * "searchString.Contains(value, comparer)" should evaluate to false. If the set S is non-empty, then we say
+        * "'searchString' contains 'value'", and the expression "searchString.Contains(value, comparer)" should
+        * evaluate to true.
+        *
+        * Given a 'searchString', 'value', and 'comparer', the behavior of the IndexOf method is that it finds the
+        * smallest possible 'endPos' for which there exists any corresponding 'startPos' which makes the above
+        * expression evaluate to true, then it returns any 'startPos' within that subset. For example:
+        *
+        * let searchString = "<ZWJ><ZWJ>hihi" (where <ZWJ> = U+200D ZERO WIDTH JOINER, a weightless code point)
+        * let value = "hi"
+        * let comparer = a linguistic culture-invariant comparer (e.g., StringComparison.InvariantCulture)
+        * then S = { (0, 4), (1, 4), (2, 4), (4, 6) }
+        * so the expression "<ZWJ><ZWJ>hihi".IndexOf("hi", comparer) can evaluate to any of { 0, 1, 2 }.
+        *
+        * n.b. ordinal comparers (e.g., StringComparison.Ordinal and StringComparison.OrdinalIgnoreCase) do not
+        * exhibit this ambiguity, as any given 'startPos' or 'endPos' will appear at most exactly once across
+        * all entries from set S. With the above example, S = { (2, 4), (4, 6) }, so IndexOf = 2 unambiguously.
+        *
+        * There exists a relationship between IndexOf and StartsWith. If there exists in set S any entry with
+        * the tuple values (startPos = 0, endPos = <anything>), we say "'searchString' starts with 'value'", and
+        * the expression "searchString.StartsWith(value, comparer)" should evaluate to true. If there exists
+        * no such entry in set S, then we say "'searchString' does not start with 'value'", and the expression
+        * "searchString.StartsWith(value, comparer)" should evaluate to false.
+        *
+        * LastIndexOf and EndsWith have a similar relationship as IndexOf and StartsWith. The behavior of the
+        * LastIndexOf method is that it finds the largest possible 'endPos' for which there exists any corresponding
+        * 'startPos' which makes the expression evaluate to true, then it returns any 'startPos' within that
+        * subset. For example:
+        *
+        * let searchString = "hi<ZWJ><ZWJ>hi" (this is slightly modified from the earlier example)
+        * let value = "hi"
+        * let comparer = StringComparison.InvariantCulture
+        * then S = { (0, 2), (0, 3), (0, 4), (2, 6), (3, 6), (4, 6) }
+        * so the expression "hi<ZWJ><ZWJ>hi".LastIndexOf("hi", comparer) can evaluate to any of { 2, 3, 4 }.
+        *
+        * If there exists in set S any entry with the tuple values (startPos = <anything>, endPos = searchString.Length),
+        * we say "'searchString' ends with 'value'", and the expression "searchString.EndsWith(value, comparer)"
+        * should evaluate to true. If there exists no such entry in set S, then we say "'searchString' does not
+        * start with 'value'", and the expression "searchString.EndsWith(value, comparer)" should evaluate to false.
+        *
+        * There are overloads of IndexOf and LastIndexOf which take an offset and length in order to constrain the
+        * search space to a substring of the original search string.
+        *
+        * For LastIndexOf specifially, overloads which take a 'startIndex' and 'count' behave differently
+        * than their IndexOf counterparts. 'startIndex' is the index of the last char element that should
+        * be considered when performing the search. For example, if startIndex = 4, then the caller is
+        * indicating "when finding the match I want you to include the char element at index 4, but not
+        * any char elements past that point."
+        *
+        *                        idx = 0123456 ("abcdefg".Length = 7)
+        * So, if the search string is "abcdefg", startIndex = 5 and count = 3, then the search space will
+        *                                 ~~~    be the substring "def", as highlighted to the left.
+        * Essentially: "the search space should be of length 3 chars and should end *just after* the char
+        * element at index 5."
+        *
+        * Since this behavior can introduce off-by-one errors in the boundary cases, we allow startIndex = -1
+        * with a zero-length 'searchString' (treated as equivalent to startIndex = 0), and we allow
+        * startIndex = searchString.Length (treated as equivalent to startIndex = searchString.Length - 1).
+        *
+        * Note also that this behavior can introduce errors when dealing with UTF-16 surrogate pairs.
+        * If the search string is the 3 chars "[BMP][HI][LO]", startIndex = 1 and count = 2, then the
+        *                                      ~~~~~~~~~       search space wil be the substring "[BMP][ HI]".
+        * This means that the char [HI] is incorrectly seen as a standalone high surrogate, which could
+        * lead to incorrect matching behavior, or it could cause LastIndexOf to incorrectly report that
+        * a zero-weight character could appear between the [HI] and [LO] chars.
+        */
+
         public int IndexOf(string value)
         {
             return IndexOf(value, StringComparison.CurrentCulture);
@@ -439,32 +518,7 @@ namespace System
 
         public int LastIndexOf(string value, int startIndex, int count, StringComparison comparisonType)
         {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            // Special case for 0 length input strings
-            if (this.Length == 0 && (startIndex == -1 || startIndex == 0))
-                return (value.Length == 0) ? 0 : -1;
-
-            // Now after handling empty strings, make sure we're not out of range
-            if (startIndex < 0 || startIndex > this.Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
-
-            // Make sure that we allow startIndex == this.Length
-            if (startIndex == this.Length)
-            {
-                startIndex--;
-                if (count > 0)
-                    count--;
-            }
-
-            // 2nd half of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
-            if (count < 0 || startIndex - count + 1 < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
-
-            // If we are looking for nothing, just return startIndex
-            if (value.Length == 0)
-                return startIndex;
+            // Parameter checking will be done by CompareInfo.LastIndexOf.
 
             switch (comparisonType)
             {
@@ -478,10 +532,12 @@ namespace System
 
                 case StringComparison.Ordinal:
                 case StringComparison.OrdinalIgnoreCase:
-                    return CompareInfo.LastIndexOfOrdinal(this, value, startIndex, count, GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);
+                    return CompareInfo.Invariant.LastIndexOf(this, value, startIndex, count, GetCompareOptionsFromOrdinalStringComparison(comparisonType));
 
                 default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
+                    throw (value is null)
+                        ? new ArgumentNullException(nameof(value))
+                        : new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/13382.
Fixes https://github.com/dotnet/runtime/issues/13383.

`string.LastIndexOf` and `MemoryExtensions.LastIndexOf` are inconsistent with how they handle zero-length target strings with various `StringComparison` arguments. In some cases they return `string.Length - 1`. In some cases they return `span.Length`. And in some cases they return `0`.

This PR normalizes the behavior of all of these APIs so that a zero-length target substring is always found at the end of the search space. Since `LastIndexOf`'s parameters vary significantly from `IndexOf`'s parameters, I also included a code comment right in front of `string.IndexOf(string)` that explains the concept of "search space" vis-à-vis this particular API.

There's also some small comment cleanup throughout the code paths which deal with these checks.

This PR was extracted from https://github.com/dotnet/runtime/pull/1514 into its own standalone review. This PR addresses only `LastIndexOf` and doesn't address the zero-weight code point issue tracked by that PR.