### PR TITLE
[mono] iOS Test runner

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "reportgenerator"
       ]
+    },
+    "microsoft.dotnet.xharness.cli": {
+      "version": "1.0.0-prerelease.20214.1",
+      "commands": [
+        "xharness"
+      ]
     }
   }
 }

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -170,5 +170,9 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>8caef57d1f3bc7a188e5dd26d43a2d34151223f9</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.XHarness.Tests.Runners" Version="1.0.0-prerelease.20214.2">
+      <Uri>https://github.com/dotnet/xharness</Uri>
+      <Sha>b5bfc4fcd431ab1fd560bdea7642c7998e30f24d</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,6 +114,7 @@
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.7.0-preview-20200408-06</MicrosoftNETTestSdkVersion>
+    <MicrosoftDotNetXHarnessTestsRunnersVersion>1.0.0-prerelease.20214.2</MicrosoftDotNetXHarnessTestsRunnersVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <TraceEventVersion>2.0.5</TraceEventVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -3,7 +3,7 @@
     <DefineConstants>$(DefineConstants);XMLSERIALIZERGENERATORTESTS</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <CoverageSupported>false</CoverageSupported>
-    <SkipTestsOnPlatform Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
+    <SkipTestsOnPlatform Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Reuse the same runtimeconfig used by MSBuild. -->

--- a/src/libraries/Native/Unix/System.Native/pal_log.h
+++ b/src/libraries/Native/Unix/System.Native/pal_log.h
@@ -9,6 +9,8 @@
 
 PALEXPORT void SystemNative_Log(uint8_t* buffer, int32_t length);
 
+PALEXPORT int32_t SystemNative_InitializeTerminalAndSignalHandling(void);
+
 // Called by pal_signal.cpp to reinitialize the console on SIGCONT/SIGCHLD.
 void ReinitializeTerminal(void) {}
 void UninitializeTerminal(void) {}

--- a/src/libraries/Native/Unix/System.Native/pal_log.m
+++ b/src/libraries/Native/Unix/System.Native/pal_log.m
@@ -40,3 +40,8 @@ void SystemNative_Log (uint8_t* buffer, int32_t length)
     }
     [msg release];
 }
+
+int32_t SystemNative_InitializeTerminalAndSignalHandling(void)
+{
+    return 0;
+}

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -44,11 +44,11 @@ namespace System
         // underlying API expects only utf-16
         public static void SetConsoleOutputEncoding(Encoding enc) => throw new PlatformNotSupportedException();
 
-        public static bool IsInputRedirectedCore() => true;
+        public static bool IsInputRedirectedCore() => false;
 
-        public static bool IsOutputRedirectedCore() => true;
+        public static bool IsOutputRedirectedCore() => false;
 
-        public static bool IsErrorRedirectedCore() => true;
+        public static bool IsErrorRedirectedCore() => false;
 
         internal static TextReader GetOrCreateReader() => throw new PlatformNotSupportedException();
 

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -44,11 +44,11 @@ namespace System
         // underlying API expects only utf-16
         public static void SetConsoleOutputEncoding(Encoding enc) => throw new PlatformNotSupportedException();
 
-        public static bool IsInputRedirectedCore() => false;
+        public static bool IsInputRedirectedCore() => true;
 
-        public static bool IsOutputRedirectedCore() => false;
+        public static bool IsOutputRedirectedCore() => true;
 
-        public static bool IsErrorRedirectedCore() => false;
+        public static bool IsErrorRedirectedCore() => true;
 
         internal static TextReader GetOrCreateReader() => throw new PlatformNotSupportedException();
 

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -907,8 +907,10 @@
     <PropertyGroup>
       <TestDir>$(ArtifactsDir)bin\$(TestName)\$(NetCoreAppCurrent)-$(Configuration)</TestDir>
       <BclDir>$(ArtifactsDir)bin\runtime\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BclDir>
+      <BundleDir>$(TestDir)\Bundle</BundleDir>
     </PropertyGroup>
     <ItemGroup>
+      <TestBinaries Include="$(TestDir)\*.*"/>
       <AppleTestRunnerBinaries Include="msbuild\AppleTestRunner\bin\*.*" />
       <BclBinaries Include="$(BclDir)\*.*" Exclude="$(BclDir)\System.Runtime.WindowsRuntime.dll" />
       <MonoRuntimeBinaries Include="$(BinDir)\*.*" />
@@ -918,22 +920,25 @@
     <Error Condition="!Exists('$(TestDir)')" Text="TestDir=$(TestDir) doesn't exist" />
     <Error Condition="!Exists('$(BclDir)')" Text="BclDir=$(BclDir) doesn't exist" />
 
-    <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
-    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
-    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
+    <RemoveDir Directories="$(BundleDir)" />
+
+    <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" />
+    <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
 
    <AppleAppBuilderTask 
         Arch="$(TargetArchitecture)"
         ProjectName="$(TestName)"
-        MonoInclude="$(BinDir)include\mono-2.0"
+        MonoRuntimeHeaders="$(BinDir)include\mono-2.0"
         CrossCompiler="$(BinDir)cross\mono-aot-cross"
         MainLibraryFileName="AppleTestRunner.dll"
         UseConsoleUITemplate="True"
         GenerateXcodeProject="True"
         BuildAppBundle="True"
         DevTeamProvisioning="$(DevTeamProvisioning)"
-        OutputDirectory="$(TestDir)\Bundle"
-        AppDir="$(TestDir)">
+        OutputDirectory="$(BundleDir)"
+        AppDir="$(BundleDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
     </AppleAppBuilderTask>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -947,12 +947,15 @@
     <Message Importance="High" Text="App: $(AppBundlePath)"/>
 
     <!-- Demo: use xcrun to deploy & launch on a simulator
-         to be replaced with xharness -->
+         to be replaced with xharness
+         
+         For quite mode: %dashdash%auto-exit before "testlib:" and 'open -a Simulator' can be removed
+    -->
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl shutdown &quot;iPhone 11&quot;" ContinueOnError="WarnAndContinue" />
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl boot &quot;iPhone 11&quot;" />
     <Exec Condition="'$(TargetArchitecture)' == 'x64' and '$(ShowIosSimulator)' != 'false'" Command="open -a Simulator" />
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl install &quot;iPhone 11&quot; $(AppBundlePath)" />
-    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl launch booted net.dot.$(TestName) testlib:$(TestName).dll" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl launch --console booted net.dot.$(TestName) testlib:$(TestName).dll" />
   </Target>
 
   <!-- Ordering matters! Overwriting the Build target. -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -890,8 +890,12 @@
 
   <Import Project="Directory.Build.targets" />
 
+
   <Target Name="BuildAppleAppBuilder">
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AppleAppBuilder\AppleAppBuilder.csproj"
+             Properties="Configuration=$(Configuration)"
+             Targets="Restore;Build" />
+    <MSBuild Projects="$(MonoProjectRoot)msbuild\AppleTestRunner\AppleTestRunner.csproj"
              Properties="Configuration=$(Configuration)"
              Targets="Restore;Build" />
   </Target>
@@ -899,25 +903,50 @@
   <UsingTask TaskName="AppleAppBuilderTask" 
              AssemblyFile="$(ArtifactsObjDir)mono\AppleAppBuilder\$(TargetArchitecture)\$(Configuration)\AppleAppBuilder.dll" />
 
-  <Target Name="BuildAppleApp" DependsOnTargets="BuildAppleAppBuilder">
-    <AppleAppBuilderTask 
+  <Target Name="BuildAppleTestBundle" DependsOnTargets="BuildAppleAppBuilder">
+    <PropertyGroup>
+      <TestDir>$(ArtifactsDir)bin\$(TestName)\$(NetCoreAppCurrent)-$(Configuration)</TestDir>
+      <BclDir>$(ArtifactsDir)bin\runtime\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BclDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <AppleTestRunnerBinaries Include="msbuild\AppleTestRunner\bin\*.*" />
+      <BclBinaries Include="$(BclDir)\*.*" Exclude="$(BclDir)\System.Runtime.WindowsRuntime.dll" />
+      <MonoRuntimeBinaries Include="$(BinDir)\*.*" />
+    </ItemGroup>
+
+    <Error Condition="'$(TestName)' == ''" Text="TestName is not set" />
+    <Error Condition="!Exists('$(TestDir)')" Text="TestDir=$(TestDir) doesn't exist" />
+    <Error Condition="!Exists('$(BclDir)')" Text="BclDir=$(BclDir) doesn't exist" />
+
+    <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(TestDir)\%(RecursiveDir)" />
+
+   <AppleAppBuilderTask 
         Arch="$(TargetArchitecture)"
-        ProjectName="$(ProjectName)"
-        Optimized="$(Optimized)"
+        ProjectName="$(TestName)"
         MonoInclude="$(BinDir)include\mono-2.0"
         CrossCompiler="$(BinDir)cross\mono-aot-cross"
-        MainLibraryFileName="$(MainLibraryFileName)"
-        NativeMainSource="$(NativeMainSource)"
-        GenerateXcodeProject="$(GenerateXcodeProject)"
-        BuildAppBundle="$(BuildAppBundle)"
+        MainLibraryFileName="AppleTestRunner.dll"
+        UseConsoleUITemplate="True"
+        GenerateXcodeProject="True"
+        BuildAppBundle="True"
         DevTeamProvisioning="$(DevTeamProvisioning)"
-        OutputDirectory="$(BinDir)\$(ProjectName)"
-        AppDir="$(AppDir)">
+        OutputDirectory="$(TestDir)\Bundle"
+        AppDir="$(TestDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
     </AppleAppBuilderTask>
     <Message Importance="High" Text="Xcode: $(XcodeProjectPath)"/>
     <Message Importance="High" Text="App: $(AppBundlePath)"/>
+
+    <!-- Demo: use xcrun to deploy & launch on a simulator
+         to be replaced with xharness -->
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl shutdown &quot;iPhone 11&quot;" ContinueOnError="WarnAndContinue" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl boot &quot;iPhone 11&quot;" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="open -a Simulator" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl install &quot;iPhone 11&quot; $(AppBundlePath)" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl launch booted net.dot.$(TestName)" />
   </Target>
 
   <!-- Ordering matters! Overwriting the Build target. -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -944,9 +944,9 @@
          to be replaced with xharness -->
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl shutdown &quot;iPhone 11&quot;" ContinueOnError="WarnAndContinue" />
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl boot &quot;iPhone 11&quot;" />
-    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="open -a Simulator" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64' and '$(ShowIosSimulator)' != 'false'" Command="open -a Simulator" />
     <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl install &quot;iPhone 11&quot; $(AppBundlePath)" />
-    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl launch booted net.dot.$(TestName)" />
+    <Exec Condition="'$(TargetArchitecture)' == 'x64'" Command="xcrun simctl launch booted net.dot.$(TestName) testlib:$(TestName).dll" />
   </Target>
 
   <!-- Ordering matters! Overwriting the Build target. -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -906,6 +906,7 @@
   <Target Name="BuildAppleTestBundle" DependsOnTargets="BuildAppleAppBuilder">
     <PropertyGroup>
       <TestDir>$(ArtifactsDir)bin\$(TestName)\$(NetCoreAppCurrent)-$(Configuration)</TestDir>
+      <TestDir Condition="!Exists('$(TestDir)')">$(ArtifactsDir)bin\$(TestName)\$(NetCoreAppCurrent)-Unix-$(Configuration)</TestDir>
       <BclDir>$(ArtifactsDir)bin\runtime\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BclDir>
       <BundleDir>$(TestDir)\Bundle</BundleDir>
     </PropertyGroup>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -923,10 +923,10 @@
 
     <RemoveDir Directories="$(BundleDir)" />
 
-    <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" />
-    <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
-    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
-    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
 
    <AppleAppBuilderTask 
         Arch="$(TargetArchitecture)"

--- a/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
@@ -54,7 +54,8 @@ internal class AotCompiler
             .Append("dwarfdebug,")
             .Append("outfile=").Append(Path.Combine(binDir, libName + ".dll.s,"))
             .Append("msym-dir=").Append(Path.Combine(binDir, "Msym,"))
-            .Append("data-outfile=").Append(Path.Combine(binDir, libName + ".aotdata,"))
+            // TODO: enable aotdata
+            //.Append("data-outfile=").Append(Path.Combine(binDir, libName + ".aotdata,"))
             //  TODO: enable direct-pinvokes (to get rid of -force_loads)
             //.Append("direct-pinvoke,")
             .Append("full,");

--- a/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
@@ -53,7 +53,7 @@ internal class AotCompiler
             .Append("nodebug,")
             .Append("dwarfdebug,")
             .Append("outfile=").Append(Path.Combine(binDir, libName + ".dll.s,"))
-            .Append("msym-dir=").Append(Path.Combine(binDir, "Msym"))
+            .Append("msym-dir=").Append(Path.Combine(binDir, "Msym,"))
             .Append("data-outfile=").Append(Path.Combine(binDir, libName + ".aotdata,"))
             //  TODO: enable direct-pinvokes (to get rid of -force_loads)
             //.Append("direct-pinvoke,")

--- a/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
@@ -50,11 +50,11 @@ internal class AotCompiler
             .Append("static,")
             .Append("asmonly,")
             .Append("direct-icalls,")
-            .Append("no-direct-calls,")
+            .Append("nodebug,")
             .Append("dwarfdebug,")
             .Append("outfile=").Append(Path.Combine(binDir, libName + ".dll.s,"))
-            //  TODO: enable aotdata
-            //.Append("data-outfile=").Append(Path.Combine(binDir, libName + ".aotdata,"))
+            .Append("msym-dir=").Append(Path.Combine(binDir, "Msym"))
+            .Append("data-outfile=").Append(Path.Combine(binDir, libName + ".aotdata,"))
             //  TODO: enable direct-pinvokes (to get rid of -force_loads)
             //.Append("direct-pinvoke,")
             .Append("full,");

--- a/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
@@ -34,7 +34,7 @@ public class AppleAppBuilderTask : Task
     /// Path to Mono public headers (*.h)
     /// </summary>
     [Required]
-    public string MonoInclude { get; set; } = ""!;
+    public string MonoRuntimeHeaders { get; set; } = ""!;
 
     /// <summary>
     /// This library will be used as an entry-point (e.g. TestRunner.dll)
@@ -165,7 +165,7 @@ public class AppleAppBuilderTask : Task
         if (GenerateXcodeProject)
         {
             XcodeProjectPath = Xcode.GenerateXCode(ProjectName, MainLibraryFileName, 
-                AppDir, binDir, MonoInclude, UseConsoleUITemplate, NativeMainSource);
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, NativeMainSource);
 
             if (BuildAppBundle)
             {

--- a/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
@@ -122,8 +122,10 @@ public class AppleAppBuilderTask : Task
             throw new ArgumentException($"MainLibraryFileName='{MainLibraryFileName}' was not found in AppDir='{AppDir}'");
         }
 
-        // escape spaces
-        ProjectName = ProjectName.Replace(" ", "-");
+        if (ProjectName.Contains(" "))
+        {
+            throw new ArgumentException($"ProjectName='{ProjectName}' should not contain spaces");
+        }
 
         string[] excludes = new string[0];
         if (ExcludeFromAppDir != null)
@@ -179,7 +181,6 @@ public class AppleAppBuilderTask : Task
                         Arch, Optimized, DevTeamProvisioning);
                 }
             }
-            Utils.LogInfo($"Xcode: {XcodeProjectPath}\n App: {AppBundlePath}");
         }
 
         return true;

--- a/src/mono/msbuild/AppleAppBuilder/Templates/main-console.m
+++ b/src/mono/msbuild/AppleAppBuilder/Templates/main-console.m
@@ -34,7 +34,7 @@ UITextView* logLabel;
 
     CGRect applicationFrame = [[UIScreen mainScreen] applicationFrame];
     logLabel = [[UITextView alloc] initWithFrame:
-        CGRectMake(2.0, 50.0, applicationFrame.size.width, applicationFrame.size.height)];
+        CGRectMake(2.0, 50.0, applicationFrame.size.width - 2.0, applicationFrame.size.height - 50.0)];
     logLabel.font = [UIFont systemFontOfSize:9.0];
     logLabel.backgroundColor = [UIColor blackColor];
     logLabel.textColor = [UIColor greenColor];
@@ -43,7 +43,7 @@ UITextView* logLabel;
     logLabel.editable = NO;
     logLabel.clipsToBounds = YES;
 
-    summaryLabel = [[UILabel alloc] initWithFrame: CGRectMake(10.0, 0.0, applicationFrame.size.width, 50)];
+    summaryLabel = [[UILabel alloc] initWithFrame: CGRectMake(10.0, 0.0, applicationFrame.size.width - 10.0, 50)];
     summaryLabel.textColor = [UIColor whiteColor];
     summaryLabel.font = [UIFont boldSystemFontOfSize: 14];
     summaryLabel.numberOfLines = 2;

--- a/src/mono/msbuild/AppleAppBuilder/Templates/main-console.m
+++ b/src/mono/msbuild/AppleAppBuilder/Templates/main-console.m
@@ -80,9 +80,10 @@ mono_ios_append_output (const char* value)
     NSString* nsstr = [NSString stringWithUTF8String:strdup(value)];
     dispatch_async(dispatch_get_main_queue(), ^{
         logLabel.text = [logLabel.text stringByAppendingString:nsstr];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [logLabel scrollRangeToVisible: NSMakeRange(logLabel.text.length -1, 1)];
-        });
+        CGRect caretRect = [logLabel caretRectForPosition:logLabel.endOfDocument];
+        [logLabel scrollRectToVisible:caretRect animated:NO];
+        [logLabel setScrollEnabled:NO];
+        [logLabel setScrollEnabled:YES];
     });
 }
 

--- a/src/mono/msbuild/AppleAppBuilder/Templates/runtime.m
+++ b/src/mono/msbuild/AppleAppBuilder/Templates/runtime.m
@@ -233,6 +233,9 @@ mono_ios_runtime_init (void)
     const char* bundle = get_bundle_path ();
     chdir (bundle);
 
+    // TODO: set TRUSTED_PLATFORM_ASSEMBLIES, APP_PATHS and NATIVE_DLL_SEARCH_DIRECTORIES
+    monovm_initialize(0, NULL, NULL);
+
 #if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
     register_dllmap ();
     // register modules

--- a/src/mono/msbuild/AppleAppBuilder/Templates/runtime.m
+++ b/src/mono/msbuild/AppleAppBuilder/Templates/runtime.m
@@ -233,9 +233,8 @@ mono_ios_runtime_init (void)
     const char* bundle = get_bundle_path ();
     chdir (bundle);
 
-    register_dllmap ();
-
 #if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+    register_dllmap ();
     // register modules
     mono_ios_register_modules ();
     mono_jit_set_aot_mode (MONO_AOT_MODE_FULL);

--- a/src/mono/msbuild/AppleAppBuilder/Xcode.cs
+++ b/src/mono/msbuild/AppleAppBuilder/Xcode.cs
@@ -23,6 +23,7 @@ internal class Xcode
     {
         // bundle everything as resources excluding native files
         string[] excludes = {".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a"};
+
         string[] resources = Directory.GetFiles(workspace)
             .Where(f => !excludes.Any(e => f.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)))
             .Concat(Directory.GetFiles(binDir, "*.aotdata"))

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
@@ -13,13 +13,14 @@ using Microsoft.DotNet.XHarness.Tests.Runners.Core;
 
 public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 {
-    private static List<string> testLibs;
+    private static List<string> testLibs = new List<string>();
 
     public static async Task<int> Main(string[] args)
     {
         // Redirect all Console.WriteLines to iOS UI
         Console.SetOut(new AppleConsole());
-        Console.WriteLine($"ProcessorCount = {Environment.ProcessorCount}")
+        Console.WriteLine($"ProcessorCount = {Environment.ProcessorCount}");
+
         Console.Write("Args: ");
         foreach (string arg in args)
         {
@@ -27,7 +28,6 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
         }
         Console.WriteLine(".");
 
-        testLibs = new List<string>();
         foreach (string arg in args.Where(a => a.StartsWith("testlib:")))
         {
             testLibs.Add(arg.Remove(0, "testlib:".Length));
@@ -62,7 +62,7 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 
     protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies()
     {
-        foreach (string file in testLibs)
+        foreach (string file in testLibs!)
         {
             yield return new TestAssemblyInfo(Assembly.LoadFrom(file), file);
         }
@@ -79,21 +79,21 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 
     protected override TestRunnerType TestRunner => TestRunnerType.Xunit;
 
-    protected override string IgnoreFilesDirectory { get; }
+    protected override string? IgnoreFilesDirectory { get; }
 
     public string BundleIdentifier => "net.dot.test-runner";
 
-    public string UniqueIdentifier { get; }
+    public string? UniqueIdentifier { get; }
 
-    public string Name { get; }
+    public string? Name { get; }
 
-    public string Model { get; }
+    public string? Model { get; }
 
-    public string SystemName { get; }
+    public string? SystemName { get; }
 
-    public string SystemVersion { get; }
+    public string? SystemVersion { get; }
 
-    public string Locale { get; }
+    public string? Locale { get; }
 }
 
 internal class AppleConsole : TextWriter

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using Microsoft.DotNet.XHarness.Tests.Runners;
+using Microsoft.DotNet.XHarness.Tests.Runners.Core;
+
+public class AppleConsole : TextWriter
+{
+    public override Encoding Encoding => Encoding.Default;
+
+    [DllImport("__Internal")]
+    public extern static void mono_ios_append_output (string value);
+
+    [DllImport("__Internal")]
+    public extern static void mono_ios_set_summary (string value);
+
+    public override void Write(string? value)
+    {
+        if (value != null)
+        {
+            mono_ios_append_output(value);
+        }
+    }
+}
+
+public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
+{
+    private static string[] testLibs;
+
+    public static async Task<int> Main(string[] args)
+    {
+        // Redirect all Console.WriteLines to iOS UI
+        Console.SetOut(new AppleConsole());
+
+        Console.Write("Args: ");
+        foreach (string arg in args)
+        {
+            Console.Write(arg);
+        }
+        Console.WriteLine(".");
+
+        testLibs = Directory.GetFiles(Environment.CurrentDirectory, "*.Tests.dll");
+        if (testLibs.Length < 1)
+        {
+            Console.WriteLine("Test libs were not found (*.Tests.dll)");
+            return -1;
+        }
+
+        Console.Write("Test libs: ");
+        foreach (string testLib in testLibs)
+        {
+            Console.WriteLine(testLib);
+        }
+        Console.WriteLine(".");
+
+        AppleConsole.mono_ios_set_summary($"Running\n{Path.GetFileName(testLibs[0])} tests...");
+        var simpleTestRunner = new SimpleTestRunner();
+        await simpleTestRunner.RunAsync();
+        AppleConsole.mono_ios_set_summary("Done.");
+        Console.WriteLine("----- Done -----");
+        return 0;
+    }
+
+    protected override IEnumerable<TestAssemblyInfo> GetTestAssemblies()
+    {
+        foreach (string file in testLibs)
+        {
+            yield return new TestAssemblyInfo(Assembly.LoadFrom(file), file);
+        }
+    }
+
+    protected override void TerminateWithSuccess()
+    {
+        Console.WriteLine("[TerminateWithSuccess]");
+    }
+
+    protected override int? MaxParallelThreads => 4;
+    protected override IDevice Device => this;
+    protected override TestRunnerType TestRunner => TestRunnerType.Xunit;
+    protected override string IgnoreFilesDirectory { get; }
+
+    public string BundleIdentifier => "net.dot.test-runner";
+    public string UniqueIdentifier { get; }
+    public string Name { get; }
+    public string Model { get; }
+    public string SystemName { get; }
+    public string SystemVersion { get; }
+    public string Locale { get; }
+}

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
@@ -11,25 +11,6 @@ using System.Runtime.CompilerServices;
 using Microsoft.DotNet.XHarness.Tests.Runners;
 using Microsoft.DotNet.XHarness.Tests.Runners.Core;
 
-public class AppleConsole : TextWriter
-{
-    public override Encoding Encoding => Encoding.Default;
-
-    [DllImport("__Internal")]
-    public extern static void mono_ios_append_output (string value);
-
-    [DllImport("__Internal")]
-    public extern static void mono_ios_set_summary (string value);
-
-    public override void Write(string? value)
-    {
-        if (value != null)
-        {
-            mono_ios_append_output(value);
-        }
-    }
-}
-
 public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 {
     private static List<string> testLibs;
@@ -38,7 +19,7 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
     {
         // Redirect all Console.WriteLines to iOS UI
         Console.SetOut(new AppleConsole());
-
+        Console.WriteLine($"ProcessorCount = {Environment.ProcessorCount}")
         Console.Write("Args: ");
         foreach (string arg in args)
         {
@@ -92,16 +73,44 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
         Console.WriteLine("[TerminateWithSuccess]");
     }
 
-    protected override int? MaxParallelThreads => 4;
+    protected override int? MaxParallelThreads => Environment.ProcessorCount;
+
     protected override IDevice Device => this;
+
     protected override TestRunnerType TestRunner => TestRunnerType.Xunit;
+
     protected override string IgnoreFilesDirectory { get; }
 
     public string BundleIdentifier => "net.dot.test-runner";
+
     public string UniqueIdentifier { get; }
+
     public string Name { get; }
+
     public string Model { get; }
+
     public string SystemName { get; }
+
     public string SystemVersion { get; }
+
     public string Locale { get; }
+}
+
+internal class AppleConsole : TextWriter
+{
+    public override Encoding Encoding => Encoding.Default;
+
+    [DllImport("__Internal")]
+    public extern static void mono_ios_append_output (string value);
+
+    [DllImport("__Internal")]
+    public extern static void mono_ios_set_summary (string value);
+
+    public override void Write(string? value)
+    {
+        if (value != null)
+        {
+            mono_ios_append_output(value);
+        }
+    }
 }

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
@@ -60,7 +60,7 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 
         if (testLibs.Count < 1)
         {
-            Console.WriteLine("Test libs were not found (*.Tests.dll)");
+            Console.WriteLine($"Test libs were not found (*.Tests.dll was not found in {Environment.CurrentDirectory})");
             return -1;
         }
 

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.cs
@@ -32,7 +32,7 @@ public class AppleConsole : TextWriter
 
 public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
 {
-    private static string[] testLibs;
+    private static List<string> testLibs;
 
     public static async Task<int> Main(string[] args)
     {
@@ -46,8 +46,19 @@ public class SimpleTestRunner : iOSApplicatonEntryPoint, IDevice
         }
         Console.WriteLine(".");
 
-        testLibs = Directory.GetFiles(Environment.CurrentDirectory, "*.Tests.dll");
-        if (testLibs.Length < 1)
+        testLibs = new List<string>();
+        foreach (string arg in args.Where(a => a.StartsWith("testlib:")))
+        {
+            testLibs.Add(arg.Remove(0, "testlib:".Length));
+        }
+
+        if (testLibs.Count < 1)
+        {
+            // Look for *.Tests.dll files if target test suites are not set via "testlib:" arguments
+            testLibs = Directory.GetFiles(Environment.CurrentDirectory, "*.Tests.dll").ToList();
+        }
+
+        if (testLibs.Count < 1)
         {
             Console.WriteLine("Test libs were not found (*.Tests.dll)");
             return -1;

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <OutputPath>bin</OutputPath>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="1.0.0-prerelease.20214.1" />
+  </ItemGroup>
+</Project>

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
@@ -3,9 +3,8 @@
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="1.0.0-prerelease.20214.1" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It's currently WIP, it doesn't use runtime packs yet but it's already possible to run any test suite (well, any without remote-executor based tests inside, see https://github.com/dotnet/arcade/issues/5129 such tests usually have `<IncludeRemoteExecutor>true</IncludeRemoteExecutor>` inside csprojs). It uses dotnet/xharness test runner, copies everything including the whole BCL into a test folder and runs the AOT/Bundle generation.
  
Steps to run a test suite:
```sh
# make sure everything is built for iOS (can be arm64 instead of x64 for devices and fullAOT)
./build.sh -c Release -os iOS -arch x64 -subset Mono+Libs+Libs.Tests /p:DisableCrossgen=true

# TestName can be any test suite, e.g. System.Collections.Tests
./dotnet.sh msbuild src/mono/mono.proj /t:BuildAppleTestBundle \
/p:Configuration=Release /p:TestName=System.Buffers.Tests \
/p:TargetOS=iOS /p:TargetArchitecture=x64
```
for x64 it should build everything and launch an iphone simulator with tests. For arm64 devices it needs `xharness` tool (with `mlaunch` inside - it's not yet there) and a provisioning profile.
If you want to try arm64 now you can run the script above ^ (replace x64 with arm64) and open the xcode project (generated) and deploy to a personal device with auto-generated provisioning. Some tests might crash on arm64, e.g.:
```
Assertion at /Users/egorbo/prj/runtime-3/src/mono/mono/metadata/class.c:1845, 
condition `method->is_inflated' not met
```
or some missing *aotdata stuff. Arm64 needs some work.

![image](https://user-images.githubusercontent.com/523221/79280119-3e264880-7eb8-11ea-8174-e4ffd69b09c5.png)

I guess the expected workflow is the following:
```
cd src/libraries/System.Buffers/tests
dotnet publish -c Release -r ios-x64
dotnet tool xharness test ios --app path/to/app/bunndle.app
```