### PR TITLE
Fix missing array ctor(int32,int32) test failures.

### DIFF
--- a/src/mono/mono/mini/iltests.il
+++ b/src/mono/mono/mini/iltests.il
@@ -17,7 +17,7 @@
 
 	.method static public int32 Main(string[] args) il managed {
 		.entrypoint
-		
+
 		ldtoken Tests
 		call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
 		ldarg.0
@@ -3556,5 +3556,121 @@ L3:
 		IL_0023:  ldloc.2
 		IL_0024:  ret
 	 }
+
+	.method private hidebysig static int32 validate_alloc_array_length_lbound(class [mscorlib]System.Array test_array) cil managed
+	{
+		// Code size       88 (0x58)
+		.maxstack  2
+		.locals init ([0] bool V_0, [1] int32 V_1, [2] bool V_2, [3] bool V_3, [4] bool V_4)
+		IL_0000:  nop
+		IL_0001:  ldarg.0
+		IL_0002:  callvirt   instance int32 [mscorlib]System.Array::get_Length()
+		IL_0007:  ldc.i4.6
+		IL_0008:  ceq
+		IL_000a:  ldc.i4.0
+		IL_000b:  ceq
+		IL_000d:  stloc.0
+		IL_000e:  ldloc.0
+		IL_000f:  brfalse.s  IL_0015
+		IL_0011:  ldc.i4.1
+		IL_0012:  stloc.1
+		IL_0013:  br.s       IL_0056
+		IL_0015:  ldarg.0
+		IL_0016:  callvirt   instance int32 [mscorlib]System.Array::get_Rank()
+		IL_001b:  ldc.i4.1
+		IL_001c:  ceq
+		IL_001e:  ldc.i4.0
+		IL_001f:  ceq
+		IL_0021:  stloc.2
+		IL_0022:  ldloc.2
+		IL_0023:  brfalse.s  IL_0029
+		IL_0025:  ldc.i4.2
+		IL_0026:  stloc.1
+		IL_0027:  br.s       IL_0056
+		IL_0029:  ldarg.0
+		IL_002a:  ldc.i4.0
+		IL_002b:  callvirt   instance int32 [mscorlib]System.Array::GetLowerBound(int32)
+		IL_0030:  ldc.i4 0x2710
+		IL_0031:  cgt.un
+		IL_0033:  stloc.3
+		IL_0034:  ldloc.3
+		IL_0035:  brfalse.s  IL_003b
+		IL_0037:  ldc.i4.3
+		IL_0038:  stloc.1
+		IL_0039:  br.s       IL_0056
+		IL_003b:  ldarg.0
+		IL_003c:  ldc.i4.0
+		IL_003d:  callvirt   instance int32 [mscorlib]System.Array::GetUpperBound(int32)
+		IL_0042:  ldc.i4 0x2715
+		IL_0043:  ceq
+		IL_0045:  ldc.i4.0
+		IL_0046:  ceq
+		IL_0048:  stloc.s    V_4
+		IL_004a:  ldloc.s    V_4
+		IL_004c:  brfalse.s  IL_0052
+		IL_004e:  ldc.i4.4
+		IL_004f:  stloc.1
+		IL_0050:  br.s       IL_0056
+		IL_0052:  ldc.i4.0
+		IL_0053:  stloc.1
+		IL_0054:  br.s       IL_0056
+		IL_0056:  ldloc.1
+		IL_0057:  ret
+	}
+
+	.method public hidebysig static int32  test_0_alloc_array_int16_length_lbound() cil managed
+	{
+		.maxstack  2
+		.locals init ([0] int16[] test_array, [1] int32 V_1)
+		ldc.i4 10000
+		ldc.i4 6
+		newobj instance void int16[10000...10005]::.ctor(int32, int32)
+		call int32 class Tests::validate_alloc_array_length_lbound(class [mscorlib]System.Array)
+		ret
+	}
+
+	.method public hidebysig static int32  test_0_alloc_array_int32_length_lbound() cil managed
+	{
+		.maxstack  2
+		.locals init ([0] int32[] test_array, [1] int32 V_1)
+		ldc.i4 10000
+		ldc.i4 6
+		newobj instance void int32[10000...10005]::.ctor(int32, int32)
+		call int32 class Tests::validate_alloc_array_length_lbound(class [mscorlib]System.Array)
+		ret
+	}
+
+	.method public hidebysig static int32  test_0_alloc_array_int64_length_lbound() cil managed
+	{
+		.maxstack  2
+		.locals init ([0] int64[] test_array, [1] int32 V_1)
+		ldc.i4 10000
+		ldc.i4 6
+		newobj instance void int64[10000...10005]::.ctor(int32, int32)
+		call int32 class Tests::validate_alloc_array_length_lbound(class [mscorlib]System.Array)
+		ret
+	}
+
+	.method public hidebysig static int32  test_0_alloc_array_float32_length_lbound() cil managed
+	{
+		.maxstack  2
+		.locals init ([0] float32[] test_array, [1] int32 V_1)
+		ldc.i4 10000
+		ldc.i4 6
+		newobj instance void float32[10000...10005]::.ctor(int32, int32)
+		call int32 class Tests::validate_alloc_array_length_lbound(class [mscorlib]System.Array)
+		ret
+	}
+
+	.method public hidebysig static int32  test_0_alloc_array_float64_length_lbound() cil managed
+	{
+		.maxstack  2
+		.locals init ([0] float64[] test_array, [1] int32 V_1)
+		ldc.i4 10000
+		ldc.i4 6
+		newobj instance void float64[10000...10005]::.ctor(int32, int32)
+		call int32 class Tests::validate_alloc_array_length_lbound(class [mscorlib]System.Array)
+		ret
+	}
 
 }


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19494,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>According to ECMA, VES should add the following methods to arrays:

* A constructor that takes a sequence of int32 arguments, one for each dimension of the array, that specify the number of elements in each dimension beginning with the first dimension. A lower bound of zero is assumed.

* A constructor that takes twice as many int32 arguments as there are dimensions of the array. These arguments occur in pairs—one pair per dimension—with the first argument of each pair specifying the lower bound for that dimension, and the second argument specifying the total number of elements in that dimension.

* Get.

* Set.

* Address.

In Mono's case we only added the `ctor (int32, int32)` for rank 1 arrays if they were "jagged" array. Array with rank 1-4 executed an optimized code path always using the one int32 per rank constructor.

This doesn't work in cases where the array is constructed using both a length and a lower bound pattern, like:

`newobj instance void int32[10000...10005]::.ctor(int32, int32)`

this would trigger a method not found exception, since its not a jagged array, Mono wouldn't add the `ctor(int32, int32)` constructor for this type.

Fix will make sure we follow ECMA's definition of this and fix code to use right instance methods of arrays. Code also adds an assert to trap if a jagged array is created through this code path
(shouldn't happen) since current implementation would have handled it as
a 2 ranked array.

Fix also adds several tests into iltests.il allocating different variations of arrays using lower/upper bounds and validating length, rank, upper/lower bounds of allocated arrays.