### PR TITLE
[mono] Fix corlib and runtime rules in Makefile

### DIFF
--- a/src/mono/netcore/Makefile
+++ b/src/mono/netcore/Makefile
@@ -38,11 +38,11 @@ run-sample-coreclr:
 
 # build System.Private.CoreLib.dll
 bcl corelib:
-	$(DOTNET) msbuild /t:BuildCoreLib $(MONO_PROJ)
+	../../.././build.sh -c $(MONO_RUNTIME_CONFIG) -subset Mono.CoreLib
 
 # build runtime and copy to artifacts
 runtime:
-	$(DOTNET) msbuild /t:Build $(MONO_PROJ)
+	../../.././build.sh -c $(MONO_RUNTIME_CONFIG) -subset Mono.Runtime
 
 # call it if you want to use $(DOTNET_MONO) in this Makefile
 patch-mono-dotnet:


### PR DESCRIPTION
`t:BuildCoreLib` and `t:Build` were removed recently.