### PR TITLE
[mono] Use HostArch as a default TargetArchitecture

### DIFF
--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -7,7 +7,7 @@
   <!-- Set default Platform -->
   <PropertyGroup>
     <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</HostArch>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(HostArch)</TargetArchitecture>
     <Platform>$(TargetArchitecture)</Platform>
 
     <PlatformConfigPathPart>$(TargetOS).$(Platform).$(Configuration)</PlatformConfigPathPart>


### PR DESCRIPTION
Use $(HostArch) as a default $(TargetArchitecture) if it's not set
Currently when I use our Makefile scripts on arm it defaults to x64.