### PR TITLE
Fix assert while logging typeload failures

### DIFF
--- a/src/coreclr/src/vm/clsload.cpp
+++ b/src/coreclr/src/vm/clsload.cpp
@@ -3955,7 +3955,7 @@ retry:
     }
     EX_HOOK
     {
-        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->ComputeHash(), pTypeKey->GetModule()));
+        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->IsConstructed() ? pTypeKey->ComputeHash() : pTypeKey->GetTypeToken(), pTypeKey->GetModule()));
 
         if (!GetThread()->HasThreadStateNC(Thread::TSNC_LoadsTypeViolation))
         {

--- a/src/coreclr/src/vm/clsload.cpp
+++ b/src/coreclr/src/vm/clsload.cpp
@@ -3955,7 +3955,7 @@ retry:
     }
     EX_HOOK
     {
-        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->GetTypeToken(), pTypeKey->GetModule()));
+        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->ComputeHash(), pTypeKey->GetModule()));
 
         if (!GetThread()->HasThreadStateNC(Thread::TSNC_LoadsTypeViolation))
         {


### PR DESCRIPTION
Fix for this issue: https://github.com/dotnet/runtime/issues/33536
the log message as part of the type violation exception uses `pTypeKey->GetTypeToken()` which asserts `m_kind == ELEMENT_TYPE_CLASS` which fails for arrays, fnptr. Changing it to Hash instead. 