### PR TITLE
[master] Fix runtime.native.System.IO.Ports package baseline

### DIFF
--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -1448,9 +1448,10 @@
     },
     "runtime.native.System.IO.Ports": {
       "StableVersions": [
-        "4.6.0"
+        "4.6.0",
+        "4.7.0"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "4.7.0",
       "InboxOn": {}
     },
     "SMDiagnostics": {


### PR DESCRIPTION
This version is not produced in 5.0 and appears it should be baselined at 4.7.0