### PR TITLE
[debugger] Remove assert when the DebuggerTypeProxy cannot be instantiated

### DIFF
--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -6549,7 +6549,8 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 			else {
 				ERROR_DECL (error);
 				this_arg = mono_object_new_checked (domain, m->klass, error);
-				mono_error_assert_ok (error);
+				if (!is_ok (error))
+					return ERR_INVALID_ARGUMENT;
 			}
 		} else {
 			return ERR_INVALID_ARGUMENT;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19542,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Remove the assert because we don't need to stop the debug if we cannot create the object when calling the constructor using invoke_method, if it's a DebuggerTypeProxy, we are not able to show the value of the DebuggerTypeProxy, but we still can show the Raw View, if it's not the case of DebuggerTypeProxy, we just cannot evaluate this expression, but we can continue the debug session.

Fix mono/mono#19492 