### PR TITLE
Fixed a typo in ValueType.cs

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -72,7 +72,7 @@ namespace System
 
         /*=================================GetHashCode==================================
         **Action: Our algorithm for returning the hashcode is a little bit complex.  We look
-        **        for the first non-static field and get it's hashcode.  If the type has no
+        **        for the first non-static field and get its hashcode.  If the type has no
         **        non-static fields, we return the hashcode of the type.  We can't take the
         **        hashcode of a static member because if that member is of the same type as
         **        the original type, we'll end up in an infinite loop.


### PR DESCRIPTION
```We look for the first non-static field and get it's hashcode.```

To (possessive pronoun, referring to the field):

```We look for the first non-static field and get its hashcode.```