### PR TITLE
Add `-skipgenerateversion` option to not generate native version headers

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -81,6 +81,7 @@ set __CommonMSBuildArgs=
 set __BuildNative=1
 set __BuildCrossArchNative=0
 set __SkipCrossArchNative=0
+set __SkipGenerateVersion=0
 set __RestoreOptData=1
 set __CrossArch=
 set __PgoOptDataPath=
@@ -154,6 +155,7 @@ if /i "%1" == "-configureonly"       (set __ConfigureOnly=1&set __BuildNative=1&
 if /i "%1" == "-skipconfigure"       (set __SkipConfigure=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-skipnative"          (set __BuildNative=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-skipcrossarchnative" (set __SkipCrossArchNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "-skipgenerateversion" (set __SkipGenerateVersion=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-skiprestoreoptdata"  (set __RestoreOptData=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-usenmakemakefiles"   (set __NMakeMakefiles=1&set __ConfigureOnly=1&set __BuildNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-pgoinstrument"       (set __PgoInstrument=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -166,6 +168,7 @@ if /i "%1" == "configureonly"       (set __ConfigureOnly=1&set __BuildNative=1&s
 if /i "%1" == "skipconfigure"       (set __SkipConfigure=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipnative"          (set __BuildNative=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipcrossarchnative" (set __SkipCrossArchNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "skipgenerateversion" (set __SkipGenerateVersion=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skiprestoreoptdata"  (set __RestoreOptData=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "usenmakemakefiles"   (set __NMakeMakefiles=1&set __ConfigureOnly=1&set __BuildNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "pgoinstrument"       (set __PgoInstrument=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -317,16 +320,18 @@ REM ============================================================================
 
 @if defined _echo @echo on
 
-echo %__MsgPrefix%Generating native version headers
-set "__BinLog=%__LogsDir%\GenerateVersionHeaders_%__TargetOS%__%__BuildArch%__%__BuildType%.binlog"
-powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng\common\msbuild.ps1" /clp:nosummary %__ArcadeScriptArgs%^
-    %__RepoRootDir%\eng\empty.csproj /p:NativeVersionFile="%__RootBinDir%\obj\coreclr\_version.h"^
-    /t:GenerateNativeVersionFile /restore^
-    %__CommonMSBuildArgs% %__UnprocessedBuildArgs% /bl:!__BinLog!
-if not !errorlevel! == 0 (
-    set __exitCode=!errorlevel!
-    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to generate version headers.
-    goto ExitWithCode
+if %__SkipGenerateVersion% EQU 0 (
+    echo %__MsgPrefix%Generating native version headers
+    set "__BinLog=%__LogsDir%\GenerateVersionHeaders_%__TargetOS%__%__BuildArch%__%__BuildType%.binlog"
+    powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__RepoRootDir%\eng\common\msbuild.ps1" /clp:nosummary %__ArcadeScriptArgs%^
+        %__RepoRootDir%\eng\empty.csproj /p:NativeVersionFile="%__RootBinDir%\obj\coreclr\_version.h"^
+        /t:GenerateNativeVersionFile /restore^
+        %__CommonMSBuildArgs% %__UnprocessedBuildArgs% /bl:!__BinLog!
+    if not !errorlevel! == 0 (
+        set __exitCode=!errorlevel!
+        echo %__ErrMsgPrefix%%__MsgPrefix%Error: Failed to generate version headers.
+        goto ExitWithCode
+    )
 )
 
 REM =========================================================================================
@@ -690,6 +695,7 @@ echo -skipconfigure: skip CMake ^(default: CMake is run^)
 echo -skipnative: skip building native components ^(default: native components are built^).
 echo -skipcrossarchnative: skip building cross-architecture native components ^(default: components are built^).
 echo -skiprestoreoptdata: skip restoring optimization data used by profile-based optimizations.
+echo -skipgenerateversion: skip generating the native version headers.
 echo -priority=^<N^> : specify a set of test that will be built and run, with priority N.
 echo portable : build for portable RID.
 echo.


### PR DESCRIPTION
This allows skipping yet another thing when doing incremental builds.