### PR TITLE
Script changes enabling composite R2R build with shared framework

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -1,0 +1,56 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 6 * * *"
+  displayName: Mon through Sun at 10:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/run-test-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+      readyToRun: true
+      crossgen2: true
+      compositeBuildMode: true
+      displayNameArgs: Composite
+      liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/templates/run-test-job.yml
+++ b/eng/pipelines/coreclr/templates/run-test-job.yml
@@ -11,6 +11,7 @@ parameters:
   readyToRun: false
   liveLibrariesBuildConfig: ''
   crossgen2: false
+  compositeBuildMode: false
   helixQueues: ''
   # If true, run the corefx tests instead of the coreclr ones
   corefxTests: false
@@ -91,6 +92,9 @@ jobs:
           value: 'crossgen2'
         - name: LogNamePrefix
           value: TestRunLogs_R2R_CG2
+      - ${{ if eq(parameters.compositeBuildMode, true) }}:
+        - name: crossgenArg
+          value: 'composite'
 
     # Set job timeouts
     #
@@ -140,6 +144,10 @@ jobs:
         value: 300
       - name: timeoutPerTestInMinutes
         value: 90
+
+    - ${{ if eq(parameters.compositeBuildMode, true) }}:
+      - name: crossgenArg
+        value: 'composite'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-HelixApi-Access
@@ -277,6 +285,7 @@ jobs:
 
         runCrossGen: ${{ and(eq(parameters.readyToRun, true), ne(parameters.crossgen2, true)) }}
         runCrossGen2: ${{ and(eq(parameters.readyToRun, true), eq(parameters.crossgen2, true)) }}
+        compositeBuildMode: ${{ parameters.compositeBuildMode }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/pipelines/coreclr/templates/send-to-helix-step.yml
+++ b/eng/pipelines/coreclr/templates/send-to-helix-step.yml
@@ -16,6 +16,7 @@ parameters:
   timeoutPerTestInMinutes: ''
   runCrossGen: ''
   runCrossGen2: ''
+  compositeBuildMode: false
   helixProjectArguments: ''
   runInUnloadableContext: ''
   longRunningGcTests: ''
@@ -47,6 +48,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _RunCrossGen2: ${{ parameters.runCrossGen2 }}
+      _CompositeBuildMode: ${{ parameters.compositeBuildMode }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}
@@ -86,6 +88,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _RunCrossGen2: ${{ parameters.runCrossGen2 }}
+      _CompositeBuildMode: ${{ parameters.compositeBuildMode }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -59,6 +59,7 @@ set __RuntimeId=
 set __TargetsWindows=1
 set __DoCrossgen=
 set __DoCrossgen2=
+set __CompositeBuildMode=
 set __CopyNativeTestBinaries=0
 set __CopyNativeProjectsAfterCombinedTestBuild=true
 set __SkipGenerateLayout=0
@@ -106,6 +107,7 @@ if /i "%1" == "buildagainstpackages"  (echo error: Remove /BuildAgainstPackages 
 if /i "%1" == "skiprestorepackages"   (set __SkipRestorePackages=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen"              (set __DoCrossgen=1&set __TestBuildMode=crossgen&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen2"             (set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __DoCrossgen2=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
@@ -627,18 +629,45 @@ exit /b 1
 set __TotalPrecompiled=0
 set __FailedToPrecompile=0
 set __FailedAssemblies=
-for %%F in ("%CORE_ROOT%\System.*.dll";"%CORE_ROOT%\Microsoft.*.dll") do (
+set __CompositeOutputDir=%CORE_ROOT%\composite.out
+set __CompositeResponseFile=%__CompositeOutputDir%\framework-r2r.dll.rsp
+
+if defined __CompositeBuildMode (
+    mkdir !__CompositeOutputDir!
+    echo --composite>>!__CompositeResponseFile!
+    echo -O>>!__CompositeResponseFile!
+    echo --out^:%__CompositeOutputDir%\framework-r2r.dll>>!__CompositeResponseFile!
+)
+
+for %%F in ("%CORE_ROOT%\System.*.dll";"%CORE_ROOT%\Microsoft.*.dll";%CORE_ROOT%\netstandard.dll;%CORE_ROOT%\mscorlib.dll) do (
     if not "%%~nxF"=="Microsoft.CodeAnalysis.VisualBasic.dll" (
     if not "%%~nxF"=="Microsoft.CodeAnalysis.CSharp.dll" (
     if not "%%~nxF"=="Microsoft.CodeAnalysis.dll" (
     if not "%%~nxF"=="System.Runtime.WindowsRuntime.dll" (
-        call :PrecompileAssembly "%%F" %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
-        echo Processed: !__TotalPrecompiled!, failed !__FailedToPrecompile!
+        if defined __CompositeBuildMode (
+            echo %%F>>!__CompositeResponseFile!
+        ) else (
+            call :PrecompileAssembly "%%F" %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
+            echo Processed: !__TotalPrecompiled!, failed !__FailedToPrecompile!
+        )
     )))))
 )
 
+echo Composite response line^: %__CompositeResponseFile%
+type "%__CompositeResponseFile%"
+
+if defined __CompositeBuildMode (
+    set __CompositeCommandLine="%CORE_ROOT%\corerun"
+    set __CompositeCommandLine=!__CompositeCommandLine! "%CORE_ROOT%\crossgen2\crossgen2.dll"
+    set __CompositeCommandLine=!__CompositeCommandLine! "@%__CompositeResponseFile%"
+    echo Building composite R2R framework^: !__CompositeCommandLine!
+    !__CompositeCommandLine!
+    set __FailedToPrecompile=!ERRORLEVEL!
+    copy /Y "!__CompositeOutputDir!\*.*" "!CORE_ROOT!\"
+)
+
 if !__FailedToPrecompile! NEQ 0 (
-    echo Failed assemblies:
+    @echo Failed assemblies:
     FOR %%G IN (!__FailedAssemblies!) do echo   %%G
 )
 

--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -107,7 +107,7 @@ if /i "%1" == "buildagainstpackages"  (echo error: Remove /BuildAgainstPackages 
 if /i "%1" == "skiprestorepackages"   (set __SkipRestorePackages=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen"              (set __DoCrossgen=1&set __TestBuildMode=crossgen&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen2"             (set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __DoCrossgen2=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -27,6 +27,7 @@
         PublishTestResults=$(_PublishTestResults);
         RunCrossGen=$(_RunCrossGen);
         RunCrossGen2=$(_RunCrossGen2);
+        CompositeBuildMode=$(_CompositeBuildMode);
         LongRunningGCTests=$(_LongRunningGCTests);
         GcSimulatorTests=$(_GcSimulatorTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
@@ -194,6 +195,7 @@
     <HelixPreCommand Include="set _NT_SYMBOL_PATH=%HELIX_CORRELATION_PAYLOAD%\PDB" />
     <HelixPreCommand Include="set RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
     <HelixPreCommand Include="set RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
+    <HelixPreCommand Include="set CompositeBuildMode=1" Condition=" '$(CompositeBuildMode)' == 'true' " />
     <HelixPreCommand Include="set RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="set RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="set RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
@@ -209,6 +211,7 @@
     <HelixPreCommand Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
     <HelixPreCommand Include="export RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
     <HelixPreCommand Include="export RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
+    <HelixPreCommand Include="export CompositeBuildMode=1" Condition=" '$(CompositeBuildMode)' == 'true' " />
     <HelixPreCommand Include="export RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="export RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="export RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -82,7 +82,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         __OutputFile=$PWD/$(MSBuildProjectName).dll
     fi
 
-    __ResponseFile=$__OutputFile ".rsp"
+    __ResponseFile="$(__OutputFile).rsp"
     rm $__ResponseFile
 
     __Command=$_DebuggerFullPath

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -76,8 +76,15 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       fi
     fi
 
-    __ResponseFile=$PWD/composite-r2r.dll.rsp
+    if [ ! -z ${CompositeBuildMode+x} ]%3B then
+        __OutputFile=$PWD/composite-r2r.dll
+    else
+        __OutputFile=$PWD/$(MSBuildProjectName).dll
+    fi
+
+    __ResponseFile=$__OutputFile ".rsp"
     rm $__ResponseFile
+
     __Command=$_DebuggerFullPath
     __Command+=" $CORE_ROOT/corerun"
     __Command+=" $CORE_ROOT/crossgen2/crossgen2.dll"
@@ -86,14 +93,14 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
     if [ ! -z ${CompositeBuildMode+x} ]%3B then
       echo --composite>>$__ResponseFile
-      echo -o:$(scriptPath)composite-r2r.dll>>$__ResponseFile
       echo $PWD/IL/*.dll>>$__ResponseFile
     else
       echo --inputbubble>>$__ResponseFile
-      echo -o:$(scriptPath)$(MSBuildProjectName).dll>>$__ResponseFile
+      echo $PWD/IL/$(MSBuildProjectName).dll>>$__ResponseFile
       echo -r:$PWD/IL/*.dll>>$__ResponseFile
     fi
 
+    echo -o:$(__OutputFile)>>$__ResponseFile
     echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
     echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
     echo -r:$CORE_ROOT/mscorlib.dll>>$__ResponseFile
@@ -164,7 +171,13 @@ if defined RunCrossGen2 (
         )
     )
 
-    set __ResponseFile=!scriptPath!\composite-r2r.dll.rsp
+    if defined CompositeBuildMode (
+        set __OutputFile=!scriptPath!\composite-r2r.dll
+    ) else (
+        set __OutputFile=!scriptPath!\$(MSBuildProjectName).dll
+    )
+
+    set __ResponseFile=!__OutputFile!.rsp
     del /Q !__ResponseFile!
 
     set __Command=!_DebuggerFullPath!
@@ -175,15 +188,15 @@ if defined RunCrossGen2 (
 
     if defined CompositeBuildMode (
         echo --composite>>!__ResponseFile!
-        echo -o:!scriptPath!composite-r2r.dll>>!__ResponseFile!
         rem In composite mode, treat all dll's in the test folder as rooting inputs
         echo !scriptPath!IL\*.dll>>!__ResponseFile!
     ) else (
         echo --inputbubble>>!__ResponseFile!
-        echo -o:!scriptPath!$(MSBuildProjectName).dll>>!__ResponseFile!
-        echo -r:%21scriptPath%21IL\*.dll>>!__ResponseFile!
+        echo !scriptPath!IL\$(MSBuildProjectName).dll>>!__ResponseFile!
+        echo -r:!scriptPath!IL\*.dll>>!__ResponseFile!
     )
 
+    echo -o:!__OutputFile!>>!__ResponseFile!
     echo --targetarch:x64>>!__ResponseFile!
     echo -O>>!__ResponseFile!
     echo -r:!CORE_ROOT!\System.*.dll>>!__ResponseFile!

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -65,25 +65,54 @@ if [ ! -z ${RunCrossGen+x} ]%3B then
 fi
 # CrossGen2 Script
 if [ ! -z ${RunCrossGen2+x} ]%3B then
-    if [ ! -f $(MSBuildProjectName).org ]%3B then
-        TakeLock
-        if [ ! -f $(MSBuildProjectName).org ]%3B then
-          mkdir IL
-          cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
-          mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/crossgen2/crossgen2.dll" -r:$CORE_ROOT/System.*.dll -r:$CORE_ROOT/Microsoft.*.dll -r:$CORE_ROOT/mscorlib.dll -r:$CORE_ROOT/netstandard.dll -r:$PWD/*.dll --targetarch=x64 -O --inputbubble $ExtraCrossGen2Args -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
-          echo $__Command
-          $__Command
-          __cg2ExitCode=$?
-          if [ $__cg2ExitCode -ne 0 ]
-          then
-            echo Crossgen2 failed with exitcode: $__cg2ExitCode
-            ReleaseLock
-            exit 1
-          fi
-        fi
-        ReleaseLock
+    TakeLock
+    if [ ! -d IL ]%3B then
+      mkdir IL
+      if [ ! -z ${CompositeBuildMode+x} ]%3B then
+        cp $(MSBuildProjectName).dll IL/
+        cp $CORE_ROOT/lib*.so $CORE_ROOT/lib*.dylib $(scriptPath)
+      else
+        cp *.dll IL/
+      fi
     fi
+
+    __ResponseFile=$PWD/composite-r2r.dll.rsp
+    rm $__ResponseFile
+    __Command=$_DebuggerFullPath
+    __Command+=" $CORE_ROOT/corerun"
+    __Command+=" $CORE_ROOT/crossgen2/crossgen2.dll"
+    __Command+=" @$__ResponseFile"
+    __Command+=" $ExtraCrossGen2Args"
+
+    if [ ! -z ${CompositeBuildMode+x} ]%3B then
+      echo --composite>>$__ResponseFile
+      echo -o:$(scriptPath)composite-r2r.dll>>$__ResponseFile
+      echo $PWD/IL/*.dll>>$__ResponseFile
+    else
+      echo --inputbubble>>$__ResponseFile
+      echo -o:$(scriptPath)$(MSBuildProjectName).dll>>$__ResponseFile
+      echo -r:$PWD/IL/*.dll>>$__ResponseFile
+    fi
+
+    echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
+    echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
+    echo -r:$CORE_ROOT/mscorlib.dll>>$__ResponseFile
+    echo --targetarch=x64>>$__ResponseFile
+    echo -O>>$__ResponseFile
+
+    echo "Response file: $__ResponseFile"
+    cat $__ResponseFile
+    echo "Running CrossGen2: $__Command"
+    $__Command
+    __cg2ExitCode=$?
+    if [ $__cg2ExitCode -ne 0 ]
+    then
+      echo Crossgen2 failed with exitcode: $__cg2ExitCode
+      ReleaseLock
+      exit 1
+    fi
+
+    ReleaseLock
 fi
         ]]>
       </CrossgenBashScript>
@@ -124,23 +153,54 @@ if defined RunCrossGen (
 REM CrossGen2 Script
 if defined RunCrossGen2 (
     if defined LargeVersionBubble ( set OptionalArguments=!OptionalArguments! /largeversionbubble)
-    if not exist "$(MSBuildProjectName).org" (
-        call :TakeLock
-        set CrossGen2Status=0
-        if not exist "$(MSBuildProjectName).org" (
-            mkdir IL
-            copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
-            ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\CoreRun.exe" "!CORE_ROOT!\crossgen2\crossgen2.dll" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble %21ExtraCrossGen2Args%21 -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\netstandard.dll" -r:"!CORE_ROOT!\mscorlib.dll" -r:%25cd%25\*.dll
-            echo "!__Command!"
-            call !__Command!
-            set CrossGen2Status=!ERRORLEVEL!
+    call :TakeLock
+    set CrossGen2Status=0
+    if not exist "IL" (
+        mkdir IL
+        if defined CompositeBuildMode (
+          copy *.dll IL\
+        ) else (
+          copy $(MSBuildProjectName).dll IL\
         )
-        call :ReleaseLock
-        IF NOT !CrossGen2Status!==0 (
-            ECHO Crossgen2 failed with exitcode - !CrossGen2Status!
-            Exit /b 1
-        )
+    )
+
+    set __ResponseFile=!scriptPath!\composite-r2r.dll.rsp
+    del /Q !__ResponseFile!
+
+    set __Command=!_DebuggerFullPath!
+    set __Command=!__Command! "!CORE_ROOT!\CoreRun.exe"
+    set __Command=!__Command! "!CORE_ROOT!\crossgen2\crossgen2.dll"
+    set __Command=!__Command! @"!__ResponseFile!"
+    set __Command=!__Command! !ExtraCrossGen2Args!
+
+    if defined CompositeBuildMode (
+        echo --composite>>!__ResponseFile!
+        echo -o:!scriptPath!composite-r2r.dll>>!__ResponseFile!
+        rem In composite mode, treat all dll's in the test folder as rooting inputs
+        echo !scriptPath!IL\*.dll>>!__ResponseFile!
+    ) else (
+        echo --inputbubble>>!__ResponseFile!
+        echo -o:!scriptPath!$(MSBuildProjectName).dll>>!__ResponseFile!
+        echo -r:%21scriptPath%21IL\*.dll>>!__ResponseFile!
+    )
+
+    echo --targetarch:x64>>!__ResponseFile!
+    echo -O>>!__ResponseFile!
+    echo -r:!CORE_ROOT!\System.*.dll>>!__ResponseFile!
+    echo -r:!CORE_ROOT!\Microsoft.*.dll>>!__ResponseFile!
+    echo -r:!CORE_ROOT!\mscorlib.dll>>!__ResponseFile!
+    echo -r:!CORE_ROOT!\netstandard.dll>>!__ResponseFile!
+
+    echo Response file: !__ResponseFile!
+    type !__ResponseFile!
+
+    echo "!__Command!"
+    call !__Command!
+    set CrossGen2Status=!ERRORLEVEL!
+    call :ReleaseLock
+    IF NOT !CrossGen2Status!==0 (
+        ECHO Crossgen2 failed with exitcode - !CrossGen2Status!
+        Exit /b 1
     )
 )
         ]]>

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -76,13 +76,14 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       fi
     fi
 
+    __OutputFile="$PWD/"
     if [ ! -z ${CompositeBuildMode+x} ]%3B then
-        __OutputFile=$PWD/composite-r2r.dll
+        __OutputFile+="composite-r2r.dll"
     else
-        __OutputFile=$PWD/$(MSBuildProjectName).dll
+        __OutputFile+="$(MSBuildProjectName).dll"
     fi
 
-    __ResponseFile="$(__OutputFile).rsp"
+    __ResponseFile="$__OutputFile.rsp"
     rm $__ResponseFile
 
     __Command=$_DebuggerFullPath
@@ -100,7 +101,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       echo -r:$PWD/IL/*.dll>>$__ResponseFile
     fi
 
-    echo -o:$(__OutputFile)>>$__ResponseFile
+    echo -o:$__OutputFile>>$__ResponseFile
     echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
     echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
     echo -r:$CORE_ROOT/mscorlib.dll>>$__ResponseFile


### PR DESCRIPTION
This change basically does three things:

1) Adds code to build-test.cmd/sh to Crossgen2 framework in composite mode;

2) Adds code to CLRTest.Crossgen.targets to run Crossgen2 in Helix in composite mode when told to do so via the CompositeBuildMode environment variable;

3) Implements YML fixes for composite pipeline support (sadly the jobs don't pass yet, apparently due to a codegen bug in CoreLib I'm currently investigating).

Thanks

Tomas