### PR TITLE
Add copy constructor to JsonSerializerOptions

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -208,6 +208,7 @@ namespace System.Text.Json
     public sealed partial class JsonSerializerOptions
     {
         public JsonSerializerOptions() { }
+        public JsonSerializerOptions(System.Text.Json.JsonSerializerOptions options) { }
         public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonConverter> Converters { get { throw null; } }
         public int DefaultBufferSize { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConverterList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConverterList.cs
@@ -20,6 +20,12 @@ namespace System.Text.Json.Serialization
             _options = options;
         }
 
+        public ConverterList(JsonSerializerOptions options, ConverterList source)
+        {
+            _options = options;
+            _list = new List<JsonConverter>(source._list);
+        }
+
         public JsonConverter this[int index]
         {
             get

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -20,6 +20,8 @@ namespace System.Text.Json
 
         private readonly ConcurrentDictionary<Type, JsonClassInfo> _classes = new ConcurrentDictionary<Type, JsonClassInfo>();
 
+        // For any new option added, adding it to the options copied in the copy constructor below must be considered.
+
         private MemberAccessor? _memberAccessorStrategy;
         private JsonNamingPolicy? _dictionaryKeyPolicy;
         private JsonNamingPolicy? _jsonPropertyNamingPolicy;
@@ -42,6 +44,37 @@ namespace System.Text.Json
         public JsonSerializerOptions()
         {
             Converters = new ConverterList(this);
+        }
+
+        /// <summary>
+        /// Copies the options from a <see cref="JsonSerializerOptions"/> instance to a new instance.
+        /// </summary>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> instance to copy options from.</param>
+        public JsonSerializerOptions(JsonSerializerOptions options)
+        {
+            _dictionaryKeyPolicy = options._dictionaryKeyPolicy;
+            _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
+            _readCommentHandling = options._readCommentHandling;
+            _referenceHandling = options._referenceHandling;
+            _encoder = options._encoder;
+
+            _defaultBufferSize = options._defaultBufferSize;
+            _maxDepth = options._maxDepth;
+            _allowTrailingCommas = options._allowTrailingCommas;
+            _ignoreNullValues = options._ignoreNullValues;
+            _ignoreReadOnlyProperties = options._ignoreReadOnlyProperties;
+            _propertyNameCaseInsensitive = options._propertyNameCaseInsensitive;
+            _writeIndented = options._writeIndented;
+
+            Converters = new ConverterList(this);
+            for (int i = 0; i < options.Converters.Count; i++)
+            {
+                Converters.Add(options.Converters[i]);
+            }
+
+            // _memberAccessorStrategy is not copied as that is platform specific.
+            // _classes is not copied as we don't want to transfer cache information.
+            // _haveTypesBeenCreated is not copied; it's okay to make changes to this options instance.
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -52,6 +52,7 @@ namespace System.Text.Json
         /// <param name="options">The <see cref="JsonSerializerOptions"/> instance to copy options from.</param>
         public JsonSerializerOptions(JsonSerializerOptions options)
         {
+            _memberAccessorStrategy = options.MemberAccessorStrategy;
             _dictionaryKeyPolicy = options._dictionaryKeyPolicy;
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
             _readCommentHandling = options._readCommentHandling;
@@ -66,15 +67,13 @@ namespace System.Text.Json
             _propertyNameCaseInsensitive = options._propertyNameCaseInsensitive;
             _writeIndented = options._writeIndented;
 
-            Converters = new ConverterList(this);
-            for (int i = 0; i < options.Converters.Count; i++)
-            {
-                Converters.Add(options.Converters[i]);
-            }
+            Converters = new ConverterList(this, (ConverterList)options.Converters);
+            EffectiveMaxDepth = options.EffectiveMaxDepth;
 
-            // _memberAccessorStrategy is not copied as that is platform specific.
-            // _classes is not copied as we don't want to transfer cache information.
-            // _haveTypesBeenCreated is not copied; it's okay to make changes to this options instance.
+            // _classes is not copied as sharing the JsonClassInfo and JsonPropertyInfo caches can result in
+            // unnecessary references to type metadata, potentially hindering garbage collection on the source options.
+
+            // _haveTypesBeenCreated is not copied; it's okay to make changes to this options instance as (de)serialization has not occured.
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -50,8 +50,16 @@ namespace System.Text.Json
         /// Copies the options from a <see cref="JsonSerializerOptions"/> instance to a new instance.
         /// </summary>
         /// <param name="options">The <see cref="JsonSerializerOptions"/> instance to copy options from.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
         public JsonSerializerOptions(JsonSerializerOptions options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             _memberAccessorStrategy = options.MemberAccessorStrategy;
             _dictionaryKeyPolicy = options._dictionaryKeyPolicy;
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/30445.

cc @pranavkm 