### PR TITLE
profiler tests depend on jit events 

### DIFF
--- a/src/coreclr/src/vm/inlinetracking.cpp
+++ b/src/coreclr/src/vm/inlinetracking.cpp
@@ -550,7 +550,7 @@ COUNT_T PersistentInlineTrackingMapR2R::GetInliners(PTR_Module inlineeOwnerMod, 
     CONTRACTL_END;
 
     _ASSERTE(inlineeOwnerMod);
-    _ASSERTE(inliners);
+    _ASSERTE(inliners != NULL || inlinersSize == 0);
 
     if (incompleteData)
     {
@@ -692,8 +692,8 @@ COUNT_T PersistentInlineTrackingMapR2R2::GetInliners(PTR_Module inlineeOwnerMod,
                 streamSize--;
                 if (inlinerModule == nullptr && incompleteData)
                 {
-                    // We can't find module for this inlineeModuleZapIndex, it means it hasn't been loaded yet 
-                    // (maybe it never will be), we just report it to the profiler. 
+                    // We can't find module for this inlineeModuleZapIndex, it means it hasn't been loaded yet
+                    // (maybe it never will be), we just report it to the profiler.
                     // Profiler might want to try later when more modules are loaded.
                     *incompleteData = TRUE;
                     continue;

--- a/src/coreclr/src/vm/rejit.cpp
+++ b/src/coreclr/src/vm/rejit.cpp
@@ -418,12 +418,6 @@ COR_IL_MAP* ProfilerFunctionControl::GetInstrumentedMapEntries()
     return m_rgInstrumentedMapEntries;
 }
 
-//---------------------------------------------------------------------------------------
-// ReJitManager implementation
-
-// All the state-changey stuff is kept up here in the !DACCESS_COMPILE block.
-// The more read-only inspection-y stuff follows the block.
-
 #ifndef DACCESS_COMPILE
 NativeImageInliningIterator::NativeImageInliningIterator() :
         m_pModule(NULL),
@@ -505,6 +499,12 @@ MethodDesc *NativeImageInliningIterator::GetMethodDesc()
     mdMethodDef mdInliner = mm.m_methodDef;
     return pModule->LookupMethodDef(mdInliner);
 }
+
+//---------------------------------------------------------------------------------------
+// ReJitManager implementation
+
+// All the state-changey stuff is kept up here in the !DACCESS_COMPILE block.
+// The more read-only inspection-y stuff follows the block.
 
 //---------------------------------------------------------------------------------------
 //

--- a/src/coreclr/src/vm/rejit.cpp
+++ b/src/coreclr/src/vm/rejit.cpp
@@ -470,11 +470,11 @@ HRESULT NativeImageInliningIterator::Reset(Module *pModule, MethodDesc *pInlinee
 
     if (FAILED(hr))
     {
-        m_currentPos = -1;
+        m_currentPos = s_failurePos;
     }
     else
     {
-        m_currentPos = 0;
+        m_currentPos = -1;
     }
 
     return hr;
@@ -482,18 +482,19 @@ HRESULT NativeImageInliningIterator::Reset(Module *pModule, MethodDesc *pInlinee
 
 BOOL NativeImageInliningIterator::Next()
 {
-    if (m_currentPos < 0)
+    if (m_currentPos == s_failurePos)
     {
         return FALSE;
     }
 
     m_currentPos++;
+    _ASSERTE(m_currentPos >= 0);
     return m_currentPos < m_dynamicAvailable;
 }
 
 MethodDesc *NativeImageInliningIterator::GetMethodDesc()
 {
-    if (m_currentPos == (COUNT_T)-1 || m_currentPos >= m_dynamicAvailable)
+    if (m_currentPos == s_failurePos || m_currentPos >= m_dynamicAvailable)
     {
         return NULL;
     }

--- a/src/coreclr/src/vm/rejit.cpp
+++ b/src/coreclr/src/vm/rejit.cpp
@@ -488,13 +488,14 @@ BOOL NativeImageInliningIterator::Next()
     }
 
     m_currentPos++;
-    _ASSERTE(m_currentPos >= 0);
     return m_currentPos < m_dynamicAvailable;
 }
 
 MethodDesc *NativeImageInliningIterator::GetMethodDesc()
 {
-    if (m_currentPos == s_failurePos || m_currentPos >= m_dynamicAvailable)
+    // this evaluates true when m_currentPos == s_failurePos or m_currentPos == (COUNT_T)-1
+    // m_currentPos is an unsigned type
+    if (m_currentPos >= m_dynamicAvailable)
     {
         return NULL;
     }

--- a/src/coreclr/src/vm/rejit.h
+++ b/src/coreclr/src/vm/rejit.h
@@ -85,6 +85,7 @@ private:
     MethodDesc *m_pInlinee;
     NewArrayHolder<MethodInModule> m_dynamicBuffer;
     COUNT_T m_dynamicBufferSize;
+    COUNT_T m_dynamicAvailable;
     COUNT_T m_currentPos;
 
     const COUNT_T s_bufferSize = 10;

--- a/src/coreclr/src/vm/rejit.h
+++ b/src/coreclr/src/vm/rejit.h
@@ -89,6 +89,7 @@ private:
     COUNT_T m_currentPos;
 
     const COUNT_T s_bufferSize = 10;
+    const COUNT_T s_failurePos = -2;
 };
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -996,17 +996,11 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe/*">
-            <Issue>https://github.com/dotnet/runtime/issues/34624</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_r/*">
             <Issue>https://github.com/dotnet/runtime/issues/34734</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_ro/*">
             <Issue>https://github.com/dotnet/runtime/issues/34734</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/rejit/rejit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/34625</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>https://github.com/dotnet/runtime/issues/7597</Issue>

--- a/src/coreclr/tests/runtest.cmd
+++ b/src/coreclr/tests/runtest.cmd
@@ -47,14 +47,14 @@ if /i "%1" == "x64"                                     (set __BuildArch=x64&shi
 if /i "%1" == "x86"                                     (set __BuildArch=x86&shift&goto Arg_Loop)
 if /i "%1" == "arm"                                     (set __BuildArch=arm&shift&goto Arg_Loop)
 if /i "%1" == "arm64"                                   (set __BuildArch=arm64&shift&goto Arg_Loop)
-            
+
 if /i "%1" == "debug"                                   (set __BuildType=Debug&shift&goto Arg_Loop)
 if /i "%1" == "release"                                 (set __BuildType=Release&shift&goto Arg_Loop)
 if /i "%1" == "checked"                                 (set __BuildType=Checked&shift&goto Arg_Loop)
-            
+
 if /i "%1" == "vs2017"                                  (set __VSVersion=%1&shift&goto Arg_Loop)
 if /i "%1" == "vs2019"                                  (set __VSVersion=%1&shift&goto Arg_Loop)
-            
+
 if /i "%1" == "TestEnv"                                 (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "AgainstPackages"                         (echo error: Remove /AgainstPackages switch&&echo /b 1)
 if /i "%1" == "sequential"                              (set __Sequential=1&shift&goto Arg_Loop)
@@ -98,7 +98,7 @@ goto CollectMsbuildArgs
 
 set CORE_ROOT=%1
 echo %__MsgPrefix%CORE_ROOT is initially set to: "%CORE_ROOT%"
-shift 
+shift
 :ArgsDone
 
 :: Done with argument processing. Check argument values for validity.
@@ -177,7 +177,7 @@ if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
-set NEXTCMD=python3 "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
+set NEXTCMD=python "%__ProjectDir%\runtest.py" %__RuntestPyArgs%
 echo !NEXTCMD!
 !NEXTCMD!
 
@@ -188,7 +188,7 @@ exit /b %ERRORLEVEL%
 :: Note: We've disabled node reuse because it causes file locking issues.
 ::       The issue is that we extend the build with our own targets which
 ::       means that that rebuilding cannot successfully delete the task
-::       assembly. 
+::       assembly.
 set __msbuildCommonArgs=/nologo /nodeReuse:false %__msbuildExtraArgs% /p:Platform=%__MSBuildBuildArch%
 
 if not defined __Sequential (
@@ -315,7 +315,7 @@ if %__exitCode% neq 0 (
     echo Unable to precompile %2
     exit /b 0
 )
-    
+
 echo %__MsgPrefix%Successfully precompiled %2
 exit /b 0
 
@@ -456,7 +456,7 @@ REM ============================================================================
 :ResolveDependencies
 
 set __BuildLogRootName=Tests_GenerateRuntimeLayout
-call :msbuild "%__ProjectFilesDir%\src\runtest.proj" /p:GenerateRuntimeLayout=true 
+call :msbuild "%__ProjectFilesDir%\src\runtest.proj" /p:GenerateRuntimeLayout=true
 if errorlevel 1 (
     echo %__MsgPrefix%Test Dependency Resolution Failed
     exit /b 1

--- a/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.cpp
@@ -24,7 +24,7 @@ HRESULT EventPipeProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
     }
 
     // No event mask, just calling the EventPipe APIs.
-    if (FAILED(hr = _pCorProfilerInfo12->SetEventMask2(COR_PRF_MONITOR_JIT_COMPILATION, 0)))
+    if (FAILED(hr = _pCorProfilerInfo12->SetEventMask2(COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_DISABLE_ALL_NGEN_IMAGES, 0)))
     {
         _failures++;
         printf("FAIL: ICorProfilerInfo::SetEventMask2() failed hr=0x%x\n", hr);

--- a/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.cpp
@@ -24,7 +24,7 @@ HRESULT EventPipeProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
     }
 
     // No event mask, just calling the EventPipe APIs.
-    if (FAILED(hr = _pCorProfilerInfo12->SetEventMask2(COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_DISABLE_ALL_NGEN_IMAGES, 0)))
+    if (FAILED(hr = _pCorProfilerInfo12->SetEventMask2(COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_MONITOR_CACHE_SEARCHES, 0)))
     {
         _failures++;
         printf("FAIL: ICorProfilerInfo::SetEventMask2() failed hr=0x%x\n", hr);
@@ -144,6 +144,22 @@ HRESULT EventPipeProfiler::Shutdown()
 }
 
 HRESULT EventPipeProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
+{
+    return FunctionSeen(functionId);
+}
+
+HRESULT STDMETHODCALLTYPE EventPipeProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
+{
+    if (result == COR_PRF_CACHED_FUNCTION_FOUND)
+    {
+        return FunctionSeen(functionId);
+    }
+
+    return S_OK;
+}
+
+
+HRESULT EventPipeProfiler::FunctionSeen(FunctionID functionId)
 {
     String functionName = GetFunctionIDName(functionId);
     if (functionName == WCHAR("TriggerMethod"))

--- a/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.h
+++ b/src/coreclr/tests/src/profiler/native/eventpipeprofiler/eventpipeprofiler.h
@@ -21,6 +21,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
     virtual HRESULT STDMETHODCALLTYPE Shutdown();
     virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock);
+    virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result);
 
 private:
     std::atomic<int> _failures;
@@ -29,4 +30,6 @@ private:
     EVENTPIPE_EVENT _allTypesEvent;
     EVENTPIPE_EVENT _emptyEvent;
     EVENTPIPE_EVENT _simpleEvent;
+
+    HRESULT FunctionSeen(FunctionID functionId);
 };

--- a/src/coreclr/tests/src/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
+++ b/src/coreclr/tests/src/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
@@ -48,8 +48,7 @@ HRESULT MetaDataGetDispenser::Initialize(IUnknown* pICorProfilerInfoUnk)
 
     printf("Initialize started\n");
 
-    DWORD eventMaskLow = COR_PRF_MONITOR_MODULE_LOADS |
-                         COR_PRF_DISABLE_ALL_NGEN_IMAGES;
+    DWORD eventMaskLow = COR_PRF_MONITOR_MODULE_LOADS;
     DWORD eventMaskHigh = 0x0;
     if (FAILED(hr = pCorProfilerInfo->SetEventMask2(eventMaskLow, eventMaskHigh)))
     {

--- a/src/coreclr/tests/src/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
+++ b/src/coreclr/tests/src/profiler/native/metadatagetdispenser/metadatagetdispenser.cpp
@@ -48,7 +48,8 @@ HRESULT MetaDataGetDispenser::Initialize(IUnknown* pICorProfilerInfoUnk)
 
     printf("Initialize started\n");
 
-    DWORD eventMaskLow = COR_PRF_MONITOR_MODULE_LOADS;
+    DWORD eventMaskLow = COR_PRF_MONITOR_MODULE_LOADS |
+                         COR_PRF_DISABLE_ALL_NGEN_IMAGES;
     DWORD eventMaskHigh = 0x0;
     if (FAILED(hr = pCorProfilerInfo->SetEventMask2(eventMaskLow, eventMaskHigh)))
     {

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -204,7 +204,11 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCachedFunctionSearchFinished(Functio
         {
             FunctionID inlinerFuncId = GetFunctionIDFromToken(method.moduleId, method.methodId);
 
-            AddInlining(inlinerFuncId, functionId);
+            // GetFunctionIDFromToken doesn't handle generics, will return NULL
+            if (inlinerFuncId != mdTokenNil)
+            {
+                AddInlining(inlinerFuncId, functionId);
+            }
         }
     }
 
@@ -340,7 +344,7 @@ FunctionID ReJITProfiler::GetFunctionIDFromToken(ModuleID module, mdMethodDef to
                                                            &functionId)))
     {
         printf("Call to GetFunctionFromToken failed with hr=0x%x\n", hr);
-        return hr;
+        return mdTokenNil;
     }
 
     return functionId;

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -70,7 +70,9 @@ HRESULT ReJITProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
 
     INFO(L"Initialize started");
 
-    DWORD eventMaskLow = COR_PRF_ENABLE_REJIT | COR_PRF_MONITOR_JIT_COMPILATION;
+    DWORD eventMaskLow = COR_PRF_ENABLE_REJIT |
+                         COR_PRF_MONITOR_JIT_COMPILATION |
+                         COR_PRF_DISABLE_ALL_NGEN_IMAGES;
     DWORD eventMaskHigh = 0x0;
     if (FAILED(hr = pCorProfilerInfo->SetEventMask2(eventMaskLow, eventMaskHigh)))
     {

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -72,7 +72,7 @@ HRESULT ReJITProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
 
     DWORD eventMaskLow = COR_PRF_ENABLE_REJIT |
                          COR_PRF_MONITOR_JIT_COMPILATION |
-                         COR_PRF_DISABLE_ALL_NGEN_IMAGES;
+                         COR_PRF_MONITOR_CACHE_SEARCHES;
     DWORD eventMaskHigh = 0x0;
     if (FAILED(hr = pCorProfilerInfo->SetEventMask2(eventMaskLow, eventMaskHigh)))
     {
@@ -119,15 +119,10 @@ HRESULT ReJITProfiler::Shutdown()
 
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
 {
-    ModuleID moduleId = GetModuleIDForFunction(functionId);
-    String moduleName = GetModuleIDName(moduleId);
-
-    String funcName = GetFunctionIDName(functionId);
-    INFO(L"jitting started for " << funcName << L" in module " << moduleName);
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+HRESULT ReJITProfiler::FunctionSeen(FunctionID functionId)
 {
     String functionName = GetFunctionIDName(functionId);
     ModuleID moduleId = GetModuleIDForFunction(functionId);
@@ -163,14 +158,64 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationFinished(FunctionID funct
     return S_OK;
 }
 
+HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+{
+    return FunctionSeen(functionId);
+}
+
 HRESULT STDMETHODCALLTYPE ReJITProfiler::JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline)
 {
     AddInlining(callerId, calleeId);
     *pfShouldInline = TRUE;
 
-    String calleeName = GetFunctionIDName(calleeId);
-    String moduleName = GetModuleIDName(GetModuleIDForFunction(calleeId));
-    INFO(L"Inlining occurred! Inliner=" << GetFunctionIDName(callerId) << L" Inlinee=" << calleeName << L" Inlinee module name=" << moduleName);
+    return S_OK;
+}
+
+
+HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
+{
+    if (result == COR_PRF_CACHED_FUNCTION_FOUND)
+    {
+        printf("ReJITProfiler::JITCachedFunctionSearchFinished COR_PRF_CACHED_FUNCTION_FOUND\n");
+
+        HRESULT hr;
+        if(FAILED(hr = FunctionSeen(functionId)))
+        {
+            return hr;
+        }
+
+        // TODO: this only looks in the same module as the function, with version bubbles that may
+        // not hold.
+        ModuleID modId = GetModuleIDForFunction(functionId);
+        mdToken methodDef;
+        if (FAILED(hr = pCorProfilerInfo->GetFunctionInfo(functionId, NULL, NULL, &methodDef)))
+        {
+            printf("Call to GetFunctionInfo failed with hr=0x%x\n", hr);
+            return hr;
+        }
+
+        COMPtrHolder<ICorProfilerMethodEnum> pEnum = NULL;
+        if (FAILED(hr = pCorProfilerInfo->EnumNgenModuleMethodsInliningThisMethod(modId, modId, methodDef, NULL, &pEnum)))
+        {
+            printf("Call to EnumNgenModuleMethodsInliningThisMethod failed with hr=0x%x\n", hr);
+            return hr;
+        }
+
+        COR_PRF_METHOD method;
+        while (pEnum->Next(1, &method, NULL) == S_OK)
+        {
+            FunctionID inlinerFuncId;
+            if (FAILED(hr = pCorProfilerInfo->GetFunctionFromToken(method.moduleId,
+                                                                              method.methodId,
+                                                                              &inlinerFuncId)))
+            {
+                printf("Call to GetFunctionFromToken failed with hr=0x%x\n", hr);
+                return hr;
+            }
+
+            AddInlining(inlinerFuncId, functionId);
+        }
+    }
 
     return S_OK;
 }
@@ -289,6 +334,10 @@ void ReJITProfiler::AddInlining(FunctionID inliner, FunctionID inlinee)
     {
         inliners->insert(inliner);
     }
+
+    String calleeName = GetFunctionIDName(inlinee);
+    String moduleName = GetModuleIDName(GetModuleIDForFunction(inlinee));
+    INFO(L"Inlining occurred! Inliner=" << GetFunctionIDName(inliner) << L" Inlinee=" << calleeName << L" Inlinee module name=" << moduleName);
 }
 
 mdMethodDef ReJITProfiler::GetMethodDefForFunction(FunctionID functionId)

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
@@ -49,6 +49,7 @@ private:
 
     HRESULT FunctionSeen(FunctionID func);
 
+    FunctionID GetFunctionIDFromToken(ModuleID module, mdMethodDef token);
     mdMethodDef GetMethodDefForFunction(FunctionID functionId);
     ModuleID GetModuleIDForFunction(FunctionID functionId);
     bool EndsWith(const String &lhs, const String &rhs);

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
@@ -37,6 +37,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock);
     virtual HRESULT STDMETHODCALLTYPE JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock);
     virtual HRESULT STDMETHODCALLTYPE JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline);
+    virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result);
 
     virtual HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock);
     virtual HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl* pFunctionControl);
@@ -45,6 +46,8 @@ public:
 
 private:
     void AddInlining(FunctionID inliner, FunctionID inlinee);
+
+    HRESULT FunctionSeen(FunctionID func);
 
     mdMethodDef GetMethodDefForFunction(FunctionID functionId);
     ModuleID GetModuleIDForFunction(FunctionID functionId);


### PR DESCRIPTION
Fixes #34625
Fixes #34624

The profiler tests use jit events for some synchronization, running them crossgenned causes them to break. Having them test if you can disable crossgen bits with `COR_PRF_DISABLE_ALL_NGEN_IMAGES` is an interesting scenario so I would prefer to fix it this way rather than prevent them running under crossgen.