### PR TITLE
Several allocation reductions in SocketsHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayHelpers.cs
@@ -8,6 +8,9 @@ namespace System
 {
     internal static class ByteArrayHelpers
     {
+        // TODO: https://github.com/dotnet/runtime/issues/28230
+        // Use Ascii.Equals* when it's available.
+
         internal static bool EqualsOrdinalAsciiIgnoreCase(string left, ReadOnlySpan<byte> right)
         {
             Debug.Assert(left != null, "Expected non-null string");
@@ -22,16 +25,33 @@ namespace System
                 uint charA = left[i];
                 uint charB = right[i];
 
-                unchecked
-                {
-                    // We're only interested in ASCII characters here.
-                    if ((charA - 'a') <= ('z' - 'a'))
-                        charA -= ('a' - 'A');
-                    if ((charB - 'a') <= ('z' - 'a'))
-                        charB -= ('a' - 'A');
-                }
+                // We're only interested in ASCII characters here.
+                if ((charA - 'a') <= ('z' - 'a'))
+                    charA -= ('a' - 'A');
+                if ((charB - 'a') <= ('z' - 'a'))
+                    charB -= ('a' - 'A');
 
                 if (charA != charB)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool EqualsOrdinalAscii(string left, ReadOnlySpan<byte> right)
+        {
+            Debug.Assert(left != null, "Expected non-null string");
+
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (left[i] != right[i])
                 {
                     return false;
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -266,6 +266,11 @@ namespace System.Net.Http.Headers
         {
         }
 
+        internal HttpRequestHeaders(bool forceHeaderStoreItems)
+            : base(HttpHeaderType.General | HttpHeaderType.Request | HttpHeaderType.Custom, HttpHeaderType.Response, forceHeaderStoreItems)
+        {
+        }
+
         internal override void AddHeaders(HttpHeaders sourceHeaders)
         {
             base.AddHeaders(sourceHeaders);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -45,17 +45,8 @@ namespace System.Net.Http
             }
         }
 
-        public HttpRequestHeaders DefaultRequestHeaders
-        {
-            get
-            {
-                if (_defaultRequestHeaders == null)
-                {
-                    _defaultRequestHeaders = new HttpRequestHeaders();
-                }
-                return _defaultRequestHeaders;
-            }
-        }
+        public HttpRequestHeaders DefaultRequestHeaders =>
+            _defaultRequestHeaders ??= new HttpRequestHeaders(forceHeaderStoreItems: true);
 
         public Version DefaultRequestVersion
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1027,7 +1027,7 @@ namespace System.Net.Http
                 return;
             }
 
-            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+            foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
                 int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
                 Debug.Assert(headerValuesCount > 0, "No values for header??");

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -532,23 +532,24 @@ namespace System.Net.Http
                             throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
                         }
 
-                        string headerValue = descriptor.GetHeaderValue(value);
-
                         // Note we ignore the return value from TryAddWithoutValidation;
                         // if the header can't be added, we silently drop it.
                         if (_responseProtocolState == ResponseProtocolState.ExpectingTrailingHeaders)
                         {
                             Debug.Assert(_trailers != null);
+                            string headerValue = descriptor.GetHeaderValue(value);
                             _trailers.Add(KeyValuePair.Create((descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue));
                         }
                         else if ((descriptor.HeaderType & HttpHeaderType.Content) == HttpHeaderType.Content)
                         {
                             Debug.Assert(_response != null && _response.Content != null);
+                            string headerValue = descriptor.GetHeaderValue(value);
                             _response.Content.Headers.TryAddWithoutValidation(descriptor, headerValue);
                         }
                         else
                         {
                             Debug.Assert(_response != null);
+                            string headerValue = _connection.GetResponseHeaderValueWithCaching(descriptor, value);
                             _response.Headers.TryAddWithoutValidation((descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
                         }
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -593,7 +593,7 @@ namespace System.Net.Http
                 return;
             }
 
-            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+            foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
                 int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
                 Debug.Assert(headerValuesCount > 0, "No values for header??");

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -920,7 +920,7 @@ namespace System.Net.Http
             }
             else
             {
-                string headerValue = staticValue ?? descriptor.GetHeaderValue(literalValue);
+                string headerValue = staticValue ?? _connection.GetResponseHeaderValueWithCaching(descriptor, literalValue);
 
                 switch (_headerState)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -198,7 +198,7 @@ namespace System.Net.Http
         {
             if (headers.HeaderStore != null)
             {
-                foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+                foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
                 {
                     if (header.Key.KnownHeader != null)
                     {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -934,21 +934,25 @@ namespace System.Net.Http
                 pos++;
             }
 
-            string headerValue = descriptor.GetHeaderValue(line.Slice(pos));
-
             // Note we ignore the return value from TryAddWithoutValidation. If the header can't be added, we silently drop it.
-            // Request headers returned on the response must be treated as custom headers.
+            ReadOnlySpan<byte> value = line.Slice(pos);
             if (isFromTrailer)
             {
+                string headerValue = descriptor.GetHeaderValue(value);
                 response.TrailingHeaders.TryAddWithoutValidation((descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
             }
             else if ((descriptor.HeaderType & HttpHeaderType.Content) == HttpHeaderType.Content)
             {
+                string headerValue = descriptor.GetHeaderValue(value);
                 response.Content!.Headers.TryAddWithoutValidation(descriptor, headerValue);
             }
             else
             {
-                response.Headers.TryAddWithoutValidation((descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
+                // Request headers returned on the response must be treated as custom headers.
+                string headerValue = connection.GetResponseHeaderValueWithCaching(descriptor, value);
+                response.Headers.TryAddWithoutValidation(
+                    (descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor,
+                    headerValue);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -12,6 +14,30 @@ namespace System.Net.Http
 {
     internal abstract class HttpConnectionBase : IHttpTrace
     {
+        /// <summary>Cached string for the last Date header received on this connection.</summary>
+        private string? _lastDateHeaderValue;
+        /// <summary>Cached string for the last Server header received on this connection.</summary>
+        private string? _lastServerHeaderValue;
+
+        /// <summary>Uses <see cref="HeaderDescriptor.GetHeaderValue"/>, but first special-cases several known headers for which we can use caching.</summary>
+        public string GetResponseHeaderValueWithCaching(HeaderDescriptor descriptor, ReadOnlySpan<byte> value)
+        {
+            return
+                ReferenceEquals(descriptor.KnownHeader, KnownHeaders.Date) ? GetOrAddCachedValue(ref _lastDateHeaderValue, descriptor, value) :
+                ReferenceEquals(descriptor.KnownHeader, KnownHeaders.Server) ? GetOrAddCachedValue(ref _lastServerHeaderValue, descriptor, value) :
+                descriptor.GetHeaderValue(value);
+
+            static string GetOrAddCachedValue([NotNull] ref string? cache, HeaderDescriptor descriptor, ReadOnlySpan<byte> value)
+            {
+                string? lastValue = cache;
+                if (lastValue is null || !ByteArrayHelpers.EqualsOrdinalAscii(lastValue, value))
+                {
+                    cache = lastValue = descriptor.GetHeaderValue(value);
+                }
+                return lastValue;
+            }
+        }
+
         public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
         public abstract void Trace(string message, [CallerMemberName] string? memberName = null);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -732,7 +732,17 @@ namespace System.Net.Http
                 {
                     if (connection is HttpConnection)
                     {
-                        response = await SendWithNtConnectionAuthAsync((HttpConnection)connection, request, doRequestAuth, cancellationToken).ConfigureAwait(false);
+                        ((HttpConnection)connection).Acquire();
+                        try
+                        {
+                            response = await (doRequestAuth && Settings._credentials != null ?
+                                AuthenticationHelper.SendWithNtConnectionAuthAsync(request, Settings._credentials, (HttpConnection)connection, this, cancellationToken) :
+                                SendWithNtProxyAuthAsync((HttpConnection)connection, request, cancellationToken)).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            ((HttpConnection)connection).Release();
+                        }
                     }
                     else
                     {

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             FillAvailableSpaceWithOnes(buffer);
             string[] headerValues = Array.Empty<string>();
 
-            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+            foreach (KeyValuePair<HeaderDescriptor, object> header in headers.HeaderStore)
             {
                 int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref headerValues);
                 Assert.InRange(headerValuesCount, 0, int.MaxValue);


### PR DESCRIPTION
For a request like this (which I created just by looking at what headers my browser is sending):
```C#
var m = new HttpRequestMessage(HttpMethod.Get, uri);
AddHeader(m, "Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9");
AddHeader(m, "accept-encoding", "gzip, deflate, br");
AddHeader(m, "accept-language", "en-US,en;q=0.9");
AddHeader(m, "cache-control", "no-cache");
AddHeader(m, "pragma", "no-cache");
AddHeader(m, "sec-fetch-dest", "document");
AddHeader(m, "sec-fetch-mode", "navigate");
AddHeader(m, "sec-fetch-site", "none");
AddHeader(m, "sec-fetch-user", "?1");
AddHeader(m, "upgrade-insecure-requests", "1");
AddHeader(m, "user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4090.0 Safari/537.36 Edg/83.0.467.0");

using (var resp = await c.SendAsync(m, default))
using (var respStream = await resp.Content.ReadAsStreamAsync())
{
    await respStream.CopyToAsync(Stream.Null);
}
```
to a default web api application, this PR reduces allocation by ~20%.  This is a benchmark.net run of doing the above 100K times in parallel per iteration (and with the server on the same machine, so grain of salt on the timings... the most interesting numbers are the GC/allocation-related ones):

|  Method |           Toolchain |    Mean | Ratio |      Gen 0 |      Gen 1 | Allocated |
|-------- |-------------------- |--------:|------:|-----------:|-----------:|----------:|
| Request | \master\corerun.exe | 1.653 s |  1.00 | 60000.0000 | 20000.0000 | 351.92 MB |
| Request |     \pr\corerun.exe | 1.631 s |  0.99 | 46000.0000 | 15000.0000 | 272.61 MB |

Commit 1: Just manually inlines a small async method.  This removes its state machine allocation in the common case, but it also really didn't need to be its own method.

Commit 2: Today whenever a header is added to a header collection with TryAddWithoutValidation, it's wrapped in a HeaderStoreItemInfo, even though we could just store the raw string directly.  This PR changes it so that we store the raw string, and only upgrade it to being wrapped when necessary, e.g. whenever we actually parse it, if we need to.  I'm interested in feedback as to whether folks think it makes the code too complicated / whether it's worthwhile.

Commit 3: Caches the Date and Server header values on a connection.  Since Server should generally never change for all requests on a connection, and Date should only change once a second-ish, we can avoid those string allocations in the typical high-throughput case.  Again, I'm interested in feedback on whether folks see a better way to do this.

I tried this with the ASP.NET HttpClient benchmark, and it had a small but repeatable positive impact of around 1-2% on RPS.

Depends on https://github.com/dotnet/runtime/pull/34667
cc: @scalablecory, @davidsh, @dotnet/ncl