### PR TITLE
Reduce allocations in string.Normalize

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -13,10 +13,19 @@ internal static partial class Interop
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
-        internal static int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, Span<char> dstBuffer) =>
-            NormalizeString(normalizationForm, src, srcLen, ref MemoryMarshal.GetReference(dstBuffer), dstBuffer.Length);
+        internal static int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, Span<char> dstBuffer)
+        {
+            unsafe
+            {
+                fixed (char* pSrc = src)
+                fixed (char* pDest = &MemoryMarshal.GetReference(dstBuffer))
+                {
+                    return NormalizeString(normalizationForm, pSrc, srcLen, pDest, dstBuffer.Length);
+                }
+            }
+        }
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
-        private static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, ref char dstBuffer, int dstBufferCapacity);
+        private static extern unsafe int NormalizeString(NormalizationForm normalizationForm, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -11,21 +10,9 @@ internal static partial class Interop
     internal static partial class Globalization
     {
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
-        internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
-
-        internal static int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, Span<char> dstBuffer)
-        {
-            unsafe
-            {
-                fixed (char* pSrc = src)
-                fixed (char* pDest = &MemoryMarshal.GetReference(dstBuffer))
-                {
-                    return NormalizeString(normalizationForm, pSrc, srcLen, pDest, dstBuffer.Length);
-                }
-            }
-        }
+        internal static extern int IsNormalized(NormalizationForm normalizationForm, char* src, int srcLen);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
-        private static extern unsafe int NormalizeString(NormalizationForm normalizationForm, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
+        internal static extern unsafe int NormalizeString(NormalizationForm normalizationForm, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -12,7 +13,10 @@ internal static partial class Interop
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
+        internal static int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, Span<char> dstBuffer) =>
+            NormalizeString(normalizationForm, src, srcLen, ref MemoryMarshal.GetReference(dstBuffer), dstBuffer.Length);
+
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
-        internal static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, [Out] char[] dstBuffer, int dstBufferCapacity);
+        private static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, ref char dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Globalization
     {
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
-        internal static extern int IsNormalized(NormalizationForm normalizationForm, char* src, int srcLen);
+        internal static extern unsafe int IsNormalized(NormalizationForm normalizationForm, char* src, int srcLen);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
         internal static extern unsafe int NormalizeString(NormalizationForm normalizationForm, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);

--- a/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
@@ -13,15 +13,24 @@ internal static partial class Interop
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool IsNormalizedString(NormalizationForm normForm, string source, int length);
 
-        internal static int NormalizeString(NormalizationForm normForm, string source, int sourceLength, Span<char> destination) =>
-            NormalizeString(normForm, source, sourceLength, ref MemoryMarshal.GetReference(destination), destination.Length);
+        internal static int NormalizeString(NormalizationForm normForm, string source, int sourceLength, Span<char> destination)
+        {
+            unsafe
+            {
+                fixed (char* pSrc = source)
+                fixed (char* pDest = &MemoryMarshal.GetReference(destination))
+                {
+                    return NormalizeString(normForm, pSrc, sourceLength, pDest, destination.Length);
+                }
+            }
+        }
 
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern int NormalizeString(
+        private static extern unsafe int NormalizeString(
                                         NormalizationForm normForm,
-                                        string source,
+                                        char* source,
                                         int sourceLength,
-                                        ref char destination,
+                                        char* destination,
                                         int destinationLength);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -11,22 +10,10 @@ internal static partial class Interop
     internal static partial class Normaliz
     {
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool IsNormalizedString(NormalizationForm normForm, string source, int length);
-
-        internal static int NormalizeString(NormalizationForm normForm, string source, int sourceLength, Span<char> destination)
-        {
-            unsafe
-            {
-                fixed (char* pSrc = source)
-                fixed (char* pDest = &MemoryMarshal.GetReference(destination))
-                {
-                    return NormalizeString(normForm, pSrc, sourceLength, pDest, destination.Length);
-                }
-            }
-        }
+        internal static extern unsafe BOOL IsNormalizedString(NormalizationForm normForm, char* source, int length);
 
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern unsafe int NormalizeString(
+        internal static extern unsafe int NormalizeString(
                                         NormalizationForm normForm,
                                         char* source,
                                         int sourceLength,

--- a/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
+++ b/src/libraries/Common/src/Interop/Windows/Normaliz/Interop.Normalization.cs
@@ -2,22 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Normaliz
     {
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool IsNormalizedString(int normForm, string source, int length);
+        internal static extern bool IsNormalizedString(NormalizationForm normForm, string source, int length);
+
+        internal static int NormalizeString(NormalizationForm normForm, string source, int sourceLength, Span<char> destination) =>
+            NormalizeString(normForm, source, sourceLength, ref MemoryMarshal.GetReference(destination), destination.Length);
 
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int NormalizeString(
-                                        int normForm,
+        private static extern int NormalizeString(
+                                        NormalizationForm normForm,
                                         string source,
                                         int sourceLength,
-                                        [System.Runtime.InteropServices.OutAttribute]
-                                        char[]? destination,
+                                        ref char destination,
                                         int destinationLength);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
@@ -70,7 +70,10 @@ namespace System.Globalization
 
                     if (realLen <= buffer.Length)
                     {
-                        return new string(buffer.Slice(0, realLen));
+                        ReadOnlySpan<char> result = buffer.Slice(0, realLen);
+                        return result.SequenceEqual(strInput)
+                            ? strInput
+                            : new string(result);
                     }
 
                     Debug.Assert(realLen > 512);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
@@ -50,8 +50,10 @@ namespace System.Globalization
             char[]? toReturn = null;
             try
             {
-                Span<char> buffer = strInput.Length <= 512
-                    ? stackalloc char[512]
+                const int StackallocThreshold = 512;
+
+                Span<char> buffer = strInput.Length <= StackallocThreshold
+                    ? stackalloc char[StackallocThreshold]
                     : (toReturn = ArrayPool<char>.Shared.Rent(strInput.Length));
 
                 for (int attempt = 0; attempt < 2; attempt++)
@@ -76,7 +78,7 @@ namespace System.Globalization
                             : new string(result);
                     }
 
-                    Debug.Assert(realLen > 512);
+                    Debug.Assert(realLen > StackallocThreshold);
 
                     if (attempt == 0)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Unix.cs
@@ -11,7 +11,7 @@ namespace System.Globalization
 {
     internal static partial class Normalization
     {
-        internal static bool IsNormalized(string strInput, NormalizationForm normalizationForm)
+        internal static unsafe bool IsNormalized(string strInput, NormalizationForm normalizationForm)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -23,12 +23,9 @@ namespace System.Globalization
             ValidateArguments(strInput, normalizationForm);
 
             int ret;
-            unsafe
+            fixed (char* pInput = strInput)
             {
-                fixed (char* pInput = strInput)
-                {
-                    ret = Interop.Globalization.IsNormalized(normalizationForm, pInput, strInput.Length);
-                }
+                ret = Interop.Globalization.IsNormalized(normalizationForm, pInput, strInput.Length);
             }
 
             if (ret == -1)
@@ -39,7 +36,7 @@ namespace System.Globalization
             return ret == 1;
         }
 
-        internal static string Normalize(string strInput, NormalizationForm normalizationForm)
+        internal static unsafe string Normalize(string strInput, NormalizationForm normalizationForm)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -60,13 +57,10 @@ namespace System.Globalization
                 for (int attempt = 0; attempt < 2; attempt++)
                 {
                     int realLen;
-                    unsafe
+                    fixed (char* pInput = strInput)
+                    fixed (char* pDest = &MemoryMarshal.GetReference(buffer))
                     {
-                        fixed (char* pInput = strInput)
-                        fixed (char* pDest = &MemoryMarshal.GetReference(buffer))
-                        {
-                            realLen = Interop.Globalization.NormalizeString(normalizationForm, pInput, strInput.Length, pDest, buffer.Length);
-                        }
+                        realLen = Interop.Globalization.NormalizeString(normalizationForm, pInput, strInput.Length, pDest, buffer.Length);
                     }
 
                     if (realLen == -1)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
@@ -56,7 +56,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.Format(SR.UnknownError_Num, lastError));
             }
 
-            return result == Interop.BOOL.TRUE;
+            return result != Interop.BOOL.FALSE;
         }
 
         internal static unsafe string Normalize(string strInput, NormalizationForm normalizationForm)
@@ -78,8 +78,10 @@ namespace System.Globalization
             char[]? toReturn = null;
             try
             {
-                Span<char> buffer = strInput.Length <= 512
-                    ? stackalloc char[512]
+                const int StackallocThreshold = 512;
+
+                Span<char> buffer = strInput.Length <= StackallocThreshold
+                    ? stackalloc char[StackallocThreshold]
                     : (toReturn = ArrayPool<char>.Shared.Rent(strInput.Length));
 
                 while (true)
@@ -114,6 +116,7 @@ namespace System.Globalization
                                 toReturn = null;
                                 ArrayPool<char>.Shared.Return(temp);
                             }
+                            Debug.Assert(realLength > StackallocThreshold);
                             buffer = toReturn = ArrayPool<char>.Shared.Rent(realLength);
                             continue;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -24,7 +25,7 @@ namespace System.Globalization
             // The only way to know if IsNormalizedString failed is through checking the Win32 last error
             // IsNormalizedString pinvoke has SetLastError attribute property which will set the last error
             // to 0 (ERROR_SUCCESS) before executing the calls.
-            bool result = Interop.Normaliz.IsNormalizedString((int)normalizationForm, strInput, strInput.Length);
+            bool result = Interop.Normaliz.IsNormalizedString(normalizationForm, strInput, strInput.Length);
 
             int lastError = Marshal.GetLastWin32Error();
             switch (lastError)
@@ -70,7 +71,7 @@ namespace System.Globalization
             // to 0 (ERROR_SUCCESS) before executing the calls.
 
             // Guess our buffer size first
-            int iLength = Interop.Normaliz.NormalizeString((int)normalizationForm, strInput, strInput.Length, null, 0);
+            int iLength = Interop.Normaliz.NormalizeString(normalizationForm, strInput, strInput.Length, Span<char>.Empty);
 
             int lastError = Marshal.GetLastWin32Error();
             // Could have an error (actually it'd be quite hard to have an error here)
@@ -102,47 +103,64 @@ namespace System.Globalization
             // Don't break for empty strings (only possible for D & KD and not really possible at that)
             if (iLength == 0) return string.Empty;
 
-            // Someplace to stick our buffer
-            char[] cBuffer;
-
-            while (true)
+            char[]? toReturn = null;
+            try
             {
-                // (re)allocation buffer and normalize string
-                cBuffer = new char[iLength];
+                Span<char> buffer = iLength <= 512
+                    ? stackalloc char[512]
+                    : (toReturn = ArrayPool<char>.Shared.Rent(iLength));
 
-                // NormalizeString pinvoke has SetLastError attribute property which will set the last error
-                // to 0 (ERROR_SUCCESS) before executing the calls.
-                iLength = Interop.Normaliz.NormalizeString((int)normalizationForm, strInput, strInput.Length, cBuffer, cBuffer.Length);
-                lastError = Marshal.GetLastWin32Error();
-
-                if (lastError == Interop.Errors.ERROR_SUCCESS)
-                    break;
-
-                // Could have an error (actually it'd be quite hard to have an error here)
-                switch (lastError)
+                while (true)
                 {
-                    // Do appropriate stuff for the individual errors:
-                    case Interop.Errors.ERROR_INSUFFICIENT_BUFFER:
-                        iLength = Math.Abs(iLength);
-                        Debug.Assert(iLength > cBuffer.Length, "Buffer overflow should have iLength > cBuffer.Length");
-                        continue;
+                    // NormalizeString pinvoke has SetLastError attribute property which will set the last error
+                    // to 0 (ERROR_SUCCESS) before executing the calls.
+                    iLength = Interop.Normaliz.NormalizeString(normalizationForm, strInput, strInput.Length, buffer);
+                    lastError = Marshal.GetLastWin32Error();
 
-                    case Interop.Errors.ERROR_INVALID_PARAMETER:
-                    case Interop.Errors.ERROR_NO_UNICODE_TRANSLATION:
-                        // Illegal code point or order found.  Ie: FFFE or D800 D800, etc.
-                        throw new ArgumentException(SR.Argument_InvalidCharSequenceNoIndex, nameof(strInput));
+                    if (lastError == Interop.Errors.ERROR_SUCCESS)
+                        break;
 
-                    case Interop.Errors.ERROR_NOT_ENOUGH_MEMORY:
-                        throw new OutOfMemoryException();
+                    // Could have an error (actually it'd be quite hard to have an error here)
+                    switch (lastError)
+                    {
+                        // Do appropriate stuff for the individual errors:
+                        case Interop.Errors.ERROR_INSUFFICIENT_BUFFER:
+                            iLength = Math.Abs(iLength);
+                            Debug.Assert(iLength > buffer.Length, "Buffer overflow should have iLength > cBuffer.Length");
+                            if (toReturn != null)
+                            {
+                                // Clear toReturn first to ensure we don't return the same buffer twice
+                                char[] temp = toReturn;
+                                toReturn = null;
+                                ArrayPool<char>.Shared.Return(temp);
+                            }
+                            buffer = toReturn = ArrayPool<char>.Shared.Rent(iLength);
+                            continue;
 
-                    default:
-                        // We shouldn't get here...
-                        throw new InvalidOperationException(SR.Format(SR.UnknownError_Num, lastError));
+                        case Interop.Errors.ERROR_INVALID_PARAMETER:
+                        case Interop.Errors.ERROR_NO_UNICODE_TRANSLATION:
+                            // Illegal code point or order found.  Ie: FFFE or D800 D800, etc.
+                            throw new ArgumentException(SR.Argument_InvalidCharSequenceNoIndex, nameof(strInput));
+
+                        case Interop.Errors.ERROR_NOT_ENOUGH_MEMORY:
+                            throw new OutOfMemoryException();
+
+                        default:
+                            // We shouldn't get here...
+                            throw new InvalidOperationException(SR.Format(SR.UnknownError_Num, lastError));
+                    }
+                }
+
+                // Copy our buffer into our new string, which will be the appropriate size
+                return new string(buffer.Slice(0, iLength));
+            }
+            finally
+            {
+                if (toReturn != null)
+                {
+                    ArrayPool<char>.Shared.Return(toReturn);
                 }
             }
-
-            // Copy our buffer into our new string, which will be the appropriate size
-            return new string(cBuffer, 0, iLength);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
@@ -11,7 +11,7 @@ namespace System.Globalization
 {
     internal static partial class Normalization
     {
-        internal static bool IsNormalized(string strInput, NormalizationForm normalizationForm)
+        internal static unsafe bool IsNormalized(string strInput, NormalizationForm normalizationForm)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -26,12 +26,9 @@ namespace System.Globalization
             // IsNormalizedString pinvoke has SetLastError attribute property which will set the last error
             // to 0 (ERROR_SUCCESS) before executing the calls.
             Interop.BOOL result;
-            unsafe
+            fixed (char* pInput = strInput)
             {
-                fixed (char* pInput = strInput)
-                {
-                    result = Interop.Normaliz.IsNormalizedString(normalizationForm, pInput, strInput.Length);
-                }
+                result = Interop.Normaliz.IsNormalizedString(normalizationForm, pInput, strInput.Length);
             }
 
             int lastError = Marshal.GetLastWin32Error();
@@ -62,7 +59,7 @@ namespace System.Globalization
             return result == Interop.BOOL.TRUE;
         }
 
-        internal static string Normalize(string strInput, NormalizationForm normalizationForm)
+        internal static unsafe string Normalize(string strInput, NormalizationForm normalizationForm)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -91,13 +88,10 @@ namespace System.Globalization
                     // NormalizeString pinvoke has SetLastError attribute property which will set the last error
                     // to 0 (ERROR_SUCCESS) before executing the calls.
                     int realLength;
-                    unsafe
+                    fixed (char* pInput = strInput)
+                    fixed (char* pDest = &MemoryMarshal.GetReference(buffer))
                     {
-                        fixed (char* pInput = strInput)
-                        fixed (char* pDest = &MemoryMarshal.GetReference(buffer))
-                        {
-                            realLength = Interop.Normaliz.NormalizeString(normalizationForm, pInput, strInput.Length, pDest, buffer.Length);
-                        }
+                        realLength = Interop.Normaliz.NormalizeString(normalizationForm, pInput, strInput.Length, pDest, buffer.Length);
                     }
                     int lastError = Marshal.GetLastWin32Error();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
@@ -104,10 +104,6 @@ namespace System.Globalization
                     switch (lastError)
                     {
                         case Interop.Errors.ERROR_SUCCESS:
-                            if (realLength == 0)
-                            {
-                                return string.Empty;
-                            }
                             return new string(buffer.Slice(0, realLength));
 
                         // Do appropriate stuff for the individual errors:

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Windows.cs
@@ -98,7 +98,10 @@ namespace System.Globalization
                     switch (lastError)
                     {
                         case Interop.Errors.ERROR_SUCCESS:
-                            return new string(buffer.Slice(0, realLength));
+                            ReadOnlySpan<char> result = buffer.Slice(0, realLength);
+                            return result.SequenceEqual(strInput)
+                                ? strInput
+                                : new string(result);
 
                         // Do appropriate stuff for the individual errors:
                         case Interop.Errors.ERROR_INSUFFICIENT_BUFFER:


### PR DESCRIPTION
While inherently an allocatey API (`string Normalize(string)`), we can avoid allocating the temporary char[] buffer for the P/Invoke.

These char[] allocations account for ~2% of allocated bytes when using HttpClient with a non-ascii Uri in my simple test. The allocated result (even if unchanged) another ~1.5%.

Is there a common stackalloc threshold we should agree upon across runtime? Highest I've seen so far is 1024 chars. I used 512 here as that is what IdnMapping uses as well.