### PR TITLE
Fix generation of Crossgen2 zips

### DIFF
--- a/eng/pipelines/installer/jobs/steps/build-linux-package.yml
+++ b/eng/pipelines/installer/jobs/steps/build-linux-package.yml
@@ -32,5 +32,6 @@ steps:
       ${{ parameters.packagingArgs }} \
       $(CommonMSBuildArgs) \
       ${{ parameters.outputRidArg }} \
+      $(LiveOverridePathArgs) \
       /bl:artifacts/log/$(_BuildConfig)/msbuild.${{ parameters.distroRid }}.installers.binlog
   displayName: Package ${{ parameters.packageStepDescription }} - ${{ parameters.distroRid }}

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -99,7 +99,7 @@
     <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(ForceRuntimeIdentifierToBeSet)' == 'true'">
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(EnsureRuntimeIdentifierSet)' == 'true'">
     <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -99,6 +99,10 @@
     <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
+    <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(OutputRid)</TestTargetRid>
   </PropertyGroup>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -99,7 +99,7 @@
     <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == '' and '$(ForceRuntimeIdentifierToBeSet)' == 'true'">
     <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -118,14 +118,9 @@
     <!-- copy crossgen2 -->
     <ItemGroup>
       <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)*" />
-      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
       <Crossgen2Files Include="$(RepoRoot)THIRD-PARTY-NOTICES.TXT" />
       <Crossgen2Files Include="$(RepoRoot)LICENSE.TXT" />
     </ItemGroup>
-    <Message Importance="High" Text="CoreCLRCrossgen2Dir = $(CoreCLRCrossgen2Dir)" />
-    <Message Importance="High" Text="CoreCLRArtifactsPath = $(CoreCLRArtifactsPath)" />
-    <Message Importance="High" Text="RuntimeArtifactsPath = $(RuntimeArtifactsPath)" />
-    <Message Importance="High" Text="Crossgen2Files = @(Crossgen2Files)" />
 
     <Copy Sourcefiles="@(Crossgen2Files)"
           DestinationFolder="$(Crossgen2PublishRoot)%(Crossgen2Files.RecursiveDir)" />

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -125,6 +125,7 @@
     <Message Importance="High" Text="CoreCLRCrossgen2Dir = $(CoreCLRCrossgen2Dir)" />
     <Message Importance="High" Text="CoreCLRArtifactsPath = $(CoreCLRArtifactsPath)" />
     <Message Importance="High" Text="RuntimeArtifactsPath = $(RuntimeArtifactsPath)" />
+    <Message Importance="High" Text="Crossgen2Files = @(Crossgen2Files)" />
 
     <Copy Sourcefiles="@(Crossgen2Files)"
           DestinationFolder="$(Crossgen2PublishRoot)%(Crossgen2Files.RecursiveDir)" />

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -117,10 +117,15 @@
     
     <!-- copy crossgen2 -->
     <ItemGroup>
-      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)\*" />
+      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)*" />
+      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
       <Crossgen2Files Include="$(RepoRoot)THIRD-PARTY-NOTICES.TXT" />
       <Crossgen2Files Include="$(RepoRoot)LICENSE.TXT" />
     </ItemGroup>
+    <Message Importance="High" Text="CoreCLRCrossgen2Dir = $(CoreCLRCrossgen2Dir)" />
+    <Message Importance="High" Text="CoreCLRArtifactsPath = $(CoreCLRArtifactsPath)" />
+    <Message Importance="High" Text="RuntimeArtifactsPath = $(RuntimeArtifactsPath)" />
+
     <Copy Sourcefiles="@(Crossgen2Files)"
           DestinationFolder="$(Crossgen2PublishRoot)%(Crossgen2Files.RecursiveDir)" />
 

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ForceRuntimeIdentifierToBeSet>true</ForceRuntimeIdentifierToBeSet>
+  </PropertyGroup>
   <Import Project="Directory.Build.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -118,6 +118,7 @@
     <!-- copy crossgen2 -->
     <ItemGroup>
       <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)*" />
+      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
       <Crossgen2Files Include="$(RepoRoot)THIRD-PARTY-NOTICES.TXT" />
       <Crossgen2Files Include="$(RepoRoot)LICENSE.TXT" />
     </ItemGroup>

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -118,7 +118,6 @@
     <!-- copy crossgen2 -->
     <ItemGroup>
       <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)*" />
-      <Crossgen2Files Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
       <Crossgen2Files Include="$(RepoRoot)THIRD-PARTY-NOTICES.TXT" />
       <Crossgen2Files Include="$(RepoRoot)LICENSE.TXT" />
     </ItemGroup>

--- a/src/installer/pkg/packaging/installers.proj
+++ b/src/installer/pkg/packaging/installers.proj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ForceRuntimeIdentifierToBeSet>true</ForceRuntimeIdentifierToBeSet>
+    <!-- RuntimeIdentifier must be set or CoreCLRCrossgen2Dir does not get set properly. -->
+    <EnsureRuntimeIdentifierSet>true</EnsureRuntimeIdentifierSet>
   </PropertyGroup>
   <Import Project="Directory.Build.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />


### PR DESCRIPTION
The compressed crossgen2 zip file being created in the current builds are almost empty except for the license details. This fixes the problem by passing the right values into the installer project creation path, as well as setting the `RuntimeIdentifier` property as needed.
