### PR TITLE
Fix installer CI job warnings for iOS/tvOS/Android

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -65,6 +65,7 @@ jobs:
   - name: SkipTests
     value: ${{ or(
       not(in(parameters.archType, 'x64', 'x86')),
+      in(parameters.osGroup, 'iOS', 'tvOS', 'Android'),
       eq(parameters.isOfficialBuild, true),
       ne(parameters.crossrootfsDir, '')) }}
 


### PR DESCRIPTION
We don't run tests in the installer for these OSes so the PublishTestResults task complains about missing *.xml result files.