### PR TITLE
Throw DirectoryNotFoundException on Image.Save with bad directory

### DIFF
--- a/src/libraries/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/libraries/System.Drawing.Common/src/Resources/Strings.resx
@@ -456,6 +456,6 @@
     <value>The value of the {0} property is not one of the {1} values</value>
   </data>
   <data name="TargetDirectoryDoesNotExist" xml:space="preserve">
-    <value>The target directory {0} of the targetPath {1} does not exist.</value>
+    <value>The directory {0} of the filename {1} does not exist.</value>
   </data>
 </root>

--- a/src/libraries/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/libraries/System.Drawing.Common/src/Resources/Strings.resx
@@ -455,4 +455,7 @@
   <data name="ValueNotOneOfValues" xml:space="preserve">
     <value>The value of the {0} property is not one of the {1} values</value>
   </data>
+  <data name="TargetDirectoryDoesNotExist" xml:space="preserve">
+    <value>The target directory {0} of the targetPath {1} does not exist.</value>
+  </data>
 </root>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
@@ -192,7 +192,7 @@ namespace System.Drawing
             if (filename == null)
                 throw new ArgumentNullException(nameof(filename));
 
-            CheckDirectoryExists(filename);
+            ThrowIfDirectoryDoesntExist(filename);
 
             int st;
             Guid guid = encoder.Clsid;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
@@ -189,6 +189,11 @@ namespace System.Drawing
 
         public void Save(string filename, ImageCodecInfo encoder, EncoderParameters? encoderParams)
         {
+            if (filename == null)
+                throw new ArgumentNullException(nameof(filename));
+            
+            CheckDirectoryExists(filename);
+
             int st;
             Guid guid = encoder.Clsid;
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
@@ -191,7 +191,7 @@ namespace System.Drawing
         {
             if (filename == null)
                 throw new ArgumentNullException(nameof(filename));
-            
+
             CheckDirectoryExists(filename);
 
             int st;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -135,7 +135,7 @@ namespace System.Drawing
             if (encoder == null)
                 throw new ArgumentNullException(nameof(encoder));
 
-            CheckDirectoryExists(filename);
+            ThrowIfDirectoryDoesntExist(filename);
 
             IntPtr encoderParamsMemory = IntPtr.Zero;
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -135,6 +135,8 @@ namespace System.Drawing
             if (encoder == null)
                 throw new ArgumentNullException(nameof(encoder));
 
+            CheckDirectoryExists(filename);
+
             IntPtr encoderParamsMemory = IntPtr.Zero;
 
             if (encoderParams != null)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -151,7 +151,16 @@ namespace System.Drawing
         /// <summary>
         /// Saves this <see cref='Image'/> to the specified file.
         /// </summary>
-        public void Save(string filename) => Save(filename, RawFormat);
+        public void Save(string filename)
+        {
+            var directoryPart = System.IO.Path.GetDirectoryName(filename);
+            if (!System.IO.Directory.Exists(directoryPart))
+            {
+                throw new DirectoryNotFoundException(SR.Format(SR.TargetDirectoryDoesNotExist, directoryPart, filename));
+            }
+
+            Save(filename, RawFormat);
+        }
 
         /// <summary>
         /// Gets the width and height of this <see cref='Image'/>.

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -153,7 +153,7 @@ namespace System.Drawing
         /// </summary>
         public void Save(string filename) => Save(filename, RawFormat);
 
-        private static void CheckDirectoryExists(string filename)
+        private static void ThrowIfDirectoryDoesntExist(string filename)
         {
             var directoryPart = System.IO.Path.GetDirectoryName(filename);
             if (!string.IsNullOrEmpty(directoryPart) && !System.IO.Directory.Exists(directoryPart))

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -151,15 +151,15 @@ namespace System.Drawing
         /// <summary>
         /// Saves this <see cref='Image'/> to the specified file.
         /// </summary>
-        public void Save(string filename)
+        public void Save(string filename) => Save(filename, RawFormat);
+
+        private static void CheckDirectoryExists(string filename)
         {
             var directoryPart = System.IO.Path.GetDirectoryName(filename);
-            if (!System.IO.Directory.Exists(directoryPart))
+            if (!string.IsNullOrEmpty(directoryPart) && !System.IO.Directory.Exists(directoryPart))
             {
                 throw new DirectoryNotFoundException(SR.Format(SR.TargetDirectoryDoesNotExist, directoryPart, filename));
             }
-
-            Save(filename, RawFormat);
         }
 
         /// <summary>

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -202,7 +202,7 @@ namespace System.Drawing.Tests
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws ExternalException")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Save_InvalidDirecotry_ThrowsDirectoryNotFoundException()
+        public void Save_InvalidDirectory_ThrowsDirectoryNotFoundException()
         {
             using (var bitmap = new Bitmap(1, 1))
             {

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -206,7 +206,7 @@ namespace System.Drawing.Tests
             using (var bitmap = new Bitmap(1, 1))
             {
                 var badTarget = System.IO.Path.Combine("NoSuchDirectory", "NoSuchFile");
-                AssertExtensions.Throws<DirectoryNotFoundException>(() => bitmap.Save(badTarget), @"The directory NoSuchDirectory of the filename NoSuchDirectory\NoSuchFile does not exist.");
+                AssertExtensions.Throws<DirectoryNotFoundException>(() => bitmap.Save(badTarget), $"The directory NoSuchDirectory of the filename {badTarget} does not exist.");
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -200,7 +200,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_InvalidDirecotry_ThrowsDirectoryNotFoundException()
         {
             using (var bitmap = new Bitmap(1, 1))

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -200,6 +200,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws ExternalException")]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Save_InvalidDirecotry_ThrowsDirectoryNotFoundException()
         {

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -206,7 +206,7 @@ namespace System.Drawing.Tests
             using (var bitmap = new Bitmap(1, 1))
             {
                 var badTarget = System.IO.Path.Combine("NoSuchDirectory", "NoSuchFile");
-                AssertExtensions.Throws<DirectoryNotFoundException>(() => bitmap.Save(badTarget), @"The target directory NoSuchDirectory of the targetPath NoSuchDirectory\NoSuchFile does not exist.");
+                AssertExtensions.Throws<DirectoryNotFoundException>(() => bitmap.Save(badTarget), @"The directory NoSuchDirectory of the filename NoSuchDirectory\NoSuchFile does not exist.");
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -199,5 +199,15 @@ namespace System.Drawing.Tests
                     paramList.Param.Select(p => p.Encoder.Guid));
             }
         }
+
+        [Fact]
+        public void Save_InvalidDirecotry_ThrowsDirectoryNotFoundException()
+        {
+            using (var bitmap = new Bitmap(1, 1))
+            {
+                var badTarget = System.IO.Path.Combine("NoSuchDirectory", "NoSuchFile");
+                AssertExtensions.Throws<DirectoryNotFoundException>(() => bitmap.Save(badTarget), @"The target directory NoSuchDirectory of the targetPath NoSuchDirectory\NoSuchFile does not exist.");
+            }
+        }
     }
 }


### PR DESCRIPTION
This provides a more meaningful exception when saving an Image to a directory that does not exist. Addresses #31367

This does change behavior slightly per https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/breaking-changes.md#bucket-2-reasonable-grey-area, as previously, the operation would throw a System.Runtime.InteropServices.ExternalException.