### PR TITLE
[CBOR] Implement Write/ReadEncodedValue() methods

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -158,5 +158,98 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 reader.ReadEndMap();
             }
         }
+
+        public static string[] SampleCborValues =>
+            new[]
+            {
+                // numeric values
+                "01",
+                "37",
+                "3818",
+                "1818",
+                "190100",
+                "390100",
+                "1a000f4240",
+                "3affffffff",
+                // byte strings
+                "40",
+                "4401020304",
+                "5f41ab40ff",
+                // text strings
+                "60",
+                "6161",
+                "6449455446",
+                "7f62616260ff",
+                // Arrays
+                "80",
+                "840120604107",
+                "8301820203820405",
+                "9f182aff",
+                // Maps
+                "a0",
+                "a201020304",
+                "a1a1617802182a",
+                "bf01020304ff",
+                // tagged values
+                "c202",
+                "d82076687474703a2f2f7777772e6578616d706c652e636f6d",
+                // special values
+                "f4",
+                "f6",
+                "fa47c35000",
+            };
+
+        public static string[] InvalidCborValues =>
+            new[]
+            {
+                "",
+                // numeric types with missing bytes
+                "18",
+                "19ff",
+                "1affffff",
+                "1bffffffffffffff",
+                "38",
+                "39ff",
+                "3affffff",
+                "3bffffffffffffff",
+                // definite-length strings with missing bytes
+                "41",
+                "4201",
+                "61",
+                "6261",
+                // indefinite-length strings with missing break byte
+                "5f41ab40",
+                "7f62616260",
+                // definite-length arrays with missing elements
+                "81",
+                "8201",
+                // definite-length maps with missing fields
+                "a1",
+                "a20102",
+                // maps with odd number of elements
+                "a101",
+                "a2010203",
+                "bf01ff",
+                // indefinite-length collections with missing break byte
+                "9f",
+                "9f01",
+                "bf",
+                "bf0102",
+                // tags missing data
+                "d8",
+                "d9ff",
+                "daffffff",
+                "daffffffffff",
+                // valid tag not followed by value
+                "c2",
+                // floats missing data
+                "f9ff",
+                "faffffff",
+                "fbffffffffffffff",
+                // special value missing data
+                "f8",
+                // invalid special value
+                "f81f",
+            };
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -217,6 +217,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 "4201",
                 "61",
                 "6261",
+                // invalid utf8 strings
+                "61ff",
+                "62f090",
                 // indefinite-length strings with missing break byte
                 "5f41ab40",
                 "7f62616260",

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     public partial class CborReaderTests
     {
         [Theory]
-        [MemberData(nameof(SampleValues))]
+        [MemberData(nameof(SkipTestInputs))]
         public static void SkipValue_RootValue_HappyPath(string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [MemberData(nameof(SampleValues))]
+        [MemberData(nameof(SkipTestInputs))]
         public static void SkipValue_NestedValue_HappyPath(string hexEncoding)
         {
             byte[] encoding = $"8301{hexEncoding}03".HexToByteArray();
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [MemberData(nameof(SampleValues))]
+        [MemberData(nameof(SkipTestInputs))]
         public static void SkipValue_TaggedValue_HappyPath(string hexEncoding)
         {
             byte[] encoding = $"c2{hexEncoding}".HexToByteArray();
@@ -63,11 +63,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData("")]
-        [InlineData("ff")]
-        [InlineData("c2")]
-        [InlineData("bf01ff")]
-        [InlineData("7f01ff")]
+        [MemberData(nameof(SkipTestInvalidCborInputs))]
         public static void SkipValue_InvalidFormat_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();
@@ -104,39 +100,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(CborReaderState.Finished, reader.Peek());
         }
 
-        public static IEnumerable<object[]> SampleValues =>
-            new string[]
-            {
-                // numeric values
-                "01",
-                "1a000f4240",
-                "3affffffff",
-                // byte strings
-                "40",
-                "4401020304",
-                "5f41ab40ff",
-                // text strings
-                "60",
-                "6161",
-                "6449455446",
-                "7f62616260ff",
-                // Arrays
-                "80",
-                "840120604107",
-                "8301820203820405",
-                "9f182aff",
-                // Maps
-                "a0",
-                "a201020304",
-                "a1a1617802182a",
-                "bf01020304ff",
-                // tagged values
-                "c202",
-                "d82076687474703a2f2f7777772e6578616d706c652e636f6d",
-                // special values
-                "f4",
-                "f6",
-                "fa47c35000",
-            }.Select(x => new object[] { x });
+        public static IEnumerable<object[]> SkipTestInputs => SampleCborValues.Select(x => new [] { x });
+        public static IEnumerable<object[]> SkipTestInvalidCborInputs => InvalidCborValues.Select(x => new[] { x });
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -73,17 +73,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData("61ff")]
-        [InlineData("62f090")]
-        public static void SkipValue_InvalidUtf8_ShouldDecoderFallbackException(string hexEncoding)
-        {
-            byte[] encoding = hexEncoding.HexToByteArray();
-            var reader = new CborReader(encoding);
-
-            Assert.Throws<DecoderFallbackException>(() => reader.SkipValue());
-        }
-
-        [Theory]
         [InlineData(50_000)]
         public static void SkipValue_ExtremelyNestedValues_ShouldNotStackOverflow(int depth)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -73,6 +73,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData("61ff")]
+        [InlineData("62f090")]
+        public static void SkipValue_InvalidUtf8_ShouldThrowFormatException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+
+            FormatException exn = Assert.Throws<FormatException>(() => reader.SkipValue());
+            Assert.NotNull(exn.InnerException);
+            Assert.IsType<DecoderFallbackException>(exn.InnerException);
+        }
+
+        [Theory]
         [InlineData(50_000)]
         public static void SkipValue_ExtremelyNestedValues_ShouldNotStackOverflow(int depth)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -486,23 +486,23 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Theory]
         [InlineData("61ff")]
         [InlineData("62f090")]
-        public static void ReadTextString_InvalidUnicode_ShouldThrowDecoderFallbackException(string hexEncoding)
+        public static void ReadTextString_InvalidUnicode_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
-            Assert.Throws<System.Text.DecoderFallbackException>(() => reader.ReadTextString());
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
         }
 
         [Theory]
         [InlineData("61ff")]
         [InlineData("62f090")]
-        public static void TryReadTextString_InvalidUnicode_ShouldThrowDecoderFallbackException(string hexEncoding)
+        public static void TryReadTextString_InvalidUnicode_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] data = hexEncoding.HexToByteArray();
             char[] buffer = new char[32];
             var reader = new CborReader(data);
 
-            Assert.Throws<System.Text.DecoderFallbackException>(() => reader.TryReadTextString(buffer, out int _));
+            Assert.Throws<FormatException>(() => reader.TryReadTextString(buffer, out int _));
         }
 
         [Fact]
@@ -614,7 +614,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Fact]
-        public static void ReadTextString_IndefiniteLengthConcatenated_InvalidUtf8Chunks_ShouldThrowDecoderFallbackException()
+        public static void ReadTextString_IndefiniteLengthConcatenated_InvalidUtf8Chunks_ShouldThrowFormatException()
         {
             // while the concatenated string is valid utf8, the individual chunks are not,
             // which is in violation of the CBOR format.
@@ -622,7 +622,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             string hexEncoding = "7f62f090628591ff";
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
-            Assert.Throws<DecoderFallbackException>(() => reader.ReadTextString());
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -490,7 +490,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             byte[] data = hexEncoding.HexToByteArray();
             var reader = new CborReader(data);
-            Assert.Throws<FormatException>(() => reader.ReadTextString());
+            FormatException exn = Assert.Throws<FormatException>(() => reader.ReadTextString());
+            Assert.NotNull(exn.InnerException);
+            Assert.IsType<System.Text.DecoderFallbackException>(exn.InnerException);
         }
 
         [Theory]
@@ -502,7 +504,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             char[] buffer = new char[32];
             var reader = new CborReader(data);
 
-            Assert.Throws<FormatException>(() => reader.TryReadTextString(buffer, out int _));
+            FormatException exn = Assert.Throws<FormatException>(() => reader.TryReadTextString(buffer, out int _));
+            Assert.NotNull(exn.InnerException);
+            Assert.IsType<System.Text.DecoderFallbackException>(exn.InnerException);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Test.Cryptography;
 using Xunit;
 
@@ -74,5 +76,44 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(CborReaderState.Finished, reader.Peek());
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
         }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInputs))]
+        public static void ReadEncodedValue_RootValue_HappyPath(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+
+            byte[] encodedValue = reader.ReadEncodedValue().ToArray();
+            Assert.Equal(hexEncoding, encodedValue.ByteArrayToHex().ToLower());
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInputs))]
+        public static void ReadEncodedValue_NestedValue_HappyPath(string hexEncoding)
+        {
+            byte[] encoding = $"8301{hexEncoding}60".HexToByteArray();
+
+            var reader = new CborReader(encoding);
+
+            reader.ReadStartArray();
+            reader.ReadInt64();
+            byte[] encodedValue = reader.ReadEncodedValue().ToArray();
+
+            Assert.Equal(hexEncoding, encodedValue.ByteArrayToHex().ToLower());
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInvalidInputs))]
+        public static void ReadEncodedValue_InvalidCbor_ShouldThrowFormatException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+
+            Assert.Throws<FormatException>(() => reader.ReadEncodedValue());
+        }
+
+        public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new[] { x });
+        public static IEnumerable<object[]> EncodedValueInvalidInputs => CborReaderTests.InvalidCborValues.Select(x => new[] { x });
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -77,7 +77,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             // NB Xunit's InlineDataAttribute will corrupt string literals containing invalid unicode
             string invalidUnicodeString = "\ud800";
             using var writer = new CborWriter();
-            Assert.Throws<ArgumentException>(() => writer.WriteTextString(invalidUnicodeString));
+            ArgumentException exn = Assert.Throws<ArgumentException>(() => writer.WriteTextString(invalidUnicodeString));
+            Assert.NotNull(exn.InnerException);
+            Assert.IsType<System.Text.EncoderFallbackException>(exn.InnerException);
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -72,12 +72,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Fact]
-        public static void WriteTextString_InvalidUnicodeString_ShouldThrowEncoderFallbackException()
+        public static void WriteTextString_InvalidUnicodeString_ShouldThrowArgumentException()
         {
             // NB Xunit's InlineDataAttribute will corrupt string literals containing invalid unicode
             string invalidUnicodeString = "\ud800";
             using var writer = new CborWriter();
-            Assert.Throws<System.Text.EncoderFallbackException>(() => writer.WriteTextString(invalidUnicodeString));
+            Assert.Throws<ArgumentException>(() => writer.WriteTextString(invalidUnicodeString));
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -70,7 +71,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             int length = checked((int)ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + length);
             ReadOnlySpan<byte> encodedString = _buffer.Span.Slice(1 + additionalBytes, length);
-            string result = s_utf8Encoding.GetString(encodedString);
+
+            string result;
+            try
+            {
+                result = s_utf8Encoding.GetString(encodedString);
+            }
+            catch (DecoderFallbackException e)
+            {
+                throw new FormatException("Text string payload is not a valid UTF8 string.", e);
+            }
+
             AdvanceBuffer(1 + additionalBytes + length);
             AdvanceDataItemCounters();
             return result;
@@ -89,7 +100,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             EnsureBuffer(1 + additionalBytes + byteLength);
 
             ReadOnlySpan<byte> encodedSlice = _buffer.Span.Slice(1 + additionalBytes, byteLength);
-            int charLength = s_utf8Encoding.GetCharCount(encodedSlice);
+
+            int charLength = ValidateUtf8AndGetCharCount(encodedSlice);
+
             if (charLength > destination.Length)
             {
                 charsWritten = 0;
@@ -180,7 +193,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             int concatenatedStringSize = 0;
             foreach ((int o, int l) in ranges)
             {
-                concatenatedStringSize += s_utf8Encoding.GetCharCount(buffer.Slice(o, l));
+                concatenatedStringSize += ValidateUtf8AndGetCharCount(buffer.Slice(o, l));
             }
 
             if (concatenatedStringSize > destination.Length)
@@ -231,7 +244,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             foreach ((int o, int l) in ranges)
             {
-                concatenatedStringSize += s_utf8Encoding.GetCharCount(buffer.Slice(o, l));
+                concatenatedStringSize += ValidateUtf8AndGetCharCount(buffer.Slice(o, l));
             }
 
             string output = string.Create(concatenatedStringSize, (ranges, _buffer), BuildString);
@@ -310,11 +323,23 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             if (type == CborMajorType.TextString)
             {
                 ReadOnlySpan<byte> encodedSlice = buffer.Slice(1 + additionalBytes, byteLength);
-                s_utf8Encoding.GetCharCount(encodedSlice);
+                ValidateUtf8AndGetCharCount(encodedSlice);
             }
 
             AdvanceBuffer(1 + additionalBytes + byteLength);
             AdvanceDataItemCounters();
+        }
+
+        private int ValidateUtf8AndGetCharCount(ReadOnlySpan<byte> buffer)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(buffer);
+            }
+            catch (DecoderFallbackException e)
+            {
+                throw new FormatException("Text string payload is not a valid UTF8 string.", e);
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -174,6 +174,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
+        public ReadOnlyMemory<byte> ReadEncodedValue()
+        {
+            // keep a snapshot of the initial buffer state
+            ReadOnlyMemory<byte> initialBuffer = _buffer;
+            int initialBytesRead = _bytesRead;
+
+            // call skip to read and validate the next value
+            SkipValue();
+
+            // return the slice corresponding to the consumed value
+            return initialBuffer.Slice(0, _bytesRead - initialBytesRead);
+        }
+
         private CborInitialByte PeekInitialByte()
         {
             if (_remainingDataItems == 0)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -25,7 +25,16 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Implements major type 3 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
         public void WriteTextString(ReadOnlySpan<char> value)
         {
-            int length = s_utf8Encoding.GetByteCount(value);
+            int length;
+            try
+            {
+                length = s_utf8Encoding.GetByteCount(value);
+            }
+            catch (EncoderFallbackException e)
+            {
+                throw new ArgumentException("Provided text string is not valid UTF8.", e);
+            }
+
             WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);
             EnsureWriteCapacity(length);
             s_utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset));


### PR DESCRIPTION
Contributes to #32046 and #32047.

I've also made changes related to wrapping utf8 string related `EncoderFallbackException`'s and `DecoderFallbackException`s with `ArgumentException` and `FormatException` respectively.