### PR TITLE
Fix merge mistake in runtime-official.yml

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -209,7 +209,6 @@ stages:
       platforms:
       - tvOS_x64
       - tvOS_arm64
-      - iOS_arm
       # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
       - iOS_arm64
       - iOS_x64


### PR DESCRIPTION
iOS_arm should be disabled but resolving a merge conflict caused a wrong line to be added.