### PR TITLE
Fix installer signing after restore changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
   <Import Project="$(RepositoryEngineeringDir)Configurations.props" />
 
   <!--
-    Get ProjectToBuild and '<subset>ProjectToBuild' items. Using the items lets projects handle
+    Get '<subset>Project' items. Using the items lets projects handle
     $(Subset) automatically when creating project-to-project dependencies.
   -->
   <Import Project="$(RepositoryEngineeringDir)Subsets.props" />

--- a/eng/SubsetValidation.targets
+++ b/eng/SubsetValidation.targets
@@ -2,11 +2,11 @@
   <!--
     The imported file supports the '/p:Subset=<desired subset string>' dev build argument.
 
-    Each subset has its own '<subset>ProjectToBuild' items so that a project in the build can depend
+    Each subset has its own '<subset>Project' items so that a project in the build can depend
     on a whole subset, and the dependency on the subset is disregarded automatically when Subset
     doesn't contain it.
 
-    %(ProjectToBuild.SignPhase): Indicates this project must be built before a certain signing
+    %(InstallerProject.SignPhase): Indicates this project must be built before a certain signing
       phase. Projects can depend on 'signing/stages/Sign<stage>.proj' to wait until all projects
       that are part of a stage are complete. This allows the build to perform complex container
       signing that isn't (can't be?) supported by Arcade's single pass, such as MSIs and bundles:

--- a/src/installer/signing/SignBinaries.proj
+++ b/src/installer/signing/SignBinaries.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'Binaries'))" />
+    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'Binaries'))" />
   </ItemGroup>
 
 </Project>

--- a/src/installer/signing/SignBurnBundleFiles.proj
+++ b/src/installer/signing/SignBurnBundleFiles.proj
@@ -4,7 +4,7 @@
   <Target Name="ReattachAllEnginesToBundles"
           BeforeTargets="RunArcadeSigning">
     <MSBuild
-      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
+      Projects="@(InstallerProject -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
       Targets="ReattachEngineToBundle" />
   </Target>
 

--- a/src/installer/signing/SignBurnEngineFiles.proj
+++ b/src/installer/signing/SignBurnEngineFiles.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))" />
+    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))" />
   </ItemGroup>
 
   <!-- To sign the burn engines, they need to be extracted from the bundles using WiX tools. -->

--- a/src/installer/signing/SignMsiFiles.proj
+++ b/src/installer/signing/SignMsiFiles.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'MsiFiles'))" />
+    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'MsiFiles'))" />
   </ItemGroup>
 
   <!--

--- a/src/installer/signing/SignR2RBinaries.proj
+++ b/src/installer/signing/SignR2RBinaries.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'R2RBinaries'))" />
+    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'R2RBinaries'))" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This should fix the official build signing validation. I did a dryrun of signing locally and it seems like now all the files are passed down correctly.
This is from the list passed to the sign task for SignBinaries.proj:
![image](https://user-images.githubusercontent.com/22899328/78825894-87950600-7995-11ea-9d6d-b6ad9cada251.png)

This is from signing the bundle and reattaching it. 

![image](https://user-images.githubusercontent.com/22899328/78826157-e8bcd980-7995-11ea-9dfe-0527e77bb039.png)

This is from SignMsiFiles step:
![image](https://user-images.githubusercontent.com/22899328/78826339-31749280-7996-11ea-9b2f-3deec820908e.png)

cc: @dotnet/runtime-infrastructure 