### PR TITLE
Reenable some disabled warnings in CoreCLR

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -435,11 +435,6 @@ if (MSVC)
 
   # Disable Warnings:
   # 4291: Delete not defined for new, c++ exception may cause leak.
-  # 4302: Truncation from '%$S' to '%$S'.
-  # 4311: Pointer truncation from '%$S' to '%$S'.
-  # 4312: '<function-style-cast>' : conversion from '%$S' to '%$S' of greater size.
-  # 4477: Format string '%$S' requires an argument of type '%$S', but variadic argument %d has type '%$S'.
-  # add_compile_options(/wd4291 /wd4312)
   add_compile_options(/wd4291)
 
   # Treat Warnings as Errors:

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -439,8 +439,8 @@ if (MSVC)
   # 4311: Pointer truncation from '%$S' to '%$S'.
   # 4312: '<function-style-cast>' : conversion from '%$S' to '%$S' of greater size.
   # 4477: Format string '%$S' requires an argument of type '%$S', but variadic argument %d has type '%$S'.
-  # add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312)
-  add_compile_options(/wd4291 /wd4311 /wd4312)
+  # add_compile_options(/wd4291 /wd4312)
+  add_compile_options(/wd4291)
 
   # Treat Warnings as Errors:
   # 4007: 'main' : must be __cdecl.

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -439,7 +439,8 @@ if (MSVC)
   # 4311: Pointer truncation from '%$S' to '%$S'.
   # 4312: '<function-style-cast>' : conversion from '%$S' to '%$S' of greater size.
   # 4477: Format string '%$S' requires an argument of type '%$S', but variadic argument %d has type '%$S'.
-  add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312 /wd4477)
+  # add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312 /wd4477)
+  add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312)
 
   # Treat Warnings as Errors:
   # 4007: 'main' : must be __cdecl.

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -439,8 +439,8 @@ if (MSVC)
   # 4311: Pointer truncation from '%$S' to '%$S'.
   # 4312: '<function-style-cast>' : conversion from '%$S' to '%$S' of greater size.
   # 4477: Format string '%$S' requires an argument of type '%$S', but variadic argument %d has type '%$S'.
-  # add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312 /wd4477)
-  add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312)
+  # add_compile_options(/wd4291 /wd4302 /wd4311 /wd4312)
+  add_compile_options(/wd4291 /wd4311 /wd4312)
 
   # Treat Warnings as Errors:
   # 4007: 'main' : must be __cdecl.

--- a/src/coreclr/src/debug/daccess/daccess.cpp
+++ b/src/coreclr/src/debug/daccess/daccess.cpp
@@ -7351,9 +7351,9 @@ ClrDataAccess::GetDacGlobals()
 #ifdef _DEBUG
         char szMsgBuf[1024];
         _snprintf_s(szMsgBuf, sizeof(szMsgBuf), _TRUNCATE,
-            "DAC fatal error: mismatch in number of globals in DAC table. Read from file: %d, expected: %d.",
+            "DAC fatal error: mismatch in number of globals in DAC table. Read from file: %d, expected: %zd.",
             header.numGlobals,
-            offsetof(DacGlobals, EEJitManager__vtAddr) / sizeof(ULONG));
+            (size_t)offsetof(DacGlobals, EEJitManager__vtAddr) / sizeof(ULONG));
         _ASSERTE_MSG(false, szMsgBuf);
 #endif // _DEBUG
 
@@ -7366,9 +7366,9 @@ ClrDataAccess::GetDacGlobals()
 #ifdef _DEBUG
         char szMsgBuf[1024];
         _snprintf_s(szMsgBuf, sizeof(szMsgBuf), _TRUNCATE,
-            "DAC fatal error: mismatch in number of vptrs in DAC table. Read from file: %d, expected: %d.",
+            "DAC fatal error: mismatch in number of vptrs in DAC table. Read from file: %d, expected: %zd.",
             header.numVptrs,
-            (sizeof(DacGlobals) - offsetof(DacGlobals, EEJitManager__vtAddr)) / sizeof(ULONG));
+            (size_t)(sizeof(DacGlobals) - offsetof(DacGlobals, EEJitManager__vtAddr)) / sizeof(ULONG));
         _ASSERTE_MSG(false, szMsgBuf);
 #endif // _DEBUG
 

--- a/src/coreclr/src/debug/daccess/daccess.cpp
+++ b/src/coreclr/src/debug/daccess/daccess.cpp
@@ -7302,7 +7302,7 @@ ClrDataAccess::GetDacGlobals()
     }
 
     if (FAILED(status = GetResourceRvaFromResourceSectionRvaByName(m_pTarget, m_globalBase,
-        resourceSectionRVA, (DWORD)RT_RCDATA, _WIDE(DACCESS_TABLE_RESOURCE), 0,
+        resourceSectionRVA, (DWORD)(size_t)RT_RCDATA, _WIDE(DACCESS_TABLE_RESOURCE), 0,
         &rsrcRVA, &rsrcSize)))
     {
         _ASSERTE_MSG(false, "DAC fatal error: can't locate DAC table resource in " TARGET_MAIN_CLR_DLL_NAME_A);

--- a/src/coreclr/src/debug/di/process.cpp
+++ b/src/coreclr/src/debug/di/process.cpp
@@ -12788,7 +12788,7 @@ void CordbProcess::HandleDebugEventForInteropDebugging(const DEBUG_EVENT * pEven
         PORTABILITY_ASSERT("NYI: Breakpoint size offset for this platform");
 #endif
         _ASSERTE(CORDbgGetIP(&tempDebugContext) == pEvent->u.Exception.ExceptionRecord.ExceptionAddress ||
-            (DWORD)(size_t)CORDbgGetIP(&tempDebugContext) == ((DWORD)pEvent->u.Exception.ExceptionRecord.ExceptionAddress)+breakpointOpcodeSize);
+            (DWORD)(size_t)CORDbgGetIP(&tempDebugContext) == ((DWORD)(size_t)pEvent->u.Exception.ExceptionRecord.ExceptionAddress)+breakpointOpcodeSize);
     }
 #endif
 

--- a/src/coreclr/src/debug/di/process.cpp
+++ b/src/coreclr/src/debug/di/process.cpp
@@ -12788,7 +12788,7 @@ void CordbProcess::HandleDebugEventForInteropDebugging(const DEBUG_EVENT * pEven
         PORTABILITY_ASSERT("NYI: Breakpoint size offset for this platform");
 #endif
         _ASSERTE(CORDbgGetIP(&tempDebugContext) == pEvent->u.Exception.ExceptionRecord.ExceptionAddress ||
-            (DWORD)CORDbgGetIP(&tempDebugContext) == ((DWORD)pEvent->u.Exception.ExceptionRecord.ExceptionAddress)+breakpointOpcodeSize);
+            (DWORD)(size_t)CORDbgGetIP(&tempDebugContext) == ((DWORD)pEvent->u.Exception.ExceptionRecord.ExceptionAddress)+breakpointOpcodeSize);
     }
 #endif
 

--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -13947,7 +13947,7 @@ void GenericHijackFuncHelper()
     if (pEEThread != NULL)
     {
         // We've got a Thread ptr, so get the continue type out of the thread's debugger word.
-        continueType = (DWORD)threadDebuggerWord;
+        continueType = (DWORD)(size_t) threadDebuggerWord;
 
         _ASSERTE(pEEThread->GetInteropDebuggingHijacked());
         pEEThread->SetInteropDebuggingHijacked(FALSE);

--- a/src/coreclr/src/ildasm/dasm.cpp
+++ b/src/coreclr/src/ildasm/dasm.cpp
@@ -3824,7 +3824,7 @@ lDone: ;
                 }
                 else
                 {
-                    sprintf_s(szString,SZSTRING_SIZE, "INVALID METHOD ADDRESS: 0x%8.8X (RVA: 0x%8.8X)",(size_t)newTarget,dwTargetRVA);
+                    sprintf_s(szString,SZSTRING_SIZE, "INVALID METHOD ADDRESS: 0x%8.8zX (RVA: 0x%8.8X)",(size_t)newTarget,dwTargetRVA);
                     printError(GUICookie,szString);
                 }
             }
@@ -4987,7 +4987,7 @@ void DumpVTables(IMAGE_COR20_HEADER *CORHeader, void* GUICookie)
             }
             else
             {
-                sprintf_s(szString,SZSTRING_SIZE,"//         [0x%04x]            (0x%16x)", iSlot, VAL64(*(unsigned __int64 *) pSlot));
+                sprintf_s(szString,SZSTRING_SIZE,"//         [0x%04x]            (0x%16llx)", iSlot, VAL64(*(unsigned __int64 *) pSlot));
                 pSlot += sizeof(unsigned __int64);
             }
             printLine(GUICookie,szStr);

--- a/src/coreclr/src/inc/holder.h
+++ b/src/coreclr/src/inc/holder.h
@@ -609,8 +609,8 @@ class BaseWrapper : public BaseHolder<TYPE, BASE, DEFAULTVALUE, IS_NULL>
         return !!(this->m_value != TYPE(value));
     }
 
-    // This handles the NULL value that is an int and clang
-    // doesn't want to convert int to a pointer
+    // This handles the NULL value that is an int and the
+    // compiler doesn't want to convert int to a pointer.
     FORCEINLINE bool operator==(int value) const
     {
         return !!(this->m_value == TYPE((void*)(SIZE_T)value));

--- a/src/coreclr/src/inc/holder.h
+++ b/src/coreclr/src/inc/holder.h
@@ -608,7 +608,7 @@ class BaseWrapper : public BaseHolder<TYPE, BASE, DEFAULTVALUE, IS_NULL>
     {
         return !!(this->m_value != TYPE(value));
     }
-#ifdef __GNUC__
+
     // This handles the NULL value that is an int and clang
     // doesn't want to convert int to a pointer
     FORCEINLINE bool operator==(int value) const
@@ -619,7 +619,7 @@ class BaseWrapper : public BaseHolder<TYPE, BASE, DEFAULTVALUE, IS_NULL>
     {
         return !!(this->m_value != TYPE((void*)(SIZE_T)value));
     }
-#endif // __GNUC__
+
     FORCEINLINE const TYPE &operator->() const
     {
         return this->m_value;

--- a/src/coreclr/src/inc/stdmacros.h
+++ b/src/coreclr/src/inc/stdmacros.h
@@ -123,13 +123,13 @@
     #define INVALID_POINTER_CD 0xcdcdcdcdcdcdcdcd
     #define FMT_ADDR           " %08x`%08x "
     #define LFMT_ADDR          W(" %08x`%08x ")
-    #define DBG_ADDR(ptr)      (((UINT_PTR) (ptr)) >> 32), (((UINT_PTR) (ptr)) & 0xffffffff)
+    #define DBG_ADDR(ptr)      (DWORD)(((UINT_PTR) (ptr)) >> 32), (DWORD)(((UINT_PTR) (ptr)) & 0xffffffff)
 #else // HOST_64BIT
     #define INVALID_POINTER_CC 0xcccccccc
     #define INVALID_POINTER_CD 0xcdcdcdcd
     #define FMT_ADDR           " %08x "
     #define LFMT_ADDR          W(" %08x ")
-    #define DBG_ADDR(ptr)      ((UINT_PTR)(ptr))
+    #define DBG_ADDR(ptr)      (DWORD)((UINT_PTR)(ptr))
 #endif // HOST_64BIT
 
 #ifdef TARGET_ARM

--- a/src/coreclr/src/inc/utilcode.h
+++ b/src/coreclr/src/inc/utilcode.h
@@ -4848,7 +4848,7 @@ inline T* InterlockedExchangeT(
     int             value) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(value == 0);
-    return InterlockedExchangeT(target, reinterpret_cast<T*>(value));
+    return InterlockedExchangeT(target, nullptr);
 }
 
 template <typename T>
@@ -4858,7 +4858,7 @@ inline T* InterlockedCompareExchangeT(
     T*              comparand)
 {
     //STATIC_ASSERT(exchange == 0);
-    return InterlockedCompareExchangeT(destination, reinterpret_cast<T*>(exchange), comparand);
+    return InterlockedCompareExchangeT(destination, nullptr, comparand);
 }
 
 template <typename T>
@@ -4868,7 +4868,7 @@ inline T* InterlockedCompareExchangeT(
     int             comparand) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(comparand == 0);
-    return InterlockedCompareExchangeT(destination, exchange, reinterpret_cast<T*>(comparand));
+    return InterlockedCompareExchangeT(destination, exchange, nullptr);
 }
 
 // NULL pointer variants of the above to avoid having to cast NULL

--- a/src/coreclr/src/inc/utilcode.h
+++ b/src/coreclr/src/inc/utilcode.h
@@ -4844,37 +4844,6 @@ inline T* InterlockedCompareExchangeT(
 // to the appropriate pointer type.
 template <typename T>
 inline T* InterlockedExchangeT(
-    T* volatile *   target,
-    int             value) // When NULL is provided as argument.
-{
-    //STATIC_ASSERT(value == 0);
-    return InterlockedExchangeT(target, nullptr);
-}
-
-template <typename T>
-inline T* InterlockedCompareExchangeT(
-    T* volatile *   destination,
-    int             exchange,  // When NULL is provided as argument.
-    T*              comparand)
-{
-    //STATIC_ASSERT(exchange == 0);
-    return InterlockedCompareExchangeT(destination, nullptr, comparand);
-}
-
-template <typename T>
-inline T* InterlockedCompareExchangeT(
-    T* volatile *   destination,
-    T*              exchange,
-    int             comparand) // When NULL is provided as argument.
-{
-    //STATIC_ASSERT(comparand == 0);
-    return InterlockedCompareExchangeT(destination, exchange, nullptr);
-}
-
-// NULL pointer variants of the above to avoid having to cast NULL
-// to the appropriate pointer type.
-template <typename T>
-inline T* InterlockedExchangeT(
     T* volatile *  target,
     std::nullptr_t value) // When nullptr is provided as argument.
 {
@@ -4900,6 +4869,37 @@ inline T* InterlockedCompareExchangeT(
 {
     //STATIC_ASSERT(comparand == 0);
     return InterlockedCompareExchangeT(destination, exchange, static_cast<T*>(comparand));
+}
+
+// NULL pointer variants of the above to avoid having to cast NULL
+// to the appropriate pointer type.
+template <typename T>
+inline T* InterlockedExchangeT(
+    T* volatile *   target,
+    int             value) // When NULL is provided as argument.
+{
+    //STATIC_ASSERT(value == 0);
+    return InterlockedExchangeT(target, nullptr);
+}
+
+template <typename T>
+inline T* InterlockedCompareExchangeT(
+    T* volatile *   destination,
+    int             exchange,  // When NULL is provided as argument.
+    T*              comparand)
+{
+    //STATIC_ASSERT(exchange == 0);
+    return InterlockedCompareExchangeT(destination, nullptr, comparand);
+}
+
+template <typename T>
+inline T* InterlockedCompareExchangeT(
+    T* volatile *   destination,
+    T*              exchange,
+    int             comparand) // When NULL is provided as argument.
+{
+    //STATIC_ASSERT(comparand == 0);
+    return InterlockedCompareExchangeT(destination, exchange, nullptr);
 }
 
 #undef InterlockedExchangePointer

--- a/src/coreclr/src/jit/bitsetasshortlong.h
+++ b/src/coreclr/src/jit/bitsetasshortlong.h
@@ -417,7 +417,7 @@ public:
             else
             {
                 assert(sizeof(size_t) == sizeof(int));
-                sprintf_s(ptr, remaining, "%08X", bits);
+                sprintf_s(ptr, remaining, "%08X", (DWORD)bits);
             }
             return res;
         }

--- a/src/coreclr/src/jit/bitsetasshortlong.h
+++ b/src/coreclr/src/jit/bitsetasshortlong.h
@@ -412,11 +412,7 @@ public:
             char*    ptr             = res;
             if (sizeof(size_t) == sizeof(int64_t))
             {
-#ifdef HOST_64BIT
-                sprintf_s(ptr, remaining, "%016llX", bits);
-#else
-                sprintf_s(ptr, remaining, "%016lX", bits);
-#endif
+                sprintf_s(ptr, remaining, "%016zX", bits);
             }
             else
             {

--- a/src/coreclr/src/jit/bitsetasshortlong.h
+++ b/src/coreclr/src/jit/bitsetasshortlong.h
@@ -412,7 +412,7 @@ public:
             char*    ptr             = res;
             if (sizeof(size_t) == sizeof(int64_t))
             {
-                sprintf_s(ptr, remaining, "%016llX", bits);
+                sprintf_s(ptr, remaining, "%016llX", (ULONG_PTR)bits);
             }
             else
             {

--- a/src/coreclr/src/jit/bitsetasshortlong.h
+++ b/src/coreclr/src/jit/bitsetasshortlong.h
@@ -412,7 +412,11 @@ public:
             char*    ptr             = res;
             if (sizeof(size_t) == sizeof(int64_t))
             {
-                sprintf_s(ptr, remaining, "%016llX", (ULONG_PTR)bits);
+#ifdef HOST_64BIT
+                sprintf_s(ptr, remaining, "%016llX", bits);
+#else
+                sprintf_s(ptr, remaining, "%016lX", bits);
+#endif
             }
             else
             {

--- a/src/coreclr/src/md/enc/stgtiggerstorage.cpp
+++ b/src/coreclr/src/md/enc/stgtiggerstorage.cpp
@@ -993,7 +993,7 @@ ULONG TiggerStorage::PrintSizeInfo(bool verbose)
 {
     ULONG total = 0;
 
-    printf("Storage Header:  %d\n", sizeof(STORAGEHEADER));
+    printf("Storage Header:  %zu\n", sizeof(STORAGEHEADER));
     if (m_pStreamList != NULL)
     {
         PSTORAGESTREAM storStream = m_pStreamList;
@@ -1001,7 +1001,7 @@ ULONG TiggerStorage::PrintSizeInfo(bool verbose)
         for (int i = 0; i < m_StgHdr.GetiStreams(); i++)
         {
             pNext = storStream->NextStream();
-            printf("Stream #%d (%s) Header: %d, Data: %d\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
+            printf("Stream #%d (%s) Header: %d, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
             total += storStream->GetSize();
             storStream = pNext;
         }

--- a/src/coreclr/src/md/enc/stgtiggerstorage.cpp
+++ b/src/coreclr/src/md/enc/stgtiggerstorage.cpp
@@ -1001,11 +1001,7 @@ ULONG TiggerStorage::PrintSizeInfo(bool verbose)
         for (int i = 0; i < m_StgHdr.GetiStreams(); i++)
         {
             pNext = storStream->NextStream();
-#ifdef HOST_64BIT
-            printf("Stream #%d (%s) Header: %lld, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
-#else
-            printf("Stream #%d (%s) Header: %ld, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
-#endif
+            printf("Stream #%d (%s) Header: %zd, Data: %lu\n",i,storStream->GetName(), (size_t)((BYTE*)pNext - (BYTE*)storStream), storStream->GetSize());
             total += storStream->GetSize();
             storStream = pNext;
         }

--- a/src/coreclr/src/md/enc/stgtiggerstorage.cpp
+++ b/src/coreclr/src/md/enc/stgtiggerstorage.cpp
@@ -1001,7 +1001,11 @@ ULONG TiggerStorage::PrintSizeInfo(bool verbose)
         for (int i = 0; i < m_StgHdr.GetiStreams(); i++)
         {
             pNext = storStream->NextStream();
-            printf("Stream #%d (%s) Header: %d, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
+#ifdef HOST_64BIT
+            printf("Stream #%d (%s) Header: %lld, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
+#else
+            printf("Stream #%d (%s) Header: %ld, Data: %lu\n",i,storStream->GetName(), (BYTE*)pNext - (BYTE*)storStream, storStream->GetSize());
+#endif
             total += storStream->GetSize();
             storStream = pNext;
         }

--- a/src/coreclr/src/utilcode/loaderheap.cpp
+++ b/src/coreclr/src/utilcode/loaderheap.cpp
@@ -594,8 +594,8 @@ class LoaderHeapSniffer
 
                 }
                 printf(" ptr = 0x%-8p", pEvent->m_pMem);
-                printf(" rqsize = 0x%-8x", pEvent->m_dwRequestedSize);
-                printf(" actsize = 0x%-8x", pEvent->m_dwSize);
+                printf(" rqsize = 0x%-8x", (DWORD)pEvent->m_dwRequestedSize);
+                printf(" actsize = 0x%-8x", (DWORD)pEvent->m_dwSize);
                 printf(" (at %s@%d)", pEvent->m_szFile, pEvent->m_lineNum);
                 if (pEvent->m_allocationType == kFreedMem)
                 {

--- a/src/coreclr/src/utilcode/stacktrace.cpp
+++ b/src/coreclr/src/utilcode/stacktrace.cpp
@@ -793,8 +793,10 @@ CONTEXT * pContext      // Context to use (or NULL to use current)
 
 #ifdef HOST_64BIT
     #define FMT_ADDR_BARE      "%08x`%08x"
+    #define FMT_ADDR_OFFSET    "%llX"
 #else
     #define FMT_ADDR_BARE      "%08x"
+    #define FMT_ADDR_OFFSET    "%lX"
 #endif
 
 void GetStringFromSymbolInfo
@@ -816,7 +818,7 @@ __out_ecount (cchMaxAssertStackLevelStringLen) CHAR *pszString     // @parm Plac
     {
         sprintf_s(pszString,
                   cchMaxAssertStackLevelStringLen,
-                  "%s! %s + 0x%llX (0x" FMT_ADDR_BARE ")",
+                  "%s! %s + 0x" FMT_ADDR_OFFSET " (0x" FMT_ADDR_BARE ")",
                   (psi->achModule[0]) ? psi->achModule : "<no module>",
                   (psi->achSymbol[0]) ? psi->achSymbol : "<no symbol>",
                   psi->dwOffset,
@@ -824,7 +826,6 @@ __out_ecount (cchMaxAssertStackLevelStringLen) CHAR *pszString     // @parm Plac
     }
     else
     {
-
         sprintf_s(pszString, cchMaxAssertStackLevelStringLen, "<symbols not available> (0x%p)", (void *)dwAddr);
     }
 

--- a/src/coreclr/src/utilcode/stacktrace.cpp
+++ b/src/coreclr/src/utilcode/stacktrace.cpp
@@ -816,7 +816,7 @@ __out_ecount (cchMaxAssertStackLevelStringLen) CHAR *pszString     // @parm Plac
     {
         sprintf_s(pszString,
                   cchMaxAssertStackLevelStringLen,
-                  "%s! %s + 0x%X (0x" FMT_ADDR_BARE ")",
+                  "%s! %s + 0x%llX (0x" FMT_ADDR_BARE ")",
                   (psi->achModule[0]) ? psi->achModule : "<no module>",
                   (psi->achSymbol[0]) ? psi->achSymbol : "<no symbol>",
                   psi->dwOffset,

--- a/src/coreclr/src/vm/comcache.h
+++ b/src/coreclr/src/vm/comcache.h
@@ -260,7 +260,7 @@ public:
     static CtxEntry *Null()                     { LIMITED_METHOD_CONTRACT; return NULL; }
     static bool IsNull(CtxEntry *e)             { LIMITED_METHOD_CONTRACT; return (e == NULL); }
     static const LPVOID GetKey(CtxEntry *e)     { LIMITED_METHOD_CONTRACT; return e->GetCtxCookie(); }
-    static count_t Hash(LPVOID key_t)           { LIMITED_METHOD_CONTRACT; return (count_t) key_t; }
+    static count_t Hash(LPVOID key_t)           { LIMITED_METHOD_CONTRACT; return (count_t)(size_t) key_t; }
     static BOOL Equals(LPVOID lhs, LPVOID rhs)  { LIMITED_METHOD_CONTRACT; return (lhs == rhs); }
     static CtxEntry *Deleted()                  { LIMITED_METHOD_CONTRACT; return (CtxEntry *)-1; }
     static bool IsDeleted(CtxEntry *e)          { LIMITED_METHOD_CONTRACT; return e == (CtxEntry *)-1; }

--- a/src/coreclr/src/vm/compile.cpp
+++ b/src/coreclr/src/vm/compile.cpp
@@ -3024,7 +3024,7 @@ HRESULT NGenModulePdbWriter::WritePDBData()
         if (strcmp((const char *)&section[sectionIndex].Name[0], ".text") == 0) {
             _ASSERTE((iCodeSection == 0) && (pCodeBase == NULL));
             iCodeSection = (USHORT)(sectionIndex + 1);
-            pCodeBase = (BYTE *)section[sectionIndex].VirtualAddress;
+            pCodeBase = (BYTE *)(size_t)section[sectionIndex].VirtualAddress;
         }
 
         // In order to support the DIA RVA-to-lines API against the PDB we're

--- a/src/coreclr/src/vm/debughelp.cpp
+++ b/src/coreclr/src/vm/debughelp.cpp
@@ -422,7 +422,7 @@ WCHAR* formatMethodDesc(MethodDesc* pMD,
     }
 #endif
 
-    if(_snwprintf_s(&buff[wcslen(buff)], bufSize - wcslen(buff) - 1, _TRUNCATE, W("(%x)"), (size_t)pMD) < 0)
+    if(_snwprintf_s(&buff[wcslen(buff)], bufSize - wcslen(buff) - 1, _TRUNCATE, W("(%zx)"), (size_t)pMD) < 0)
     {
         return NULL;
     }
@@ -477,7 +477,7 @@ int dumpStack(BYTE* topOfStack, unsigned len)
 
         if (isRetAddr((TADDR)*ptr, &whereCalled))
         {
-            if (_snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE,  W("STK[%08X] = %08X "), (size_t)ptr, *ptr) < 0)
+            if (_snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE,  W("STK[%08X] = %08X "), (DWORD)(size_t)ptr, (DWORD)*ptr) < 0)
             {
                 return(0);
             }
@@ -545,7 +545,7 @@ int dumpStack(BYTE* topOfStack, unsigned len)
 
             if (whereCalled != 0)
             {
-                if (_snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE, W(" Caller called Entry %X"), whereCalled) < 0)
+                if (_snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE, W(" Caller called Entry %zX"), (size_t)whereCalled) < 0)
                 {
                     return(0);
                 }
@@ -562,7 +562,7 @@ int dumpStack(BYTE* topOfStack, unsigned len)
         if (pMT != 0)
         {
             buffPtr = buff;
-            if ( _snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE, W("STK[%08X] = %08X          MT PARAM "), (size_t)ptr, *ptr ) < 0)
+            if ( _snwprintf_s(buffPtr, buffEnd - buffPtr, _TRUNCATE, W("STK[%08X] = %08X          MT PARAM "), (DWORD)(size_t)ptr, (DWORD)*ptr ) < 0)
             {
                 return(0);
             }
@@ -865,7 +865,7 @@ StackWalkAction PrintStackTraceCallback(CrawlFrame* pCF, VOID* pData)
             if(_snwprintf_s(&buff[wcslen(buff)],
                           nLen - wcslen(buff) - 1,
                           _TRUNCATE,
-                          W("JIT ESP:%X MethStart:%X EIP:%X(rel %X)"),
+                          W("JIT ESP:%zX MethStart:%zX EIP:%zX(rel %X)"),
                           (size_t)GetRegdisplaySP(regs),
                           (size_t)start,
                           (size_t)GetControlPC(regs),
@@ -893,7 +893,7 @@ StackWalkAction PrintStackTraceCallback(CrawlFrame* pCF, VOID* pData)
                       nLen - wcslen(buff) - 1,
                       _TRUNCATE,
                       W("EE Frame is") LFMT_ADDR,
-                      (size_t)DBG_ADDR(frame)) < 0)
+                      DBG_ADDR(frame)) < 0)
         {
             return SWA_CONTINUE;
         }

--- a/src/coreclr/src/vm/frames.cpp
+++ b/src/coreclr/src/vm/frames.cpp
@@ -258,7 +258,7 @@ void Frame::LogFrame(
     {
         _ASSERTE(!"New Frame type needs to be added to FrameTypeName()");
         // Pointer is up to 17chars + vtbl@ = 22 chars
-        sprintf_s(buf, COUNTOF(buf), "vtbl@%p", GetVTablePtr());
+        sprintf_s(buf, COUNTOF(buf), "vtbl@%p", (VOID *)GetVTablePtr());
         pFrameType = buf;
     }
 

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -174,7 +174,7 @@ namespace
         public:
             using key_t = void*;
             static const key_t GetKey(_In_ element_t e) { LIMITED_METHOD_CONTRACT; return (key_t)e->Identity; }
-            static count_t Hash(_In_ key_t key) { LIMITED_METHOD_CONTRACT; return (count_t)key; }
+            static count_t Hash(_In_ key_t key) { LIMITED_METHOD_CONTRACT; return (count_t)(size_t)key; }
             static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { LIMITED_METHOD_CONTRACT; return (lhs == rhs); }
         };
 

--- a/src/coreclr/src/vm/invokeutil.cpp
+++ b/src/coreclr/src/vm/invokeutil.cpp
@@ -696,7 +696,7 @@ OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
     case ELEMENT_TYPE_FNPTR:
         {
             LPVOID capturedValue = *(LPVOID*)pValue;
-            INDEBUG(pValue = (LPVOID)0xcccccccc); // We're about to allocate a GC object - can no longer trust pValue
+            INDEBUG(pValue = (LPVOID)(size_t)0xcccccccc); // We're about to allocate a GC object - can no longer trust pValue
             obj = AllocateObject(MscorlibBinder::GetElementType(ELEMENT_TYPE_I));
             *(LPVOID*)(obj->UnBox()) = capturedValue;
         }

--- a/src/coreclr/src/vm/methodtable.cpp
+++ b/src/coreclr/src/vm/methodtable.cpp
@@ -1870,7 +1870,7 @@ MethodTable::DebugDumpVtable(LPCUTF8 szClassName, BOOL fDebug)
                            name,
                            pszName,
                            IsMdFinal(dwAttrs) ? " (final)" : "",
-                           pMD->GetMethodEntryPoint(),
+                           (VOID *)pMD->GetMethodEntryPoint(),
                            pMD->GetSlot()
                           );
                 WszOutputDebugString(buff);
@@ -1884,7 +1884,7 @@ MethodTable::DebugDumpVtable(LPCUTF8 szClassName, BOOL fDebug)
                      pMD->GetClass()->GetDebugClassName(),
                      pszName,
                      IsMdFinal(dwAttrs) ? " (final)" : "",
-                     pMD->GetMethodEntryPoint(),
+                     (VOID *)pMD->GetMethodEntryPoint(),
                      pMD->GetSlot()
                     ));
             }

--- a/src/coreclr/src/vm/runtimecallablewrapper.h
+++ b/src/coreclr/src/vm/runtimecallablewrapper.h
@@ -1998,7 +1998,7 @@ private:
         static RCW *Null()                         { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(RCW *e)                 { LIMITED_METHOD_CONTRACT; return (e == NULL); }
         static const LPVOID GetKey(RCW *e)         { LIMITED_METHOD_CONTRACT; return e->m_pIdentity; }
-        static count_t Hash(LPVOID key_t)          { LIMITED_METHOD_CONTRACT; return (count_t)key_t; }
+        static count_t Hash(LPVOID key_t)          { LIMITED_METHOD_CONTRACT; return (count_t)(size_t) key_t; }
         static BOOL Equals(LPVOID lhs, LPVOID rhs) { LIMITED_METHOD_CONTRACT; return (lhs == rhs); }
         static RCW *Deleted()                      { LIMITED_METHOD_CONTRACT; return (RCW *)-1; }
         static bool IsDeleted(RCW *e)              { LIMITED_METHOD_CONTRACT; return e == (RCW *)-1; }

--- a/src/coreclr/src/vm/stublink.cpp
+++ b/src/coreclr/src/vm/stublink.cpp
@@ -2552,7 +2552,7 @@ VOID ArgBasedStubCache::Dump()
         if (!pStub) {
             printf("empty\n");
         } else {
-            printf("%lxh   - refcount is %lu\n",
+            printf("%zxh   - refcount is %lu\n",
                    (size_t)(pStub->GetEntryPoint()),
                    (ULONG)( *( ( ((ULONG*)(pStub->GetEntryPoint())) - 1))));
         }
@@ -2564,7 +2564,7 @@ VOID ArgBasedStubCache::Dump()
 
         printf("  Dyna. slot %lu: ", (ULONG)(pSlotEntry->m_key));
         Stub *pStub = pSlotEntry->m_pStub;
-        printf("%lxh   - refcount is %lu\n",
+        printf("%zxh   - refcount is %lu\n",
                (size_t)(pStub->GetEntryPoint()),
                (ULONG)( *( ( ((ULONG*)(pStub->GetEntryPoint())) - 1))));
 

--- a/src/coreclr/src/vm/typestring.cpp
+++ b/src/coreclr/src/vm/typestring.cpp
@@ -833,7 +833,7 @@ void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation t
             if (format & FormatDebug)
             {
                 WCHAR wzAddress[128];
-                _snwprintf_s(wzAddress, 128, _TRUNCATE, W("(%p)"), dac_cast<TADDR>(ty.AsPtr()));
+                _snwprintf_s(wzAddress, 128, _TRUNCATE, W("(%p)"), (VOID *)dac_cast<TADDR>(ty.AsPtr()));
                 tnb.AddName(wzAddress);
             }
 #endif

--- a/src/coreclr/src/vm/virtualcallstub.cpp
+++ b/src/coreclr/src/vm/virtualcallstub.cpp
@@ -158,6 +158,7 @@ void VirtualCallStubManager::StartupLogging()
 }
 
 #define OUTPUT_FORMAT_INT "\t%-30s %d\r\n"
+#define OUTPUT_FORMAT_SIZE "\t%-30s %zu\r\n"
 #define OUTPUT_FORMAT_PCT "\t%-30s %#5.2f%%\r\n"
 #define OUTPUT_FORMAT_INT_PCT "\t%-30s %5d (%#5.2f%%)\r\n"
 
@@ -366,7 +367,7 @@ void VirtualCallStubManager::LoggingDump()
         size_t total, used;
         g_resolveCache->GetLoadFactor(&total, &used);
 
-        sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "cache_entry_used", used);
+        sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_SIZE, "cache_entry_used", used);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
         sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "cache_entry_counter", g_cache_entry_counter);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
@@ -381,7 +382,7 @@ void VirtualCallStubManager::LoggingDump()
         sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "bucket_space_dead", g_bucket_space_dead);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
 
-        sprintf_s(szPrintStr, COUNTOF(szPrintStr), "\r\ncache_load:\t%d used, %d total, utilization %#5.2f%%\r\n",
+        sprintf_s(szPrintStr, COUNTOF(szPrintStr), "\r\ncache_load:\t%zu used, %zu total, utilization %#5.2f%%\r\n",
                 used, total, 100.0 * double(used) / double(total));
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
 
@@ -3112,14 +3113,14 @@ void VirtualCallStubManager::LogStats()
         size_t total, used;
         g_resolveCache->GetLoadFactor(&total, &used);
 
-        sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "cache_entry_used", used);
+        sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_SIZE, "cache_entry_used", used);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
         sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "cache_entry_counter", stats.cache_entry_counter);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
         sprintf_s(szPrintStr, COUNTOF(szPrintStr), OUTPUT_FORMAT_INT, "cache_entry_space", stats.cache_entry_space);
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
 
-        sprintf_s(szPrintStr, COUNTOF(szPrintStr), "\r\ncache_load:\t%d used, %d total, utilization %#5.2f%%\r\n",
+        sprintf_s(szPrintStr, COUNTOF(szPrintStr), "\r\ncache_load:\t%zu used, %zu total, utilization %#5.2f%%\r\n",
                 used, total, 100.0 * double(used) / double(total));
         WriteFile (g_hStubLogFile, szPrintStr, (DWORD) strlen(szPrintStr), &dwWriteByte, NULL);
     }


### PR DESCRIPTION
This is a followup to PR #33902, which has been reviewed and approved. The reason for this new PR, is that Azure Pipelines tests got stuck and the solution was to get the latest changes. When rebasing the branch with master, all those commits and changes were added to the PR, thus rendering it entirely uninformative, and therefore useless for historic study and statistics.

Fixes #33743.

Added some necessary casts and fixed string formats to comply with warnings 4302, 4311, 4312, and 4477 in CoreCLR. Having these warnings back on will help improve code quality and reduce potential scenarios where unpredicted behavior might cause further issues.