### PR TITLE
Add logic for JsonIgnoreCondition.[Never|WhenNull] on properties to win over global IgnoreReadOnlyValues

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -79,8 +79,9 @@ namespace System.Text.Json
 
         public static JsonPropertyInfo AddProperty(Type propertyType, PropertyInfo propertyInfo, Type parentClassType, JsonSerializerOptions options)
         {
-            JsonIgnoreAttribute? ignoreAttribute = JsonPropertyInfo.GetAttribute<JsonIgnoreAttribute>(propertyInfo);
-            if (ignoreAttribute?.Condition == JsonIgnoreCondition.Always)
+            JsonIgnoreCondition? ignoreCondition = JsonPropertyInfo.GetAttribute<JsonIgnoreAttribute>(propertyInfo)?.Condition;
+
+            if (ignoreCondition == JsonIgnoreCondition.Always)
             {
                 return JsonPropertyInfo.CreateIgnoredPropertyPlaceholder(propertyInfo, options);
             }
@@ -98,7 +99,8 @@ namespace System.Text.Json
                 propertyInfo,
                 parentClassType,
                 converter,
-                options);
+                options,
+                ignoreCondition);
         }
 
         internal static JsonPropertyInfo CreateProperty(
@@ -107,7 +109,8 @@ namespace System.Text.Json
             PropertyInfo? propertyInfo,
             Type parentClassType,
             JsonConverter converter,
-            JsonSerializerOptions options)
+            JsonSerializerOptions options,
+            JsonIgnoreCondition? ignoreCondition = null)
         {
             // Create the JsonPropertyInfo instance.
             JsonPropertyInfo jsonPropertyInfo = converter.CreateJsonPropertyInfo();
@@ -119,6 +122,7 @@ namespace System.Text.Json
                 runtimeClassType: converter.ClassType,
                 propertyInfo,
                 converter,
+                ignoreCondition,
                 options);
 
             return jsonPropertyInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfTTypeToConvert.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfTTypeToConvert.cs
@@ -25,6 +25,7 @@ namespace System.Text.Json
             ClassType runtimeClassType,
             PropertyInfo? propertyInfo,
             JsonConverter converter,
+            JsonIgnoreCondition? ignoreCondition,
             JsonSerializerOptions options)
         {
             base.Initialize(
@@ -34,6 +35,7 @@ namespace System.Text.Json
                 runtimeClassType,
                 propertyInfo,
                 converter,
+                ignoreCondition,
                 options);
 
             if (propertyInfo != null)
@@ -57,7 +59,7 @@ namespace System.Text.Json
                 HasSetter = true;
             }
 
-            GetPolicies();
+            GetPolicies(ignoreCondition);
         }
 
         public override JsonConverter ConverterBase

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -587,7 +587,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             public int Int1 { get; set; }
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
-            public int MyInt { get; set;  }
+            public int MyInt { get; set; }
             public int Int2 { get; set; }
         }
 
@@ -708,7 +708,8 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = @"{""MyString"":""Random"",""MYSTRING"":null}";
 
-            var options = new JsonSerializerOptions {
+            var options = new JsonSerializerOptions
+            {
                 IgnoreNullValues = true,
                 PropertyNameCaseInsensitive = true
             };
@@ -780,6 +781,63 @@ namespace System.Text.Json.Serialization.Tests
 
             [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
             public Dictionary<string, string> Dictionary { get; set; } = new Dictionary<string, string> { ["Key"] = "Value" };
+        }
+
+        [Fact]
+        public static void IgnoreConditionNever_WinsOver_IgnoreReadOnlyValues()
+        {
+            var options = new JsonSerializerOptions { IgnoreReadOnlyProperties = true };
+
+            // Baseline
+            string json = JsonSerializer.Serialize(new ClassWithReadOnlyString("Hello"), options);
+            Assert.Equal("{}", json);
+
+            // With condition to never ignore
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreNever("Hello"), options);
+            Assert.Equal(@"{""MyString"":""Hello""}", json);
+
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreNever(null), options);
+            Assert.Equal(@"{""MyString"":null}", json);
+        }
+
+        [Fact]
+        public static void IgnoreConditionWhenNull_WinsOver_IgnoreReadOnlyValues()
+        {
+            var options = new JsonSerializerOptions { IgnoreReadOnlyProperties = true };
+
+            // Baseline
+            string json = JsonSerializer.Serialize(new ClassWithReadOnlyString("Hello"), options);
+            Assert.Equal("{}", json);
+
+            // With condition to ignore when null
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenNull("Hello"), options);
+            Assert.Equal(@"{""MyString"":""Hello""}", json);
+
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenNull(null), options);
+            Assert.Equal(@"{}", json);
+        }
+
+        private class ClassWithReadOnlyString
+        {
+            public string MyString { get; }
+
+            public ClassWithReadOnlyString(string myString) => MyString = myString;
+        }
+
+        private class ClassWithReadOnlyString_IgnoreNever
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+            public string MyString { get; }
+
+            public ClassWithReadOnlyString_IgnoreNever(string myString) => MyString = myString;
+        }
+
+        private class ClassWithReadOnlyString_IgnoreWhenNull
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            public string MyString { get; }
+
+            public ClassWithReadOnlyString_IgnoreWhenNull(string myString) => MyString = myString;
         }
     }
 }


### PR DESCRIPTION
Options specified on properties should win over options set on `JsonSerializerOptions`. This change affects serialization only.

`JsonIgnoreCondition` was introduced in https://github.com/dotnet/runtime/pull/34049 and was part of  preview 3. This change will thus be a behavorial breaking change between preview 3 & 4 (but will likely not be noticed).