### PR TITLE
use localSystem to start the service

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -81,6 +81,7 @@ namespace System.ServiceProcess.Tests
             controller.WaitForStatus(ServiceControllerStatus.Stopped);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34801")]
         [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnStartWithArgsThenStop()
         {
@@ -175,9 +176,8 @@ namespace System.ServiceProcess.Tests
         public void LogWritten()
         {
             string serviceName = Guid.NewGuid().ToString();
-            // The default username for installing the service is NT AUTHORITY\\LocalService which does not have access to EventLog.
             // If the username is null, then the service is created under LocalSystem Account which have access to EventLog.
-            var testService = new TestServiceProvider(serviceName, userName: null);
+            var testService = new TestServiceProvider(serviceName);
             Assert.True(EventLog.SourceExists(serviceName));
             testService.DeleteTestServices();
         }

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -12,7 +12,6 @@ namespace System.ServiceProcess.Tests
     internal sealed class TestServiceProvider
     {
         private const int readTimeout = 60000;
-        public const string LocalServiceName = "NT AUTHORITY\\LocalService";
 
         private static readonly Lazy<bool> s_runningWithElevatedPrivileges = new Lazy<bool>(
             () => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator));
@@ -48,7 +47,6 @@ namespace System.ServiceProcess.Tests
         public readonly string TestMachineName;
         public readonly TimeSpan ControlTimeout;
         public readonly string TestServiceName;
-        public readonly string Username;
         public readonly string TestServiceDisplayName;
 
         private readonly TestServiceProvider _dependentServices;
@@ -65,14 +63,13 @@ namespace System.ServiceProcess.Tests
             CreateTestServices();
         }
 
-        public TestServiceProvider(string serviceName, string userName = LocalServiceName)
+        public TestServiceProvider(string serviceName)
         {
             TestMachineName = ".";
             ControlTimeout = TimeSpan.FromSeconds(120);
             TestServiceName = serviceName;
             TestServiceDisplayName = "Test Service " + TestServiceName;
-            Username = userName;
-
+            
             // Create the service
             CreateTestServices();
         }
@@ -95,7 +92,7 @@ namespace System.ServiceProcess.Tests
             testServiceInstaller.ServiceName = TestServiceName;
             testServiceInstaller.DisplayName = TestServiceDisplayName;
             testServiceInstaller.Description = "__Dummy Test Service__";
-            testServiceInstaller.Username = Username;
+            testServiceInstaller.Username = null;
 
             if (_dependentServices != null)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1262

Tested it locally
```
C:\git\runtime>dotnet msbuild src\libraries\System.ServiceProcess.ServiceController\tests /t:rebuild;test /p:RuntimeConfiguration=release /p:Outerloop=true
    Discovering: System.ServiceProcess.ServiceController.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.ServiceProcess.ServiceController.Tests (found 35 of 37 test cases)
    Starting:    System.ServiceProcess.ServiceController.Tests (parallel test collections = on, max threads = 12)
    Finished:    System.ServiceProcess.ServiceController.Tests
  === TEST EXECUTION SUMMARY ===
     System.ServiceProcess.ServiceController.Tests  Total: 38, Errors: 0, Failed: 0, Skipped: 0, Time: 328.805s
```

OPened new issue to track the one test being disabled