### PR TITLE
Move "hostpolicy" pinvokes to Interop.HostPolicy.cs

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
+++ b/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static class HostPolicy
+    {
+#if TARGET_WINDOWS
+        private const CharSet HostpolicyCharSet = CharSet.Unicode;
+#else
+        private const CharSet HostpolicyCharSet = CharSet.Ansi;
+#endif
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        internal delegate void ResolveComponentDependenciesResultFn(string assemblyPaths,
+            string nativeSearchPaths, string resourceSearchPaths);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        internal delegate void ErrorWriterFn(string message);
+
+#pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
+
+        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_resolve_component_dependencies"
+            CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        private static extern int ResolveComponentDependencies(string componentMainAssemblyPath,
+            ResolveComponentDependenciesResultFn result);
+
+        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_set_error_writer",
+            CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        private static extern IntPtr SetErrorWriter(IntPtr errorWriter);
+
+#pragma warning restore
+    }
+}

--- a/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
+++ b/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 
 #pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
 
-        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_resolve_component_dependencies"
+        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_resolve_component_dependencies",
             CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
         private static extern int ResolveComponentDependencies(string componentMainAssemblyPath,
             corehost_resolve_component_dependencies_result_fn result);

--- a/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
+++ b/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
@@ -18,14 +18,12 @@ internal static partial class Interop
 
 #pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
 
-        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_resolve_component_dependencies",
-            CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        private static extern int ResolveComponentDependencies(string componentMainAssemblyPath,
+        [DllImport(Libraries.HostPolicy, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        internal static extern int corehost_resolve_component_dependencies(string componentMainAssemblyPath,
             corehost_resolve_component_dependencies_result_fn result);
 
-        [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_set_error_writer",
-            CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        private static extern IntPtr SetErrorWriter(IntPtr errorWriter);
+        [DllImport(Libraries.HostPolicy, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        internal static extern IntPtr corehost_set_error_writer(IntPtr errorWriter);
 
 #pragma warning restore
     }

--- a/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
+++ b/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
@@ -9,25 +9,19 @@ internal static partial class Interop
 {
     internal static class HostPolicy
     {
-#if TARGET_WINDOWS
-        private const CharSet HostpolicyCharSet = CharSet.Unicode;
-#else
-        private const CharSet HostpolicyCharSet = CharSet.Ansi;
-#endif
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        internal delegate void ResolveComponentDependenciesResultFn(string assemblyPaths,
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        internal delegate void corehost_resolve_component_dependencies_result_fn(string assemblyPaths,
             string nativeSearchPaths, string resourceSearchPaths);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        internal delegate void ErrorWriterFn(string message);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        internal delegate void corehost_error_writer_fn(string message);
 
 #pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
 
         [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_resolve_component_dependencies"
             CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
         private static extern int ResolveComponentDependencies(string componentMainAssemblyPath,
-            ResolveComponentDependenciesResultFn result);
+            corehost_resolve_component_dependencies_result_fn result);
 
         [DllImport(Libraries.HostPolicy, EntryPoint = "corehost_set_error_writer",
             CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]

--- a/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -14,5 +14,6 @@ internal static partial class Interop
         internal const string CompressionNative = "libSystem.IO.Compression.Native";
         internal const string IOPortsNative = "libSystem.IO.Ports.Native";
         internal const string Libdl = "libdl";
+        internal const string HostPolicy = "hostpolicy";
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -14,6 +14,6 @@ internal static partial class Interop
         internal const string CompressionNative = "libSystem.IO.Compression.Native";
         internal const string IOPortsNative = "libSystem.IO.Ports.Native";
         internal const string Libdl = "libdl";
-        internal const string HostPolicy = "hostpolicy";
+        internal const string HostPolicy = "libhostpolicy";
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -39,5 +39,6 @@ internal static partial class Interop
         internal const string CompressionNative = "clrcompression.dll";
         internal const string CoreWinRT = "api-ms-win-core-winrt-l1-1-0.dll";
         internal const string MsQuic = "msquic.dll";
+        internal const string HostPolicy = "hostpolicy.dll";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1014,6 +1014,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.EVENT_INFO_CLASS.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.EVENT_INFO_CLASS.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Interop.HostPolicy.cs">
+      <Link>Common\Interop\Interop.HostPolicy.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\ActivityTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\DiagnosticCounter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\CounterGroup.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -48,13 +48,13 @@ namespace System.Runtime.Loader
                 var errorWriter = new Interop.HostPolicy.corehost_error_writer_fn(message => errorMessage.AppendLine(message));
 
                 IntPtr errorWriterPtr = Marshal.GetFunctionPointerForDelegate(errorWriter);
-                IntPtr previousErrorWriterPtr = Interop.HostPolicy.SetErrorWriter(errorWriterPtr);
+                IntPtr previousErrorWriterPtr = Interop.HostPolicy.corehost_set_error_writer(errorWriterPtr);
 
                 try
                 {
                     // Call hostpolicy to do the actual work of finding .deps.json, parsing it and extracting
                     // information from it.
-                    returnCode = Interop.HostPolicy.RresolveComponentDependencies(
+                    returnCode = Interop.HostPolicy.corehost_resolve_component_dependencies(
                         componentAssemblyPath,
                         (assemblyPaths, nativeSearchPaths, resourceSearchPaths) =>
                         {
@@ -66,7 +66,7 @@ namespace System.Runtime.Loader
                 finally
                 {
                     // Reset the error write to the one used before
-                    Interop.HostPolicy.SetErrorWriter(previousErrorWriterPtr);
+                    Interop.HostPolicy.corehost_set_error_writer(previousErrorWriterPtr);
                     GC.KeepAlive(errorWriter);
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -45,7 +45,7 @@ namespace System.Runtime.Loader
             {
                 // Setup error writer for this thread. This makes the hostpolicy redirect all error output
                 // to the writer specified. Have to store the previous writer to set it back once this is done.
-                var errorWriter = new Interop.HostPolicy.ErrorWriterFn(message => errorMessage.AppendLine(message));
+                var errorWriter = new Interop.HostPolicy.corehost_error_writer_fn(message => errorMessage.AppendLine(message));
 
                 IntPtr errorWriterPtr = Marshal.GetFunctionPointerForDelegate(errorWriter);
                 IntPtr previousErrorWriterPtr = Interop.HostPolicy.SetErrorWriter(errorWriterPtr);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -45,28 +45,28 @@ namespace System.Runtime.Loader
             {
                 // Setup error writer for this thread. This makes the hostpolicy redirect all error output
                 // to the writer specified. Have to store the previous writer to set it back once this is done.
-                corehost_error_writer_fn errorWriter = new corehost_error_writer_fn(message => errorMessage.AppendLine(message));
+                var errorWriter = new Interop.HostPolicy.ErrorWriterFn(message => errorMessage.AppendLine(message));
 
                 IntPtr errorWriterPtr = Marshal.GetFunctionPointerForDelegate(errorWriter);
-                IntPtr previousErrorWriterPtr = corehost_set_error_writer(errorWriterPtr);
+                IntPtr previousErrorWriterPtr = Interop.HostPolicy.SetErrorWriter(errorWriterPtr);
 
                 try
                 {
                     // Call hostpolicy to do the actual work of finding .deps.json, parsing it and extracting
                     // information from it.
-                    returnCode = corehost_resolve_component_dependencies(
+                    returnCode = Interop.HostPolicy.RresolveComponentDependencies(
                         componentAssemblyPath,
-                        (assembly_paths, native_search_paths, resource_search_paths) =>
+                        (assemblyPaths, nativeSearchPaths, resourceSearchPaths) =>
                         {
-                            assemblyPathsList = assembly_paths;
-                            nativeSearchPathsList = native_search_paths;
-                            resourceSearchPathsList = resource_search_paths;
+                            assemblyPathsList = assemblyPaths;
+                            nativeSearchPathsList = nativeSearchPaths;
+                            resourceSearchPathsList = resourceSearchPaths;
                         });
                 }
                 finally
                 {
                     // Reset the error write to the one used before
-                    corehost_set_error_writer(previousErrorWriterPtr);
+                    Interop.HostPolicy.SetErrorWriter(previousErrorWriterPtr);
                     GC.KeepAlive(errorWriter);
                 }
             }
@@ -204,31 +204,5 @@ namespace System.Runtime.Loader
                 return pathsList.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
             }
         }
-
-#if TARGET_WINDOWS
-        private const CharSet HostpolicyCharSet = CharSet.Unicode;
-#else
-        private const CharSet HostpolicyCharSet = CharSet.Ansi;
-#endif
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        internal delegate void corehost_resolve_component_dependencies_result_fn(
-            string assembly_paths,
-            string native_search_paths,
-            string resource_search_paths);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        internal delegate void corehost_error_writer_fn(
-            string message);
-
-#pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
-        [DllImport("hostpolicy", CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        private static extern int corehost_resolve_component_dependencies(
-            string component_main_assembly_path,
-            corehost_resolve_component_dependencies_result_fn result);
-
-        [DllImport("hostpolicy", CallingConvention = CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
-        private static extern IntPtr corehost_set_error_writer(IntPtr error_writer);
-#pragma warning restore
     }
 }


### PR DESCRIPTION
For consistency, all DllImports are located there.
Also it should allow us in Mono to easily stub some unnecessary DllImports in FullAOT + direct-pinvokes mode - in this mode we convert DllImports into direct calls so unknown entry-points will fail to link.