### PR TITLE
Remove most [Fact(Skip = "...")] in library tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));
         }
 
-        [Fact(Skip = "Takes approximately 1600 seconds to execute")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public static void GenerateMaxKey()
         {
             GenerateKey(rsa => GetMax(rsa.LegalKeySizes));

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -425,56 +425,6 @@ namespace System.Collections.Immutable.Tests
             Assert.IsType<ArgumentNullException>(tie.InnerException);
         }
 
-        [Fact(Skip = "Useful to enable when collecting perf traces")]
-        public void EnumerationPerformance()
-        {
-            var dictionary = Enumerable.Range(1, 1000).ToImmutableSortedDictionary(k => k, k => k);
-
-            var timing = new TimeSpan[3];
-            var sw = new Stopwatch();
-            for (int j = 0; j < timing.Length; j++)
-            {
-                sw.Start();
-                for (int i = 0; i < 10000; i++)
-                {
-                    foreach (var entry in dictionary)
-                    {
-                    }
-                }
-
-                timing[j] = sw.Elapsed;
-                sw.Reset();
-            }
-
-            string timingText = string.Join(Environment.NewLine, timing);
-            Debug.WriteLine("Timing:{0}{1}", Environment.NewLine, timingText);
-        }
-
-        [Fact(Skip = "Useful to enable when collecting perf traces")]
-        public void EnumerationPerformance_Empty()
-        {
-            var dictionary = ImmutableSortedDictionary<int, int>.Empty;
-
-            var timing = new TimeSpan[3];
-            var sw = new Stopwatch();
-            for (int j = 0; j < timing.Length; j++)
-            {
-                sw.Start();
-                for (int i = 0; i < 10000; i++)
-                {
-                    foreach (var entry in dictionary)
-                    {
-                    }
-                }
-
-                timing[j] = sw.Elapsed;
-                sw.Reset();
-            }
-
-            string timingText = string.Join(Environment.NewLine, timing);
-            Debug.WriteLine("Timing_Empty:{0}{1}", Environment.NewLine, timingText);
-        }
-
         [Fact]
         public void ValueRef()
         {

--- a/src/libraries/System.Data.Odbc/tests/CommandBuilderTests.cs
+++ b/src/libraries/System.Data.Odbc/tests/CommandBuilderTests.cs
@@ -8,7 +8,7 @@ namespace System.Data.Odbc.Tests
 {
     public class CommandBuilderTests : IntegrationTestBase
     {
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void QuoteIdentifier_UseConnection()
         {
             var commandBuilder = new OdbcCommandBuilder();
@@ -37,7 +37,7 @@ namespace System.Data.Odbc.Tests
             Assert.Throws<InvalidOperationException>(() => commandBuilder.UnquoteIdentifier("Test"));
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void QuoteIdentifier_CustomPrefixSuffix()
         {
             var commandBuilder = new OdbcCommandBuilder();

--- a/src/libraries/System.Data.Odbc/tests/IntegrationTestBase.cs
+++ b/src/libraries/System.Data.Odbc/tests/IntegrationTestBase.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Data.Odbc.Tests
 {
@@ -15,7 +15,19 @@ namespace System.Data.Odbc.Tests
         public IntegrationTestBase()
         {
             connection = new OdbcConnection(ConnectionStrings.WorkingConnection);
-            connection.Open();
+            try
+            {
+                connection.Open();
+            }
+            catch (OdbcException e) when (e.ErrorCode == unchecked((int)0x80131937)) // Data source name not found and no default driver specified
+            {
+                throw new SkipTestException(e.Message);
+            }
+            catch (DllNotFoundException e)
+            {
+                throw new SkipTestException(e.Message);
+            }
+
             transaction = connection.BeginTransaction();
             command = connection.CreateCommand();
             command.Transaction = transaction;

--- a/src/libraries/System.Data.Odbc/tests/ReaderTests.cs
+++ b/src/libraries/System.Data.Odbc/tests/ReaderTests.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Data.Odbc.Tests
 {
     public class ReaderTests : IntegrationTestBase
     {
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void EmptyReader()
         {
             command.CommandText =
@@ -42,7 +43,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void GetValues()
         {
             command.CommandText =
@@ -75,7 +76,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void GetValueFailsWithBigIntWithBackwardsCompatibility()
         {
             command.CommandText =
@@ -110,7 +111,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void GetDataTypeName()
         {
             command.CommandText =
@@ -136,7 +137,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void GetFieldTypeIsNotSupportedInSqlite()
         {
             command.CommandText =
@@ -167,7 +168,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void IsDbNullIsNotSupportedInSqlite()
         {
             command.CommandText =
@@ -198,7 +199,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void InvalidRowIndex()
         {
             command.CommandText =
@@ -230,7 +231,7 @@ namespace System.Data.Odbc.Tests
             }
         }
 
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void InvalidRowName()
         {
             command.CommandText =

--- a/src/libraries/System.Data.Odbc/tests/SmokeTest.cs
+++ b/src/libraries/System.Data.Odbc/tests/SmokeTest.cs
@@ -8,7 +8,7 @@ namespace System.Data.Odbc.Tests
 {
     public class SmokeTest : IntegrationTestBase
     {
-        [Fact(Skip = "Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097.")]
+        [ConditionalFact]
         public void CreateInsertSelectTest()
         {
             command.CommandText =

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -14,6 +14,7 @@ using System.ComponentModel;
 using System.Security;
 using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
@@ -903,7 +904,9 @@ namespace System.Diagnostics.Tests
             Assert.Equal(workingDirectory ?? string.Empty, info.WorkingDirectory);
         }
 
-        [Fact(Skip = "Manual test")]
+        [Fact]
+        [OuterLoop("Opens a browser")]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Native dependencies missing in CI. See https://github.com/dotnet/runtime/issues/20097
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartInfo_WebPage()
         {
@@ -916,6 +919,8 @@ namespace System.Diagnostics.Tests
             using (var p = Process.Start(info))
             {
                 Assert.NotNull(p);
+                p.WaitForInputIdle();
+                p.Kill();
             }
         }
 

--- a/src/libraries/System.Linq/tests/SelectManyTests.cs
+++ b/src/libraries/System.Linq/tests/SelectManyTests.cs
@@ -210,7 +210,7 @@ namespace System.Linq.Tests
             Assert.Equal(source.Last().total, source.SelectMany((e, i) => i == 4 ? e.total : Enumerable.Empty<int?>()));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void IndexOverflow()
         {
             var selected = new FastInfiniteEnumerator<int>().SelectMany((e, i) => Enumerable.Empty<int>());

--- a/src/libraries/System.Linq/tests/SelectTests.cs
+++ b/src/libraries/System.Linq/tests/SelectTests.cs
@@ -140,7 +140,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Select((e, i) => i == 5 ? e.name : null));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void Overflow()
         {
             var selected = new FastInfiniteEnumerator<int>().Select((e, i) => e);

--- a/src/libraries/System.Linq/tests/SkipWhileTests.cs
+++ b/src/libraries/System.Linq/tests/SkipWhileTests.cs
@@ -142,7 +142,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.SkipWhile((element, index) => index < source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void IndexSkipWhileOverflowBeyondIntMaxValueElements()
         {
             var skipped = new FastInfiniteEnumerator<int>().SkipWhile((e, i) => true);

--- a/src/libraries/System.Linq/tests/TakeWhileTests.cs
+++ b/src/libraries/System.Linq/tests/TakeWhileTests.cs
@@ -117,7 +117,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().TakeWhile((element, index) => index < source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void IndexTakeWhileOverflowBeyondIntMaxValueElements()
         {
             var taken = new FastInfiniteEnumerator<int>().TakeWhile((e, i) => true);

--- a/src/libraries/System.Linq/tests/ToArrayTests.cs
+++ b/src/libraries/System.Linq/tests/ToArrayTests.cs
@@ -128,7 +128,7 @@ namespace System.Linq.Tests
             Assert.Equal(1, source.CopyToTouched);
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void ToArray_FailOnExtremelyLargeCollection()
         {
             var largeSeq = new FastInfiniteEnumerator<byte>();

--- a/src/libraries/System.Linq/tests/WhereTests.cs
+++ b/src/libraries/System.Linq/tests/WhereTests.cs
@@ -998,7 +998,7 @@ namespace System.Linq.Tests
             Assert.Equal(source.Skip(source.Length - 1), source.Where((e, i) => i == source.Length - 1));
         }
 
-        [Fact(Skip = "Valid test but too intensive to enable even in OuterLoop")]
+        [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         public void IndexOverflows()
         {
             var infiniteWhere = new FastInfiniteEnumerator<int>().Where((e, i) => true);

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -86,7 +86,7 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Throws<BadImageFormatException>(() => new PEReader(new MemoryStream(), PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/17088")]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/17088")]
         public void SubStream()
         {

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -429,7 +429,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [OuterLoop]
-        [Theory(Skip = "Can cause improbable memory allocations leading to interminable paging")]
+        [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(FuzzInputs_MemberData))]
         public void Deserialize_FuzzInput(object obj, Random rand)
         {

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/CallerArgumentExpressionAttributeTests.cs
@@ -83,8 +83,8 @@ namespace System.Runtime.CompilerServices.Tests
             return expr;
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void SimpleExpression()
         {
             int notVal = 0;
@@ -92,8 +92,8 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal("notVal", IntParamMethod(notVal));
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void ComplexExpression()
         {
             int x = 5;
@@ -102,8 +102,8 @@ namespace System.Runtime.CompilerServices.Tests
                 IntParamMethod(Math.Min(x + 20, x * x)));
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void SurroundingWhitespaceHandling()
         {
             int notVal = 0;
@@ -111,8 +111,8 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal("notVal", IntParamMethod(notVal));
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void InternalWhitespaceHandling()
         {
             int notVal = 0;
@@ -125,8 +125,8 @@ namespace System.Runtime.CompilerServices.Tests
                     notVal + 20)));
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void InternalCommentHandling()
         {
             int notVal = 0;
@@ -137,8 +137,8 @@ namespace System.Runtime.CompilerServices.Tests
                 ));
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void OptionalParameterHandling()
         {
             string suppliedVal = "supplied value";
@@ -162,8 +162,8 @@ namespace System.Runtime.CompilerServices.Tests
             return expr;
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void ExtensionMethodThisParameterHandling()
         {
             int notVal = 0;
@@ -176,8 +176,8 @@ namespace System.Runtime.CompilerServices.Tests
             return expr;
         }
 
-        [Fact(Skip = "Not yet implemented in compiler. Final behavior may differ.")]
-        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605", TestPlatforms.Any)]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/roslyn/issues/19605")]
         public static void InstanceMethodThisHandling()
         {
             var instance = new InstanceTest();

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -92,7 +92,8 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20486")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34786", TestPlatforms.AnyUnix)]
+        [Fact]
         public void LoadXml()
         {
             const string pValue = "oDZlcdJA1Kf6UeNEIZqm4KDqA6zpX7CmEtAGWi9pgnBhWOUDVEfhswfsvTLR5BCbKfE6KoHvt5Hh8D1RcAko//iZkLZ+gds9y/5Oxape8tu3TUi1BnNPWu8ieXjMtdnpyudKFsCymssJked1rBeRePG23HTVwOV1DpopjRkjBEU=";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedInfoTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedInfoTest.cs
@@ -140,7 +140,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(result, el.OuterXml);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void GetXmlWithSetProperty()
         {
             XmlDocument doc = new XmlDocument();

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -458,11 +458,11 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Null(aa2);
         }
 
-        [Fact(Skip = "SignedXmlTest.DigestValue_CRLF")]
+        [Fact]
         public void AddObject_Null()
         {
             SignedXml sx = new SignedXml();
-            Assert.Throws<ArgumentNullException>(() => sx.AddObject(null));
+            sx.AddObject(null);
         }
 
         [Fact]
@@ -558,7 +558,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Throws<CryptographicException>(() => signedXml.ComputeSignature());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void DataReferenceToNonDataObject()
         {
             XmlDocument doc = new XmlDocument();
@@ -631,7 +632,8 @@ namespace System.Security.Cryptography.Xml.Tests
             return sw.ToString();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void GetIdElement_Null()
         {
             SignedXml sign = new SignedXml();
@@ -1452,7 +1454,8 @@ namespace System.Security.Cryptography.Xml.Tests
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_ZeroLength()
         {
             string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -1480,7 +1483,8 @@ namespace System.Security.Cryptography.Xml.Tests
             CheckErratum(sign, new HMACSHA1(Encoding.ASCII.GetBytes("secret")), "4");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_SmallerThanMinimumLength()
         {
             // 72 is a multiple of 8 but smaller than the minimum of 80 bits
@@ -1489,7 +1493,8 @@ namespace System.Security.Cryptography.Xml.Tests
             CheckErratum(sign, new HMACSHA1(Encoding.ASCII.GetBytes("secret")), "72");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_MinimumLength()
         {
             // 80 bits is the minimum (and the half-size of HMACSHA1)
@@ -1498,7 +1503,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.True(sign.CheckSignature(new HMACSHA1(Encoding.ASCII.GetBytes("secret"))));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_SmallerHalfLength()
         {
             // 80bits is smaller than the half-size of HMACSHA256
@@ -1507,7 +1513,8 @@ namespace System.Security.Cryptography.Xml.Tests
             CheckErratum(sign, new HMACSHA256(Encoding.ASCII.GetBytes("secret")), "80");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_HalfLength()
         {
             // 128 is the half-size of HMACSHA256
@@ -1524,7 +1531,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.True(sign.CheckSignature(new HMACSHA1(Encoding.ASCII.GetBytes("secret"))));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_HMACOutputLength_Signature_Mismatch()
         {
             string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -1548,7 +1556,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Throws<CryptographicException>(() => sign.CheckSignature(new HMACSHA1(Encoding.ASCII.GetBytes("no clue"))));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         public void VerifyHMAC_HMACOutputLength_Invalid()
         {
             string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
@@ -375,7 +375,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(xml, output);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20487")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20487")]
+        [Fact]
         public void PrefixlessNamespaceOutput()
         {
             XmlDocument doc = new XmlDocument();

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigExcC14NTransformTest.cs
@@ -239,7 +239,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(c14xml3, output);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         // see LoadInputAsXmlNodeList2 description
         public void LoadInputAsXmlNodeList()
         {
@@ -251,7 +252,8 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal("<Test></Test>", output);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/20429")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/20429")]
+        [Fact]
         // MS has a bug that those namespace declaration nodes in
         // the node-set are written to output. Related spec section is:
         // http://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel


### PR DESCRIPTION
We've preferred to not use Skip.  Fixing some that have crept in, using other mechanisms on which we've standardized.