### PR TITLE
Some refactoring of thread suspension.

### DIFF
--- a/src/coreclr/src/debug/di/rsthread.cpp
+++ b/src/coreclr/src/debug/di/rsthread.cpp
@@ -603,7 +603,7 @@ bool CordbThread::OwnsFrame(CordbFrame * pFrame)
 // This routine is a internal helper function for ICorDebugThread2::GetTaskId.
 //
 // Arguments:
-//    pHandle - return thread handle here after fetching from the left side. Can return SWITCHOUT_HANDLE_VALUE.
+//    pHandle - return thread handle here after fetching from the left side.
 //
 // Return Value:
 //    hr - It can fail with CORDBG_E_THREAD_NOT_SCHEDULED.
@@ -628,12 +628,6 @@ void CordbThread::RefreshHandle(HANDLE * phThread)
 
     IDacDbiInterface * pDAC = GetProcess()->GetDAC();
     HANDLE hThread = pDAC->GetThreadHandle(m_vmThreadToken);
-
-    if (hThread == SWITCHOUT_HANDLE_VALUE)
-    {
-        *phThread = SWITCHOUT_HANDLE_VALUE;
-        ThrowHR(CORDBG_E_THREAD_NOT_SCHEDULED);
-    }
 
     _ASSERTE(hThread != INVALID_HANDLE_VALUE);
     PREFAST_ASSUME(hThread != NULL);

--- a/src/coreclr/src/inc/cor.h
+++ b/src/coreclr/src/inc/cor.h
@@ -143,8 +143,6 @@ typedef UNALIGNED void const *UVCP_CONSTANT;
 #define TARGET_MAIN_CLR_DLL_NAME_W    MAKE_TARGET_DLLNAME_W(MAIN_CLR_MODULE_NAME_W)
 #define TARGET_MAIN_CLR_DLL_NAME_A    MAKE_TARGET_DLLNAME_A(MAIN_CLR_MODULE_NAME_A)
 
-#define SWITCHOUT_HANDLE_VALUE ((HANDLE)(LONG_PTR)-2)
-
 //*****************************************************************************
 //*****************************************************************************
 //

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4016,9 +4016,6 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             value = gtNewIndOfIconHandleNode(TYP_INT, (size_t)addrTrap, GTF_ICON_GLOBAL_PTR, false);
         }
 
-        // Treat the reading of g_TrapReturningThreads as volatile.
-        value->gtFlags |= GTF_IND_VOLATILE;
-
         // Compare for equal to zero
         GenTree* trapRelop = gtNewOperNode(GT_EQ, TYP_INT, value, gtNewIconNode(0, TYP_INT));
 

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4016,8 +4016,11 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             value = gtNewIndOfIconHandleNode(TYP_INT, (size_t)addrTrap, GTF_ICON_GLOBAL_PTR, false);
         }
 
-        // Do not allow CSE. We want every read of the flag to actually happen.
-        value->gtFlags |= GTF_DONT_CSE;
+        // NOTE: in c++ an equivalent load is done via LoadWithoutBarrier() to ensure that the
+        // program order is preserved. (not hoisted out of a loop or cached in a local, for example)
+        //
+        // Here we introduce the read really late after all major optimizations are done, and the location
+        // is formally unknown, so noone could optimize the load, thus no special flags are needed.
 
         // Compare for equal to zero
         GenTree* trapRelop = gtNewOperNode(GT_EQ, TYP_INT, value, gtNewIconNode(0, TYP_INT));

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4016,6 +4016,9 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             value = gtNewIndOfIconHandleNode(TYP_INT, (size_t)addrTrap, GTF_ICON_GLOBAL_PTR, false);
         }
 
+        // Do not allow CSE. We want every read of the flag to actually happen.
+        value->gtFlags |= GTF_DONT_CSE;
+
         // Compare for equal to zero
         GenTree* trapRelop = gtNewOperNode(GT_EQ, TYP_INT, value, gtNewIconNode(0, TYP_INT));
 

--- a/src/coreclr/src/vm/gccover.cpp
+++ b/src/coreclr/src/vm/gccover.cpp
@@ -1266,7 +1266,7 @@ void RemoveGcCoverageInterrupt(TADDR instrPtr, BYTE * savedInstrPtr, GCCoverageI
 
 // A managed thread (T) can race with the GC as follows:
 // 1)	At the first safepoint, we notice that T is in preemptive mode during the call for GCStress
-//      So, it is put it in cooperative mode for the purpose of GCStress(fPremptiveGcDisabledForGcStress)
+//      So, it is put it in cooperative mode for the purpose of GCStress(fPreemptiveGcDisabledForGcStress)
 // 2)	We DoGCStress(). Start off background GC in a different thread.
 // 3)	Then the thread T is put back to preemptive mode (because that's where it was).
 //      Thread T continues execution along with the GC thread.

--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -9159,7 +9159,7 @@ HRESULT ProfToEEInterfaceImpl::RequestReJIT(ULONG       cFunctions,   // in
         // Yay!
         NOTHROW;
 
-        // When we suspend the runtime we drop into premptive mode
+        // When we suspend the runtime we drop into preemptive mode
         GC_TRIGGERS;
 
         // Yay!

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -388,7 +388,7 @@ BOOL Thread::Alert ()
     BOOL fRetVal = FALSE;
     {
         HANDLE handle = GetThreadHandle();
-        if (handle != INVALID_HANDLE_VALUE && handle != SWITCHOUT_HANDLE_VALUE)
+        if (handle != INVALID_HANDLE_VALUE)
         {
             fRetVal = ::QueueUserAPC(UserInterruptAPC, handle, APC_Code);
         }
@@ -422,7 +422,7 @@ DWORD Thread::JoinEx(DWORD timeout, WaitMode mode)
         mode = (WaitMode)(mode & ~WaitMode_InDeadlock);
 
         HANDLE handle = GetThreadHandle();
-        if (handle == INVALID_HANDLE_VALUE || handle == SWITCHOUT_HANDLE_VALUE) {
+        if (handle == INVALID_HANDLE_VALUE) {
             return WAIT_FAILED;
         }
         if (pCurThread) {
@@ -572,8 +572,7 @@ DWORD Thread::StartThread()
     m_Creater.Clear();
 #endif
 
-    _ASSERTE (GetThreadHandle() != INVALID_HANDLE_VALUE &&
-                GetThreadHandle() != SWITCHOUT_HANDLE_VALUE);
+    _ASSERTE (GetThreadHandle() != INVALID_HANDLE_VALUE);
     dwRetVal = ::ResumeThread(GetThreadHandle());
 
 
@@ -1000,7 +999,7 @@ HRESULT Thread::DetachThread(BOOL fDLLThreadDetach)
     }
 
     HANDLE hThread = GetThreadHandle();
-    SetThreadHandle (SWITCHOUT_HANDLE_VALUE);
+    SetThreadHandle (INVALID_HANDLE_VALUE);
     while (m_dwThreadHandleBeingUsed > 0)
     {
         // Another thread is using the handle now.

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -5181,7 +5181,16 @@ void ThreadStore::InitThreadStore()
 // additional semantics well beyond a normal lock.
 DEBUG_NOINLINE void ThreadStore::Enter()
 {
-    WRAPPER_NO_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        // we must be in preemptive mode while taking this lock
+        // if suspension is in progress, the lock is taken, and there is no way to suspend us once we block
+        MODE_PREEMPTIVE;
+    }
+    CONTRACTL_END;
+
     ANNOTATION_SPECIAL_HOLDER_CALLER_NEEDS_DYNAMIC_CONTRACT;
     CHECK_ONE_STORE();
     m_Crst.Enter();
@@ -5189,7 +5198,12 @@ DEBUG_NOINLINE void ThreadStore::Enter()
 
 DEBUG_NOINLINE void ThreadStore::Leave()
 {
-    WRAPPER_NO_CONTRACT;
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
+
     ANNOTATION_SPECIAL_HOLDER_CALLER_NEEDS_DYNAMIC_CONTRACT;
     CHECK_ONE_STORE();
     m_Crst.Leave();

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -1097,8 +1097,11 @@ public:
         TS_Unknown                = 0x00000000,    // threads are initialized this way
 
         TS_AbortRequested         = 0x00000001,    // Abort the thread
-        TS_GCSuspendPending       = 0x00000002,    // waiting to get to safe spot for GC,
-                                                   // only ThreadSuspend::SuspendRuntime writes/resets this state.
+
+        TS_GCSuspendPending       = 0x00000002,    // ThreadSuspend::SuspendRuntime watches this thread to leave coop mode.
+        TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspention routine.
+        TS_GCSuspendFlags         = TS_GCSuspendPending | TS_GCSuspendRedirected, // used to track suspension progress. Only SuspendRuntime writes/resets these.
+
         TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads?
         TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)
 

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -1097,7 +1097,8 @@ public:
         TS_Unknown                = 0x00000000,    // threads are initialized this way
 
         TS_AbortRequested         = 0x00000001,    // Abort the thread
-        TS_GCSuspendPending       = 0x00000002,    // waiting to get to safe spot for GC
+        TS_GCSuspendPending       = 0x00000002,    // waiting to get to safe spot for GC,
+                                                   // only ThreadSuspend::SuspendRuntime writes/resets this state.
         TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads?
         TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)
 
@@ -3938,7 +3939,7 @@ public:
             UnhijackThread();
 #endif // FEATURE_HIJACK
 
-        ResetThreadState(TS_GCSuspendPending);
+        _ASSERTE(!HasThreadStateOpportunistic(Thread::TS_GCSuspendPending));
     }
 
     static LPVOID GetStaticFieldAddress(FieldDesc *pFD);

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -3514,7 +3514,6 @@ private:
             CounterHolder handleHolder(&m_dwThreadHandleBeingUsed);
             HANDLE handle = m_ThreadHandle;
             _ASSERTE ( handle == INVALID_HANDLE_VALUE
-                || handle == SWITCHOUT_HANDLE_VALUE
                 || m_OSThreadId == 0
                 || m_OSThreadId == 0xbaadf00d
                 || ::MatchThreadHandleToOsId(handle, (DWORD)m_OSThreadId) );
@@ -3530,7 +3529,6 @@ private:
         LIMITED_METHOD_CONTRACT;
 #if defined(_DEBUG)
         _ASSERTE ( h == INVALID_HANDLE_VALUE
-            || h == SWITCHOUT_HANDLE_VALUE
             || m_OSThreadId == 0
             || m_OSThreadId == 0xbaadf00d
             || ::MatchThreadHandleToOsId(h, (DWORD)m_OSThreadId) );

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -2405,10 +2405,6 @@ public:
         // that either we are not allowed to call into the host, or we ran
         // out of memory.
         STR_NoStressLog,
-
-        // The EE thread is currently switched out.  This can only happen
-        // if we are hosted and the host schedules EE threads on fibers.
-        STR_SwitchedOut,
     };
 
 #if defined(FEATURE_HIJACK) && defined(TARGET_UNIX)

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -2505,6 +2505,8 @@ void Thread::RareEnablePreemptiveGC()
     // holding a spin lock in coop mode and transit to preemp mode will cause deadlock on GC
     _ASSERTE ((m_StateNC & Thread::TSNC_OwnsSpinLock) == 0);
 
+    _ASSERTE(!MethodDescBackpatchInfoTracker::IsLockOwnedByCurrentThread() || IsInForbidSuspendForDebuggerRegion());
+
 #if defined(STRESS_HEAP) && defined(_DEBUG)
     if (!IsDetached())
         PerformPreemptiveGC();

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -437,7 +437,6 @@ DWORD Thread::ResumeThread()
     CONTRACTL_END;
 
     _ASSERTE (m_ThreadHandleForResume != INVALID_HANDLE_VALUE);
-    _ASSERTE (GetThreadHandle() != SWITCHOUT_HANDLE_VALUE);
 
     //DWORD res = ::ResumeThread(GetThreadHandle());
     DWORD res = ::ResumeThread(m_ThreadHandleForResume);

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -3504,7 +3504,8 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
 
     for (;;)
     {
-        for (Thread *thread = ThreadStore::GetThreadList(NULL); thread != NULL; thread = ThreadStore::GetThreadList(thread))
+        Thread* thread = NULL;
+        while ((thread = ThreadStore::GetThreadList(thread)) != NULL)
         {
             if (thread == pCurThread)
                 continue;
@@ -3710,7 +3711,7 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
 
         // If we have just updated hijacks/redirects, then do a pass while only observing.
         // Repeat observing only as long as we see progress. Most threads react to hijack/redirect very fast and
-        // typically we can avoid waiting on an event. (except on uniporocessor where we do not spin)
+        // typically we can avoid waiting on an event. (except on uniprocessor where we do not spin)
         //
         // Otherwise redo hijacks, but check g_pGCSuspendEvent event on the way.
         // Re-hijacking unconditionally is likely to execute exactly the same hijacks,
@@ -3769,7 +3770,8 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
                 _ASSERTE(!"Timed out trying to suspend EE due to thread");
                 char message[256];
 
-                for (Thread *thread = ThreadStore::GetThreadList(NULL); thread != NULL; thread = ThreadStore::GetThreadList(thread))
+                Thread* thread = NULL;
+                while ((thread = ThreadStore::GetThreadList(thread)) != NULL)
                 {
                     if (thread == pCurThread)
                         continue;
@@ -3820,7 +3822,8 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
     // gcstress instruction updates need to occur.  Each thread can
     // have only one pending at a time.
     //
-    for (Thread *thread = ThreadStore::GetThreadList(NULL); thread != NULL; thread = ThreadStore::GetThreadList(thread))
+    Thread* thread = NULL;
+    while ((thread = ThreadStore::GetThreadList(thread)) != NULL)
     {
         thread->CommitGCStressInstructionUpdate();
     }
@@ -5869,7 +5872,6 @@ retry_for_debugger:
             // I wonder how much confusion this has caused....)
             // It seems like much of the above is redundant.  We should investigate reducing the number
             // of mechanisms we use to indicate that a suspension is in progress.
-            // +1
             GCHeapUtilities::GetGCHeap()->SetGCInProgress(true);
 
             // set tls flags for compat with SOS

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -2004,7 +2004,7 @@ void ThreadSuspend::LockThreadStore(ThreadSuspend::SUSPEND_REASON reason)
         // runtime threads for a GC that depends on the fact that we
         // do an EnablePreemptiveGC and a DisablePreemptiveGC around
         // taking this lock.
-        // besides, if the suspension is in progress, the lock is taken, we better be in premptive mode while blocked on this lock.
+        // besides, if the suspension is in progress, the lock is taken, we better be in preemptive mode while blocked on this lock.
         if (toggleGC)
             pCurThread->EnablePreemptiveGC();
 

--- a/src/coreclr/src/vm/threadsuspend.cpp
+++ b/src/coreclr/src/vm/threadsuspend.cpp
@@ -3511,7 +3511,7 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
     // we do not on uniprocessor though (spin-checking is pointless on uniprocessor)
     bool observeOnly = false;
 
-    _ASSERTE(!pCurThread->HasThreadState(Thread::TS_GCSuspendFlags));
+    _ASSERTE(!pCurThread || !pCurThread->HasThreadState(Thread::TS_GCSuspendFlags));
 #ifdef _DEBUG
     DWORD dbgStartTimeout = GetTickCount();
 #endif


### PR DESCRIPTION
Original goal was to understand better suspension code and add comments to tricky points. 
There were few places that could benefit from some refactoring. In fact there were already comments in few places recommending changes.

The major part here is merging 2 nearly identical suspend/hijack/redirect loops into one loop and changing it a bit to avoid unnecessary work. In particular, when suspension of a thread is already in progress we were too eager to retry without giving the thread enough chances to park itself.

There are some minor cleanups as well - like removing code related to fibers.
And added a few comments in places where I felt like the purpose or invariants of the code were not obvious.

The end effects on the suspension latencies is 
- some improvement in scenarios where user threads aggressively poll for GC suspension and 
- substantial improvements when threads are not polling (up to 4X faster). 

The real-world cases will be some mix of the above, so it will vary, but should improve.
