### PR TITLE
Fix HostPolicyMock (corehost_error_writer_fn was moved)

### DIFF
--- a/src/coreclr/tests/src/Common/CoreCLRTestLibrary/HostPolicyMock.cs
+++ b/src/coreclr/tests/src/Common/CoreCLRTestLibrary/HostPolicyMock.cs
@@ -31,7 +31,6 @@ namespace TestLibrary
         private static extern void Set_corehost_resolve_component_dependencies_Callback(
             IntPtr callback);
 
-        private static Type _assemblyDependencyResolverType;
         private static Type _corehost_error_writer_fnType;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
@@ -39,12 +38,10 @@ namespace TestLibrary
 
         public static void Initialize(string testBasePath, string coreRoot)
         {
-            _assemblyDependencyResolverType = typeof(AssemblyDependencyResolver);
-
             // This is needed for marshalling of function pointers to work - requires private access to the ADR unfortunately
             // Delegate marshalling doesn't support casting delegates to anything but the original type
             // so we need to use the original type.
-            _corehost_error_writer_fnType = _assemblyDependencyResolverType.GetNestedType("corehost_error_writer_fn", System.Reflection.BindingFlags.NonPublic);
+            _corehost_error_writer_fnType = typeof(object).Assembly.GetType("Interop+HostPolicy+corehost_error_writer_fn");
         }
 
         public static MockValues_corehost_resolve_component_dependencies Mock_corehost_resolve_component_dependencies(


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/34881
(the delegate was moved to Interop.HostPolicy)
