### PR TITLE
[release/5.0-preview3] Fix WriteLargeJsonToStreamWithoutFlushing test (#34489)

### DIFF
--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -752,7 +752,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(1_050_097_521, writer.BytesPending);
 
                 // Next write forces a grow beyond 2 GB
-                Assert.Throws<OverflowException>(() => writer.WriteStringValue(text3));
+                Assert.Throws<OutOfMemoryException>(() => writer.WriteStringValue(text3));
 
                 Assert.Equal(1_050_097_521, writer.BytesPending);
 


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/runtime/pull/34489 to preview 3 branch.
Fixes https://github.com/dotnet/runtime/issues/34887.

This test wasn't updated following #32587 (introduced in preview 3), where the exception for the scenario changed from `OverflowException` to `OutOfMemoryException`.

#### Impact

The test failure appears to be blocking a clean CI run for the preview 3 branch: https://github.com/dotnet/runtime/issues/34887. Not sure how crucial a fix here is but opening for consideration.