### PR TITLE
Use repo build script to restore internal tools

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -1,27 +1,14 @@
-parameters:
-  installDotnet: false
-
 steps:
-  - ${{ if eq(parameters.installDotnet, true) }}:
-    - task: UseDotNet@2
-      displayName: Install dotnet ${{ parameters.dotnetVersion }}
-      inputs:
-        packageType: sdk
-        useGlobalJson: true
-        installationPath: $(Agent.TempDirectory)/_dotnet
-
   - task: NuGetAuthenticate@0
     inputs:
       nuGetServiceConnections: 'dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true
 
-  - task: DotNetCoreCLI@2
+  - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
+            -ci
+            -restore
+            -projects $(Build.SourcesDirectory)/eng/common/internal/Tools.csproj
+            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/RestoreInternal.binlog
+            /v:normal
     displayName: Restore internal tools
     condition: and(succeeded(), ne(variables['_skipRestoreInternalTools'], 'true'))
-    inputs:
-      command: restore
-      feedsToUse: config
-      projects: 'eng/common/internal/Tools.csproj'
-      nugetConfigPath: 'eng/internal/NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-      verbosityRestore: 'diagnostic'

--- a/eng/pipelines/coreclr/templates/build-corelib-job.yml
+++ b/eng/pipelines/coreclr/templates/build-corelib-job.yml
@@ -74,14 +74,12 @@ jobs:
       - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
 
-    # # Install internal tools on official builds
-    # # Since our internal tools are behind an authenticated feed,
-    # # we need to use the DotNetCli AzDO task to restore from the feed using a service connection.
-    # # We can't do this from within the build, so we need to do this as a separate step.
+    # Install internal tools on official builds
+    # Since our internal tools are behind an authenticated feed,
+    # we need to use the DotNetCli AzDO task to restore from the feed using a service connection.
+    # We can't do this from within the build, so we need to do this as a separate step.
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
-        parameters:
-          installDotnet: true
 
     # Build Private CoreLib
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib $(crossArg) -arch $(archType) -c $(buildConfig) $(officialBuildIdArg) -ci

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -115,14 +115,12 @@ jobs:
       - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
 
-    # # Install internal tools on official builds
-    # # Since our internal tools are behind an authenticated feed,
-    # # we need to use the DotNetCli AzDO task to restore from the feed using a service connection.
-    # # We can't do this from within the build, so we need to do this as a separate step.
+    # Install internal tools on official builds
+    # Since our internal tools are behind an authenticated feed,
+    # we need to use the DotNetCli AzDO task to restore from the feed using a service connection.
+    # We can't do this from within the build, so we need to do this as a separate step.
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
-        parameters:
-          installDotnet: true
 
     # Build CoreCLR tools needed by the native runtime build
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.buildtools $(crossArg) -arch $(archType) -c $(buildConfig) $(officialBuildIdArg) -ci /bl:$(Build.SourcesDirectory)/artifacts/log/clr.buildtools.binlog

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -79,8 +79,6 @@ jobs:
 
         - ${{ if eq(parameters.isOfficialBuild, true) }}:
           - template: /eng/pipelines/common/restore-internal-tools.yml
-            parameters:
-              installDotnet: true
 
         - script: $(_buildScript)
                 -subset $(_subset)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.2.20176.6",
+    "version": "5.0.100-preview.4.20202.8",
     "allowPrerelease": true,
     "rollForward": "major"
   },


### PR DESCRIPTION
The way we were installing dotnet for the internal tools was blocking us from upgrading our minimum required SDK version in the `global.json`. This actually moves the SDK Version to the minimum required for the new restore features that were added and we're actually using.

Fixes: https://github.com/dotnet/runtime/issues/34546

Official build test: https://dev.azure.com/dnceng/internal/_build/results?buildId=596831

cc: @dotnet/runtime-infrastructure 