### PR TITLE
Find the correct OpenSSL library for FreeBSD

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -97,6 +97,23 @@ static bool OpenLibrary()
         DlOpen(MAKELIB("10"));
     }
 
+    // FreeBSD uses a different suffix numbering convention.
+    // Current supported FreeBSD releases should use the order .11 -> .111 -> .8
+    if (libssl == NULL)
+    {
+        DlOpen(MAKELIB("11"));
+    }
+
+    if (libssl == NULL)
+    {
+        DlOpen(MAKELIB("111"));
+    }
+
+    if (libssl == NULL)
+    {
+        DlOpen(MAKELIB("8"));
+    }
+
     return libssl != NULL;
 }
 


### PR DESCRIPTION
This is a minor change, it builds and works on my setup - previously dotnet crashed on first-run when trying to send  telemetry.

OpenSSL 1.1.1 -> libssl.so.11
OpenSSL 1.0.2 -> libssl.so.8

#34897

@wfurt
