### PR TITLE
Close timeout in WebSocket.Client.CloseTest increased to 20 seconds

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -75,7 +75,7 @@ namespace System.Net.WebSockets.Client.Tests
             await TestCancellation(async (cws) =>
             {
                 var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
-                var cts = new CancellationTokenSource(5);
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
 
                 await cws.SendAsync(
                     WebSocketData.GetBufferFromText(".delay5sec"),
@@ -97,7 +97,7 @@ namespace System.Net.WebSockets.Client.Tests
             await TestCancellation(async (cws) =>
             {
 
-                var cts = new CancellationTokenSource(5);
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
                 var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
 
                 await cws.SendAsync(


### PR DESCRIPTION
CloseOutputAsync_Cancel_Success tests are failing due to 2 reasons:
1. `Assert` expecting the state to be `Aborted`, finds it's `Open` - most frequent
2. Connection gets forcibly terminated on a connect attempt

However, the second failure type is not specific to this test because it affects many tests in different types during the same time. Thus, it seems to be an infra issue.
This PR fixes only the first failure type by increasing Close operation timeout.
Fixes #1725