### PR TITLE
fix compilation on freebsd

### DIFF
--- a/src/coreclr/src/gc/unix/cgroup.cpp
+++ b/src/coreclr/src/gc/unix/cgroup.cpp
@@ -23,7 +23,7 @@ Abstract:
 #include <stdio.h>
 #include <string.h>
 #include <sys/resource.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #else

--- a/src/coreclr/src/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/src/pal/src/misc/cgroup.cpp
@@ -20,7 +20,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #include "pal/virtual.h"
 #include "pal/cgroup.h"
 #include <algorithm>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/param.h>
 #include <sys/mount.h>
 #else

--- a/src/coreclr/tests/src/profiler/native/profilerstring.h
+++ b/src/coreclr/tests/src/profiler/native/profilerstring.h
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <cstring>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 // On linux the runtime uses 16 bit strings but the native platform wchar_t is 32 bit.
 // This means there aren't c runtime functions like wcslen for 16 bit strings. The idea
 // here is to provide the easy ones to avoid all the copying and transforming. If more complex
@@ -50,9 +50,9 @@ inline int wcscmp(const char16_t *lhs, const char16_t *rhs)
     return lhs[i] - rhs[i];
 }
 
-#else // defined(__linux__) || defined(__APPLE__)
+#else // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #define WCHAR(str) L##str
-#endif // defined(__linux__) || defined(__APPLE__)
+#endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
 // 16 bit string type that works cross plat and doesn't require changing widths
 // on non-windows platforms
@@ -202,11 +202,11 @@ inline std::wostream& operator<<(std::wostream& os, const String& obj)
             break;
         }
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         os << static_cast<wchar_t>(obj.buffer[i]);
-#else // defined(__linux__) || defined(__APPLE__)
+#else // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         os << obj.buffer[i];
-#endif // defined(__linux__) || defined(__APPLE__)
+#endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
     }
 
     return os;


### PR DESCRIPTION
regression caused by #34334:
```
Scanning dependencies of target cee_wks
/home/furt/github/wfurt-runtime2/src/coreclr/src/gc/unix/cgroup.cpp:30:10: fatal error: 'sys/vfs.h' file not found
#include <sys/vfs.h>
         ^~~~~~~~~~~
1 error generated.
src/gc/CMakeFiles/clrgc.dir/build.make:296: recipe for target 'src/gc/CMakeFiles/clrgc.dir/unix/cgroup.cpp.o' failed
make[2]: *** [src/gc/CMakeFiles/clrgc.dir/unix/cgroup.cpp.o] Error 1
```

It may be better long run include vfs.h only if exist but this is fix follows current pattern based on OS. 