### PR TITLE
mono.proj: use --build-id=sha1

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -646,8 +646,8 @@
 
     <!-- Linux options -->
     <ItemGroup Condition="'$(TargetsLinux)' == true">
-      <_MonoCFLAGS Include="-Wl,--build-id" />
-      <_MonoCXXFLAGS Include="-Wl,--build-id" />
+      <_MonoCFLAGS Include="-Wl,--build-id=sha1" />
+      <_MonoCXXFLAGS Include="-Wl,--build-id=sha1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(MonoCrossDir)' != '' and ('$(TargetArchitecture)' == 'arm' Or '$(TargetArchitecture)' == 'arm64')">


### PR DESCRIPTION
To mirror what the coreclr/libraries builds are using