### PR TITLE
Enables the hanging test

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -81,7 +81,6 @@ namespace System.ServiceProcess.Tests
             controller.WaitForStatus(ServiceControllerStatus.Stopped);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34801")]
         [ConditionalFact(nameof(IsProcessElevated))]
         public void TestOnStartWithArgsThenStop()
         {
@@ -94,10 +93,9 @@ namespace System.ServiceProcess.Tests
             controller.Start(new string[] { "StartWithArguments", "a", "b", "c" });
             _testService.Client = null;
             _testService.Client.Connect();
+            Assert.Equal((int)(PipeMessageByteCode.Connected), _testService.GetByte());
 
-            // There is no definite order between start and connected when tests are running on multiple threads.
-            // In this case we dont care much about the order, so we are just checking whether the appropiate bytes have been sent.
-            Assert.Equal((int)(PipeMessageByteCode.Connected | PipeMessageByteCode.Start), _testService.GetByte() | _testService.GetByte());
+            Assert.Equal((int)(PipeMessageByteCode.Start), _testService.GetByte());           
             controller.WaitForStatus(ServiceControllerStatus.Running);
 
             controller.Stop();


### PR DESCRIPTION
FIxes #34801

The hang doesnot reproduce using a clean build. It sometimes repro when a service gets hanged or not started properly or named pipe drops the byte.

I verified the required behavior using a debugview independently and serviceController start behaves as expected.

The order of connected and start bytes is also a strict one i.e. connected is always before start.

```
C:\git\runtime>dotnet msbuild src\libraries\System.ServiceProcess.ServiceController\tests /t:rebuild;test /p:RuntimeConfiguration=release /p:Outerloop=true /p:XunitmethodName=System.ServiceProcess.Tests.ServiceBaseTests.TestOnStartWithArgsThenStop

  ===========================================================================================================
    Discovering: System.ServiceProcess.ServiceController.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.ServiceProcess.ServiceController.Tests (found 1 of 37 test case)
    Starting:    System.ServiceProcess.ServiceController.Tests (parallel test collections = on, max threads = 12)
    Finished:    System.ServiceProcess.ServiceController.Tests
  === TEST EXECUTION SUMMARY ===
     System.ServiceProcess.ServiceController.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0, Time: 4.278s
  ----- end Mon 04/13/2020 11:33:11.39 ----- exit code 0 ----------------------------------------------------------
```