### PR TITLE
Add arg aliases for runtimeConfiguration and librariesConfiguration

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -11,7 +11,7 @@ Param(
   [string]$testscope,
   [switch]$testnobuild,
   [string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
-  [Parameter(Position=0)][string]$subset,
+  [Parameter(Position=0)][string][Alias('s')]$subset,
   [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
   [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
@@ -19,7 +19,7 @@ Param(
 
 function Get-Help() {
   Write-Host "Common settings:"
-  Write-Host "  -subset                   Build a subset, print available subsets with -subset help"
+  Write-Host "  -subset                   Build a subset, print available subsets with -subset help (short: -s)"
   Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
   Write-Host "  -os                       Build operating system: Windows_NT or Unix"
   Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -a). Pass a comma-separated list to build for multiple architectures."

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,8 +12,8 @@ Param(
   [switch]$testnobuild,
   [string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
   [Parameter(Position=0)][string]$subset,
-  [ValidateSet("Debug","Release","Checked")][string]$runtimeConfiguration,
-  [ValidateSet("Debug","Release")][string]$librariesConfiguration,
+  [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
+  [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -24,15 +24,15 @@ function Get-Help() {
   Write-Host "  -os                       Build operating system: Windows_NT or Unix"
   Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -a). Pass a comma-separated list to build for multiple architectures."
   Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
-  Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked"
-  Write-Host "  -librariesConfiguration   Libraries build configuration: Debug or Release"
+  Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked (short: -rc)"
+  Write-Host "  -librariesConfiguration   Libraries build configuration: Debug or Release (short: -lc)"
   Write-Host "  -verbosity                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   Write-Host "  -binaryLog                Output binary log (short: -bl)"
   Write-Host "  -help                     Print help and exit (short: -h)"
   Write-Host ""
 
   Write-Host "Actions (defaults to -restore -build):"
-  Write-Host "  -restore                Restore dependencies (short: -r)"
+  Write-Host "  -restore                Restore dependencies"
   Write-Host "  -build                  Build all source projects (short: -b)"
   Write-Host "  -rebuild                Rebuild all source projects"
   Write-Host "  -test                   Build and run tests (short: -t)"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -17,7 +17,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 usage()
 {
   echo "Common settings:"
-  echo "  --subset                   Build a subset, print available subsets with -subset help"
+  echo "  --subset                   Build a subset, print available subsets with -subset help (short: -s)"
   echo "  --os                       Build operating system: Windows_NT, Linux, FreeBSD, OSX, tvOS, iOS or Android"
   echo "  --arch                     Build platform: x86, x64, arm, armel or arm64"
   echo "  --configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c)"
@@ -97,7 +97,7 @@ while [[ $# > 0 ]]; do
       usage
       exit 0
       ;;
-     -subset)
+     -subset|-s)
       arguments="$arguments /p:Subset=$2"
       shift 2
       ;;

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -21,8 +21,8 @@ usage()
   echo "  --os                       Build operating system: Windows_NT, Linux, FreeBSD, OSX, tvOS, iOS or Android"
   echo "  --arch                     Build platform: x86, x64, arm, armel or arm64"
   echo "  --configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c)"
-  echo "  --runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked"
-  echo "  --librariesConfiguration   Libraries build configuration: Debug or Release"
+  echo "  --runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked (short: -rc)"
+  echo "  --librariesConfiguration   Libraries build configuration: Debug or Release (short: -lc)"
   echo "  --projects <value>         Project or solution file(s) to build"
   echo "  --verbosity                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --binaryLog                Output binary log (short: -bl)"
@@ -136,12 +136,12 @@ while [[ $# > 0 ]]; do
       arguments="$arguments /p:Coverage=true"
       shift 1
       ;;
-     -runtimeconfiguration)
+     -runtimeconfiguration|-rc)
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
       arguments="$arguments /p:RuntimeConfiguration=$val"
       shift 2
       ;;
-     -librariesconfiguration)
+     -librariesconfiguration|-lc)
       arguments="$arguments /p:LibrariesConfiguration=$2"
       shift 2
       ;;


### PR DESCRIPTION
I feel like people type a lot just to pass in either runtimeConfiguration or librariesConfiguration to the build scripts.

This also fixes the help text as -r is not supported in powershell for restore as powershell takes it as the runtimeConfiguration because it matches substrings on parameters.

Fixes: https://github.com/dotnet/runtime/issues/2172

cc: @stephentoub @jkotas @dotnet/runtime-infrastructure 