### PR TITLE
Added additional LoggerMessage overloads

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
@@ -99,12 +99,19 @@ namespace Microsoft.Extensions.Logging
         public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, System.IDisposable> DefineScope<T1>(string formatString) { throw null; }
         public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, System.IDisposable> DefineScope<T1, T2>(string formatString) { throw null; }
         public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, System.IDisposable> DefineScope<T1, T2, T3>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, System.IDisposable> DefineScope<T1, T2, T3, T4>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, T7, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6, T7>(string formatString) { throw null; }
+        public static System.Func<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, T7, T8, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6, T7, T8>(string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, System.Exception> Define<T1>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, System.Exception> Define<T1, T2>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, System.Exception> Define<T1, T2, T3>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, System.Exception> Define<T1, T2, T3, T4>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, System.Exception> Define<T1, T2, T3, T4, T5>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
         public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, System.Exception> Define<T1, T2, T3, T4, T5, T6>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
+        public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, T7, System.Exception> Define<T1, T2, T3, T4, T5, T6, T7>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
+        public static System.Action<Microsoft.Extensions.Logging.ILogger, T1, T2, T3, T4, T5, T6, T7, T8, System.Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, string formatString) { throw null; }
     }
     public partial class Logger<T> : Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.ILogger<T>
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessage.cs
@@ -71,6 +71,96 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
+        /// Creates a delegate which can be invoked to create a log scope.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        public static Func<ILogger, T1, T2, T3, T4, IDisposable> DefineScope<T1, T2, T3, T4>(string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
+
+            return (logger, arg1, arg2, arg3, arg4) => logger.BeginScope(new LogValues<T1, T2, T3, T4>(formatter, arg1, arg2, arg3, arg4));
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked to create a log scope.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        public static Func<ILogger, T1, T2, T3, T4, T5, IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 5);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5>(formatter, arg1, arg2, arg3, arg4, arg5));
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked to create a log scope.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sisxth parameter passed to the named format string.</typeparam>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        public static Func<ILogger, T1, T2, T3, T4, T5, T6, IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 6);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5, T6>(formatter, arg1, arg2, arg3, arg4, arg5, arg6));
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked to create a log scope.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sisxth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter passed to the named format string.</typeparam>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        public static Func<ILogger, T1, T2, T3, T4, T5, T6, T7, IDisposable> DefineScope<T1, T2, T3, T4, T5, T6, T7>(string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 7);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6, arg7) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5, T6, T7>(formatter, arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked to create a log scope.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sisxth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter passed to the named format string.</typeparam>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log scope.</returns>
+        public static Func<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, IDisposable> DefineScope<T1, T2, T3, T4, T5, T6, T7, T8>(string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 8);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => logger.BeginScope(new LogValues<T1, T2, T3, T4, T5, T6, T7, T8>(formatter, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+        }
+
+        /// <summary>
         /// Creates a delegate which can be invoked for logging a message.
         /// </summary>
         /// <param name="logLevel">The <see cref="LogLevel"/></param>
@@ -247,6 +337,61 @@ namespace Microsoft.Extensions.Logging
                 if (logger.IsEnabled(logLevel))
                 {
                     logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4, T5, T6>(formatter, arg1, arg2, arg3, arg4, arg5, arg6), exception, LogValues<T1, T2, T3, T4, T5, T6>.Callback);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, Exception> Define<T1, T2, T3, T4, T5, T6, T7>(LogLevel logLevel, EventId eventId, string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 7);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6, arg7, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4, T5, T6, T7>(formatter, arg1, arg2, arg3, arg4, arg5, arg6, arg7), exception, LogValues<T1, T2, T3, T4, T5, T6, T7>.Callback);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a delegate which can be invoked for logging a message.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter passed to the named format string.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter passed to the named format string.</typeparam>
+        /// <param name="logLevel">The <see cref="LogLevel"/></param>
+        /// <param name="eventId">The event id</param>
+        /// <param name="formatString">The named format string</param>
+        /// <returns>A delegate which when invoked creates a log message.</returns>
+        public static Action<ILogger, T1, T2, T3, T4, T5, T6, T7, T8, Exception> Define<T1, T2, T3, T4, T5, T6, T7, T8>(LogLevel logLevel, EventId eventId, string formatString)
+        {
+            var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 8);
+
+            return (logger, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, exception) =>
+            {
+                if (logger.IsEnabled(logLevel))
+                {
+                    logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4, T5, T6, T7, T8>(formatter, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), exception, LogValues<T1, T2, T3, T4, T5, T6, T7, T8>.Callback);
                 }
             };
         }
@@ -635,6 +780,156 @@ namespace Microsoft.Extensions.Logging
             }
 
             private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5 };
+
+            public override string ToString() => _formatter.Format(ToArray());
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2, T3, T4, T5, T6> : IReadOnlyList<KeyValuePair<string, object>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5, T6>, Exception, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
+            private readonly T5 _value5;
+            private readonly T6 _value6;
+
+            public int Count => 8;
+
+            public KeyValuePair<string, object> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[3], _value3);
+                        case 4:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[4], _value4);
+                        case 5:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[5], _value5);
+                        case 6:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[6], _value6);
+                        case 7:
+                            return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+                _value3 = value3;
+                _value4 = value4;
+                _value5 = value5;
+                _value6 = value6;
+            }
+
+            private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5, _value6 };
+
+            public override string ToString() => _formatter.Format(ToArray());
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                for (int i = 0; i < Count; ++i)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private readonly struct LogValues<T0, T1, T2, T3, T4, T5, T6, T7> : IReadOnlyList<KeyValuePair<string, object>>
+        {
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5, T6, T7>, Exception, string> Callback = (state, exception) => state.ToString();
+
+            private readonly LogValuesFormatter _formatter;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
+            private readonly T5 _value5;
+            private readonly T6 _value6;
+            private readonly T7 _value7;
+
+            public int Count => 9;
+
+            public KeyValuePair<string, object> this[int index]
+            {
+                get
+                {
+                    switch (index)
+                    {
+                        case 0:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[1], _value1);
+                        case 2:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[2], _value2);
+                        case 3:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[3], _value3);
+                        case 4:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[4], _value4);
+                        case 5:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[5], _value5);
+                        case 6:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[6], _value6);
+                        case 7:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[7], _value7);
+                        case 8:
+                            return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
+                    }
+                }
+            }
+
+            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+            {
+                _formatter = formatter;
+                _value0 = value0;
+                _value1 = value1;
+                _value2 = value2;
+                _value3 = value3;
+                _value4 = value4;
+                _value5 = value5;
+                _value6 = value6;
+                _value7 = value7;
+            }
+
+            private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5, _value6, _value7 };
 
             public override string ToString() => _formatter.Format(ToArray());
 

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerMessageTest.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData(4)]
         [InlineData(5)]
         [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
         public void DefineMessage_ThrowsException_WhenExpectedFormatStringParameterCount_NotFound(
             int expectedNamedParameterCount)
         {
@@ -251,6 +253,14 @@ namespace Microsoft.Extensions.Logging.Test
                     exception = Assert.Throws<ArgumentException>(
                         () => LoggerMessage.Define<string, string, string, string, string, string>(LogLevel.Error, 0, formatString));
                     break;
+                case 7:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.Define<string, string, string, string, string, string, string>(LogLevel.Error, 0, formatString));
+                    break;
+                case 8:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.Define<string, string, string, string, string, string, string, string>(LogLevel.Error, 0, formatString));
+                    break;
                 default:
                     throw new ArgumentException($"Invalid value for '{nameof(expectedNamedParameterCount)}'");
             }
@@ -277,6 +287,11 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
         public void DefineScope_ThrowsException_WhenExpectedFormatStringParameterCount_NotFound(
             int expectedNamedParameterCount)
         {
@@ -301,6 +316,26 @@ namespace Microsoft.Extensions.Logging.Test
                     exception = Assert.Throws<ArgumentException>(
                         () => LoggerMessage.DefineScope<string, string, string>(formatString));
                     break;
+                case 4:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.DefineScope<string, string, string, string>(formatString));
+                    break;
+                case 5:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.DefineScope<string, string, string, string, string>(formatString));
+                    break;
+                case 6:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.DefineScope<string, string, string, string, string, string>(formatString));
+                    break;
+                case 7:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.DefineScope<string, string, string, string, string, string, string>(formatString));
+                    break;
+                case 8:
+                    exception = Assert.Throws<ArgumentException>(
+                        () => LoggerMessage.DefineScope<string, string, string, string, string, string, string, string>(formatString));
+                    break;
                 default:
                     throw new ArgumentException($"Invalid value for '{nameof(expectedNamedParameterCount)}'");
             }
@@ -317,6 +352,8 @@ namespace Microsoft.Extensions.Logging.Test
             new object[] { LoggerMessage.Define<string, string, string, string>(LogLevel.Error, 4, "Log {P0} {P1} {P2} {P3}"), 4 },
             new object[] { LoggerMessage.Define<string, string, string, string, string>(LogLevel.Error, 5, "Log {P0} {P1} {P2} {P3} {P4}"), 5 },
             new object[] { LoggerMessage.Define<string, string, string, string, string, string>(LogLevel.Error, 6, "Log {P0} {P1} {P2} {P3} {P4} {P5}"), 6 },
+            new object[] { LoggerMessage.Define<string, string, string, string, string, string, string>(LogLevel.Error, 6, "Log {P0} {P1} {P2} {P3} {P4} {P5} {P6}"), 7 },
+            new object[] { LoggerMessage.Define<string, string, string, string, string, string, string, string>(LogLevel.Error, 6, "Log {P0} {P1} {P2} {P3} {P4} {P5} {P6} {P7}"), 8 },
         };
 
         private void AssertLogValues(


### PR DESCRIPTION
Added additional LoggerMessage overloads, with more type parameters (up to 8, like elsewhere). 

Resolves https://github.com/dotnet/extensions/issues/3010