### PR TITLE
LoopbackServer.ReadAsync: Fixed data corruption bug

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -447,7 +447,7 @@ namespace System.Net.Test.Common
                 int readLength = await _stream.ReadAsync(tempBuffer, 0, size).ConfigureAwait(false);
                 if (readLength > 0)
                 {
-                    tempBuffer.AsSpan(readLength).CopyTo(buffer.Span.Slice(offset, size));
+                    tempBuffer.AsSpan(0, readLength).CopyTo(buffer.Span.Slice(offset, size));
                 }
 
                 return readLength;


### PR DESCRIPTION
This caused the unused parts of the temp buffer to be copied to buffer, returning zeros to the caller instead of the actual data.
This caused several tests to fail when targeting .NET Standard 2.0