### PR TITLE
Build coreclr targetGeneric tests separately for CI

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -6,6 +6,7 @@ parameters:
   container: ''
   testGroup: ''
   liveRuntimeBuildConfig: ''
+  testBuildPhase: ''
 
   # When set to a non-empty value (Debug / Release), it determines libraries
   # build configuration to use for the tests. Setting this property implies
@@ -51,12 +52,18 @@ jobs:
       continueOnError: true
 
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p0_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri0 Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
+      testPriority: '0'
     ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p1_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri1 Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      testPriority: '1'
+
+    # Compute job name from template parameters
+    ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ testPriority }} Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+
+    ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
+      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ testPriority }} Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
 
     # Since the condition is being altered, merge the default with the additional conditions.
     # See https://docs.microsoft.com/azure/devops/pipelines/process/conditions
@@ -120,7 +127,7 @@ jobs:
 
 
     # Build managed test components
-    - script: $(coreClrRepoRootDir)build-test$(scriptExt) skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(crossArg) $(priorityArg) ci $(librariesOverrideArg)
+    - script: $(coreClrRepoRootDir)build-test$(scriptExt) ${{ parameters.testBuildPhase }} skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(crossArg) $(priorityArg) ci $(librariesOverrideArg)
       displayName: Build managed test components
 
 
@@ -129,24 +136,32 @@ jobs:
       parameters:
         rootFolder: $(managedTestArtifactRootFolderPath)
         includeRootFolder: false
-        archiveType: $(archiveType)
-        tarCompression: $(tarCompression)
-        archiveExtension: $(archiveExtension)
-        artifactName: $(managedTestArtifactName)
-        displayName: 'managed test components'
+        ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+          archiveExtension: $(archiveExtension)
+          archiveType: $(archiveType)
+          tarCompression: $(tarCompression)
+          artifactName: $(managedTestArtifactName)
+          displayName: 'managed test components'
+        ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+          artifactName: $(managedGenericTestArtifactName)
+          displayName: 'managed test components (generic)'
 
 
     # Publish .packages/microsoft.net.sdk.il needed for traversing
     # test projects during the copynativeonly command in run test job.
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(microsoftNetSdkIlFolderPath)
-        includeRootFolder: false
-        archiveType: $(archiveType)
-        tarCompression: $(tarCompression)
-        archiveExtension: $(archiveExtension)
-        artifactName: $(microsoftNetSdkIlArtifactName)
-        displayName: 'Microsoft.NET.Sdk.IL package'
+    - ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(microsoftNetSdkIlFolderPath)
+          includeRootFolder: false
+          archiveType: $(archiveType)
+          tarCompression: $(tarCompression)
+          archiveExtension: $(archiveExtension)
+          artifactName: $(microsoftNetSdkIlArtifactName)
+          displayName: 'Microsoft.NET.Sdk.IL package'
 
 
     # Publish Logs
@@ -154,6 +169,9 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
+        ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+          artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
+        ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
+          artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_AnyOS_AnyCPU_$(buildConfig)_Lib${{ parameters.liveLibrariesBuildConfig }}_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -51,19 +51,24 @@ jobs:
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       continueOnError: true
 
-    ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      testPriority: '0'
-    ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      testPriority: '1'
-
     # Compute job name from template parameters
-    ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ parameters.testPriority }} Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+      ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+        name: '${{ parameters.runtimeFlavor }}_common_test_build_p0_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+        displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri0 Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+    ${{ if ne(parameters.testGroup, 'innerloop') }}:
+      ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
+        name: '${{ parameters.runtimeFlavor }}_common_test_build_p1_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+        displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri1 Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
-    ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ parameters.testPriority }} Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
+    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+      ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
+        name: '${{ parameters.runtimeFlavor }}_common_test_build_p0_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+        displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri0 Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
+    ${{ if ne(parameters.testGroup, 'innerloop') }}:
+      ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
+        name: '${{ parameters.runtimeFlavor }}_common_test_build_p1_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+        displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri1 Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
 
     # Since the condition is being altered, merge the default with the additional conditions.
     # See https://docs.microsoft.com/azure/devops/pipelines/process/conditions

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -58,12 +58,12 @@ jobs:
 
     # Compute job name from template parameters
     ${{ if ne(parameters.testBuildPhase, 'targetGeneric') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ testPriority }} Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ parameters.testPriority }} Test Build ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     ${{ if eq(parameters.testBuildPhase, 'targetGeneric') }}:
-      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ testPriority }} Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
+      name: '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_AnyOS_AnyCPU_${{ parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} Common Pri${{ parameters.testPriority }} Test Build AnyOS AnyCPU ${{ parameters.buildConfig }} Libraries:${{ parameters.liveLibrariesBuildConfig }}'
 
     # Since the condition is being altered, merge the default with the additional conditions.
     # See https://docs.microsoft.com/azure/devops/pipelines/process/conditions

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -52,16 +52,17 @@ jobs:
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       continueOnError: true
 
-    ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      testPriority: '0'
-    ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      testPriority: '1'
-
     dependsOn:
     - ${{ if ne(parameters.corefxTests, true) }}:
-      - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - ${{ if eq(parameters.testGroup, 'innerloop') }}:
+        - '${{ parameters.runtimeFlavor }}_common_test_build_p0_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - ${{ if ne(parameters.testGroup, 'innerloop') }}:
+        - '${{ parameters.runtimeFlavor }}_common_test_build_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
       - ${{ if eq(parameters.testBuildPhased, true) }}:
-        - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+        - ${{ if eq(parameters.testGroup, 'innerloop') }}:
+          - '${{ parameters.runtimeFlavor }}_common_test_build_p0_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+        - ${{ if ne(parameters.testGroup, 'innerloop') }}:
+          - '${{ parameters.runtimeFlavor }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
     - ${{ if ne(parameters.stagedBuild, true) }}:
       - ${{ format('{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeFlavor, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -22,6 +22,7 @@ parameters:
   variables: {}
   pool: ''
   runtimeFlavorDisplayName: 'CoreCLR'
+  testBuildPhased : false
 
 ### Test run job
 
@@ -51,12 +52,16 @@ jobs:
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       continueOnError: true
 
+    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+      testPriority: '0'
+    ${{ if ne(parameters.testGroup, 'innerloop') }}:
+      testPriority: '1'
+
     dependsOn:
     - ${{ if ne(parameters.corefxTests, true) }}:
-      - ${{ if eq(parameters.testGroup, 'innerloop') }}:
-        - '${{ parameters.runtimeFlavor }}_common_test_build_p0_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
-      - ${{ if ne(parameters.testGroup, 'innerloop') }}:
-        - '${{ parameters.runtimeFlavor }}_common_test_build_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - ${{ if eq(parameters.testBuildPhased, true) }}:
+        - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
     - ${{ if ne(parameters.stagedBuild, true) }}:
       - ${{ format('{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeFlavor, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
@@ -189,6 +194,13 @@ jobs:
 
     # Download and unzip managed test artifacts
     - ${{ if ne(parameters.corefxTests, true) }}:
+      - ${{ if eq(parameters.testBuildPhased, true) }}:
+        - template: /eng/pipelines/common/download-artifact-step.yml
+          parameters:
+            unpackFolder: '$(managedTestArtifactRootFolderPath)'
+            artifactFileName: '$(managedGenericTestArtifactName).tar.gz'
+            artifactName: '$(managedGenericTestArtifactName)'
+            displayName: 'generic managed test artifacts'
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
           unpackFolder: '$(managedTestArtifactRootFolderPath)'

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -59,9 +59,9 @@ jobs:
 
     dependsOn:
     - ${{ if ne(parameters.corefxTests, true) }}:
-      - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
       - ${{ if eq(parameters.testBuildPhased, true) }}:
-        - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ testPriority }}_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
+        - '${{ parameters.runtimeFlavor }}_common_test_build_p${{ parameters.testPriority }}_AnyOS_AnyCPU_${{parameters.buildConfig }}_Lib${{ parameters.liveLibrariesBuildConfig }}'
     - ${{ if ne(parameters.stagedBuild, true) }}:
       - ${{ format('{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeFlavor, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -97,6 +97,16 @@ jobs:
     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
     buildConfig: checked
     platforms:
+    - OSX_x64
+    testGroup: outerloop
+    jobParameters:
+      liveLibrariesBuildConfig: Release
+      testBuildPhase: targetGeneric
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    buildConfig: checked
+    platforms:
     - Linux_arm
     - Linux_arm64
     - OSX_x64
@@ -107,6 +117,7 @@ jobs:
     testGroup: outerloop
     jobParameters:
       liveLibrariesBuildConfig: Release
+      testBuildPhase: targetSpecific
 
 #
 # Checked JIT test runs
@@ -121,6 +132,7 @@ jobs:
     jobParameters:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
+      testBuildPhased: true
 
 #
 # Checked R2R test runs
@@ -146,6 +158,7 @@ jobs:
       readyToRun: true
       displayNameArgs: R2R
       liveLibrariesBuildConfig: Release
+      testBuildPhased: true
 
 #
 # Crossgen-comparison jobs

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -104,7 +104,7 @@ jobs:
       testBuildPhase: targetGeneric
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
     buildConfig: checked
     platforms:
     - Linux_arm

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -78,6 +78,9 @@ jobs:
     - name: corelibProductArtifactName
       value: 'CoreLib_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
+    - name: managedGenericTestArtifactName
+      value: 'CoreCLRManagedTestArtifacts_AnyOS_AnyCPU_$(buildConfig)_Lib${{ parameters.liveLibrariesBuildConfig }}'
+
     - name: managedTestArtifactName
       value: 'CoreCLRManagedTestArtifacts_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_$(archType)_$(buildConfig)'
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -611,7 +611,7 @@ jobs:
           eq(variables['isFullMatrix'], true))
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
     buildConfig: checked
     platforms:
     - Linux_arm 
@@ -648,7 +648,7 @@ jobs:
             eq(variables['isFullMatrix'], true)))
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
     buildConfig: checked
     platforms:
     - OSX_x64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -386,6 +386,25 @@ jobs:
       liveRuntimeBuildConfig: release
 
 #
+# Build libraries using live CoreLib
+# These are part of the test coreclr generic test build.
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    buildConfig: Release
+    platforms:
+    - OSX_x64
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      condition: >-
+        and(
+          ne(variables['debugOnPrReleaseOnRolling'], 'Release'),
+          or(
+            eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
+            eq(variables['isFullMatrix'], true)))
+
+#
 # Build libraries using Mono CoreLib only
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -581,6 +600,20 @@ jobs:
     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
     buildConfig: checked
     platforms:
+    - OSX_x64
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: Release
+      testBuildPhase: targetGeneric
+      condition: >-
+        or(
+          eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
+          eq(variables['isFullMatrix'], true))
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    buildConfig: checked
+    platforms:
     - Linux_arm 
     - Windows_NT_x86
     - Windows_NT_arm
@@ -588,6 +621,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
+      testBuildPhase: targetSpecific
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -603,12 +637,28 @@ jobs:
     buildConfig: checked
     platforms:
     - OSX_x64
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      testBuildPhase: targetGeneric
+      condition: >-
+        and(ne(variables['debugOnPrReleaseOnRolling'], 'Release'),
+          or(
+            eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
+            eq(variables['isFullMatrix'], true)))
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_x64
     - Linux_x64
     - Linux_arm64
     - Windows_NT_x64
     jobParameters:
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      testBuildPhase: targetSpecific
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -632,6 +682,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       liveLibrariesBuildConfig: Release
+      testBuildPhased: true
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -651,6 +702,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      testBuildPhased: true
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/src/coreclr/tests/src/Interop/COM/Activator/Activator.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Activator.csproj
@@ -32,4 +32,10 @@
     </ItemGroup>
     <Move SourceFiles="@(ServerAssembly)" DestinationFolder="$(ServerAssemblyDest)" />
   </Target>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyA.csproj
@@ -11,4 +11,10 @@
     <ProjectReference Include="AssemblyC.csproj" />
     <ProjectReference Include="AssemblyContracts.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyB.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyB.csproj
@@ -10,4 +10,10 @@
     <ProjectReference Include="AssemblyC.csproj" />
     <ProjectReference Include="AssemblyContracts.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyC.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyC.csproj
@@ -6,4 +6,10 @@
   <ItemGroup>
     <Compile Include="AssemblyC.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyContracts.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Activator/Servers/AssemblyContracts.csproj
@@ -6,4 +6,10 @@
   <ItemGroup>
     <Compile Include="AssemblyContracts.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
@@ -14,4 +14,10 @@
   <ItemGroup>
     <ProjectReference Include="../MockReferenceTrackerRuntime/CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTests.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTests.csproj
@@ -34,4 +34,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Dynamic/Dynamic.csproj
@@ -22,4 +22,10 @@
     <ProjectReference Include="Server/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -31,4 +31,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="NetClientPrimitives.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
+++ b/src/coreclr/tests/src/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
@@ -5,4 +5,10 @@
   <ItemGroup>
     <Compile Include="NETServer.DefaultInterfaces.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/NETServer/NETServer.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETServer/NETServer.csproj
@@ -8,4 +8,10 @@
     <Compile Include="../ServerContracts/Server.Contracts.cs" />
     <Compile Include="../ServerContracts/ServerGuids.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tests/src/Interop/COM/Reflection/Reflection.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Reflection/Reflection.csproj
@@ -12,4 +12,10 @@
       <Name>NETServer</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestNeedTarget>1</CLRTestNeedTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <TraitTags Include="OsSpecific" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #34508

This PR change splits the building of `targetGeneric` and `targetSpecific` tests in ci.yml

+ Add `testBuildPhase` parameter to build-test-job
  + Modify names of artifacts and logs for `targetGeneric` build
+ Add `testBuildPhased` parameter to run-test job
  + Add `DependsOn` as needed
  + Add additional test download as needed
+ Modifies CI.yml to call build-test-job twice.  Once with`testBuildPhase:targetGeneric` and once with `testBuildPhase:targetSpecific`
+ Modifies CI.yml to call run-test-job with `testBuildPhased:true`
