### PR TITLE
Add EccSecurityTransforms to credscan suppresions to unblock code-mirror

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -6,6 +6,7 @@
       "/eng/common/internal-feed-operations.ps1",
       "/eng/common/internal-feed-operations.sh",
       "/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs",
+      "/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs",
       "/src/libraries/Common/tests/System/Net/Configuration.Certificates.cs",
       "/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Authentication.cs",
       "/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs",


### PR DESCRIPTION
Code-mirror is currently blocked because commit: https://github.com/dotnet/runtime/commit/10828e147d1c678ef1f6ab6e258f601d58b9f7e8 has `password` in a variable and credscan is flagging it.

We can remove this file if we want after I merge this, we just need to include it so that code-mirror doesn't flagg it for the next mirror.

cc: @bartonjs @dotnet/runtime-infrastructure 