### PR TITLE
[wasm] Configure the wasm target runtime using --with-lazy-gc-thread-creation=yes.

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -630,6 +630,7 @@
       <_MonoConfigureParams Include="--disable-mcs-build" />
       <_MonoConfigureParams Include="--disable-nls" />
       <_MonoConfigureParams Include="--disable-visibility-hidden" />
+      <_MonoConfigureParams Include="--with-lazy-gc-thread-creation=yes" />
       <_MonoConfigureParams Include="--enable-maintainer-mode" />
       <_MonoConfigureParams Include="--enable-llvm-runtime"/>
       <_MonoConfigureParams Include="--enable-icall-export"/>


### PR DESCRIPTION
This flag got lost in the move to mono.proj.