### PR TITLE
Add support to pass subset without arg specifier in Unix

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -94,7 +94,7 @@ firstArgumentChecked=0
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
 
-  if [[ $firstArgumentChecked -eq 0 && $opt =~ ^[a-zA-Z\.\+]+ ]]; then
+  if [[ $firstArgumentChecked -eq 0 && $opt =~ ^[a-zA-Z.+]+$ ]]; then
     arguments="$arguments /p:Subset=$1"
     shift 1
     continue

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -89,9 +89,19 @@ source $scriptroot/native/init-os-and-arch.sh
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
 actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
+i=0
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
+
+  if [[ $i -eq 0 && $opt =~ ^[a-zA-Z\.\+]+ ]]; then
+    arguments="$arguments /p:Subset=$1"
+    shift 1
+    continue
+  fi
+
+  i=$(( i + 1 ))
+
   case "$opt" in
      -help|-h)
       usage

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -89,18 +89,18 @@ source $scriptroot/native/init-os-and-arch.sh
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
 actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
-i=0
+firstArgumentChecked=0
 
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
 
-  if [[ $i -eq 0 && $opt =~ ^[a-zA-Z\.\+]+ ]]; then
+  if [[ $firstArgumentChecked -eq 0 && $opt =~ ^[a-zA-Z\.\+]+ ]]; then
     arguments="$arguments /p:Subset=$1"
     shift 1
     continue
   fi
 
-  i=$(( i + 1 ))
+  firstArgumentChecked=1
 
   case "$opt" in
      -help|-h)


### PR DESCRIPTION
In windows you can pass the subsets in the first position of the arguments without specifying `-subset|-s` but in bash we didn't have support for that. This adds support for that, giving the same behavior as Windows as it has to be on the first position of the arguments.

cc: @jkotas @dotnet/runtime-infrastructure 