### PR TITLE
Adding unit test to provoke exception using Sch_WhiteSpaceRestriction…

### DIFF
--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1774,7 +1774,7 @@
     <value>It is an error if 'whiteSpace' is among the facets of the type definition, its value is 'replace' or 'preserve', and the value of the parent 'whiteSpace' is 'collapse'.</value>
   </data>
   <data name="Sch_WhiteSpaceRestriction2" xml:space="preserve">
-    <value>It is an error if 'whiteSpace' is among the members of {facets} of {base type definition}, {value} is 'preserve', and the {value} of the parent 'whiteSpace' is 'replace'.</value>
+    <value>It is an error if 'whiteSpace' is among the facets of the type definition, its value is 'preserve', and the value of the parent 'whiteSpace' is 'replace'.</value>
   </data>
   <data name="Sch_XsiNilAndFixed" xml:space="preserve">
     <value>There must be no fixed value when an attribute is 'xsi:nil' and has a value of 'true'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1684,7 +1684,7 @@
     <value>Derived attribute's use has to be required if base attribute's use is required.</value>
   </data>
   <data name="Sch_AttributeRestrictionInvalidFromWildcard" xml:space="preserve">
-    <value>The {base type definition} must have an {attribute wildcard} and the {target namespace} of the R's {attribute declaration} must be valid with respect to that wildcard.</value>
+    <value>The base type definition must have an attribute wildcard and the target namespace of the attribute declaration in the 'redefine' must be valid with respect to that wildcard.</value>
   </data>
   <data name="Sch_NoDerivedAttribute" xml:space="preserve">
     <value>The base attribute '{0}' whose use = 'required' does not have a corresponding derived attribute while redefining attribute group '{1}'.</value>

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -1771,7 +1771,7 @@
     <value>Values that are declared with fixed='true' in a base type can not be changed in a derived type.</value>
   </data>
   <data name="Sch_WhiteSpaceRestriction1" xml:space="preserve">
-    <value>It is an error if 'whiteSpace' is among the members of {facets} of {base type definition}, {value} is 'replace' or 'preserve', and the {value} of the parent 'whiteSpace' is 'collapse'.</value>
+    <value>It is an error if 'whiteSpace' is among the facets of the type definition, its value is 'replace' or 'preserve', and the value of the parent 'whiteSpace' is 'collapse'.</value>
   </data>
   <data name="Sch_WhiteSpaceRestriction2" xml:space="preserve">
     <value>It is an error if 'whiteSpace' is among the members of {facets} of {base type definition}, {value} is 'preserve', and the {value} of the parent 'whiteSpace' is 'replace'.</value>

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1177,7 +1177,11 @@ namespace System.Xml.Tests
         public void WhiteSpaceRestriction1_Throws(string schema)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
-            ss.Add(null, XmlReader.Create(new StringReader(schema)));
+            using (StringReader sr = new StringReader(schema))
+            using (XmlReader xmlrdr = XmlReader.Create(sr))
+            {
+                ss.Add(null, xmlrdr);
+            }
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
 

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1302,11 +1302,6 @@ namespace System.Xml.Tests
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
 
-            // Issue 30218: invalid formatters
-            // TODO remove once invalid formatter is removed from Sch_AttributeRestrictionInvalidFromWildcard.
-            Text.RegularExpressions.Regex rx = new Text.RegularExpressions.Regex(@"\{[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
-
             Assert.Contains("wildcard", ex.Message);
             Assert.Contains("redefine", ex.Message);
         }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -7,7 +7,6 @@ using Xunit.Abstractions;
 using System.IO;
 using System.Xml.Schema;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace System.Xml.Tests
 {
@@ -1185,11 +1184,6 @@ namespace System.Xml.Tests
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
 
-            // Issue 30218: invalid formatters
-            // TODO remove once invalid formatter is removed from Sch_WhiteSpaceRestriction1.
-            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
-
             Assert.Contains("whiteSpace", ex.Message);
             Assert.Contains("collapse", ex.Message);
             Assert.Contains("preserve", ex.Message);
@@ -1238,11 +1232,6 @@ namespace System.Xml.Tests
             }
 
             Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
-
-            // Issue 30218: invalid formatters
-            // TODO remove once invalid formatter is removed from Sch_WhiteSpaceRestriction1.
-            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
-            Assert.Empty(rx.Matches(ex.Message));
 
             Assert.Contains("whiteSpace", ex.Message);
             Assert.DoesNotContain("collapse", ex.Message);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1196,5 +1196,59 @@ namespace System.Xml.Tests
             Assert.Contains("replace", ex.Message);
         }
         #endregion
+
+        #region tests causing XmlSchemaException with Sch_WhiteSpaceRestriction2
+        public static IEnumerable<object[]> WhiteSpaceRestriction2_Throws_TestData
+        {
+            get
+            {
+                return new List<object[]>()
+                {
+                    new object[]
+                    {
+@"<?xml version='1.0' encoding='utf-8'?>
+<xs:schema elementFormDefault='qualified'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='baseType'>
+        <xs:restriction base='xs:string'>
+            <xs:whiteSpace value='replace'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='restrictedType'>
+        <xs:restriction base='baseType'>
+            <xs:whiteSpace value='preserve'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WhiteSpaceRestriction2_Throws_TestData))]
+        public void WhiteSpaceRestriction2_Throws(string schema)
+        {
+            XmlSchemaSet ss = new XmlSchemaSet();
+            using (StringReader sr = new StringReader(schema))
+            using (XmlReader xmlrdr = XmlReader.Create(sr))
+            {
+                ss.Add(null, xmlrdr);
+            }
+
+            Exception ex = Assert.Throws<XmlSchemaException>(() => ss.Compile());
+
+            // Issue 30218: invalid formatters
+            // TODO remove once invalid formatter is removed from Sch_WhiteSpaceRestriction1.
+            Regex rx = new Regex(@"\{[a-zA-Z ]+[^\}]*\}");
+            Assert.Empty(rx.Matches(ex.Message));
+
+            Assert.Contains("whiteSpace", ex.Message);
+            Assert.DoesNotContain("collapse", ex.Message);
+            Assert.Contains("preserve", ex.Message);
+            Assert.Contains("replace", ex.Message);
+        }
+        #endregion
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Compile.cs
@@ -1138,31 +1138,36 @@ namespace System.Xml.Tests
 <xs:schema elementFormDefault='qualified'
             xmlns:xs='http://www.w3.org/2001/XMLSchema'>
     <xs:simpleType name='baseType'>
-        <xs:restriction base='xs:normalizedString'>
-            <xs:whitespace value='collapse'/>
+        <xs:restriction base='xs:string'>
+            <xs:whiteSpace value='collapse'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='restrictedType'>
+        <xs:restriction base='baseType'>
+            <xs:whiteSpace value='preserve'/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>
 "
-                    }//,
-//                    new object[]
-//                    {
-//@"<?xml version='1.0' encoding='utf-8'?>
-//<xs:schema elementFormDefault='qualified'
-//            xmlns:xs='http://www.w3.org/2001/XMLSchema'>
-//    <xs:simpleType name='baseType'>
-//        <xs:restriction base='string'>
-//            <xs:whitespace value='collapse'/>
-//        </xs:restriction>
-//    </xs:simpleType>
-//    <xs:simpleType name='restrictedType'>
-//        <xs:restriction base='baseType'>
-//            <xs:whitespace value='preserve'/>
-//        </xs:restriction>
-//    </xs:simpleType>
-//</xs:schema>
-//"
-//                    }
+                    },
+                    new object[]
+                    {
+@"<?xml version='1.0' encoding='utf-8'?>
+<xs:schema elementFormDefault='qualified'
+            xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+    <xs:simpleType name='baseType'>
+        <xs:restriction base='xs:string'>
+            <xs:whiteSpace value='collapse'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name='restrictedType'>
+        <xs:restriction base='baseType'>
+            <xs:whiteSpace value='replace'/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+"
+                    }
                 };
             }
         }


### PR DESCRIPTION
@buyaa-n 
Per your suggestion in PR#33890, I'm using a second pull request.

This contains my attempt to provoke the exception using Sch_WhiteSpaceRestriction1 as its message.  However, it is provoking a different exception:
![image](https://user-images.githubusercontent.com/62225294/79372194-e0731a00-7f12-11ea-99df-8d48f19b4758.png)

I suspect this is a bug, as the XSD I'm trying to compile differs from the example in [Paragraph 4.3.6](https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/datatypes.html#rf-whiteSpace) only in the name of the type and the presence of the namespace qualifier. (I'm pretty sure I've got the correct version of the spec now. :-))

The active test case is attempting to determine what was going wrong.  The commented out test case is the one to actually try to provoked the exception.

Fixes  #30218: