### PR TITLE
Reduce libraries build matrix with mono

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -414,33 +414,23 @@ jobs:
     runtimeFlavor: mono
     platforms:
     - Android_x64
-    - Android_x86
     - Android_arm
-    - Android_arm64
-    - tvOS_x64
     - tvOS_arm64
     # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
-    - iOS_arm64
     - iOS_x64
-    - WebAssembly_wasm
     jobParameters:
       liveRuntimeBuildConfig: release
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Debug
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     runtimeFlavor: mono
     platforms:
-    - Android_x64
     - Android_x86
-    - Android_arm
     - Android_arm64
     - tvOS_x64
-    - tvOS_arm64
-    # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
     - iOS_arm64
-    - iOS_x64
     - WebAssembly_wasm
     jobParameters:
       liveRuntimeBuildConfig: debug
@@ -534,15 +524,24 @@ jobs:
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     runtimeFlavor: mono
     platforms:
-      - tvOS_x64
-      - tvOS_arm64
-      - iOS_x64
-      # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
-      - iOS_arm64
-      - Android_x64
-      - Android_x86
-      - Android_arm
-      - Android_arm64
+    - Android_x64
+    - Android_arm
+    - tvOS_arm64
+    # - iOS_arm # https://github.com/dotnet/runtime/issues/34465
+    - iOS_x64
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/installer/installer-matrix.yml
+  parameters:
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    runtimeFlavor: mono
+    platforms:
+    - Android_x86
+    - Android_arm64
+    - tvOS_x64
+    - iOS_arm64
     jobParameters:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}


### PR DESCRIPTION
I noticed we're building all the Xamarin configurations in Libraries for both Release and Debug. We usually try to keep this as a mix matrix where we try to cover debug and release by swaping archs and flavors in between configurations. 

These builds are not that expensive, but they still take resources and the larger set we have of builds on PRs/CI the more prone to errors we're with network issues, etc.

cc: @steveisok @mdh1418 @dotnet/runtime-infrastructure 