### PR TITLE
Fix small install_clr issue that creates 'in' folder in output path

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -338,7 +338,7 @@ function(install_clr)
     if (NOT DEFINED CLR_CROSS_COMPONENTS_LIST OR NOT ${INDEX} EQUAL -1)
         strip_symbols(${targetName} symbol_file)
 
-        foreach(destination in ${destinations})
+        foreach(destination ${destinations})
           # We don't need to install the export libraries for our DLLs
           # since they won't be directly linked against.
           install(PROGRAMS $<TARGET_FILE:${targetName}> DESTINATION ${destination})


### PR DESCRIPTION
I've noticed the directory always ends up having a `artifacts/bin/coreclr/.../in` and `artifacts/bin/coreclr/.../sharedFramework/in` folders. This fixes that.