### PR TITLE
Creating a runtime pack artifacts directory in the libraries build

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -280,7 +280,8 @@
     <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
     <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
     <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\native</NETCoreAppRuntimePackNativePath>
-    <RuntimePackTargetFrameworkPath>runtimes/$(__RuntimeId)</RuntimePackTargetFrameworkPath>
+    <!--<RuntimePackTargetFrameworkPath>runtimes/$(__RuntimeId)</RuntimePackTargetFrameworkPath>-->
+    <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 
@@ -308,10 +309,12 @@
 
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' != 'iOS'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Android'">false</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(BinPlaceTestSharedFramework)' == '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 
-    <BinPlaceTestRuntimePack Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' == 'iOS'">true</BinPlaceTestRuntimePack>
+    <BinPlaceTestRuntimePack Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Android'">true</BinPlaceTestRuntimePack>
 
     <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -276,11 +276,7 @@
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
-    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\lib</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\native</NETCoreAppRuntimePackNativePath>
-    <NETCoreAppRuntimePackNativeIncludePath>$(NETCoreAppRuntimePackNativePath)\include</NETCoreAppRuntimePackNativeIncludePath>
-    <NETCoreAppRuntimePackNativeCrossPath>$(NETCoreAppRuntimePackNativePath)\cross</NETCoreAppRuntimePackNativeCrossPath>
+
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 
@@ -317,6 +313,15 @@
     <TestHostRuntimePath Condition="'$(BinPlaceNETFXRuntime)' == 'true'">$(TestHostRootPath)</TestHostRuntimePath>
 
     <PlatformManifestFile Condition="'$(BinPlaceTestSharedFramework)' == 'true'">$(TestHostRuntimePath)PlatformManifest.txt</PlatformManifestFile>
+
+    <!-- Add extra binplacing for the Runtime pack testing framework -->
+    <BinPlaceTestRuntimePack Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android')">true</BinPlaceTestRuntimePack>
+
+    <NETCoreAppRuntimePackPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
+    <NETCoreAppRuntimePackLibPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackPath)\lib</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackPath)\native</NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackNativeIncludePath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackNativePath)\include</NETCoreAppRuntimePackNativeIncludePath>
+    <NETCoreAppRuntimePackNativeCrossPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackNativePath)\cross</NETCoreAppRuntimePackNativeCrossPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PlatformManifestFile)' != '' and '$(IsTestProject)' == 'true'">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -277,6 +277,10 @@
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
+    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
+    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\native</NETCoreAppRuntimePackNativePath>
+    <RuntimePackTargetFrameworkPath>runtimes/$(__RuntimeId)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 
@@ -304,8 +308,10 @@
 
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' != 'iOS'">true</BinPlaceTestSharedFramework>
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
+
+    <BinPlaceTestRuntimePack Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' == 'iOS'">true</BinPlaceTestRuntimePack>
 
     <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
 
@@ -313,15 +319,6 @@
     <TestHostRuntimePath Condition="'$(BinPlaceNETFXRuntime)' == 'true'">$(TestHostRootPath)</TestHostRuntimePath>
 
     <PlatformManifestFile Condition="'$(BinPlaceTestSharedFramework)' == 'true'">$(TestHostRuntimePath)PlatformManifest.txt</PlatformManifestFile>
-
-    <!-- Add extra binplacing for the Runtime pack testing framework -->
-    <BinPlaceTestRuntimePack Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and ('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android')">true</BinPlaceTestRuntimePack>
-
-    <NETCoreAppRuntimePackPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackPath)\lib</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackPath)\native</NETCoreAppRuntimePackNativePath>
-    <NETCoreAppRuntimePackNativeIncludePath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackNativePath)\include</NETCoreAppRuntimePackNativeIncludePath>
-    <NETCoreAppRuntimePackNativeCrossPath Condition="'$(BinPlaceTestRuntimePack)' == 'true'">$(NETCoreAppRuntimePackNativePath)\cross</NETCoreAppRuntimePackNativeCrossPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PlatformManifestFile)' != '' and '$(IsTestProject)' == 'true'">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -280,7 +280,6 @@
     <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
     <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
     <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\native</NETCoreAppRuntimePackNativePath>
-    <!--<RuntimePackTargetFrameworkPath>runtimes/$(__RuntimeId)</RuntimePackTargetFrameworkPath>-->
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -278,8 +278,8 @@
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
     <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(__RuntimeId)\native</NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\native</NETCoreAppRuntimePackNativePath>>
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -308,8 +308,7 @@
 
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Android'">false</BinPlaceTestSharedFramework>
-    <BinPlaceTestSharedFramework Condition="'$(BinPlaceTestSharedFramework)' == '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
     
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -276,7 +276,11 @@
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
-
+    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)lib-runtime-packs/</NetCoreAppRuntimePackPath>
+    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)lib/<NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)native/<NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackNativeIncludePath>$(NETCoreAppRuntimePackNativePath)include/<NETCoreAppRuntimePackNativeIncludePath>
+    <NETCoreAppRuntimePackNativeCrossPath>$(NETCoreAppRuntimePackNativePath)cross/<NETCoreAppRuntimePackNativeCrossPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -276,11 +276,11 @@
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
-    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)lib-runtime-packs/</NetCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)lib/<NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)native/<NETCoreAppRuntimePackNativePath>
-    <NETCoreAppRuntimePackNativeIncludePath>$(NETCoreAppRuntimePackNativePath)include/<NETCoreAppRuntimePackNativeIncludePath>
-    <NETCoreAppRuntimePackNativeCrossPath>$(NETCoreAppRuntimePackNativePath)cross/<NETCoreAppRuntimePackNativeCrossPath>
+    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
+    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\lib</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\native</NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackNativeIncludePath>$(NETCoreAppRuntimePackNativePath)\include</NETCoreAppRuntimePackNativeIncludePath>
+    <NETCoreAppRuntimePackNativeCrossPath>$(NETCoreAppRuntimePackNativePath)\cross</NETCoreAppRuntimePackNativeCrossPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -308,7 +308,7 @@
 
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
     
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -277,9 +277,9 @@
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
-    <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\native</NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'lib-runtime-packs'))</NETCoreAppRuntimePackPath>
+    <NETCoreAppRuntimePackLibPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)', 'lib', '$(NETCoreAppFramework)'))</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)', 'native'))</NETCoreAppRuntimePackNativePath>
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -308,7 +308,7 @@
 
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
-    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
+    <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetsMobile)' != 'true'">true</BinPlaceTestSharedFramework>
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 
     <BinPlaceTestRuntimePack Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Android'">true</BinPlaceTestRuntimePack>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -271,7 +271,7 @@
     <!-- Paths to binplace package content -->
     <NETCoreAppPackageRefPath>$(ArtifactsBinDir)pkg\$(NetCoreAppCurrent)\ref</NETCoreAppPackageRefPath>
     <NETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\$(NetCoreAppCurrent)\lib</NETCoreAppPackageRuntimePath>
-    
+
     <ASPNETCoreAppPackageRefPath>$(ArtifactsBinDir)pkg\aspnetcoreapp\ref</ASPNETCoreAppPackageRefPath>
     <ASPNETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\aspnetcoreapp\lib</ASPNETCoreAppPackageRuntimePath>
 
@@ -279,7 +279,7 @@
 
     <NETCoreAppRuntimePackPath>$(ArtifactsBinDir)\lib-runtime-packs</NETCoreAppRuntimePackPath>
     <NETCoreAppRuntimePackLibPath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\lib\$(NETCoreAppFramework)</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\native</NETCoreAppRuntimePackNativePath>>
+    <NETCoreAppRuntimePackNativePath>$(NETCoreAppRuntimePackPath)\runtimes\$(PackageRID)\native</NETCoreAppRuntimePackNativePath>
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
@@ -309,7 +309,6 @@
   <PropertyGroup Condition="'$(BuildAllConfigurations)' != 'true'">
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
-    
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
 
     <BinPlaceTestRuntimePack Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Android'">true</BinPlaceTestRuntimePack>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -92,14 +92,13 @@
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
-    <!-- Setup the mobile testing directory -->
-    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+    <!-- Setup the runtime pack structure for mobile platforms (for testing and installer) -->
+    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackLibPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
-
-    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
-      <ItemName>BinMobileNative</ItemName>
+      <ItemName>NativeRuntimePackBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
 
     <!-- binplace targeting packs which may be different from Build TargetFramework -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -92,6 +92,16 @@
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
+    <!-- Setup the mobile testing directory -->
+    <BinPlaceTargetFrameworks Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+      <RuntimePath>$(NETCoreAppRuntimePackLibPath)</RuntimePath>
+    </BinPlaceTargetFrameworks>
+
+    <BinPlaceTargetFrameworks Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+      <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
+      <ItemName>BinMobileNative</ItemName>
+    </BinPlaceTargetFrameworks>
+
     <!-- binplace targeting packs which may be different from Build TargetFramework -->
     <BinPlaceTargetFrameworks Include="netstandard2.0">
       <RefPath>$(NetStandard20RefPath)</RefPath>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -93,11 +93,11 @@
     </BinPlaceTargetFrameworks>
 
     <!-- Setup the mobile testing directory -->
-    <BinPlaceTargetFrameworks Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
       <RuntimePath>$(NETCoreAppRuntimePackLibPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
-    <BinPlaceTargetFrameworks Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
+    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)" >
       <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
       <ItemName>BinMobileNative</ItemName>
     </BinPlaceTargetFrameworks>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -93,9 +93,11 @@
     </BinPlaceTargetFrameworks>
 
     <!-- Setup the runtime pack structure for mobile platforms (for testing and installer) -->
+    <!-- Corresponding assemblies are added to lib -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackLibPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
+    <!-- Corresponding libMono and system.native libraries are added to native -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
       <ItemName>NativeRuntimePackBinPlaceItem</ItemName>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -100,7 +100,7 @@
     <!-- Corresponding libMono and system.native libraries are added to native -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
-      <ItemName>NativeBinPlaceItems</ItemName>
+      <ItemName>NativeBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
 
     <!-- binplace targeting packs which may be different from Build TargetFramework -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -100,7 +100,7 @@
     <!-- Corresponding libMono and system.native libraries are added to native -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
-      <ItemName>NativeRuntimePackBinPlaceItem</ItemName>
+      <ItemName>NativeBinPlaceItems</ItemName>
     </BinPlaceTargetFrameworks>
 
     <!-- binplace targeting packs which may be different from Build TargetFramework -->

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -10,7 +10,7 @@
 
   <!-- Ordering matters! Overriding GetBinPlaceItems and Build targets after the Sdk import. -->
   <Target Name="GetBinPlaceItems">
-    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == ''">
+    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' != 'true'">
       <BinPlaceItem Include="$(NativeBinDir)*.dll" />
       <BinPlaceItem Include="$(NativeBinDir)*.pdb" />
       <BinPlaceItem Include="$(NativeBinDir)*.lib" />

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -20,7 +20,7 @@
       <BinPlaceItem Include="$(NativeBinDir)*.dbg" />
       <BinPlaceItem Include="$(NativeBinDir)*.dylib" />
       <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
-      <BinMobileNative Include="@(BinPlaceItem)" />
+      <BinMobileNative Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="@(BinPlaceItem)" />
       <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -20,7 +20,6 @@
       <BinPlaceItem Include="$(NativeBinDir)*.dbg" />
       <BinPlaceItem Include="$(NativeBinDir)*.dylib" />
       <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
-      <BinMobileNative Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="@(BinPlaceItem)" />
       <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
     <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true'">

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -20,6 +20,7 @@
       <BinPlaceItem Include="$(NativeBinDir)*.dbg" />
       <BinPlaceItem Include="$(NativeBinDir)*.dylib" />
       <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
+      <BinMobileNative Include="@(BinPlaceItem)" />
       <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -10,7 +10,7 @@
 
   <!-- Ordering matters! Overriding GetBinPlaceItems and Build targets after the Sdk import. -->
   <Target Name="GetBinPlaceItems">
-    <ItemGroup>
+    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == ''">
       <BinPlaceItem Include="$(NativeBinDir)*.dll" />
       <BinPlaceItem Include="$(NativeBinDir)*.pdb" />
       <BinPlaceItem Include="$(NativeBinDir)*.lib" />
@@ -22,6 +22,18 @@
       <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
       <BinMobileNative Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="@(BinPlaceItem)" />
       <FileWrites Include="@(BinPlaceItem)" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dll" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.pdb" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.lib" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.a" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.bc" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.so" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dbg" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dylib" />
+      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dwarf" />
+      <FileWrites Include="@(NativeRuntimePackBinPlaceItem)" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -10,29 +10,19 @@
 
   <!-- Ordering matters! Overriding GetBinPlaceItems and Build targets after the Sdk import. -->
   <Target Name="GetBinPlaceItems">
-    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' != 'true'">
-      <BinPlaceItem Include="$(NativeBinDir)*.dll" />
-      <BinPlaceItem Include="$(NativeBinDir)*.pdb" />
-      <BinPlaceItem Include="$(NativeBinDir)*.lib" />
-      <BinPlaceItem Include="$(NativeBinDir)*.a" />
-      <BinPlaceItem Include="$(NativeBinDir)*.bc" />
-      <BinPlaceItem Include="$(NativeBinDir)*.so" />
-      <BinPlaceItem Include="$(NativeBinDir)*.dbg" />
-      <BinPlaceItem Include="$(NativeBinDir)*.dylib" />
-      <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
-      <FileWrites Include="@(BinPlaceItem)" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dll" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.pdb" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.lib" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.a" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.bc" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.so" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dbg" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dylib" />
-      <NativeRuntimePackBinPlaceItem Include="$(NativeBinDir)/*.dwarf" />
-      <FileWrites Include="@(NativeRuntimePackBinPlaceItem)" />
+    <ItemGroup>
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.dll" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.pdb" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.lib" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.a" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.bc" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.so" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.dbg" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.dylib" />
+      <NativeBinPlaceItems Include="$(NativeBinDir)*.dwarf" />
+
+      <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItems)" />
+      <FileWrites Include="@(NativeBinPlaceItems)" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -11,18 +11,18 @@
   <!-- Ordering matters! Overriding GetBinPlaceItems and Build targets after the Sdk import. -->
   <Target Name="GetBinPlaceItems">
     <ItemGroup>
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.dll" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.pdb" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.lib" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.a" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.bc" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.so" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.dbg" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.dylib" />
-      <NativeBinPlaceItems Include="$(NativeBinDir)*.dwarf" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.dll" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.pdb" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.lib" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.a" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.bc" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.so" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.dbg" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.dylib" />
+      <NativeBinPlaceItem Include="$(NativeBinDir)*.dwarf" />
 
-      <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItems)" />
-      <FileWrites Include="@(NativeBinPlaceItems)" />
+      <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItem)" />
+      <FileWrites Include="@(NativeBinPlaceItem)" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,5 +1,13 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
+  <PropertyGroup Condition="'$(DotNetBuildTasksSharedFrameworkTaskDir)' == ''">
+    <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</DotNetBuildTasksSharedFrameworkTaskDir>
+    <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetBuildTasksSharedFrameworkTaskDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DotNetBuildTasksSharedFrameworkTaskFile>$(DotNetBuildTasksSharedFrameworkTaskDir)Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.dll</DotNetBuildTasksSharedFrameworkTaskFile>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
-  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
+
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
   <PropertyGroup Condition="'$(DotNetBuildTasksSharedFrameworkTaskDir)' == ''">
     <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</DotNetBuildTasksSharedFrameworkTaskDir>
     <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetBuildTasksSharedFrameworkTaskDir>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
+    <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
+    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
   </PropertyGroup>
 
   <!-- Explicitly build the runtime.depproj project first to correctly set up the testhost. -->
@@ -35,7 +37,7 @@
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
   <Target Name="GenerateFileVersionProps"
           DependsOnTargets="CollectSharedFrameworkRuntimeFiles"
-          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'"
+          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' != 'iOS'"
           AfterTargets="RestoreTestHost">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="Microsoft.NETCore.App"
@@ -57,5 +59,39 @@
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NETCoreAppTestSharedFrameworkPath)"
                                          RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"
                                          TargetRuntimeIdentifier="$(PackageRID)" />
+  </Target>
+
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
+  <Target Name="GenerateFrameworkListFile"
+          Condition="'$(BinPlaceTestRuntimePack)' == 'true'"
+          AfterTargets="RestoreTestHost">
+    <PropertyGroup>
+      <FrameworkListFilename>RuntimeList.xml</FrameworkListFilename>
+      <FrameworkListFile>$(NETCoreAppRuntimePackPath)/data/$(FrameworkListFilename)</FrameworkListFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_rpLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*" />
+      <_rpNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*" />
+
+      <_runtimePackFiles Include="@(_rpLibFiles)">
+        <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NETCoreAppFramework)</TargetPath>
+        <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
+      </_runtimePackFiles>
+      <_runtimePackFiles Include="@(_rpNativeFiles)">
+        <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
+        <IsNative>true</IsNative>
+      </_runtimePackFiles>
+      <FrameworkListRootAttributes Include="Name" Value=".NET $(NETCoreAppFrameworkVersion)" />
+      <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
+      <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(NETCoreAppFrameworkVersion)" />
+      <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
+    </ItemGroup>
+
+    <CreateFrameworkListFile
+      Files="@(_runtimePackFiles)"
+      TargetFile="$(FrameworkListFile)"
+      TargetFilePrefixes="ref/;runtimes/"
+      RootAttributes="@(FrameworkListRootAttributes)" />
   </Target>
 </Project>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -71,17 +71,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_rpLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*" />
-      <_rpNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*" />
-
-      <_runtimePackFiles Include="@(_rpLibFiles)">
+      <_rpLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NETCoreAppFramework)</TargetPath>
         <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
-      </_runtimePackFiles>
-      <_runtimePackFiles Include="@(_rpNativeFiles)">
+      </_rpLibFiles>
+      <_rpNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
         <IsNative>true</IsNative>
-      </_runtimePackFiles>
+      </_rpNativeFiles>
+
       <FrameworkListRootAttributes Include="Name" Value=".NET $(NETCoreAppFrameworkVersion)" />
       <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
       <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(NETCoreAppFrameworkVersion)" />
@@ -89,7 +87,7 @@
     </ItemGroup>
 
     <CreateFrameworkListFile
-      Files="@(_runtimePackFiles)"
+      Files="@(_rpLibFiles);@(_rpNativeFiles)"
       TargetFile="$(FrameworkListFile)"
       TargetFilePrefixes="ref/;runtimes/"
       RootAttributes="@(FrameworkListRootAttributes)" />

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
@@ -61,7 +62,7 @@
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 
-  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
   <Target Name="GenerateFrameworkListFile"
           Condition="'$(BinPlaceTestRuntimePack)' == 'true'"
           AfterTargets="RestoreTestHost">
@@ -71,14 +72,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_rpLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*">
+      <_runtimePackLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NETCoreAppFramework)</TargetPath>
         <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
-      </_rpLibFiles>
-      <_rpNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*">
+      </_runtimePackLibFiles>
+      <_runtimePackNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
         <IsNative>true</IsNative>
-      </_rpNativeFiles>
+      </_runtimePackNativeFiles>
 
       <FrameworkListRootAttributes Include="Name" Value=".NET $(NETCoreAppFrameworkVersion)" />
       <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
@@ -87,7 +88,7 @@
     </ItemGroup>
 
     <CreateFrameworkListFile
-      Files="@(_rpLibFiles);@(_rpNativeFiles)"
+      Files="@(_runtimePackLibFiles);@(_runtimePackNativeFiles)"
       TargetFile="$(FrameworkListFile)"
       TargetFilePrefixes="ref/;runtimes/"
       RootAttributes="@(FrameworkListRootAttributes)" />

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -37,7 +37,7 @@
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
   <Target Name="GenerateFileVersionProps"
           DependsOnTargets="CollectSharedFrameworkRuntimeFiles"
-          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetOS)' != 'iOS'"
+          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(BinplaceTestSharedFramework)' == 'true'"
           AfterTargets="RestoreTestHost">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="Microsoft.NETCore.App"

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -39,7 +39,7 @@
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(InstallerTasksAssemblyPath)"/>
   <Target Name="GenerateFileVersionProps"
           DependsOnTargets="CollectSharedFrameworkRuntimeFiles"
-          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(BinplaceTestSharedFramework)' == 'true'"
+          Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'"
           AfterTargets="RestoreTestHost">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="Microsoft.NETCore.App"

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,14 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
-  <PropertyGroup Condition="'$(DotNetBuildTasksSharedFrameworkTaskDir)' == ''">
-    <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(MSBuildThisFileDirectory)../tools/netcoreapp2.1/</DotNetBuildTasksSharedFrameworkTaskDir>
-    <DotNetBuildTasksSharedFrameworkTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(MSBuildThisFileDirectory)../tools/net472/</DotNetBuildTasksSharedFrameworkTaskDir>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DotNetBuildTasksSharedFrameworkTaskFile>$(DotNetBuildTasksSharedFrameworkTaskDir)Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk.dll</DotNetBuildTasksSharedFrameworkTaskFile>
-  </PropertyGroup>
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
-  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
@@ -94,4 +93,6 @@
       TargetFilePrefixes="ref/;runtimes/"
       RootAttributes="@(FrameworkListRootAttributes)" />
   </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
 </Project>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
-    <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
+    <NETCoreAppFrameworkIdentifier>$(TargetFrameworkIdentifier)</NETCoreAppFrameworkIdentifier>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
   </PropertyGroup>
 

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -73,11 +73,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_runtimePackLibFiles Include="$(NETCoreAppRuntimePackLibPath)\*.*">
+      <_runtimePackLibFiles Include="$(NETCoreAppRuntimePackLibPath)*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NETCoreAppFramework)</TargetPath>
         <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
       </_runtimePackLibFiles>
-      <_runtimePackNativeFiles Include="$(NETCoreAppRuntimePackNativePath)\*.*">
+      <_runtimePackNativeFiles Include="$(NETCoreAppRuntimePackNativePath)*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
         <IsNative>true</IsNative>
       </_runtimePackNativeFiles>

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -70,6 +70,34 @@
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(TargetOS)' != 'Windows_NT' and '$(OS)' != 'Windows_NT'"/>
   </Target>
 
+  <!-- Setup the runtime packs for mobile app testing -->
+  <Target Name="SetupMobileTesting"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
+          AfterTargets="AfterResolveReferences"
+          Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'">
+
+    <ItemGroup>
+      <MobileFile Include="@(RuntimeFiles)" />
+      <CrossFile Include="@(MonoCrossFiles)" />
+      <IncludeFile Include="@(MonoIncludeFiles)" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(MobileFile)"
+          DestinationFolder="$(NETCoreAppRuntimePackNativePath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+
+    <Copy SourceFiles="@(CrossFile)"
+          DestinationFolder="$(NETCoreAppRuntimePackNativeCrossPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+
+    <Copy SourceFiles="@(IncludeFile)"
+          DestinationFolder="$(NETCoreAppRuntimePackNativeIncludePath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+  </Target>
+
   <Target Name="OverrideRuntimeCoreCLR"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -109,7 +109,7 @@
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' == 'Mono'">
-    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == ''">
+    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' != 'true'">
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -74,7 +74,7 @@
   <Target Name="SetupMobileTesting"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences"
-          Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android'">
+          Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
 
     <ItemGroup>
       <MobileFile Include="@(RuntimeFiles)" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -44,9 +44,6 @@
           Condition="'$(BinPlaceTestSharedFramework)' == 'true'"
           AfterTargets="AfterResolveReferences">
     <PropertyGroup>
-      <GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</GlobalJsonContent>
-      <DotNetVersion>$([System.Text.RegularExpressions.Regex]::Match($(GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</DotNetVersion>
-
       <HostFxrFileName Condition="'$(TargetsWindows)' == 'true'">hostfxr</HostFxrFileName>
       <HostFxrFileName Condition="'$(TargetsWindows)' != 'true'">libhostfxr</HostFxrFileName>
 

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -26,6 +26,15 @@
     <FileToExclude Include="apphost" />
   </ItemGroup>
 
+  <!-- In-tree runtime packs do not require the host, so exclude --> 
+  <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
+    <FileToExclude Include="dotnet" />
+    <FileToExclude Include="libnethost" />
+    <FileToExclude Include="libhostfxr" />
+    <FileToExclude Include="libhostpolicy" />
+    <FileToExclude Include="nethost" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- System.Data.SqlClient is not live-built anymore -->
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
@@ -70,32 +79,18 @@
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(TargetOS)' != 'Windows_NT' and '$(OS)' != 'Windows_NT'"/>
   </Target>
 
-  <!-- Setup the runtime packs for mobile app testing -->
-  <Target Name="SetupMobileTesting"
-          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
-          AfterTargets="AfterResolveReferences"
-          Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
-
-    <ItemGroup>
-      <MobileFile Include="@(RuntimeFiles)" />
-      <CrossFile Include="@(MonoCrossFiles)" />
-      <IncludeFile Include="@(MonoIncludeFiles)" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(MobileFile)"
+  <Target Name="SetupRuntimePackNative"
+          Condition="'$(BinPlaceTestRuntimePack)' == 'true' and '$(RuntimeFlavor)' == 'Mono'"
+          AfterTargets="AfterResolveReferences">
+    <Copy SourceFiles="@(RuntimeFiles)"
           DestinationFolder="$(NETCoreAppRuntimePackNativePath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
-
-    <Copy SourceFiles="@(CrossFile)"
-          DestinationFolder="$(NETCoreAppRuntimePackNativeCrossPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
-
-    <Copy SourceFiles="@(IncludeFile)"
-          DestinationFolder="$(NETCoreAppRuntimePackNativeIncludePath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(MonoCrossFiles)"
+          DestinationFolder="$(NETCoreAppRuntimePackNativePath)/cross"
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(MonoIncludeFiles)"
+          DestinationFolder="$(NETCoreAppRuntimePackNativePath)/include/%(RecursiveDir)"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"
@@ -114,7 +109,7 @@
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences;FilterNugetPackages"
           Condition="'$(RuntimeFlavor)' == 'Mono'">
-    <ItemGroup>
+    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == ''">
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -17,18 +17,16 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostVersion)" />
-    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
+  <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' != 'true'">
+    <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostVersion)" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
     <!-- We do not need apphost.exe and the 3.0 SDK will actually remove it.
          Exclude here so that when building with the 2.x SDK we don't place it in the test shared framework.
          This can be removed once we have a new SDK -->
     <FileToExclude Include="apphost" />
-  </ItemGroup>
 
-  <ItemGroup>
     <!-- System.Data.SqlClient is not live-built anymore -->
-    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <!-- Exclude live-built dependencies -->
     <FileToExclude Include="Microsoft.Win32.Registry" />
     <FileToExclude Include="System.Security.AccessControl" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -74,13 +74,13 @@
           Condition="'$(BinPlaceTestRuntimePack)' == 'true' and '$(RuntimeFlavor)' == 'Mono'"
           AfterTargets="AfterResolveReferences">
     <ItemGroup>
-      <NativeBinPlaceItems Include="@(RuntimeFiles)" />
-      <NativeBinPlaceItems Include="@(MonoCrossFiles)">
+      <NativeBinPlaceItem Include="@(RuntimeFiles)" />
+      <NativeBinPlaceItem Include="@(MonoCrossFiles)">
         <DestinationSubDirectory>cross/</DestinationSubDirectory>
-      </NativeBinPlaceItems>
-      <NativeBinPlaceItems Include="@(MonoIncludeFiles)">
+      </NativeBinPlaceItem>
+      <NativeBinPlaceItem Include="@(MonoIncludeFiles)">
         <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
-      </NativeBinPlaceItems>
+      </NativeBinPlaceItem>
     </ItemGroup>
   </Target>
 

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostVersion)" />
-    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
+    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostVersion)" />
+    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
     <!-- We do not need apphost.exe and the 3.0 SDK will actually remove it.
          Exclude here so that when building with the 2.x SDK we don't place it in the test shared framework.
          This can be removed once we have a new SDK -->
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <!-- System.Data.SqlClient is not live-built anymore -->
-    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
+    <PackageReference Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
     <!-- Exclude live-built dependencies -->
     <FileToExclude Include="Microsoft.Win32.Registry" />
     <FileToExclude Include="System.Security.AccessControl" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -73,15 +73,15 @@
   <Target Name="SetupRuntimePackNative"
           Condition="'$(BinPlaceTestRuntimePack)' == 'true' and '$(RuntimeFlavor)' == 'Mono'"
           AfterTargets="AfterResolveReferences">
-    <Copy SourceFiles="@(RuntimeFiles)"
-          DestinationFolder="$(NETCoreAppRuntimePackNativePath)"
-          SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(MonoCrossFiles)"
-          DestinationFolder="$(NETCoreAppRuntimePackNativePath)/cross"
-          SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(MonoIncludeFiles)"
-          DestinationFolder="$(NETCoreAppRuntimePackNativePath)/include/%(RecursiveDir)"
-          SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <NativeBinPlaceItems Include="@(RuntimeFiles)" />
+      <NativeBinPlaceItems Include="@(MonoCrossFiles)">
+        <DestinationSubDirectory>cross/</DestinationSubDirectory>
+      </NativeBinPlaceItems>
+      <NativeBinPlaceItems Include="@(MonoIncludeFiles)">
+        <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
+      </NativeBinPlaceItems>
+    </ItemGroup>
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -26,15 +26,6 @@
     <FileToExclude Include="apphost" />
   </ItemGroup>
 
-  <!-- In-tree runtime packs do not require the host, so exclude --> 
-  <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true'">
-    <FileToExclude Include="dotnet" />
-    <FileToExclude Include="libnethost" />
-    <FileToExclude Include="libhostfxr" />
-    <FileToExclude Include="libhostpolicy" />
-    <FileToExclude Include="nethost" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- System.Data.SqlClient is not live-built anymore -->
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />


### PR DESCRIPTION
This PR looks to create a runtime package in the `artifacts/bin` directory through the libraries build process for the purpose testing the mobile apps (iOS and Android).

The desired directory hierarchy is as follows
```
- lib-runtime-packs
    - data
    - runtimes
       - <RID>
          - lib
             - <netcoreapp5.0>
          - native
             - include
             - cross
```
