### PR TITLE
Enumerate compiled methods faster

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
@@ -45,16 +45,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Build a map from inlinee to the list of inliners
             // We are only interested in the generic definitions of these.
-            foreach (MethodWithGCInfo methodNode in factory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo methodNode in factory.EnumerateCompiledMethods(_module, null))
             {
                 MethodDesc[] inlinees = methodNode.InlinedMethods;
                 MethodDesc inliner = methodNode.Method;
                 EcmaMethod inlinerDefinition = (EcmaMethod)inliner.GetTypicalMethodDefinition();
-                if (inlinerDefinition.Module != _module)
-                {
-                    // Only encode inlining info for inliners within the active module
-                    continue;
-                }
+
+                // Only encode inlining info for inliners within the active module
+                Debug.Assert(inlinerDefinition.Module == _module);
 
                 foreach (MethodDesc inlinee in inlinees)
                 {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InliningInfoNode.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Build a map from inlinee to the list of inliners
             // We are only interested in the generic definitions of these.
-            foreach (MethodWithGCInfo methodNode in factory.EnumerateCompiledMethods(_module, null))
+            foreach (MethodWithGCInfo methodNode in factory.EnumerateCompiledMethods(_module, CompiledMethodCategory.All))
             {
                 MethodDesc[] inlinees = methodNode.InlinedMethods;
                 MethodDesc inliner = methodNode.Method;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -50,46 +50,45 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Dictionary<byte[], BlobVertex> uniqueFixups = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
             Dictionary<byte[], BlobVertex> uniqueSignatures = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
 
-            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(null, true))
             {
-                if (method.Method.HasInstantiation || method.Method.OwningType.HasInstantiation)
+                Debug.Assert(method.Method.HasInstantiation || method.Method.OwningType.HasInstantiation);
+
+                int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
+
+                // In composite R2R format, always enforce owning type to let us share generic instantiations among modules
+                EcmaMethod typicalMethod = (EcmaMethod)method.Method.GetTypicalMethodDefinition();
+                ModuleToken moduleToken = new ModuleToken(typicalMethod.Module, typicalMethod.Handle);
+
+                ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
+                signatureBuilder.EmitMethodSignature(
+                    new MethodWithToken(method.Method, moduleToken, constrainedType: null),
+                    enforceDefEncoding: true,
+                    enforceOwningType: _factory.CompilationModuleGroup.EnforceOwningType(moduleToken.Module),
+                    factory.SignatureContext,
+                    isUnboxingStub: false,
+                    isInstantiatingStub: false);
+                byte[] signature = signatureBuilder.ToArray();
+                BlobVertex signatureBlob;
+                if (!uniqueSignatures.TryGetValue(signature, out signatureBlob))
                 {
-                    int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
-
-                    // In composite R2R format, always enforce owning type to let us share generic instantiations among modules
-                    EcmaMethod typicalMethod = (EcmaMethod)method.Method.GetTypicalMethodDefinition();
-                    ModuleToken moduleToken = new ModuleToken(typicalMethod.Module, typicalMethod.Handle);
-
-                    ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
-                    signatureBuilder.EmitMethodSignature(
-                        new MethodWithToken(method.Method, moduleToken, constrainedType: null),
-                        enforceDefEncoding: true,
-                        enforceOwningType: _factory.CompilationModuleGroup.EnforceOwningType(moduleToken.Module),
-                        factory.SignatureContext,
-                        isUnboxingStub: false,
-                        isInstantiatingStub: false);
-                    byte[] signature = signatureBuilder.ToArray();
-                    BlobVertex signatureBlob;
-                    if (!uniqueSignatures.TryGetValue(signature, out signatureBlob))
-                    {
-                        signatureBlob = new BlobVertex(signature);
-                        hashtableSection.Place(signatureBlob);
-                        uniqueSignatures.Add(signature, signatureBlob);
-                    }
-
-                    byte[] fixup = method.GetFixupBlob(factory);
-                    BlobVertex fixupBlob = null;
-                    if (fixup != null && !uniqueFixups.TryGetValue(fixup, out fixupBlob))
-                    {
-                        fixupBlob = new BlobVertex(fixup);
-                        hashtableSection.Place(fixupBlob);
-                        uniqueFixups.Add(fixup, fixupBlob);
-                    }
-
-                    EntryPointVertex entryPointVertex = new EntryPointWithBlobVertex((uint)methodIndex, fixupBlob, signatureBlob);
-                    hashtableSection.Place(entryPointVertex);
-                    vertexHashtable.Append(unchecked((uint)ReadyToRunHashCode.MethodHashCode(method.Method)), entryPointVertex);
+                    signatureBlob = new BlobVertex(signature);
+                    hashtableSection.Place(signatureBlob);
+                    uniqueSignatures.Add(signature, signatureBlob);
                 }
+
+                byte[] fixup = method.GetFixupBlob(factory);
+                BlobVertex fixupBlob = null;
+                if (fixup != null && !uniqueFixups.TryGetValue(fixup, out fixupBlob))
+                {
+                    fixupBlob = new BlobVertex(fixup);
+                    hashtableSection.Place(fixupBlob);
+                    uniqueFixups.Add(fixup, fixupBlob);
+                }
+
+                EntryPointVertex entryPointVertex = new EntryPointWithBlobVertex((uint)methodIndex, fixupBlob, signatureBlob);
+                hashtableSection.Place(entryPointVertex);
+                vertexHashtable.Append(unchecked((uint)ReadyToRunHashCode.MethodHashCode(method.Method)), entryPointVertex);
             }
 
             MemoryStream hashtableContent = new MemoryStream();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Dictionary<byte[], BlobVertex> uniqueFixups = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
             Dictionary<byte[], BlobVertex> uniqueSignatures = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
 
-            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(null, true))
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(null, CompiledMethodCategory.Instantiated))
             {
                 Debug.Assert(method.Method.HasInstantiation || method.Method.OwningType.HasInstantiation);
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -58,23 +58,24 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             List<EntryPoint> ridToEntryPoint = new List<EntryPoint>();
 
-            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(_module, false))
             {
-                if (method.Method is EcmaMethod ecmaMethod && ecmaMethod.Module == _module)
+                Debug.Assert(method.Method is EcmaMethod);
+                EcmaMethod ecmaMethod = (EcmaMethod)method.Method;
+                Debug.Assert(ecmaMethod.Module == _module);
+
+                // Strip away the token type bits, keep just the low 24 bits RID
+                uint rid = SignatureBuilder.RidFromToken((mdToken)MetadataTokens.GetToken(ecmaMethod.Handle));
+                Debug.Assert(rid != 0);
+                rid--;
+
+                while (ridToEntryPoint.Count <= rid)
                 {
-                    // Strip away the token type bits, keep just the low 24 bits RID
-                    uint rid = SignatureBuilder.RidFromToken((mdToken)MetadataTokens.GetToken(ecmaMethod.Handle));
-                    Debug.Assert(rid != 0);
-                    rid--;
-
-                    while (ridToEntryPoint.Count <= rid)
-                    {
-                        ridToEntryPoint.Add(EntryPoint.Null);
-                    }
-
-                    int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
-                    ridToEntryPoint[(int)rid] = new EntryPoint(methodIndex, method);
+                    ridToEntryPoint.Add(EntryPoint.Null);
                 }
+
+                int methodIndex = factory.RuntimeFunctionsTable.GetIndex(method);
+                ridToEntryPoint[(int)rid] = new EntryPoint(methodIndex, method);
             }
 
             NativeWriter writer = new NativeWriter();

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodEntryPointTableNode.cs
@@ -58,7 +58,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             List<EntryPoint> ridToEntryPoint = new List<EntryPoint>();
 
-            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(_module, false))
+            foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods(_module, CompiledMethodCategory.NonInstantiated))
             {
                 Debug.Assert(method.Method is EcmaMethod);
                 EcmaMethod ecmaMethod = (EcmaMethod)method.Method;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -417,12 +417,12 @@ namespace ILCompiler.DependencyAnalysis
 
         public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods()
         {
-            return EnumerateCompiledMethods(null, null);
+            return EnumerateCompiledMethods(null, CompiledMethodCategory.All);
         }
 
-        public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods(EcmaModule module, bool? genericInstantiations)
+        public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods(EcmaModule moduleToEnumerate, CompiledMethodCategory methodCategory)
         {
-            foreach (IMethodNode methodNode in MetadataManager.GetCompiledMethods(module, genericInstantiations))
+            foreach (IMethodNode methodNode in MetadataManager.GetCompiledMethods(moduleToEnumerate, methodCategory))
             {
                 MethodDesc method = methodNode.Method;
                 Debug.Assert(methodNode == MethodEntrypoint(method));

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -417,9 +417,15 @@ namespace ILCompiler.DependencyAnalysis
 
         public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods()
         {
-            foreach (MethodDesc method in MetadataManager.GetCompiledMethods())
+            return EnumerateCompiledMethods(null, null);
+        }
+
+        public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods(EcmaModule module, bool? genericInstantiations)
+        {
+            foreach (IMethodNode methodNode in MetadataManager.GetCompiledMethods(module, genericInstantiations))
             {
-                IMethodNode methodNode = MethodEntrypoint(method);
+                MethodDesc method = methodNode.Method;
+                Debug.Assert(methodNode == MethodEntrypoint(method));
                 MethodWithGCInfo methodCodeNode = methodNode as MethodWithGCInfo;
                 if (methodCodeNode == null && methodNode is LocalMethodImport localMethodImport)
                 {


### PR DESCRIPTION
- Split up the data structure that holds the list of compiled methods into per module, generic and non-generic method lists.
- Hold IMethodNodes in the data structure instead of MethodDescs
- This delivers a *significant* improvement to compile times for composite image build
  - A sample application went from 456 seconds to compile down to 100 seconds in wall clock time