### PR TITLE
Fix incorrect behavior noted via asserts

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -109,7 +109,7 @@ namespace Internal.JitInterface
         [DllImport(JitSupportLibrary)]
         private extern static char* GetExceptionMessage(IntPtr obj);
 
-        private readonly UnboxingMethodDescFactory _unboxingThunkFactory;
+        private static readonly UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
 
         public static void Startup()
         {
@@ -125,8 +125,6 @@ namespace Internal.JitInterface
             }
 
             _unmanagedCallbacks = GetUnmanagedCallbacks(out _keepAlive);
-
-            _unboxingThunkFactory = new UnboxingMethodDescFactory();
         }
 
         public TextWriter Log

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1882,7 +1882,7 @@ namespace Internal.JitInterface
                             MethodDesc md = HandleToObject(pResolvedToken.hMethod);
                             TypeDesc td = HandleToObject(pResolvedToken.hClass);
 
-                            if (td.IsValueType)
+                            if ((td.IsValueType) && !md.Signature.IsStatic)
                             {
                                 md = _unboxingThunkFactory.GetUnboxingMethod(md);
                             }


### PR DESCRIPTION
- Multi-thread handling of UnboxingMethodDesc was incorrect. It would result in incorrect caching of fixups to unboxing methods. This would cause asserts and determinism failures.
- ldtoken of a static method on a valuetype should not refer to an unboxing stub, This is unlikely to cause a failure, but will cause asserts to fire