### PR TITLE
Implement generic IEnumerable on ManagementObjectCollection (#34803)

### DIFF
--- a/src/libraries/System.Management/ref/System.Management.cs
+++ b/src/libraries/System.Management/ref/System.Management.cs
@@ -305,7 +305,7 @@ namespace System.Management
         public System.Management.ManagementPath Put(System.Management.PutOptions options) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class ManagementObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
+    public partial class ManagementObjectCollection : System.Collections.Generic.IEnumerable<ManagementObject>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
     {
         internal ManagementObjectCollection() { }
         public int Count { get { throw null; } }
@@ -316,11 +316,12 @@ namespace System.Management
         public void Dispose() { }
         ~ManagementObjectCollection() { }
         public System.Management.ManagementObjectCollection.ManagementObjectEnumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<ManagementObject> System.Collections.Generic.IEnumerable<ManagementObject>.GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public partial class ManagementObjectEnumerator : System.Collections.IEnumerator, System.IDisposable
+        public partial class ManagementObjectEnumerator : System.Collections.Generic.IEnumerator<ManagementObject>, System.Collections.IEnumerator, System.IDisposable
         {
             internal ManagementObjectEnumerator() { }
-            public System.Management.ManagementBaseObject Current { get { throw null; } }
+            public System.Management.ManagementObject Current { get { throw null; } }
             object System.Collections.IEnumerator.Current { get { throw null; } }
             public void Dispose() { }
             ~ManagementObjectEnumerator() { }

--- a/src/libraries/System.Management/src/System/Management/ManagementBaseObject.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementBaseObject.cs
@@ -789,7 +789,7 @@ namespace System.Management
             }
         }
 
-        private static bool _IsClass(IWbemClassObjectFreeThreaded wbemObject)
+        internal static bool _IsClass(IWbemClassObjectFreeThreaded wbemObject)
         {
             object val = null;
             int dummy1 = 0, dummy2 = 0;

--- a/src/libraries/System.Management/src/System/Management/ManagementObject.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementObject.cs
@@ -180,23 +180,30 @@ namespace System.Management
             IWbemClassObjectFreeThreaded wbemObject,
             ManagementScope scope)
         {
-            ManagementObject newObject = new ManagementObject();
-            newObject.wbemObject = wbemObject;
+            ManagementObject newObject = null;
+            if (_IsClass(wbemObject))
+            {
+                newObject = ManagementClass.GetManagementClass(wbemObject, scope);
+            }
+            else
+            {
+                newObject = new ManagementObject();
+                newObject.wbemObject = wbemObject;
 
-            newObject.path = new ManagementPath(ManagementPath.GetManagementPath(wbemObject));
-            newObject.path.IdentifierChanged += new IdentifierChangedEventHandler(newObject.HandleIdentifierChange);
+                newObject.path = new ManagementPath(ManagementPath.GetManagementPath(wbemObject));
+                newObject.path.IdentifierChanged += new IdentifierChangedEventHandler(newObject.HandleIdentifierChange);
 
-            newObject.scope = ManagementScope._Clone(scope, new IdentifierChangedEventHandler(newObject.HandleIdentifierChange));
+                newObject.scope = ManagementScope._Clone(scope, new IdentifierChangedEventHandler(newObject.HandleIdentifierChange));
 
-            // Since we have an object, we should mark it as bound. Note
-            // that we do this AFTER setting Scope and Path, since those
-            // have side-effects of setting isBound=false.
-            //
-            // ***
-            // *    Changed isBound flag to wbemObject==null check.
-            // *    newObject.isBound = true;
-            // ***
-
+                // Since we have an object, we should mark it as bound. Note
+                // that we do this AFTER setting Scope and Path, since those
+                // have side-effects of setting isBound=false.
+                //
+                // ***
+                // *    Changed isBound flag to wbemObject==null check.
+                // *    newObject.isBound = true;
+                // ***
+            }
             return newObject;
         }
 

--- a/src/libraries/System.Management/src/System/Management/ManagementObjectCollection.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementObjectCollection.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace System.Management
@@ -56,7 +57,7 @@ namespace System.Management
     ///    </code>
     /// </example>
     //CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC//
-    public class ManagementObjectCollection : ICollection, IEnumerable, IDisposable
+    public class ManagementObjectCollection : IEnumerable<ManagementObject>, ICollection, IEnumerable, IDisposable
     {
         private static readonly string name = typeof(ManagementObjectCollection).FullName;
 
@@ -331,6 +332,18 @@ namespace System.Management
             }
         }
 
+        /// <internalonly/>
+        /// <summary>
+        ///    <para>Returns an enumerator that can iterate through a collection.</para>
+        /// </summary>
+        /// <returns>
+        ///    An <see cref='System.Collections.Generic.IEnumerable{T}'/> that can be used to iterate
+        ///    through the collection.
+        /// </returns>
+        IEnumerator<ManagementObject> IEnumerable<ManagementObject>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
         /// <internalonly/>
         /// <summary>
@@ -398,7 +411,7 @@ namespace System.Management
         ///    </code>
         /// </example>
         //CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-        public class ManagementObjectEnumerator : IEnumerator, IDisposable
+        public class ManagementObjectEnumerator : IEnumerator<ManagementObject>, IEnumerator, IDisposable
         {
             private static readonly string name = typeof(ManagementObjectEnumerator).FullName;
             private IEnumWbemClassObject enumWbem;
@@ -469,7 +482,7 @@ namespace System.Management
             /// <value>
             ///    <para>The current object in the enumeration.</para>
             /// </value>
-            public ManagementBaseObject Current
+            public ManagementObject Current
             {
                 get
                 {
@@ -479,7 +492,7 @@ namespace System.Management
                     if (cacheIndex < 0)
                         throw new InvalidOperationException();
 
-                    return ManagementBaseObject.GetBaseObject(cachedObjects[cacheIndex],
+                    return ManagementObject.GetManagementObject(cachedObjects[cacheIndex],
                         collectionObject.scope);
                 }
             }


### PR DESCRIPTION
This is a PR for #34803 
Changed ManagementBaseObject._IsClass visibility from private to internal.
Changed ManagementObject.GetManagementObject to use _IsClass method to decide whether to return a ManagementClass instance or to return a ManagementObject instance.
Changed property "Current" of ManagementObjectCollection.ManagementObjectEnumerator to return ManagementObject instead of ManagementBaseObject.
ManagementObjectCollection.ManagementObjectEnumerator now implements IEnumerator\<ManagementObject\>.
ManagementObjectCollection now implements IEnumerable\<ManagementObject\>.
