### PR TITLE
System.Net.Http ref sources regenerated.

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -268,7 +268,7 @@ namespace System.Net.Http
         public bool AllowAutoRedirect { get { throw null; } set { } }
         public System.Net.DecompressionMethods AutomaticDecompression { get { throw null; } set { } }
         public System.TimeSpan ConnectTimeout { get { throw null; } set { } }
-        [System.Diagnostics.CodeAnalysis.AllowNull]
+        [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
         public System.Net.ICredentials? DefaultProxyCredentials { get { throw null; } set { } }
@@ -347,7 +347,7 @@ namespace System.Net.Http.Headers
         public static System.Net.Http.Headers.CacheControlHeaderValue Parse(string? input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.CacheControlHeaderValue? parsedValue) { throw null; }
+        public static bool TryParse(string? input, out System.Net.Http.Headers.CacheControlHeaderValue? parsedValue) { throw null; }
     }
     public partial class ContentDispositionHeaderValue : System.ICloneable
     {
@@ -569,7 +569,7 @@ namespace System.Net.Http.Headers
         public static System.Net.Http.Headers.ProductHeaderValue Parse(string? input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
-        public static bool TryParse(string? input, out System.Net.Http.Headers.ProductHeaderValue? parsedValue) { throw null; }
+        public static bool TryParse(string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.ProductHeaderValue? parsedValue) { throw null; }
     }
     public partial class ProductInfoHeaderValue : System.ICloneable
     {


### PR DESCRIPTION
The dotnet-maestro commit https://github.com/dotnet/runtime/commit/365c91674a32b6b54181c8248c32cf38a85069b2 changed some of the `[NotNullWhen(true)]` attributes of HTTP headers, but it didn't updated the ref sources.
This PR just regenerates the `System.Net.Http.cs`.

This change might be wrong and rather the source classes should be reverted. I'll do that if that's the case.

I also noticed that the ref source generator creates a change in return object nullability in some of the `IClonable.Clone` implementations:
``` C#
public partial class ContentDispositionHeaderValue : System.ICloneable
{
...
    object? System.ICloneable.Clone() { throw null; }
...
}
```
Which must be rolled back by hand since they cannot be compiled ` error CS8616: Nullability of reference types in return type doesn't match implemented member`.

Ping: @buyaa-n @safern 