### PR TITLE
remove unused local of genId in BinaryObjectReader in System.Runtime.Serialization.Formatters

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -362,8 +362,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         // Array object encountered in stream
         private void ParseArray(ParseRecord pr)
         {
-            long genId = pr._objectId;
-
             Debug.Assert(_stack != null);
             if (pr._arrayTypeEnum == InternalArrayTypeE.Base64)
             {


### PR DESCRIPTION
Partially fixes issue #30457 

cc @stephentoub 