### PR TITLE
Reduce allocations in UriHelper.StripBidiControlCharacters

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -230,14 +230,7 @@ namespace System
                 return hostname.ToLowerInvariant();
             }
 
-            string bidiStrippedHost;
-            unsafe
-            {
-                fixed (char* hostnamePtr = hostname)
-                {
-                    bidiStrippedHost = UriHelper.StripBidiControlCharacter(hostnamePtr, 0, hostname.Length);
-                }
-            }
+            string bidiStrippedHost = UriHelper.StripBidiControlCharacters(hostname);
 
             try
             {
@@ -306,7 +299,7 @@ namespace System
             if (end <= start)
                 return idn;
 
-            string unescapedHostname = UriHelper.StripBidiControlCharacter(hostname, start, (end - start));
+            string unescapedHostname = UriHelper.StripBidiControlCharacters(hostname + start, (end - start));
 
             string? unicodeEqvlHost = null;
             int curPos = 0;

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -230,7 +230,7 @@ namespace System
                 return hostname.ToLowerInvariant();
             }
 
-            string bidiStrippedHost = UriHelper.StripBidiControlCharacters(hostname);
+            string bidiStrippedHost = UriHelper.StripBidiControlCharacters(hostname, hostname);
 
             try
             {
@@ -299,7 +299,7 @@ namespace System
             if (end <= start)
                 return idn;
 
-            string unescapedHostname = UriHelper.StripBidiControlCharacters(hostname + start, (end - start));
+            string unescapedHostname = UriHelper.StripBidiControlCharacters(new ReadOnlySpan<char>(hostname + start, end - start));
 
             string? unicodeEqvlHost = null;
             int curPos = 0;

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4329,10 +4329,10 @@ namespace System
 
             if (hasUnicode)
             {
-                string temp = UriHelper.StripBidiControlCharacter(pString, start, end - start);
+                string temp = UriHelper.StripBidiControlCharacters(pString + start, end - start);
                 try
                 {
-                    newHost += ((temp != null) ? temp.Normalize(NormalizationForm.FormC) : null);
+                    newHost += temp.Normalize(NormalizationForm.FormC);
                 }
                 catch (ArgumentException)
                 {

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4329,7 +4329,7 @@ namespace System
 
             if (hasUnicode)
             {
-                string temp = UriHelper.StripBidiControlCharacters(pString + start, end - start);
+                string temp = UriHelper.StripBidiControlCharacters(new ReadOnlySpan<char>(pString + start, end - start));
                 try
                 {
                     newHost += temp.Normalize(NormalizationForm.FormC);

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -820,14 +820,13 @@ namespace System
             {
                 return string.Create(strToClean.Length - charsToRemove, (StrToClean: (IntPtr)pStrToClean, strToClean.Length), (buffer, state) =>
                 {
-                    char* source = (char*)state.StrToClean;
+                    var strToClean = new ReadOnlySpan<char>((char*)state.StrToClean, state.Length);
                     int destIndex = 0;
-                    int length = state.Length;
-                    for (int i = 0; i < length; i++)
+                    foreach (char c in strToClean)
                     {
-                        if ((uint)(source[i] - '\u200E') > ('\u202E' - '\u200E') || !IsBidiControlCharacter(source[i]))
+                        if ((uint)(c - '\u200E') > ('\u202E' - '\u200E') || !IsBidiControlCharacter(c))
                         {
-                            buffer[destIndex++] = source[i];
+                            buffer[destIndex++] = c;
                         }
                     }
                     Debug.Assert(buffer.Length == destIndex);


### PR DESCRIPTION
* Avoid using a temporary char[] buffer.
* Don't allocate a new string if we already have one and no characters were removed.

Reduces HttpClient allocations when using a non-ascii Uri in simple GET requests by ~4%.