### PR TITLE
ComWrappers: Add support for ICustomQueryInterface 

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -313,14 +313,10 @@ namespace System.Runtime.InteropServices
             if (customQueryInterface is null)
             {
                 ppObject = IntPtr.Zero;
-                return 1; // S_FALSE
+                return -1; // See TryInvokeICustomQueryInterfaceResult
             }
 
-            return customQueryInterface.GetInterface(ref iid, out ppObject) switch
-                {
-                    CustomQueryInterfaceResult.Handled => 0,    // S_OK
-                    _ => unchecked((int)0x80004002),            // E_NOINTERFACE
-                };
+            return (int)customQueryInterface.GetInterface(ref iid, out ppObject);
         }
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -306,5 +306,21 @@ namespace System.Runtime.InteropServices
 
         [DllImport(RuntimeHelpers.QCall)]
         private static extern void GetIUnknownImplInternal(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease);
+
+        internal static int CallICustomQueryInterface(object customQueryInterfaceMaybe, ref Guid iid, out IntPtr ppObject)
+        {
+            var customQueryInterface = customQueryInterfaceMaybe as ICustomQueryInterface;
+            if (customQueryInterface is null)
+            {
+                ppObject = IntPtr.Zero;
+                return 1; // S_FALSE
+            }
+
+            return customQueryInterface.GetInterface(ref iid, out ppObject) switch
+                {
+                    CustomQueryInterfaceResult.Handled => 0,    // S_OK
+                    _ => unchecked((int)0x80004002),            // E_NOINTERFACE
+                };
+        }
     }
 }

--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -586,18 +586,19 @@ HRESULT ManagedObjectWrapper::QueryInterface(
     if (*ppvObject == nullptr)
     {
         // Check if the managed object has implemented ICustomQueryInterface
-        if (!IsSet(CreateComInterfaceFlagsEx::LacksICustomQueryInterface))
-        {
-            HRESULT hr = InteropLibImports::TryInvokeICustomQueryInterface(Target, riid, ppvObject);
-            if (hr != S_FALSE)
-                return hr;
+        if (IsSet(CreateComInterfaceFlagsEx::LacksICustomQueryInterface))
+            return E_NOINTERFACE;
 
+        HRESULT hr = InteropLibImports::TryInvokeICustomQueryInterface(Target, riid, ppvObject);
+        if (hr == S_FALSE)
+        {
             // Set the 'lacks' flag since our attempt to use ICustomQueryInterface
             // indicated the object lacks an implementation.
             SetFlag(CreateComInterfaceFlagsEx::LacksICustomQueryInterface);
+            return E_NOINTERFACE;
         }
 
-        return E_NOINTERFACE;
+        return hr;
     }
 
     (void)AddRef();

--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -9,6 +9,7 @@
 
 using OBJECTHANDLE = InteropLib::OBJECTHANDLE;
 using AllocScenario = InteropLibImports::AllocScenario;
+using TryInvokeICustomQueryInterfaceResult = InteropLibImports::TryInvokeICustomQueryInterfaceResult;
 
 namespace ABI
 {
@@ -488,9 +489,8 @@ ULONGLONG ManagedObjectWrapper::UniversalRelease(_In_ ULONGLONG dec)
     return refCount;
 }
 
-void* ManagedObjectWrapper::As(_In_ REFIID riid)
+void* ManagedObjectWrapper::AsRuntimeDefined(_In_ REFIID riid)
 {
-    // Find target interface and return dispatcher or null if not found.
     for (int32_t i = 0; i < _runtimeDefinedCount; ++i)
     {
         if (IsEqualGUID(_runtimeDefined[i].IID, riid))
@@ -499,6 +499,11 @@ void* ManagedObjectWrapper::As(_In_ REFIID riid)
         }
     }
 
+    return nullptr;
+}
+
+void* ManagedObjectWrapper::AsUserDefined(_In_ REFIID riid)
+{
     for (int32_t i = 0; i < _userDefinedCount; ++i)
     {
         if (IsEqualGUID(_userDefined[i].IID, riid))
@@ -508,6 +513,16 @@ void* ManagedObjectWrapper::As(_In_ REFIID riid)
     }
 
     return nullptr;
+}
+
+void* ManagedObjectWrapper::As(_In_ REFIID riid)
+{
+    // Find target interface and return dispatcher or null if not found.
+    void* typeMaybe = AsRuntimeDefined(riid);
+    if (typeMaybe == nullptr)
+        typeMaybe = AsUserDefined(riid);
+
+    return typeMaybe;
 }
 
 bool ManagedObjectWrapper::TrySetObjectHandle(_In_ OBJECTHANDLE objectHandle, _In_ OBJECTHANDLE current)
@@ -582,23 +597,40 @@ HRESULT ManagedObjectWrapper::QueryInterface(
         return E_POINTER;
 
     // Find target interface
-    *ppvObject = As(riid);
+    *ppvObject = AsRuntimeDefined(riid);
     if (*ppvObject == nullptr)
     {
         // Check if the managed object has implemented ICustomQueryInterface
-        if (IsSet(CreateComInterfaceFlagsEx::LacksICustomQueryInterface))
-            return E_NOINTERFACE;
-
-        HRESULT hr = InteropLibImports::TryInvokeICustomQueryInterface(Target, riid, ppvObject);
-        if (hr == S_FALSE)
+        if (!IsSet(CreateComInterfaceFlagsEx::LacksICustomQueryInterface))
         {
-            // Set the 'lacks' flag since our attempt to use ICustomQueryInterface
-            // indicated the object lacks an implementation.
-            SetFlag(CreateComInterfaceFlagsEx::LacksICustomQueryInterface);
-            return E_NOINTERFACE;
+            TryInvokeICustomQueryInterfaceResult result = InteropLibImports::TryInvokeICustomQueryInterface(Target, riid, ppvObject);
+            switch (result)
+            {
+                default:
+                    _ASSERTE(false && "Unknown result value");
+                case TryInvokeICustomQueryInterfaceResult::FailedToInvoke:
+                    // Set the 'lacks' flag since our attempt to use ICustomQueryInterface
+                    // indicated the object lacks an implementation.
+                    SetFlag(CreateComInterfaceFlagsEx::LacksICustomQueryInterface);
+                    break;
+
+                case TryInvokeICustomQueryInterfaceResult::Handled:
+                    _ASSERTE(*ppvObject != nullptr);
+                    return S_OK;
+
+                case TryInvokeICustomQueryInterfaceResult::NotHandled:
+                    // Continue querying the static tables.
+                    break;
+
+                case TryInvokeICustomQueryInterfaceResult::Failed:
+                    _ASSERTE(*ppvObject == nullptr);
+                    return E_NOINTERFACE;
+            }
         }
 
-        return hr;
+        *ppvObject = AsUserDefined(riid);
+        if (*ppvObject == nullptr)
+            return E_NOINTERFACE;
     }
 
     (void)AddRef();

--- a/src/coreclr/src/interop/comwrappers.hpp
+++ b/src/coreclr/src/interop/comwrappers.hpp
@@ -86,8 +86,16 @@ private:
     // the wrapper. Supplied with a decrementing value.
     ULONGLONG UniversalRelease(_In_ ULONGLONG dec);
 
+    // Query the runtime defined tables.
+    void* AsRuntimeDefined(_In_ REFIID riid);
+
+    // Query the user defined tables.
+    void* AsUserDefined(_In_ REFIID riid);
+
 public:
+    // N.B. Does not impact the reference count of the object.
     void* As(_In_ REFIID riid);
+
     // Attempt to set the target object handle based on an assumed current value.
     bool TrySetObjectHandle(_In_ InteropLib::OBJECTHANDLE objectHandle, _In_ InteropLib::OBJECTHANDLE current = nullptr);
     bool IsSet(_In_ CreateComInterfaceFlagsEx flag) const;

--- a/src/coreclr/src/interop/comwrappers.hpp
+++ b/src/coreclr/src/interop/comwrappers.hpp
@@ -15,11 +15,12 @@ enum class CreateComInterfaceFlagsEx : int32_t
     CallerDefinedIUnknown = InteropLib::Com::CreateComInterfaceFlags_CallerDefinedIUnknown,
     TrackerSupport = InteropLib::Com::CreateComInterfaceFlags_TrackerSupport,
 
-    // Highest bit is reserved for internal usage
+    // Highest bits are reserved for internal usage
+    LacksICustomQueryInterface = 1 << 29,
     IsComActivated = 1 << 30,
     IsPegged = 1 << 31,
 
-    InternalMask = IsPegged | IsComActivated,
+    InternalMask = IsPegged | IsComActivated | LacksICustomQueryInterface,
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(CreateComInterfaceFlagsEx);

--- a/src/coreclr/src/interop/inc/interoplibimports.h
+++ b/src/coreclr/src/interop/inc/interoplibimports.h
@@ -77,13 +77,14 @@ namespace InteropLibImports
     // and the case where the object doesn't support ICustomQueryInterface.
     enum class TryInvokeICustomQueryInterfaceResult
     {
+        OnGCThread = -2,
         FailedToInvoke = -1,
         Handled = 0,
         NotHandled = 1,
         Failed = 2,
 
         // Range checks
-        Min = FailedToInvoke,
+        Min = OnGCThread,
         Max = Failed,
     };
 

--- a/src/coreclr/src/interop/inc/interoplibimports.h
+++ b/src/coreclr/src/interop/inc/interoplibimports.h
@@ -72,6 +72,13 @@ namespace InteropLibImports
         _In_ InteropLib::Com::CreateObjectFlags externalObjectFlags,
         _In_ InteropLib::Com::CreateComInterfaceFlags trackerTargetFlags,
         _Outptr_ void** trackerTarget) noexcept;
+
+    // Attempt to call the ICustomQueryInterface on the supplied object.
+    // Returns S_FALSE if the object doesn't support ICustomQueryInterface.
+    HRESULT TryInvokeICustomQueryInterface(
+        _In_ InteropLib::OBJECTHANDLE handle,
+        _In_ REFGUID iid,
+        _Outptr_result_maybenull_ void** obj) noexcept;
 }
 
 #endif // _INTEROP_INC_INTEROPLIBIMPORTS_H_

--- a/src/coreclr/src/interop/inc/interoplibimports.h
+++ b/src/coreclr/src/interop/inc/interoplibimports.h
@@ -73,9 +73,23 @@ namespace InteropLibImports
         _In_ InteropLib::Com::CreateComInterfaceFlags trackerTargetFlags,
         _Outptr_ void** trackerTarget) noexcept;
 
+    // The enum describes the value of System.Runtime.InteropServices.CustomQueryInterfaceResult
+    // and the case where the object doesn't support ICustomQueryInterface.
+    enum class TryInvokeICustomQueryInterfaceResult
+    {
+        FailedToInvoke = -1,
+        Handled = 0,
+        NotHandled = 1,
+        Failed = 2,
+
+        // Range checks
+        Min = FailedToInvoke,
+        Max = Failed,
+    };
+
     // Attempt to call the ICustomQueryInterface on the supplied object.
     // Returns S_FALSE if the object doesn't support ICustomQueryInterface.
-    HRESULT TryInvokeICustomQueryInterface(
+    TryInvokeICustomQueryInterfaceResult TryInvokeICustomQueryInterface(
         _In_ InteropLib::OBJECTHANDLE handle,
         _In_ REFGUID iid,
         _Outptr_result_maybenull_ void** obj) noexcept;

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -1065,6 +1065,11 @@ namespace InteropLibImports
 
         *obj = NULL;
 
+        // If this is a GC thread, then someone is trying to query for something
+        // at a time when we can't run managed code.
+        if (IsGCThread())
+            return TryInvokeICustomQueryInterfaceResult::OnGCThread;
+
         auto result = TryInvokeICustomQueryInterfaceResult::FailedToInvoke;
         HRESULT hr = S_OK;
         BEGIN_EXTERNAL_ENTRYPOINT(&hr)

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -504,6 +504,11 @@ namespace
         args[ARGNUM_2]  = PTR_TO_ARGHOLDER(ppObject);
         CALL_MANAGED_METHOD(hr, HRESULT, args);
 
+        // Assert the supported return values.
+        _ASSERTE(hr == S_OK
+                || hr == S_FALSE
+                || hr == E_NOINTERFACE);
+
         return hr;
     }
 

--- a/src/coreclr/src/vm/metasig.h
+++ b/src/coreclr/src/vm/metasig.h
@@ -199,6 +199,7 @@ DEFINE_METASIG_T(SM(Exception_IntPtr_RetException, C(EXCEPTION) I, C(EXCEPTION))
 DEFINE_METASIG_T(SM(ComWrappers_Obj_CreateFlags_RefInt_RetPtrVoid, C(COMWRAPPERS) j g(CREATECOMINTERFACEFLAGS) r(i), P(v)))
 DEFINE_METASIG_T(SM(ComWrappers_IntPtr_CreateFlags_RetObj, C(COMWRAPPERS) I g(CREATEOBJECTFLAGS), j))
 DEFINE_METASIG_T(SM(ComWrappers_IEnumerable_RetVoid, C(COMWRAPPERS) C(IENUMERABLE), v))
+DEFINE_METASIG_T(SM(Obj_RefGuid_RefIntPtr_RetInt, j r(g(GUID)) r(I), i))
 #endif // FEATURE_COMINTEROP
 DEFINE_METASIG(SM(Int_RetVoid, i, v))
 DEFINE_METASIG(SM(Int_Int_RetVoid, i i, v))

--- a/src/coreclr/src/vm/mscorlib.h
+++ b/src/coreclr/src/vm/mscorlib.h
@@ -465,6 +465,7 @@ DEFINE_CLASS(CREATEOBJECTFLAGS,           Interop,          CreateObjectFlags)
 DEFINE_METHOD(COMWRAPPERS,                COMPUTE_VTABLES,  CallComputeVtables,         SM_ComWrappers_Obj_CreateFlags_RefInt_RetPtrVoid)
 DEFINE_METHOD(COMWRAPPERS,                CREATE_OBJECT,    CallCreateObject,           SM_ComWrappers_IntPtr_CreateFlags_RetObj)
 DEFINE_METHOD(COMWRAPPERS,                RELEASE_OBJECTS,  CallReleaseObjects,         SM_ComWrappers_IEnumerable_RetVoid)
+DEFINE_METHOD(COMWRAPPERS,     CALL_ICUSTOMQUERYINTERFACE,  CallICustomQueryInterface,  SM_Obj_RefGuid_RefIntPtr_RetInt)
 #endif //FEATURE_COMINTEROP
 
 DEFINE_CLASS(SERIALIZATION_INFO,        Serialization,      SerializationInfo)

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
@@ -113,7 +113,10 @@ namespace ComWrappersTests
         {
             Console.WriteLine($"Running {nameof(ValidateFallbackQueryInterface)}...");
 
-            var testObj = new Test();
+            var testObj = new Test()
+                {
+                    EnableICustomQueryInterface = true
+                };
 
             var wrappers = new TestComWrappers();
 
@@ -124,24 +127,16 @@ namespace ComWrappersTests
 
             IntPtr result;
             var anyGuid = new Guid("1E42439C-DCB5-4701-ACBD-87FE92E785DE");
-            Assert.AreNotEqual(anyGuid, typeof(ITest).GUID);
-
             testObj.ICustomQueryInterface_GetInterfaceIID = anyGuid;
             int hr = Marshal.QueryInterface(comWrapper, ref anyGuid, out result);
             Assert.AreEqual(hr, 0);
             Assert.AreEqual(result, testObj.ICustomQueryInterface_GetInterfaceResult);
 
             var anyGuid2 = new Guid("7996D0F9-C8DD-4544-B708-0F75C6FF076F");
-            Assert.AreNotEqual(anyGuid2, typeof(ITest).GUID);
             hr = Marshal.QueryInterface(comWrapper, ref anyGuid2, out result);
             const int E_NOINTERFACE = unchecked((int)0x80004002);
             Assert.AreEqual(hr, E_NOINTERFACE);
             Assert.AreEqual(result, IntPtr.Zero);
-
-            var anyGuid3 = typeof(ITest).GUID;
-            hr = Marshal.QueryInterface(comWrapper, ref anyGuid3, out result);
-            Assert.AreEqual(hr, 0);
-            Assert.AreNotEqual(result, IntPtr.Zero);
         }
 
         static void ValidateCreateObjectCachingScenario()

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
@@ -109,6 +109,36 @@ namespace ComWrappersTests
             Assert.AreEqual(count, 0);
         }
 
+        static void ValidateFallbackQueryInterface()
+        {
+            Console.WriteLine($"Running {nameof(ValidateFallbackQueryInterface)}...");
+
+            var testObj = new Test();
+
+            var wrappers = new TestComWrappers();
+
+            // Allocate a wrapper for the object
+            IntPtr comWrapper = wrappers.GetOrCreateComInterfaceForObject(testObj, CreateComInterfaceFlags.None);
+
+            testObj.ICustomQueryInterface_GetInterfaceResult = new IntPtr(0x2000000);
+
+            IntPtr result;
+            var anyGuid = new Guid("1E42439C-DCB5-4701-ACBD-87FE92E785DE");
+            Assert.AreNotEqual(anyGuid, typeof(ITest).GUID);
+
+            testObj.ICustomQueryInterface_GetInterfaceIID = anyGuid;
+            int hr = Marshal.QueryInterface(comWrapper, ref anyGuid, out result);
+            Assert.AreEqual(hr, 0);
+            Assert.AreEqual(result, testObj.ICustomQueryInterface_GetInterfaceResult);
+
+            var anyGuid2 = new Guid("7996D0F9-C8DD-4544-B708-0F75C6FF076F");
+            Assert.AreNotEqual(anyGuid2, typeof(ITest).GUID);
+            hr = Marshal.QueryInterface(comWrapper, ref anyGuid2, out result);
+            const int E_NOINTERFACE = unchecked((int)0x80004002);
+            Assert.AreEqual(hr, E_NOINTERFACE);
+            Assert.AreEqual(result, IntPtr.Zero);
+        }
+
         static void ValidateCreateObjectCachingScenario()
         {
             Console.WriteLine($"Running {nameof(ValidateCreateObjectCachingScenario)}...");
@@ -325,6 +355,7 @@ namespace ComWrappersTests
             try
             {
                 ValidateComInterfaceCreation();
+                ValidateFallbackQueryInterface();
                 ValidateCreateObjectCachingScenario();
                 ValidatePrecreatedExternalWrapper();
                 ValidateIUnknownImpls();

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/Program.cs
@@ -137,6 +137,11 @@ namespace ComWrappersTests
             const int E_NOINTERFACE = unchecked((int)0x80004002);
             Assert.AreEqual(hr, E_NOINTERFACE);
             Assert.AreEqual(result, IntPtr.Zero);
+
+            var anyGuid3 = typeof(ITest).GUID;
+            hr = Marshal.QueryInterface(comWrapper, ref anyGuid3, out result);
+            Assert.AreEqual(hr, 0);
+            Assert.AreNotEqual(result, IntPtr.Zero);
         }
 
         static void ValidateCreateObjectCachingScenario()

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
@@ -33,7 +33,11 @@ namespace ComWrappersTests.Common
         CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
         {
             ppv = IntPtr.Zero;
-            if (iid != ICustomQueryInterface_GetInterfaceIID)
+            if (iid == typeof(ITest).GUID)
+            {
+                return CustomQueryInterfaceResult.NotHandled;
+            }
+            else if (iid != ICustomQueryInterface_GetInterfaceIID)
             {
                 return CustomQueryInterfaceResult.Failed;
             }

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
@@ -16,7 +16,7 @@ namespace ComWrappersTests.Common
         void SetValue(int i);
     }
 
-    class Test : ITest
+    class Test : ITest, ICustomQueryInterface
     {
         public static int InstanceCount = 0;
 
@@ -26,6 +26,21 @@ namespace ComWrappersTests.Common
 
         public void SetValue(int i) => this.value = i;
         public int GetValue() => this.value;
+
+        public Guid ICustomQueryInterface_GetInterfaceIID { get; set; }
+        public IntPtr ICustomQueryInterface_GetInterfaceResult { get; set; }
+
+        CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
+        {
+            ppv = IntPtr.Zero;
+            if (iid != ICustomQueryInterface_GetInterfaceIID)
+            {
+                return CustomQueryInterfaceResult.Failed;
+            }
+
+            ppv = this.ICustomQueryInterface_GetInterfaceResult;
+            return CustomQueryInterfaceResult.Handled;
+        }
     }
 
     public struct IUnknownVtbl

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/Common.cs
@@ -27,17 +27,19 @@ namespace ComWrappersTests.Common
         public void SetValue(int i) => this.value = i;
         public int GetValue() => this.value;
 
+        public bool EnableICustomQueryInterface { get; set; } = false;
         public Guid ICustomQueryInterface_GetInterfaceIID { get; set; }
         public IntPtr ICustomQueryInterface_GetInterfaceResult { get; set; }
 
         CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
         {
             ppv = IntPtr.Zero;
-            if (iid == typeof(ITest).GUID)
+            if (!EnableICustomQueryInterface)
             {
                 return CustomQueryInterfaceResult.NotHandled;
             }
-            else if (iid != ICustomQueryInterface_GetInterfaceIID)
+
+            if (iid != ICustomQueryInterface_GetInterfaceIID)
             {
                 return CustomQueryInterfaceResult.Failed;
             }


### PR DESCRIPTION
If the managed object wrapper doesn't know about the IID but implements [`ICustomQueryInterface`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.icustomqueryinterface.getinterface), ask the implementation to find the interface.

Fixes https://github.com/dotnet/runtime/issues/34717

/cc @jkoritzinsky @elinor-fung @jkotas @davidwrighton 