### PR TITLE
JIT: fix recursive inline checking

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -21912,7 +21912,7 @@ unsigned Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
 
     for (; inlineContext != nullptr; inlineContext = inlineContext->GetParent())
     {
-
+        assert(inlineContext->GetCode() != nullptr);
         depth++;
 
         if (inlineContext->GetCode() == candidateCode)

--- a/src/coreclr/src/jit/inline.cpp
+++ b/src/coreclr/src/jit/inline.cpp
@@ -1171,6 +1171,7 @@ InlineContext* InlineStrategy::NewRoot()
     InlineContext* rootContext = new (m_Compiler, CMK_Inlining) InlineContext(this);
 
     rootContext->m_ILSize = m_Compiler->info.compILCodeSize;
+    rootContext->m_Code   = m_Compiler->info.compCode;
 
 #if defined(DEBUG) || defined(INLINE_DATA)
 

--- a/src/coreclr/src/jit/inline.h
+++ b/src/coreclr/src/jit/inline.h
@@ -662,7 +662,7 @@ public:
     }
 
     // Get the code pointer for this context.
-    BYTE* GetCode() const
+    const BYTE* GetCode() const
     {
         return m_Code;
     }
@@ -731,7 +731,7 @@ private:
     InlineContext*    m_Parent;            // logical caller (parent)
     InlineContext*    m_Child;             // first child
     InlineContext*    m_Sibling;           // next child of the parent
-    BYTE*             m_Code;              // address of IL buffer for the method
+    const BYTE*       m_Code;              // address of IL buffer for the method
     unsigned          m_ILSize;            // size of IL buffer for the method
     unsigned          m_ImportedILSize;    // estimated size of imported IL
     IL_OFFSETX        m_Offset;            // call site location within parent


### PR DESCRIPTION
We were not setting `m_Code` in the root inline context, and so were
sometimes allowing one level of recursive inlining.