### PR TITLE
fix runing tests with targetFramework property and -f flag

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -49,6 +49,7 @@
  
     <!-- Initialize BuildSettings from the individual properties if it wasn't already explicitly set -->
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <BuildTargetFramework Condition="'$(BuildAllProjects)' != 'true' and '$(TargetFramework)' != ''">$(TargetFramework)</BuildTargetFramework>
     <BuildSettings Condition="'$(BuildSettings)' == ''">$(BuildTargetFramework)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</BuildSettings>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33059

There is still issue running with the -f switch as you will need to pass --no-restore flag to make it work.
I verified with the cli team that this is bug in cli behavior and logged issue with them. 
https://github.com/dotnet/sdk/issues/11305