### PR TITLE
[mono] Reintroduce an internal Marshal class method used by the runtime

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1043,6 +1043,15 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/Reflection/Reflection/**">
+            <Issue>https://github.com/dotnet/runtime/issues/34371</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICastable/Castable/**">
+            <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/**">
+            <Issue>https://github.com/dotnet/runtime/issues/34072</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1043,15 +1043,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/Reflection/Reflection/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34371</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICastable/Castable/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34072</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1052,12 +1052,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/**">
             <Issue>https://github.com/dotnet/runtime/issues/34072</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34372</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/Primitives/ICustomMarshaler/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34374</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1052,6 +1052,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/**">
             <Issue>https://github.com/dotnet/runtime/issues/34072</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/Primitives/ICustomMarshaler/**">
+            <Issue>https://github.com/dotnet/runtime/issues/34374</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -818,5 +818,9 @@
 		<type fullname="Interop/Globalization">
 			<method name="GetICUVersion" />
 		</type>
+		<type fullname="System.Runtime.InteropServices.Marshal">
+			<!-- marshal-ilgen.c: emit_marshal_custom_get_instance -->
+			<method name="GetCustomMarshalerInstance" />
+		</type>
 	</assembly>
 </linker>

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
@@ -4,6 +4,8 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Collections.Generic;
 
 namespace System.Runtime.InteropServices
 {
@@ -352,6 +354,85 @@ namespace System.Runtime.InteropServices
                 return IntPtr.Zero;
             fixed (char* fixed_s = s)
                 return BufferToBSTR(fixed_s, s.Length);
+        }
+
+        internal class MarshalerInstanceKeyComparer : IEqualityComparer<(Type, string)>
+        {
+            public bool Equals((Type, string) lhs, (Type, string) rhs)
+            {
+                return lhs.CompareTo(rhs) == 0;
+            }
+
+            public int GetHashCode((Type, string) key)
+            {
+                return key.GetHashCode();
+            }
+        }
+
+        internal static Dictionary<(Type, string), ICustomMarshaler>? MarshalerInstanceCache;
+
+        internal static ICustomMarshaler? GetCustomMarshalerInstance(Type type, string cookie)
+        {
+            var key = (type, cookie);
+
+            LazyInitializer.EnsureInitialized(
+                ref MarshalerInstanceCache,
+                () => new Dictionary<(Type, string), ICustomMarshaler>(new MarshalerInstanceKeyComparer())
+            );
+
+            ICustomMarshaler? result;
+            bool gotExistingInstance;
+            lock (MarshalerInstanceCache)
+                gotExistingInstance = MarshalerInstanceCache.TryGetValue(key, out result);
+
+            if (!gotExistingInstance)
+            {
+                RuntimeMethodInfo? getInstanceMethod;
+                try
+                {
+                    getInstanceMethod = (RuntimeMethodInfo?)type.GetMethod(
+                        "GetInstance", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
+                        null, new Type[] { typeof(string) }, null
+                    );
+                }
+                catch (AmbiguousMatchException)
+                {
+                    throw new ApplicationException($"Custom marshaler '{type.FullName}' implements multiple static GetInstance methods that take a single string parameter.");
+                }
+
+                if ((getInstanceMethod == null) ||
+                    (getInstanceMethod.ReturnType != typeof(ICustomMarshaler)))
+                {
+                    throw new ApplicationException($"Custom marshaler '{type.FullName}' does not implement a static GetInstance method that takes a single string parameter and returns an ICustomMarshaler.");
+                }
+
+                Exception? exc;
+                try
+                {
+                    result = (ICustomMarshaler?)getInstanceMethod.InternalInvoke(null, new object[] { cookie }, out exc);
+                }
+                catch (Exception e)
+                {
+                    // FIXME: mscorlib's legacyUnhandledExceptionPolicy is apparently 1,
+                    //  so exceptions are thrown instead of being passed through the outparam
+                    exc = e;
+                    result = null;
+                }
+
+                if (exc != null)
+                {
+                    var edi = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exc);
+                    edi.Throw();
+                }
+
+                if (result == null)
+                    throw new ApplicationException($"A call to GetInstance() for custom marshaler '{type.FullName}' returned null, which is not allowed.");
+
+                lock (MarshalerInstanceCache)
+                    MarshalerInstanceCache[key] = result;
+            }
+
+            return result;
         }
 
         #region PlatformNotSupported

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Mono.cs
@@ -356,7 +356,7 @@ namespace System.Runtime.InteropServices
                 return BufferToBSTR(fixed_s, s.Length);
         }
 
-        internal class MarshalerInstanceKeyComparer : IEqualityComparer<(Type, string)>
+        private sealed class MarshalerInstanceKeyComparer : IEqualityComparer<(Type, string)>
         {
             public bool Equals((Type, string) lhs, (Type, string) rhs)
             {
@@ -369,7 +369,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        internal static Dictionary<(Type, string), ICustomMarshaler>? MarshalerInstanceCache;
+        private static Dictionary<(Type, string), ICustomMarshaler>? MarshalerInstanceCache;
 
         internal static ICustomMarshaler? GetCustomMarshalerInstance(Type type, string cookie)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/34372
Contributes to https://github.com/dotnet/runtime/issues/34374