### PR TITLE
Optimize HttpDateParser.TryStringToDate

### DIFF
--- a/src/libraries/Common/src/System/Net/HttpDateParser.cs
+++ b/src/libraries/Common/src/System/Net/HttpDateParser.cs
@@ -35,17 +35,23 @@ namespace System.Net
             "d MMM yyyy H:m:s", // RFC 5322 no day-of-week, no zone
         };
 
-        // Try the various date formats in the order listed above.
-        // We should accept a wide variety of common formats, but only output RFC 1123 style dates.
-        internal static bool TryStringToDate(ReadOnlySpan<char> input, out DateTimeOffset result) =>
-             DateTimeOffset.TryParseExact(
-                 input,
-                 s_dateFormats,
-                 DateTimeFormatInfo.InvariantInfo,
-                 DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal,
-                 out result);
+        internal static bool TryStringToDate(ReadOnlySpan<char> input, out DateTimeOffset result)
+        {
+            // None of the relevant patterns have whitespace at the beginning or end, so trim the input of
+            // any whitespace.  We can then use strict "r" matching, or if we have to fall back to trying
+            // lots of patterns, only allow inner whitespace rather than leading or trailing whitespace.
+            input = input.Trim();
 
-        // Format according to RFC1123; 'r' uses invariant info (DateTimeFormatInfo.InvariantInfo).
+            // First try strict parsing for "r" with no options, as it's an order of magnitude faster than general parsing for
+            // any individual format in s_dateFormats, allocation-free, and also likely to succeed.  If it doesn't, then
+            // fall back to trying each of the various date formats listed earlier, in order, to be accomodating and
+            // accept a wide variety of old formats.
+            return
+                DateTimeOffset.TryParseExact(input, "r", null, DateTimeStyles.None, out result) || // no culture specified, as "r" doesn't use it
+                DateTimeOffset.TryParseExact(input, s_dateFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AllowInnerWhite | DateTimeStyles.AssumeUniversal, out result);
+        }
+
+        // Format according to RFC1123
         internal static string DateToString(DateTimeOffset dateTime) =>
             dateTime.ToUniversalTime().ToString("r");
     }

--- a/src/libraries/Common/src/System/Net/HttpDateParser.cs
+++ b/src/libraries/Common/src/System/Net/HttpDateParser.cs
@@ -35,7 +35,7 @@ namespace System.Net
             "d MMM yyyy H:m:s", // RFC 5322 no day-of-week, no zone
         };
 
-        internal static bool TryStringToDate(ReadOnlySpan<char> input, out DateTimeOffset result)
+        internal static bool TryParse(ReadOnlySpan<char> input, out DateTimeOffset result)
         {
             // None of the relevant patterns have whitespace at the beginning or end, so trim the input of
             // any whitespace.  We can then use strict "r" matching, or if we have to fall back to trying
@@ -47,7 +47,7 @@ namespace System.Net
             // fall back to trying each of the various date formats listed earlier, in order, to be accomodating and
             // accept a wide variety of old formats.
             return
-                DateTimeOffset.TryParseExact(input, "r", null, DateTimeStyles.None, out result) || // no culture specified, as "r" doesn't use it
+                DateTimeOffset.TryParseExact(input, "r", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out result) ||
                 DateTimeOffset.TryParseExact(input, s_dateFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AllowInnerWhite | DateTimeStyles.AssumeUniversal, out result);
         }
 

--- a/src/libraries/Common/tests/Tests/System/Net/HttpDateParserTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/HttpDateParserTests.cs
@@ -11,7 +11,7 @@ namespace Tests.System.Net.Http
 {
     public static class HttpDateParserTests
     {
-        public static IEnumerable<object[]> TryStringToDate_Data()
+        public static IEnumerable<object[]> TryParse_Data()
         {
             DateTimeOffset zeroOffset = new DateTimeOffset(1994, 11, 6, 8, 49, 37, TimeSpan.Zero);
 
@@ -42,12 +42,12 @@ namespace Tests.System.Net.Http
         }
 
         [Theory]
-        [MemberData(nameof(TryStringToDate_Data))]
+        [MemberData(nameof(TryParse_Data))]
         // We don't need extensive tests, since we let DateTimeOffset do the parsing. This test is just
         // to validate that we use the correct parameters when calling into DateTimeOffset.ToString().
-        public static void TryStringToDate_UseOfValidDateTimeStringsInDifferentFormats_ParsedCorrectly(string input, DateTimeOffset expected)
+        public static void TryParse_UseOfValidDateTimeStringsInDifferentFormats_ParsedCorrectly(string input, DateTimeOffset expected)
         {
-            Assert.True(HttpDateParser.TryStringToDate(input, out var result));
+            Assert.True(HttpDateParser.TryParse(input, out var result));
             Assert.Equal(expected, result);
         }
 
@@ -55,9 +55,9 @@ namespace Tests.System.Net.Http
         [InlineData("Sun, 06 Nov 1994 08:49:37 GMT invalid")]
         [InlineData("Sun, 06 Nov 1994 08:49:37 GMT,")]
         [InlineData(",Sun, 06 Nov 1994 08:49:37 GMT")]
-        public static void TryStringToDate_UseInvalidDateTimeString(string invalid)
+        public static void TryParse_UseInvalidDateTimeString(string invalid)
         {
-            Assert.False(HttpDateParser.TryStringToDate(invalid, out var result));
+            Assert.False(HttpDateParser.TryParse(invalid, out var result));
             Assert.Equal(default, result);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -322,7 +322,7 @@ namespace System.Net.Http.Headers
                 {
                     dateString = dateString.Slice(1, dateString.Length - 2);
                 }
-                if (HttpDateParser.TryStringToDate(dateString, out date))
+                if (HttpDateParser.TryParse(dateString, out date))
                 {
                     return date;
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/DateHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/DateHeaderParser.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http.Headers
             }
 
             DateTimeOffset date;
-            if (!HttpDateParser.TryStringToDate(dateString, out date))
+            if (!HttpDateParser.TryParse(dateString, out date))
             {
                 return false;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeConditionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeConditionHeaderValue.cs
@@ -157,7 +157,7 @@ namespace System.Net.Http.Headers
             }
             else
             {
-                if (!HttpDateParser.TryStringToDate(input.AsSpan(current), out date))
+                if (!HttpDateParser.TryParse(input.AsSpan(current), out date))
                 {
                     return 0;
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
@@ -158,7 +158,7 @@ namespace System.Net.Http.Headers
             }
             else
             {
-                if (!HttpDateParser.TryStringToDate(input.AsSpan(current), out date))
+                if (!HttpDateParser.TryParse(input.AsSpan(current), out date))
                 {
                     return 0;
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -298,7 +298,7 @@ namespace System.Net.Http.Headers
                 }
 
                 DateTimeOffset temp;
-                if (!HttpDateParser.TryStringToDate(input.AsSpan(dateStartIndex, current - dateStartIndex), out temp))
+                if (!HttpDateParser.TryParse(input.AsSpan(dateStartIndex, current - dateStartIndex), out temp))
                 {
                     return false;
                 }

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1445,7 +1445,7 @@ namespace System.Net
                 {
                     return DateTime.MinValue; // MinValue means header is not present
                 }
-                if (HttpDateParser.TryStringToDate(headerValue, out DateTimeOffset dateTimeOffset))
+                if (HttpDateParser.TryParse(headerValue, out DateTimeOffset dateTimeOffset))
                 {
                     return dateTimeOffset.LocalDateTime;
                 }

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -159,7 +159,7 @@ namespace System.Net
                     return DateTime.Now;
                 }
 
-                if (HttpDateParser.TryStringToDate(lastmodHeaderValue, out var dateTimeOffset))
+                if (HttpDateParser.TryParse(lastmodHeaderValue, out DateTimeOffset dateTimeOffset))
                 {
                     return dateTimeOffset.LocalDateTime;
                 }


### PR DESCRIPTION
When HttpResponseMessage headers are enumerated, even though SocketsHttpHandler adds headers with TryAddWithoutValidation, the enumeration ends up validating them (that's something to be discussed and follow-up on separately).  As part of that, it validates the Date header that's required of most responses. It does so using DateTimeOffset.TryParseExact, but using a long list of allowed formats as well as options that knock TryParseExact's processing off the fast path.  Since most responses are going to contain a date using RFC1123 format (aka "r"), we just try that first, in a way that will generally result in hitting the optimized "r" code path which is much faster.

|        Method |        Job |           Toolchain |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |----------- |-------------------- |-----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
| DatePreferred | Job-TUINSB | \master\corerun.exe | 1,534.1 ns |  28.19 ns |  34.62 ns |  1.00 |    0.00 | 0.0877 |     - |     - |     552 B |
| DatePreferred | Job-HCLEYD |     \pr\corerun.exe |   279.2 ns |   4.09 ns |   3.62 ns |  0.18 |    0.00 | 0.0825 |     - |     - |     520 B |
|               |            |                     |            |           |           |       |         |        |       |       |           |
|   DateAsctime | Job-TUINSB | \master\corerun.exe | 5,936.1 ns | 118.33 ns | 110.68 ns |  1.00 |    0.00 | 0.0763 |     - |     - |     520 B |
|   DateAsctime | Job-HCLEYD |     \pr\corerun.exe | 5,628.2 ns | 110.32 ns |  97.80 ns |  0.95 |    0.03 | 0.0763 |     - |     - |     520 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Net.Http;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    [Benchmark]
    public DateTimeOffset? DatePreferred()
    {
        var m = new HttpResponseMessage();
        m.Headers.TryAddWithoutValidation("Date", "Sun, 06 Nov 1994 08:49:37 GMT");
        return m.Headers.Date;
    }

    [Benchmark]
    public DateTimeOffset? DateAsctime()
    {
        var m = new HttpResponseMessage();
        m.Headers.TryAddWithoutValidation("Date", "Sun Nov  6 08:49:37 1994");
        return m.Headers.Date;
    }
}
```

cc: @davidsh, @scalablecory 