### PR TITLE
Try enabling System.Runtime.Serialization.Xml test assembly for Mono on Windows

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Xml/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Xunit;
-
-[assembly: ActiveIssue("Disabled due to multiple crashes.", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="$(TestSourceFolder)DataContractSerializerStressTests.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)SerializationTypes.RuntimeOnly.cs" />


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/32592#pullrequestreview-391381885.
Let's try enabling `System.Runtime.Serialization.Xml.Tests` namespace first because it seems to pass locally.

@akoeplinger 