### PR TITLE
Fix store/load float LCL_FIELD with unaligned offsets on arm32.

### DIFF
--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1004,10 +1004,10 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     assert(!data->isContained());
     genConsumeReg(data);
     regNumber dataReg = data->GetRegNum();
-    if (varTypeIsFloating(targetType) && ((offset % emitTypeSize(TYP_FLOAT)) != 0))
+    if (tree->IsOffsetMisaligned())
     {
         // Arm supports unaligned access only for integer types,
-        // convert the storing floating data into 2 integer registers and write them as int.
+        // convert the storing floating data into 1 or 2 integer registers and write them as int.
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offset);
         if (targetType == TYP_FLOAT)

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1004,7 +1004,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     assert(!data->isContained());
     genConsumeReg(data);
     regNumber dataReg = data->GetRegNum();
-    if (varTypeIsFloating(targetType) && ((offset % emitTypeSize(tree)) != 0))
+    if (varTypeIsFloating(targetType) && ((offset % emitTypeSize(TYP_FLOAT)) != 0))
     {
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offset);

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -999,7 +999,6 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
 
     GenTree* data = tree->gtOp1;
-    emitAttr attr = emitTypeSize(targetType);
 
     assert(!data->isContained());
     genConsumeReg(data);
@@ -1009,7 +1008,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
         // Arm supports unaligned access only for integer types,
         // convert the storing floating data into 1 or 2 integer registers and write them as int.
         regNumber addr = tree->ExtractTempReg();
-        emit->emitIns_R_S(INS_lea, attr, addr, varNum, offset);
+        emit->emitIns_R_S(INS_lea, EA_PTRSIZE, addr, varNum, offset);
         if (targetType == TYP_FLOAT)
         {
             regNumber floatAsInt = tree->GetSingleTempReg();
@@ -1027,7 +1026,8 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     }
     else
     {
-        instruction ins = ins_Store(targetType);
+        emitAttr    attr = emitTypeSize(targetType);
+        instruction ins  = ins_Store(targetType);
         emit->emitIns_S_R(ins, attr, dataReg, varNum, offset);
     }
 

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1006,6 +1006,8 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     regNumber dataReg = data->GetRegNum();
     if (varTypeIsFloating(targetType) && ((offset % emitTypeSize(TYP_FLOAT)) != 0))
     {
+        // Arm supports unaligned access only for integer types,
+        // convert the storing floating data into 2 integer registers and write them as int.
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offset);
         if (targetType == TYP_FLOAT)

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1786,6 +1786,8 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
 #ifdef TARGET_ARM
     if (varTypeIsFloating(targetType) && ((offs % emitTypeSize(TYP_FLOAT)) != 0))
     {
+        // Arm supports unaligned access only for integer types,
+        // load the floating data as 2 integer registers and convert them to float.
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offs);
 

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1784,7 +1784,7 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     instruction ins  = ins_Load(targetType);
 
 #ifdef TARGET_ARM
-    if (varTypeIsFloating(targetType) && ((offs % emitTypeSize(tree)) != 0))
+    if (varTypeIsFloating(targetType) && ((offs % emitTypeSize(TYP_FLOAT)) != 0))
     {
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offs);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1775,7 +1775,6 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     NYI_IF(targetType == TYP_STRUCT, "GT_LCL_FLD: struct load local field not supported");
     assert(targetReg != REG_NA);
 
-    emitAttr size   = emitTypeSize(targetType);
     unsigned offs   = tree->GetLclOffs();
     unsigned varNum = tree->GetLclNum();
     assert(varNum < compiler->lvaCount);
@@ -1784,10 +1783,10 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     instruction ins  = ins_Load(targetType);
 
 #ifdef TARGET_ARM
-    if (varTypeIsFloating(targetType) && ((offs % emitTypeSize(TYP_FLOAT)) != 0))
+    if (tree->IsOffsetMisaligned())
     {
         // Arm supports unaligned access only for integer types,
-        // load the floating data as 2 integer registers and convert them to float.
+        // load the floating data as 1 or 2 integer registers and convert them to float.
         regNumber addr = tree->ExtractTempReg();
         emit->emitIns_R_S(INS_lea, attr, addr, varNum, offs);
 

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1779,16 +1779,13 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     unsigned varNum = tree->GetLclNum();
     assert(varNum < compiler->lvaCount);
 
-    emitAttr    attr = emitActualTypeSize(targetType);
-    instruction ins  = ins_Load(targetType);
-
 #ifdef TARGET_ARM
     if (tree->IsOffsetMisaligned())
     {
         // Arm supports unaligned access only for integer types,
         // load the floating data as 1 or 2 integer registers and convert them to float.
         regNumber addr = tree->ExtractTempReg();
-        emit->emitIns_R_S(INS_lea, attr, addr, varNum, offs);
+        emit->emitIns_R_S(INS_lea, EA_PTRSIZE, addr, varNum, offs);
 
         if (targetType == TYP_FLOAT)
         {
@@ -1804,12 +1801,12 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
             emit->emitIns_R_R_I(INS_ldr, EA_4BYTE, halfdoubleAsInt2, addr, 4);
             emit->emitIns_R_R_R(INS_vmov_i2d, EA_8BYTE, targetReg, halfdoubleAsInt1, halfdoubleAsInt2);
         }
-
-        emit->emitIns_R_R(ins, attr, targetReg, addr);
     }
     else
 #endif // TARGET_ARM
     {
+        emitAttr    attr = emitActualTypeSize(targetType);
+        instruction ins  = ins_Load(targetType);
         emit->emitIns_R_S(ins, attr, targetReg, varNum, offs);
     }
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -19099,3 +19099,20 @@ regNumber GenTree::ExtractTempReg(regMaskTP mask /* = (regMaskTP)-1 */)
     gtRsvdRegs &= ~tempRegMask;
     return genRegNumFromMask(tempRegMask);
 }
+
+#ifdef TARGET_ARM
+//------------------------------------------------------------------------
+// IsOffsetMisaligned: check if the field needs a special handling on arm.
+//
+// Return Value:
+//    true if it is a float field with a misaligned offset, false otherwise.
+//
+bool GenTreeLclFld::IsOffsetMisaligned() const
+{
+    if (varTypeIsFloating(gtType))
+    {
+        return ((m_lclOffs % emitTypeSize(TYP_FLOAT)) != 0);
+    }
+    return false;
+}
+#endif // TARGET_ARM

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3376,6 +3376,10 @@ public:
         m_fieldSeq = fieldSeq;
     }
 
+#ifdef TARGET_ARM
+    bool IsOffsetMisaligned() const;
+#endif // TARGET_ARM
+
 #if DEBUGGABLE_GENTREE
     GenTreeLclFld() : GenTreeLclVarCommon()
     {

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -242,7 +242,7 @@ int LinearScan::BuildNode(GenTree* tree)
             {
                 GenTreeLclFld* fld    = lclVar->AsLclFld();
                 uint16_t       offset = fld->GetLclOffs();
-                if ((offset % emitTypeSize(fieldType)) != 0)
+                if ((offset % emitTypeSize(TYP_FLOAT)) != 0)
                 {
                     buildInternalIntRegisterDefForNode(fld); // to generate address.
                     buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -237,21 +237,15 @@ int LinearScan::BuildNode(GenTree* tree)
                 return 0;
             }
 
-            var_types fieldType = lclVar->TypeGet();
-            if (lclVar->OperIs(GT_LCL_FLD) && varTypeIsFloating(fieldType))
+            if (lclVar->OperIs(GT_LCL_FLD) && lclVar->AsLclFld()->IsOffsetMisaligned())
             {
-                GenTreeLclFld* fld    = lclVar->AsLclFld();
-                uint16_t       offset = fld->GetLclOffs();
-                if ((offset % emitTypeSize(TYP_FLOAT)) != 0)
+                buildInternalIntRegisterDefForNode(lclVar); // to generate address.
+                buildInternalIntRegisterDefForNode(lclVar); // to move float into an int reg.
+                if (lclVar->TypeIs(TYP_DOUBLE))
                 {
-                    buildInternalIntRegisterDefForNode(fld); // to generate address.
-                    buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.
-                    if (fieldType == TYP_DOUBLE)
-                    {
-                        buildInternalIntRegisterDefForNode(fld); // to move the second half into an int reg.
-                    }
-                    buildInternalRegisterUses();
+                    buildInternalIntRegisterDefForNode(lclVar); // to move the second half into an int reg.
                 }
+                buildInternalRegisterUses();
             }
 
             srcCount = 0;

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -230,11 +230,30 @@ int LinearScan::BuildNode(GenTree* tree)
             // is processed, unless this is marked "isLocalDefUse" because it is a stack-based argument
             // to a call or an orphaned dead node.
             //
-            LclVarDsc* const varDsc = &compiler->lvaTable[tree->AsLclVarCommon()->GetLclNum()];
+            GenTreeLclVarCommon* const lclVar = tree->AsLclVarCommon();
+            LclVarDsc* const           varDsc = compiler->lvaGetDesc(lclVar);
             if (isCandidateVar(varDsc))
             {
                 return 0;
             }
+
+            var_types fieldType = lclVar->TypeGet();
+            if (lclVar->OperIs(GT_LCL_FLD) && varTypeIsFloating(fieldType))
+            {
+                GenTreeLclFld* fld    = lclVar->AsLclFld();
+                uint16_t       offset = fld->GetLclOffs();
+                if ((offset % emitTypeSize(fieldType)) != 0)
+                {
+                    buildInternalIntRegisterDefForNode(fld); // to generate address.
+                    buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.
+                    if (fieldType == TYP_DOUBLE)
+                    {
+                        buildInternalIntRegisterDefForNode(fld); // to move the second half into an int reg.
+                    }
+                    buildInternalRegisterUses();
+                }
+            }
+
             srcCount = 0;
             BuildDef(tree);
         }

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3123,6 +3123,25 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     buildInternalRegisterUses();
 #endif // FEATURE_SIMD
 
+#ifdef TARGET_ARM
+
+    var_types fieldType = storeLoc->TypeGet();
+    if (storeLoc->OperIs(GT_STORE_LCL_FLD) && varTypeIsFloating(fieldType))
+    {
+        GenTreeLclFld* fld    = storeLoc->AsLclFld();
+        uint16_t       offset = fld->GetLclOffs();
+        if ((offset % emitTypeSize(fieldType)) != 0)
+        {
+            buildInternalIntRegisterDefForNode(fld); // to generate address.
+            buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.
+            if (fieldType == TYP_DOUBLE)
+            {
+                buildInternalIntRegisterDefForNode(fld); // to move the second half into an int reg.
+            }
+        }
+    }
+#endif // TARGET_ARM
+
     // Fourth, define destination registers.
 
     // Add the lclVar to currentLiveVars (if it will remain live)

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3120,20 +3120,13 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
 
 // Third, use internal registers.
 #ifdef TARGET_ARM
-
-    var_types fieldType = storeLoc->TypeGet();
-    if (storeLoc->OperIs(GT_STORE_LCL_FLD) && varTypeIsFloating(fieldType))
+    if (storeLoc->OperIs(GT_STORE_LCL_FLD) && storeLoc->AsLclFld()->IsOffsetMisaligned())
     {
-        GenTreeLclFld* fld    = storeLoc->AsLclFld();
-        uint16_t       offset = fld->GetLclOffs();
-        if ((offset % emitTypeSize(TYP_FLOAT)) != 0)
+        buildInternalIntRegisterDefForNode(storeLoc); // to generate address.
+        buildInternalIntRegisterDefForNode(storeLoc); // to move float into an int reg.
+        if (storeLoc->TypeIs(TYP_DOUBLE))
         {
-            buildInternalIntRegisterDefForNode(fld); // to generate address.
-            buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.
-            if (fieldType == TYP_DOUBLE)
-            {
-                buildInternalIntRegisterDefForNode(fld); // to move the second half into an int reg.
-            }
+            buildInternalIntRegisterDefForNode(storeLoc); // to move the second half into an int reg.
         }
     }
 #endif // TARGET_ARM

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3130,7 +3130,7 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     {
         GenTreeLclFld* fld    = storeLoc->AsLclFld();
         uint16_t       offset = fld->GetLclOffs();
-        if ((offset % emitTypeSize(fieldType)) != 0)
+        if ((offset % emitTypeSize(TYP_FLOAT)) != 0)
         {
             buildInternalIntRegisterDefForNode(fld); // to generate address.
             buildInternalIntRegisterDefForNode(fld); // to move float into an int reg.

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3119,10 +3119,6 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     }
 
 // Third, use internal registers.
-#ifdef FEATURE_SIMD
-    buildInternalRegisterUses();
-#endif // FEATURE_SIMD
-
 #ifdef TARGET_ARM
 
     var_types fieldType = storeLoc->TypeGet();
@@ -3141,6 +3137,10 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
         }
     }
 #endif // TARGET_ARM
+
+#if defined(FEATURE_SIMD) || defined(TARGET_ARM)
+    buildInternalRegisterUses();
+#endif // FEATURE_SIMD || TARGET_ARM
 
     // Fourth, define destination registers.
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13027,6 +13027,22 @@ DONE_MORPHING_CHILDREN:
                 }
                 else if (op1->OperGet() == GT_ADD)
                 {
+#ifdef TARGET_ARM
+                    // Check for a misalignment floating point indirection.
+                    if (varTypeIsFloating(typ))
+                    {
+                        GenTree* addOp2 = op1->AsOp()->gtGetOp2();
+                        if (addOp2->IsCnsIntOrI())
+                        {
+                            ssize_t offset = addOp2->AsIntCon()->gtIconVal;
+                            if ((offset % emitTypeSize(TYP_FLOAT)) != 0)
+                            {
+                                tree->gtFlags |= GTF_IND_UNALIGNED;
+                            }
+                        }
+                    }
+#endif // TARGET_ARM
+
                     /* Try to change *(&lcl + cns) into lcl[cns] to prevent materialization of &lcl */
 
                     if (op1->AsOp()->gtOp1->OperGet() == GT_ADDR && op1->AsOp()->gtOp2->OperGet() == GT_CNS_INT &&
@@ -13076,19 +13092,6 @@ DONE_MORPHING_CHILDREN:
                             {
                                 break;
                             }
-
-#ifdef TARGET_ARM
-                            // Check for a LclVar TYP_STRUCT with misalignment on a Floating Point field
-                            //
-                            if (varTypeIsFloating(typ))
-                            {
-                                if ((ival1 % emitTypeSize(TYP_FLOAT)) != 0)
-                                {
-                                    tree->gtFlags |= GTF_IND_UNALIGNED;
-                                    break;
-                                }
-                            }
-#endif
                         }
                         // Now we can fold this into a GT_LCL_FLD below
                         //   where we check (temp != nullptr)

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -13082,7 +13082,7 @@ DONE_MORPHING_CHILDREN:
                             //
                             if (varTypeIsFloating(typ))
                             {
-                                if ((ival1 % emitTypeSize(typ)) != 0)
+                                if ((ival1 % emitTypeSize(TYP_FLOAT)) != 0)
                                 {
                                     tree->gtFlags |= GTF_IND_UNALIGNED;
                                     break;

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -398,9 +398,6 @@
 
     <!-- Windows arm32 specific excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/explicit/coverage/expl_float_1_*/*">
-            <Issue>https://github.com/dotnet/runtime/issues/34170</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/Primitives/NETClientPrimitives/*">
             <Issue>https://github.com/dotnet/runtime/issues/11360</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct FloatNonAlignedFieldWithSmallOffset
+{
+    [FieldOffset(1)]
+    public float field;
+
+    public FloatNonAlignedFieldWithSmallOffset(float a)
+    {
+        field = a;
+    }
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct FloatNonAlignedFieldWithLargeOffset
+{
+    [FieldOffset(1021)]
+    public float field;
+
+    public FloatNonAlignedFieldWithLargeOffset(float a)
+    {
+        field = a;
+    }
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct DoubleNonAlignedFieldWithSmallOffset
+{
+    [FieldOffset(1)]
+    public double field;
+
+    public DoubleNonAlignedFieldWithSmallOffset(float a)
+    {
+        field = a;
+    }
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct DoubleNonAlignedFieldWithLargeOffset
+{
+    [FieldOffset(1021)]
+    public double field;
+
+    public DoubleNonAlignedFieldWithLargeOffset(float a)
+    {
+        field = a;
+    }
+}
+
+struct SimpleStruct
+{
+    // the field is aligned inside SimpleStruct.
+    public float field;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+internal struct StructNonAlignedField
+{
+    // SimpleStruct is unaligned, so the result offset to its float field is unaligned.
+    [FieldOffset(1)]
+    public SimpleStruct field;
+
+    public StructNonAlignedField(float a)
+    {
+        field.field = a;
+    }
+}
+
+class Test
+{
+    private static unsafe int Main()
+    {
+        
+        var a = new FloatNonAlignedFieldWithSmallOffset(1);
+        Debug.Assert(a.field == 1);
+        Console.WriteLine(a.field);
+        var b = new FloatNonAlignedFieldWithLargeOffset(1);
+        Debug.Assert(b.field == 1);
+        Console.WriteLine(b.field);
+
+        var c = new DoubleNonAlignedFieldWithSmallOffset(1);
+        Debug.Assert(c.field == 1);
+        Console.WriteLine(c.field);
+        var d = new DoubleNonAlignedFieldWithLargeOffset(1);
+        Debug.Assert(d.field == 1);
+        Console.WriteLine(d.field);
+        
+        var e = new StructNonAlignedField(1);
+        Debug.Assert(e.field.field == 1);
+        Console.WriteLine(e.field.field);
+
+        return 100;
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Use lea to instantiate LCL_VAR address in a register.

Also, after the change we have better code size for the test, before lclmorph regression change:
```
IN0003: 000024  4B      addw    r3, sp, 0x828	// [V00 loc0]
IN0004: 000028  2B      adds    r3, r3, 1
```
now:
```
IN0003: 000024  4B      addw    r3, sp, 0x829
```

Commits:
feb321aafeb: Add an additional test for the issue.
cecd8e466bc: Reenable the test.
b91991bae2d: Fix arm32 access to unaligned float fields.

Fixes #34170.