### PR TITLE
Change policheck words

### DIFF
--- a/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
@@ -506,7 +506,7 @@ namespace System.Net
         {
             if ((_intCompleted & ~HighBit) == 0 && (Interlocked.Increment(ref _intCompleted) & ~HighBit) == 1)
             {
-                // Set no result so that just in case there are waiters, they don't stop responding in the spin lock.
+                // Set no result so that just in case there are waiters, they don't get stuck in the spin lock.
                 _result = null;
                 Cleanup();
             }

--- a/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
@@ -506,7 +506,7 @@ namespace System.Net
         {
             if ((_intCompleted & ~HighBit) == 0 && (Interlocked.Increment(ref _intCompleted) & ~HighBit) == 1)
             {
-                // Set no result so that just in case there are waiters, they don't hang in the spin lock.
+                // Set no result so that just in case there are waiters, they don't stop responding in the spin lock.
                 _result = null;
                 Cleanup();
             }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -900,7 +900,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     // and no ExpressionKind.EK_CAST is generated. We'd rather not give a "you're writing
                     // to a read-only property" error in the case where the property access
                     // is not explicit in the source code.  Fortunately in this case the
-                    // cast is still hanging around in the parse tree, so we can look for it.
+                    // cast is still present in the parse tree, so we can look for it.
 
                     // POSSIBLE ERROR: It would be nice to also give this error for other situations
                     // POSSIBLE ERROR: in which the user is attempting to assign to a value, such as

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
@@ -14,7 +14,7 @@ namespace System.Configuration
     // the necessary information for reporting filename / line numbers.
     // Note: these classes will go away if webdata ever decides to incorporate line numbers
     // into the default XML classes.  This class could also go away if webdata brings back
-    // the UserData property to stop responding any info off of any node.
+    // the UserData property to attach any info off of any node.
     public sealed class ConfigXmlDocument : XmlDocument, IConfigErrorInfo
     {
         private XmlTextReader _reader;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
@@ -14,7 +14,7 @@ namespace System.Configuration
     // the necessary information for reporting filename / line numbers.
     // Note: these classes will go away if webdata ever decides to incorporate line numbers
     // into the default XML classes.  This class could also go away if webdata brings back
-    // the UserData property to hang any info off of any node.
+    // the UserData property to stop responding any info off of any node.
     public sealed class ConfigXmlDocument : XmlDocument, IConfigErrorInfo
     {
         private XmlTextReader _reader;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ErrorInfoXmlDocument.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ErrorInfoXmlDocument.cs
@@ -13,7 +13,7 @@ namespace System.Configuration
     // the necessary information for reporting filename / line numbers.
     // Note: these classes will go away if webdata ever decides to incorporate line numbers
     // into the default XML classes.  This class could also go away if webdata brings back
-    // the UserData property to stop responding any info off of any node.
+    // the UserData property to attach any info off of any node.
     internal sealed class ErrorInfoXmlDocument : XmlDocument, IConfigErrorInfo
     {
         private string _filename;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ErrorInfoXmlDocument.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ErrorInfoXmlDocument.cs
@@ -13,7 +13,7 @@ namespace System.Configuration
     // the necessary information for reporting filename / line numbers.
     // Note: these classes will go away if webdata ever decides to incorporate line numbers
     // into the default XML classes.  This class could also go away if webdata brings back
-    // the UserData property to hang any info off of any node.
+    // the UserData property to stop responding any info off of any node.
     internal sealed class ErrorInfoXmlDocument : XmlDocument, IConfigErrorInfo
     {
         private string _filename;

--- a/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -45,7 +45,7 @@ namespace System.Diagnostics
         {
             // First make sure it's a file we can actually read from.  Only regular files are relevant,
             // and attempting to open and read from a file such as a named pipe file could cause us to
-            // hang (waiting for someone else to open and write to the file).
+            // stop responding (waiting for someone else to open and write to the file).
             Interop.Sys.FileStatus fileStatus;
             if (Interop.Sys.Stat(_fileName, out fileStatus) != 0 ||
                 (fileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) != Interop.Sys.FileTypes.S_IFREG)

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -325,7 +325,7 @@ namespace System.IO
 
             // As we successfully removed all of the files we shouldn't care about the directory itself
             // not being empty. As file deletion is just a marker to remove the file when all handles
-            // are closed we could still have contents hanging around.
+            // are closed we could still have undeleted contents.
             RemoveDirectoryInternal(fullPath, topLevel: topLevel, allowDirectoryNotEmpty: true);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -420,7 +420,7 @@ namespace System.Text.Unicode
                     // in to the text. If this happens strip it off now before seeing if the next character
                     // consists of three code units.
 
-                    // Branchless: consume a 3-byte UTF-8 sequence and optionally an extra ASCII byte hanging off the end
+                    // Branchless: consume a 3-byte UTF-8 sequence and optionally an extra ASCII byte from the end.
 
                     nint asciiAdjustment;
                     if (BitConverter.IsLittleEndian)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
@@ -58,7 +58,7 @@ namespace System.Threading
 
         // Lock specification for _spinLock:  This lock protects exactly the local fields associated with this
         // instance of ReaderWriterLockSlim.  It does NOT protect the memory associated with
-        // the events that stop responding off this lock (eg writeEvent, readEvent upgradeEvent).
+        // the events that are raised by this lock (eg writeEvent, readEvent upgradeEvent).
         private SpinLock _spinLock;
 
         // These variables allow use to avoid Setting events (which is expensive) if we don't have to.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
@@ -58,7 +58,7 @@ namespace System.Threading
 
         // Lock specification for _spinLock:  This lock protects exactly the local fields associated with this
         // instance of ReaderWriterLockSlim.  It does NOT protect the memory associated with
-        // the events that hang off this lock (eg writeEvent, readEvent upgradeEvent).
+        // the events that stop responding off this lock (eg writeEvent, readEvent upgradeEvent).
         private SpinLock _spinLock;
 
         // These variables allow use to avoid Setting events (which is expensive) if we don't have to.

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HeapBlockRetainer.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HeapBlockRetainer.cs
@@ -14,7 +14,7 @@ using Microsoft.Win32.SafeHandles;
 namespace Internal.Cryptography.Pal.Windows
 {
     //
-    // Some CryptoApis take structure parameters that have a huge number of sub blocks hanging off it. This convenience class lets us
+    // Some CryptoApis take structure parameters that have a huge number of sub blocks attached to it. This convenience class lets us
     // allocate and preserve a collection of heap blocks in one single object.
     //
     internal sealed class HeapBlockRetainer : IDisposable

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HeapBlockRetainer.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HeapBlockRetainer.cs
@@ -14,7 +14,7 @@ using Microsoft.Win32.SafeHandles;
 namespace Internal.Cryptography.Pal.Windows
 {
     //
-    // Some CryptoApis take structure parameters that have a huge number of sub blocks attached to it. This convenience class lets us
+    // Some CryptoApis take structure parameters that have a huge number of sub blocks attached. This convenience class lets us
     // allocate and preserve a collection of heap blocks in one single object.
     //
     internal sealed class HeapBlockRetainer : IDisposable

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -57,7 +57,7 @@ namespace System.ServiceProcess
         /// <devdoc>
         /// When this method is called from OnStart, OnStop, OnPause or OnContinue,
         /// the specified wait hint is passed to the
-        /// Service Control Manager to avoid having the service marked as hung.
+        /// Service Control Manager to avoid having the service marked as not responding.
         /// </devdoc>
         public unsafe void RequestAdditionalTime(int milliseconds)
         {


### PR DESCRIPTION
Most of the words are flagged by policheck are geopolitical eg language names like "Bengali , Oriya" or word country.
I went through the rest of them and made  the appropiate changes.
This is done for the libraries subset.