### PR TITLE
Test build target agnostic separately from target specific tests

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -165,6 +165,10 @@ initDistroRidGlobal()
                 distroRid="android-$buildArch"
             elif [ "$targetOs" = "FreeBSD" ]; then
                 distroRid="freebsd-$buildArch"
+            elif [ "$targetOs" = "AnyOS" ]; then
+                if [ "$buildArch" = "AnyCPU" ]; then
+                    distroRid="any"
+                fi
             fi
         fi
 

--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -165,10 +165,6 @@ initDistroRidGlobal()
                 distroRid="android-$buildArch"
             elif [ "$targetOs" = "FreeBSD" ]; then
                 distroRid="freebsd-$buildArch"
-            elif [ "$targetOs" = "AnyOS" ]; then
-                if [ "$buildArch" = "AnyCPU" ]; then
-                    distroRid="any"
-                fi
             fi
         fi
 

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -73,6 +73,9 @@ set __GenerateLayoutOnly=0
 set __Priority=0
 set __PriorityArg=
 
+set __BuildNeedTarget=2
+set __BuildNeedTargetArg=
+
 :Arg_Loop
 if "%1" == "" goto ArgsDone
 
@@ -108,6 +111,7 @@ if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!pro
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-priority"             (set __Priority=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
+if /i "%1" == "-needTarget"           (set __BuildNeedTarget=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
 if /i "%1" == "copynativeonly"        (set __CopyNativeTestBinaries=1&set __SkipNative=1&set __CopyNativeProjectsAfterCombinedTestBuild=false&set __SkipCrossgenFramework=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipgeneratelayout"    (set __SkipGenerateLayout=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "generatelayoutonly"    (set __SkipManaged=1&set __SkipNative=1&set __CopyNativeProjectsAfterCombinedTestBuild=false&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -127,6 +131,14 @@ if [!processedArgs!]==[] (
 @REM Special handling for -priority=N argument.
 if %__Priority% GTR 0 (
     set "__PriorityArg=/p:CLRTestPriorityToBuild=%__Priority%"
+)
+
+if %__BuildNeedTarget% NEQ 2 (
+    set "__BuildNeedTargetArg=/p:CLRTestNeedTargetToBuild=%__BuildNeedTarget%"
+    if %__BuildNeedTarget% EQU 0 (
+        set __TargetOS=AnyOS
+        set __BuildArch=AnyCPU
+    )
 )
 
 set TargetsWindowsArg=
@@ -300,7 +312,7 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__RepoRootDir%\
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   %__SkipFXRestoreArg%^
-  !__Logging! %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
+  !__Logging! %__CommonMSBuildArgs% %__PriorityArg% %__BuildNeedTargetArg% %__UnprocessedBuildArgs%
 
 if errorlevel 1 (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Package restoration failed. Refer to the build log files for details:
@@ -360,7 +372,7 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__Logging!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !TargetsWindowsMsbuildArg!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__msbuildArgs!
-        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__PriorityArg!
+        set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__PriorityArg! !__BuildNeedTargetArg!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! !__UnprocessedBuildArgs!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! /p:CopyNativeProjectBinaries=!__CopyNativeProjectsAfterCombinedTestBuild!
         set __MSBuildBuildArgs=!__MSBuildBuildArgs! /p:__SkipPackageRestore=true
@@ -379,7 +391,7 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
             goto     :Exit_Failure
         )
     ) else (
-        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:0 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
+        set __MSBuildBuildArgs=!__ProjectDir!\tests\build.proj -warnAsError:0 /nodeReuse:false !__Logging! !TargetsWindowsMsbuildArg! !__msbuildArgs!  !__PriorityArg! !__BuildNeedTargetArg! !__SkipFXRestoreArg! !__UnprocessedBuildArgs! "/t:CopyAllNativeProjectReferenceBinaries"
         echo Running: msbuild !__MSBuildBuildArgs!
         !__CommonMSBuildCmdPrefix! !__MSBuildBuildArgs!
 
@@ -464,7 +476,7 @@ powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   %__SkipFXRestoreArg%^
-  !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__UnprocessedBuildArgs%
+  !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__BuildNeedTargetArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Create Test Overlay failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -606,6 +618,7 @@ echo -priority=^<N^> : specify a set of tests that will be built and run, with p
 echo     0: Build only priority 0 cases as essential testcases (default)
 echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
+echo -needTarget=^<0^|1^> : only build tests which do=1 or do not require a specific target
 echo -verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1
 

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -135,10 +135,6 @@ if %__Priority% GTR 0 (
 
 if %__BuildNeedTarget% NEQ 2 (
     set "__BuildNeedTargetArg=/p:CLRTestNeedTargetToBuild=%__BuildNeedTarget%"
-    if %__BuildNeedTarget% EQU 0 (
-        set __TargetOS=AnyOS
-        set __BuildArch=AnyCPU
-    )
 )
 
 set TargetsWindowsArg=

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -73,7 +73,6 @@ set __GenerateLayoutOnly=0
 set __Priority=0
 set __PriorityArg=
 
-set __BuildNeedTarget=2
 set __BuildNeedTargetArg=
 
 :Arg_Loop
@@ -111,7 +110,8 @@ if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!pro
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-priority"             (set __Priority=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
-if /i "%1" == "-needTarget"           (set __BuildNeedTarget=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
+if /i "%1" == "targetGeneric"         (set "__BuildNeedTargetArg=/p:CLRTestNeedTargetToBuild=%1"&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "targetSpecific"        (set "__BuildNeedTargetArg=/p:CLRTestNeedTargetToBuild=%1"&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "copynativeonly"        (set __CopyNativeTestBinaries=1&set __SkipNative=1&set __CopyNativeProjectsAfterCombinedTestBuild=false&set __SkipCrossgenFramework=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipgeneratelayout"    (set __SkipGenerateLayout=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "generatelayoutonly"    (set __SkipManaged=1&set __SkipNative=1&set __CopyNativeProjectsAfterCombinedTestBuild=false&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -131,10 +131,6 @@ if [!processedArgs!]==[] (
 @REM Special handling for -priority=N argument.
 if %__Priority% GTR 0 (
     set "__PriorityArg=/p:CLRTestPriorityToBuild=%__Priority%"
-)
-
-if %__BuildNeedTarget% NEQ 2 (
-    set "__BuildNeedTargetArg=/p:CLRTestNeedTargetToBuild=%__BuildNeedTarget%"
 )
 
 set TargetsWindowsArg=
@@ -614,7 +610,8 @@ echo -priority=^<N^> : specify a set of tests that will be built and run, with p
 echo     0: Build only priority 0 cases as essential testcases (default)
 echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
-echo -needTarget=^<0^|1^> : only build tests which do=1 or do not require a specific target
+echo targetGeneric: Only build tests which run on any target platform.
+echo targetSpecific: Only build tests which run on a specific target platform.
 echo -verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1
 

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -494,8 +494,8 @@ usage_list+=("-crossgen2: Precompiles the framework managed assemblies in corero
 usage_list+=("-generatetesthostonly: only generate the test host.")
 usage_list+=("-generatelayoutonly: only pull down dependencies and build coreroot.")
 usage_list+=("-priority1: include priority=1 tests in the build.")
-usage_list+=("-needTarget0: to only build tests which run on any platform in the build.")
-usage_list+=("-needTarget1: to only build tests which run on a specific platform  in the build.")
+usage_list+=("-targetGeneric: Only build tests which run on any target platform.")
+usage_list+=("-targetSpecific: Only build tests which run on a specific target platform.")
 
 usage_list+=("-rebuild: if tests have already been built - rebuild them.")
 usage_list+=("-runtests: run tests after building them.")
@@ -549,12 +549,12 @@ handle_arguments_local() {
             __UnprocessedBuildArgs+=("/p:CLRTestPriorityToBuild=1")
             ;;
 
-        needTarget0|-needTarget0)
-            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=0")
+        targetGeneric|-targetGeneric)
+            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=targetGeneric")
             ;;
 
-        needTarget1|-needTarget1)
-            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=1")
+        targetSpecific|-targetSpecific)
+            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=targetSpecific")
             ;;
 
         rebuild|-rebuild)

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -494,6 +494,9 @@ usage_list+=("-crossgen2: Precompiles the framework managed assemblies in corero
 usage_list+=("-generatetesthostonly: only generate the test host.")
 usage_list+=("-generatelayoutonly: only pull down dependencies and build coreroot.")
 usage_list+=("-priority1: include priority=1 tests in the build.")
+usage_list+=("-needTarget0: to only build tests which run on any platform in the build.")
+usage_list+=("-needTarget1: to only build tests which run on a specific platform  in the build.")
+
 usage_list+=("-rebuild: if tests have already been built - rebuild them.")
 usage_list+=("-runtests: run tests after building them.")
 usage_list+=("-skiprestorepackages: skip package restore.")
@@ -503,6 +506,7 @@ usage_list+=("-excludemonofailures: Mark the build as running on Mono runtime so
 # Obtain the location of the bash script to figure out where the root of the repo is.
 __ProjectRoot="$(cd "$(dirname "$0")"; pwd -P)"
 __RepoRootDir="$(cd "$__ProjectRoot"/../..; pwd -P)"
+__BuildArch=
 
 handle_arguments_local() {
     case "$1" in
@@ -545,6 +549,16 @@ handle_arguments_local() {
             __UnprocessedBuildArgs+=("/p:CLRTestPriorityToBuild=1")
             ;;
 
+        needTarget0|-needTarget0)
+            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=0")
+            __BuildArch=AnyCPU
+            __TargetOS=AnyOS
+            ;;
+
+        needTarget1|-needTarget1)
+            __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=1")
+            ;;
+
         rebuild|-rebuild)
             __RebuildTests=1
             ;;
@@ -570,7 +584,6 @@ handle_arguments_local() {
     esac
 }
 
-__BuildArch=
 __BuildType=Debug
 __CodeCoverage=
 __IncludeTests=INCLUDE_TESTS

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -551,8 +551,6 @@ handle_arguments_local() {
 
         needTarget0|-needTarget0)
             __UnprocessedBuildArgs+=("/p:CLRTestNeedTargetToBuild=0")
-            __BuildArch=AnyCPU
-            __TargetOS=AnyOS
             ;;
 
         needTarget1|-needTarget1)

--- a/src/coreclr/tests/Directory.Build.props
+++ b/src/coreclr/tests/Directory.Build.props
@@ -57,6 +57,15 @@
     <CLRTestPriorityToBuild>0</CLRTestPriorityToBuild>
   </PropertyGroup>
 
+  <!-- Which tests can we build? Default: All tests.
+    At the command-line, the user can specify:
+    +  /p:CLRTestNeedTargetToBuild=0 and tests which do not "need a target specified" will build.
+    +  /p:CLRTestNeedTargetToBuild=1 and tests which do "need a target specified" will build.
+   -->
+  <PropertyGroup>
+    <CLRTestNeedTargetToBuild></CLRTestNeedTargetToBuild>
+  </PropertyGroup>
+
   <!-- Where to put a "testhost" for running corefx tests -->
   <PropertyGroup>
     <TestHostVersion>$(ProductVersion)</TestHostVersion>

--- a/src/coreclr/tests/Directory.Build.props
+++ b/src/coreclr/tests/Directory.Build.props
@@ -59,8 +59,8 @@
 
   <!-- Which tests can we build? Default: All tests.
     At the command-line, the user can specify:
-    +  /p:CLRTestNeedTargetToBuild=0 and tests which do not "need a target specified" will build.
-    +  /p:CLRTestNeedTargetToBuild=1 and tests which do "need a target specified" will build.
+    +  /p:CLRTestNeedTargetToBuild=targetGeneric    Only build tests which run on any target platform.
+    +  /p:CLRTestNeedTargetToBuild=targetSpecific   Only build tests which run on a specific target platform.
    -->
   <PropertyGroup>
     <CLRTestNeedTargetToBuild></CLRTestNeedTargetToBuild>

--- a/src/coreclr/tests/build.proj
+++ b/src/coreclr/tests/build.proj
@@ -27,7 +27,6 @@
 
   <Target Name="BuildTargetingPack" AfterTargets="BatchRestorePackages" Condition="$(__SkipTargetingPackBuild) != 'true'">
     <Message Text="Building Targeting Pack" Importance="High" />
-    <Error  Text="TargetOS has not been specified. Please do that then run build again."  Condition="'$(TargetOS)' == 'AnyOS'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)external\external.csproj"
              Targets="Build" />
   </Target>

--- a/src/coreclr/tests/build.proj
+++ b/src/coreclr/tests/build.proj
@@ -27,6 +27,7 @@
 
   <Target Name="BuildTargetingPack" AfterTargets="BatchRestorePackages" Condition="$(__SkipTargetingPackBuild) != 'true'">
     <Message Text="Building Targeting Pack" Importance="High" />
+    <Error  Text="TargetOS has not been specified. Please do that then run build again."  Condition="'$(TargetOS)' == 'AnyOS'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)external\external.csproj"
              Targets="Build" />
   </Target>

--- a/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/src/coreclr/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -28,6 +28,10 @@
     </ItemGroup>
   </Target>
 
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+
   <Target Name="AddLibrariesToCoreRoot" BeforeTargets="CopyDependencyToCoreRoot" DependsOnTargets="ResolveLibrariesFromLocalBuild">
     <ItemGroup>
       <RuntimeCopyLocalItems Include="@(LibrariesRuntimeFiles)" />

--- a/src/coreclr/tests/src/Directory.Build.targets
+++ b/src/coreclr/tests/src/Directory.Build.targets
@@ -73,7 +73,8 @@
     <_WillCLRTestProjectBuild Condition="'$(_WillCLRTestProjectBuild)' == ''">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' != 'true'">true</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' == 'true' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'">true</_WillCLRTestProjectBuild>
-    <_WillCLRTestProjectBuild Condition="'$(CLRTestNeedTargetToBuild)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestNeedTargetToBuild)'">false</_WillCLRTestProjectBuild>
+    <_WillCLRTestProjectBuild Condition="'$(CLRTestNeedTargetToBuild)' == 'targetGeneric' And '$(CLRTestNeedTarget)' == '1'">false</_WillCLRTestProjectBuild>
+    <_WillCLRTestProjectBuild Condition="'$(CLRTestNeedTargetToBuild)' == 'targetSpecific' And '$(CLRTestNeedTarget)' != '1'">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(DisableProjectBuild)' == 'true'">false</_WillCLRTestProjectBuild>
   </PropertyGroup>
 

--- a/src/coreclr/tests/src/Directory.Build.targets
+++ b/src/coreclr/tests/src/Directory.Build.targets
@@ -4,6 +4,7 @@
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Library'">SharedLibrary</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildAndRun</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
+    <CLRTestNeedTarget Condition="'$(CLRTestNeedTarget)' == ''">0</CLRTestNeedTarget>
   </PropertyGroup>
 
   <!-- All CLRTests need to be of a certain "kind". These kinds are enumerated below.
@@ -72,6 +73,7 @@
     <_WillCLRTestProjectBuild Condition="'$(_WillCLRTestProjectBuild)' == ''">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' != 'true'">true</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' == 'true' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'">true</_WillCLRTestProjectBuild>
+    <_WillCLRTestProjectBuild Condition="'$(CLRTestNeedTargetToBuild)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestNeedTargetToBuild)'">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(DisableProjectBuild)' == 'true'">false</_WillCLRTestProjectBuild>
   </PropertyGroup>
 
@@ -102,6 +104,7 @@
     <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)'==''">CSharp</ProjectLanguage>
 
     <SkipImportILTargets Condition="'$(CLRTestPriority)' &gt; '$(CLRTestPriorityToBuild)'">true</SkipImportILTargets>
+    <SkipImportILTargets Condition="'$(CLRTestNeedTargetToBuild)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestNeedTargetToBuild)'">true</SkipImportILTargets>
   </PropertyGroup>
 
   <Import Project="CLRTest.Execute.targets" />

--- a/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
+++ b/src/coreclr/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
@@ -9,6 +9,9 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -16,6 +16,9 @@
     <ProjectReference Include="../NetServer/NetServer.DefaultInterfaces.ilproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
@@ -16,6 +16,9 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
@@ -16,6 +16,9 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -16,6 +16,9 @@
     <ProjectReference Include="../NetServer/NetServer.csproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -19,6 +19,9 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
+++ b/src/coreclr/tests/src/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
@@ -9,6 +9,9 @@
     <ProjectReference Include="CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
+++ b/src/coreclr/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
@@ -10,6 +10,9 @@
     <Compile Include="ICustomMarshaler.cs" />
     <Compile Include="..\..\common\XunitBase.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackStressTest.csproj
+++ b/src/coreclr/tests/src/Interop/NativeLibrary/Callback/CallbackStressTest.csproj
@@ -11,6 +11,9 @@
   <ItemGroup>
     <ProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
@@ -14,4 +14,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="ArchSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
@@ -14,6 +14,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="ArchSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
@@ -14,4 +14,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="ArchSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
@@ -14,6 +14,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="ArchSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
@@ -14,4 +14,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="ArchSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
@@ -14,6 +14,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="ArchSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
@@ -14,4 +14,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="ArchSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
+++ b/src/coreclr/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
@@ -14,6 +14,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'arm64'" Include="arglist64.il" />
     <Compile Condition="'$(TargetArchitecture)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="ArchSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
@@ -8,6 +8,9 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="StructABI.cs" />
     <Compile Include="StructABI.Windows.cs" Condition="'$(TargetOS)' == 'Windows_NT'" />
     <Compile Include="StructABI.Unix.cs" Condition="'$(TargetOS)' == 'Linux' Or '$(TargetOS)' == 'FreeBSD'" />

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
@@ -7,6 +7,9 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Directed/arglist/vararg.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/arglist/vararg.csproj
@@ -17,6 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="sizeof-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="sizeof-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="sizeof-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="sizeof-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -13,6 +13,9 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -13,4 +13,7 @@
     <Compile Condition="'$(TargetArchitecture)' ==   'arm'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(TargetArchitecture)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
@@ -11,4 +11,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
@@ -11,6 +11,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
@@ -11,6 +11,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof32.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
@@ -11,4 +11,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof32.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
@@ -11,4 +11,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
@@ -11,6 +11,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
@@ -11,6 +11,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof32.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
@@ -11,4 +11,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof32.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
@@ -11,6 +11,9 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof64.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
@@ -11,4 +11,7 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof64.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -20,4 +20,7 @@
   <ItemGroup Condition=" '$(PointerSize)' == '32' ">
     <Compile Include="DevDiv_278523_32.il" />
   </ItemGroup>
+  <ItemGroup>
+    <TraitTags Include="BitSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -20,6 +20,9 @@
   <ItemGroup Condition=" '$(PointerSize)' == '32' ">
     <Compile Include="DevDiv_278523_32.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -23,6 +23,9 @@ export COMPlus_GcStressOnDirectCalls=1
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_r.csproj
@@ -13,6 +13,9 @@
     <Compile Include="VectorConvert.cs" />
     <Compile Include="VectorUtil.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
+++ b/src/coreclr/tests/src/JIT/SIMD/VectorConvert_ro.csproj
@@ -13,6 +13,9 @@
     <Compile Include="VectorConvert.cs" />
     <Compile Include="VectorUtil.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="BitSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
+++ b/src/coreclr/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
@@ -10,6 +10,9 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
   <ItemGroup>
     <TraitTags Include="OsSpecific" />
   </ItemGroup>

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -65,10 +65,15 @@
 
     <Message Text="Found $(TestCount) built tests"/>
 
-    <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &lt;= 2000" Text="Unexpected test count. Expected &gt; 2000, found $(TestCount).'" />
-    <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &gt;= 3000" Text="Unexpected test count. Expected &lt; 3000, found $(TestCount).'" />
-    <Error Condition="'$(CLRTestPriorityToBuild)' == '1' and '$(TestCount)' &lt;= 9000" Text="Unexpected test count. Expected &gt; 9000, found $(TestCount).'" />
-    <Error Condition="'$(CLRTestPriorityToBuild)' != '0' and '$(CLRTestPriorityToBuild)' != '1'" Text="Unknown priority $(CLRTestPriorityToBuild)" />
+    <ItemGroup Condition="$(CLRTestNeedTargetToBuild) != 1">
+      <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &lt;= 2000" Text="Unexpected test count. Expected &gt; 2000, found $(TestCount).'" />
+      <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &gt;= 3000" Text="Unexpected test count. Expected &lt; 3000, found $(TestCount).'" />
+      <Error Condition="'$(CLRTestPriorityToBuild)' == '1' and '$(TestCount)' &lt;= 9000" Text="Unexpected test count. Expected &gt; 9000, found $(TestCount).'" />
+      <Error Condition="'$(CLRTestPriorityToBuild)' != '0' and '$(CLRTestPriorityToBuild)' != '1'" Text="Unknown priority $(CLRTestPriorityToBuild)" />
+    </ItemGroup>
+    <ItemGroup Condition="$(CLRTestNeedTargetToBuild) == 1">
+      <Error Condition="'$(TestCount)' &lt;= 100" Text="Unexpected test count. Expected &lt; 100, found $(TestCount).'" />
+    </ItemGroup>
   </Target>
 
   <Import Project="$(__Exclude)" Condition="'$(__Exclude)' != '' AND '$(XunitTestBinBase)' != ''" />

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -65,13 +65,15 @@
 
     <Message Text="Found $(TestCount) built tests"/>
 
-    <ItemGroup Condition="$(CLRTestNeedTargetToBuild) != 1">
+    <Error Condition="'$(CLRTestNeedTargetToBuild)' != '' and '$(CLRTestNeedTargetToBuild)' != 'targetGeneric' and '$(CLRTestNeedTargetToBuild)' != 'targetSpecific'" Text="Unknown CLRTestNeedTargetToBuild $(CLRTestNeedTargetToBuild)" />
+
+    <ItemGroup Condition="'$(CLRTestNeedTargetToBuild)' != 'targetSpecific'">
       <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &lt;= 2000" Text="Unexpected test count. Expected &gt; 2000, found $(TestCount).'" />
       <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &gt;= 3000" Text="Unexpected test count. Expected &lt; 3000, found $(TestCount).'" />
       <Error Condition="'$(CLRTestPriorityToBuild)' == '1' and '$(TestCount)' &lt;= 9000" Text="Unexpected test count. Expected &gt; 9000, found $(TestCount).'" />
       <Error Condition="'$(CLRTestPriorityToBuild)' != '0' and '$(CLRTestPriorityToBuild)' != '1'" Text="Unknown priority $(CLRTestPriorityToBuild)" />
     </ItemGroup>
-    <ItemGroup Condition="$(CLRTestNeedTargetToBuild) == 1">
+    <ItemGroup Condition="'$(CLRTestNeedTargetToBuild)' == 'targetSpecific'">
       <Error Condition="'$(TestCount)' &lt;= 100" Text="Unexpected test count. Expected &lt; 100, found $(TestCount).'" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Part of #33066

Modifies build-test to add options to allow building target agnostic tests separately from target specific tests.

+ Audited the `TraitTag`s found a few cases where `TraitTag`s were missed in #637.  Also added `ArchSpecific`
+ @VSadov is working on a generic filtering mechanism.  While waiting for it this PR add an extra property `CLRTestNeedTarget` to indicate a test which is not target agnostic.
+ I had originally tried to build the agnostic tests with `AnyOS` and `AnyCPU`, but I ran into lots of issues.  So I reverted that.