### PR TITLE
Enclose paths with quotes in testPackages.proj

### DIFF
--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -177,7 +177,7 @@
           Condition="'$(ArchiveTests)' != 'true'">
 
     <PropertyGroup>
-      <TestRestoreCommand>$(TestDotNetPath)</TestRestoreCommand>
+      <TestRestoreCommand>&quot;$(TestDotNetPath)&quot;</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) restore</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) --packages "$(TestPackageDir)"</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /p:LocalPackagesPath=$(PackageOutputPath)</TestRestoreCommand>
@@ -195,7 +195,7 @@
           Condition="'$(ArchiveTests)' != 'true'">
 
     <PropertyGroup>
-      <TestBuildCommand>$(TestDotNetPath)</TestBuildCommand>
+      <TestBuildCommand>&quot;$(TestDotNetPath)&quot;</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) msbuild</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /t:Test</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /nr:false</TestBuildCommand>

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -177,7 +177,7 @@
           Condition="'$(ArchiveTests)' != 'true'">
 
     <PropertyGroup>
-      <TestRestoreCommand>&quot;$(TestDotNetPath)&quot;</TestRestoreCommand>
+      <TestRestoreCommand>"$(TestDotNetPath)"</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) restore</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) --packages "$(TestPackageDir)"</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /p:LocalPackagesPath=$(PackageOutputPath)</TestRestoreCommand>
@@ -195,7 +195,7 @@
           Condition="'$(ArchiveTests)' != 'true'">
 
     <PropertyGroup>
-      <TestBuildCommand>&quot;$(TestDotNetPath)&quot;</TestBuildCommand>
+      <TestBuildCommand>"$(TestDotNetPath)"</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) msbuild</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /t:Test</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /nr:false</TestBuildCommand>


### PR DESCRIPTION
Enclosing these two paths with double quotes fixes the following error:

```
D:\runtime> .\build.cmd-subset libs.tests -runtimeConfiguration release -allconfigurations

 Determining projects to restore...
Tool 'coverlet.console' (version '1.7.0') was restored. Available commands: coverlet
Tool 'dotnet-reportgenerator-globaltool' (version '4.5.2') was restored. Available commands: reportgenerator
Restore was successful.
All projects are up-to-date for restore.
Determining projects to restore...
All projects are up-to-date for restore.
*** Restoring ***
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
D:\runtime\src\libraries\pkg\test\testPackages.proj(190,5): error MSB3073: The command "C:\Program Files\dotnet\dotnet restore --packages "D:\runtime\artifacts\bin\testPackages" /p:LocalPackagesPath=D:\runtime
\artifacts\packages\Debug\Shipping\ /nr:false /warnaserror "D:\runtime\artifacts\bin\testPkg/support/test.msbuild"" exited with code 9009.
Build FAILED.
D:\runtime\src\libraries\pkg\test\testPackages.proj(190,5): error MSB3073: The command "C:\Program Files\dotnet\dotnet restore --packages "D:\runtime\artifacts\bin\testPackages" /p:LocalPackagesPath=D:\runtime
\artifacts\packages\Debug\Shipping\ /nr:false /warnaserror "D:\runtime\artifacts\bin\testPkg/support/test.msbuild"" exited with code 9009.
 0 Warning(s)
 1 Error(s)
Time Elapsed 00:00:03.98
Build failed.
Some builds failed:
Configuration: Debug, Architecture: x64
```