### PR TITLE
Add back support for Delegate field marshaling

### DIFF
--- a/src/coreclr/src/vm/comdelegate.cpp
+++ b/src/coreclr/src/vm/comdelegate.cpp
@@ -1315,13 +1315,10 @@ OBJECTREF COMDelegate::ConvertToDelegate(LPVOID pCallback, MethodTable* pMT)
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
+        PRECONDITION(pCallback != NULL);
+        PRECONDITION(pMT != NULL);
     }
     CONTRACTL_END;
-
-    if (!pCallback)
-    {
-        return NULL;
-    }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Check if this callback was originally a managed method passed out to unmanaged code.
@@ -1358,6 +1355,9 @@ OBJECTREF COMDelegate::ConvertToDelegate(LPVOID pCallback, MethodTable* pMT)
         return pDelegate;
     }
 
+    // Validate the MethodTable is a delegate type
+    if (!pMT->IsDelegate())
+        COMPlusThrow(kArgumentException);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // This is an unmanaged callsite. We need to create a new delegate.

--- a/src/coreclr/src/vm/mscorlib.h
+++ b/src/coreclr/src/vm/mscorlib.h
@@ -497,8 +497,10 @@ DEFINE_CLASS(MARSHAL,               Interop,                Marshal)
 #ifdef FEATURE_COMINTEROP
 DEFINE_METHOD(MARSHAL,              GET_HR_FOR_EXCEPTION,              GetHRForException,             SM_Exception_RetInt)
 #endif // FEATURE_COMINTEROP
-DEFINE_METHOD(MARSHAL,              GET_FUNCTION_POINTER_FOR_DELEGATE, GetFunctionPointerForDelegate, SM_Delegate_RetIntPtr)
-DEFINE_METHOD(MARSHAL,              GET_DELEGATE_FOR_FUNCTION_POINTER, GetDelegateForFunctionPointer, SM_IntPtr_Type_RetDelegate)
+DEFINE_METHOD(MARSHAL,              GET_FUNCTION_POINTER_FOR_DELEGATE,          GetFunctionPointerForDelegate,          SM_Delegate_RetIntPtr)
+DEFINE_METHOD(MARSHAL,              GET_DELEGATE_FOR_FUNCTION_POINTER,          GetDelegateForFunctionPointer,          SM_IntPtr_Type_RetDelegate)
+DEFINE_METHOD(MARSHAL,              GET_DELEGATE_FOR_FUNCTION_POINTER_INTERNAL, GetDelegateForFunctionPointerInternal,  SM_IntPtr_Type_RetDelegate)
+
 DEFINE_METHOD(MARSHAL,              ALLOC_CO_TASK_MEM,                 AllocCoTaskMem,                SM_Int_RetIntPtr)
 DEFINE_METHOD(MARSHAL,              FREE_CO_TASK_MEM,                  FreeCoTaskMem,                 SM_IntPtr_RetVoid)
 DEFINE_FIELD(MARSHAL,               SYSTEM_MAX_DBCS_CHAR_SIZE,         SystemMaxDBCSCharSize)

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -1280,7 +1280,7 @@ namespace
 
 extern "C" DLL_EXPORT void* STDMETHODCALLTYPE GetNativeIntIntFunction()
 {
-    return &IntIntImpl;
+    return (void*)&IntIntImpl;
 }
 
 extern "C" DLL_EXPORT void STDMETHODCALLTYPE MarshalStructAsParam_DelegateFieldMarshaling(DelegateFieldMarshaling* d)

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -1262,3 +1262,28 @@ extern "C" DLL_EXPORT MultipleBools STDMETHODCALLTYPE GetBools(BOOL b1, BOOL b2)
 {
     return {b1, b2};
 }
+
+using IntIntDelegate = int (STDMETHODCALLTYPE*)(int a);
+
+struct DelegateFieldMarshaling
+{
+    IntIntDelegate IntIntFunction;
+};
+
+namespace
+{
+    int STDMETHODCALLTYPE IntIntImpl(int a)
+    {
+        return a;
+    }
+}
+
+extern "C" DLL_EXPORT void* STDMETHODCALLTYPE GetNativeIntIntFunction()
+{
+    return &IntIntImpl;
+}
+
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE MarshalStructAsParam_DelegateFieldMarshaling(DelegateFieldMarshaling* d)
+{
+    // Nothing to do
+}

--- a/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/Struct.cs
+++ b/src/coreclr/tests/src/Interop/StructMarshalling/PInvoke/Struct.cs
@@ -495,3 +495,11 @@ public struct UnicodeCharArrayClassification
     public char[] arr;
     public float f;
 }
+
+delegate int IntIntDelegate(int a);
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DelegateFieldMarshaling
+{
+    public Delegate IntIntFunction;
+}


### PR DESCRIPTION
Block route trip of native function pointer as `Delegate` field.
Add tests for scenario.

Fixes https://github.com/dotnet/runtime/issues/33919 #34584

/cc @jkoritzinsky @elinor-fung 