### PR TITLE
CoreCLR product build should depend on CoreLib build

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -40,6 +40,8 @@ jobs:
       name: ${{ format('coreclr_product_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('CoreCLR Product Build {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 
+    dependsOn: ${{ format('coreclr_corelib_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, 'release') }}
+
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml
     container: ${{ parameters.container }}


### PR DESCRIPTION
In my private testing I noticed that the CoreCLR product build jobs
start even before the corresponding CoreLib jobs finished. I believe
this is a bug as CoreCLR product build job still Crossgens CoreLib
so it needs it as a prerequisite.

Thanks

Tomas