### PR TITLE
Add new media type name

### DIFF
--- a/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
@@ -328,6 +328,7 @@ namespace System.Net.Mime
             public const string Gif = "image/gif";
             public const string Jpeg = "image/jpeg";
             public const string Tiff = "image/tiff";
+            public const string Png = "image/png";
         }
         public static partial class Text
         {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
@@ -30,6 +30,7 @@ namespace System.Net.Mime
             public const string Gif = "image/gif";
             public const string Tiff = "image/tiff";
             public const string Jpeg = "image/jpeg";
+            public const string Png = "image/png";
         }
     }
 }


### PR DESCRIPTION
I have added image/png because it is a common media type and don't know why it's not in there.