### PR TITLE
Resetting _waitForCompletion to null was removed from DuplexContent

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1937,13 +1937,11 @@ namespace System.Net.Http.Functional.Tests
             public void Complete()
             {
                 _waitForCompletion.SetResult(true);
-                _waitForCompletion = null;
             }
 
             public void Fail(Exception e)
             {
                 _waitForCompletion.SetException(e);
-                _waitForCompletion = null;
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1936,7 +1936,7 @@ namespace System.Net.Http.Functional.Tests
 
             public void Complete()
             {
-                _waitForCompletion.SetResult(true);
+                _waitForCompletion.SetResult(true); 
             }
 
             public void Fail(Exception e)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1936,7 +1936,7 @@ namespace System.Net.Http.Functional.Tests
 
             public void Complete()
             {
-                _waitForCompletion.SetResult(true); 
+                _waitForCompletion.SetResult(true);
             }
 
             public void Fail(Exception e)


### PR DESCRIPTION
`_waitForCompletion` gets reset to null in `DuplexContent.Complete` and `Fail` which leads to race condition with `SerializeToStreamAsync`. This reset seems redundant since `_waitForCompletion` is always unconditionally initialized on each call to `SerializeToStreamAsync`. This PR removes that reset logic.

Fixes #33141