### PR TITLE
Call `SetParentAssembly` when binding from native manifest

### DIFF
--- a/src/coreclr/src/vm/zapsig.cpp
+++ b/src/coreclr/src/vm/zapsig.cpp
@@ -658,6 +658,7 @@ Module *ZapSig::DecodeModuleFromIndex(Module *fromModule,
                 spec.InitializeSpec(TokenFromRid(index, mdtAssemblyRef),
                                 fromModule->GetNativeAssemblyImport(),
                                 NULL);
+                spec.SetParentAssembly(fromModule->GetDomainAssembly());
                 pAssembly = spec.LoadAssembly(FILE_LOADED);
             }
             fromModule->SetNativeMetadataAssemblyRefInCache(index, pAssembly);


### PR DESCRIPTION
In large version bubble mode, Crossgen2 uses the native manifest table to encode assembly references. When a referenced module is decoded and an `AssemblySpec` is created, set the parent assembly for the bind.

Fixes Loader\binding\tracing\BinderTracingTest.Basic regression, which checks parent assembly is correctly set in the bind result.

Fixes https://github.com/dotnet/runtime/issues/34509
