### PR TITLE
 Include key when throwing KeyNotFoundException in indexer

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/Resources/Strings.resx
+++ b/src/libraries/System.Collections.Immutable/src/Resources/Strings.resx
@@ -79,7 +79,7 @@
     <value>Collection was modified; enumeration operation may not execute.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
-    <value>An element with the same key but a different value already exists. Key: {0}</value>
+    <value>An element with the same key but a different value already exists. Key: '{0}'</value>
   </data>
   <data name="InvalidEmptyOperation" xml:space="preserve">
     <value>This operation does not apply to an empty instance.</value>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -254,7 +254,7 @@ namespace System.Collections.Immutable
                     return value;
                 }
 
-                throw new KeyNotFoundException();
+                throw new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
             }
         }
 

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -377,6 +377,15 @@ namespace System.Collections.Immutable.Tests
             Assert.True(clearedDictionary.ContainsKey("A"));
         }
 
+        [Fact]
+        public void Indexer_KeyNotFoundException_ContainsKeyInMessage()
+        {
+            var map = ImmutableDictionary.Create<string, string>()
+                .Add("a", "1").Add("b", "2");
+            var exception = Assert.Throws<KeyNotFoundException>(() => map["c"]);
+            Assert.Contains("'c'", exception.Message);
+        }
+
         protected override IImmutableDictionary<TKey, TValue> Empty<TKey, TValue>()
         {
             return ImmutableDictionaryTest.Empty<TKey, TValue>();

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -506,6 +506,15 @@ namespace System.Collections.Immutable.Tests
             Assert.Throws<KeyNotFoundException>(() => dictionary.ValueRef("c"));
         }
 
+        [Fact]
+        public void Indexer_KeyNotFoundException_ContainsKeyInMessage()
+        {
+            var map = ImmutableSortedDictionary.Create<string, string>()
+                .Add("a", "1").Add("b", "2");
+            var exception = Assert.Throws<KeyNotFoundException>(() => map["c"]);
+            Assert.Contains("'c'", exception.Message);
+        }
+
         protected override IImmutableDictionary<TKey, TValue> Empty<TKey, TValue>()
         {
             return ImmutableSortedDictionaryTest.Empty<TKey, TValue>();


### PR DESCRIPTION
Fixes #34703

I based this primarily on https://github.com/dotnet/corefx/pull/185 which was linked there and fixed a similar issue. Also adds quotes around the only replacement marker that hadn't any.