### PR TITLE
Update Microsoft.NET.HostModel to reference System.Text.Json 5.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -166,6 +166,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
     </Dependency>
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.4.20202.18">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+    </Dependency>
     <Dependency Name="ILLink.Tasks" Version="5.0.0-preview.3.20210.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>8caef57d1f3bc7a188e5dd26d43a2d34151223f9</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,6 +79,7 @@
     <MicrosoftNETSdkILVersion>5.0.0-preview.4.20202.18</MicrosoftNETSdkILVersion>
     <MicrosoftFileFormatsVersion>1.0.120601</MicrosoftFileFormatsVersion>
     <!-- Libraries dependencies -->
+    <SystemTextJsonVersion>5.0.0-preview.4.20202.18</SystemTextJsonVersion>
     <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19563.3</runtimenativeSystemIOPortsVersion>
     <!-- Runtime-Assets dependencies -->
     <SystemComponentModelTypeConverterTestDataVersion>5.0.0-beta.20206.1</SystemComponentModelTypeConverterTestDataVersion>

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.8.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft.Extensions.DependencyModel and Microsoft.NET.HostModel are both used on .NET Framework's MSBuild by dotnet/sdk's Microsoft.NET.Build.Tasks assembly. However, they are referencing differnet versions of System.Text.Json, which is causing file load errors on .NET Framework.

Fixing this by updating Microsoft.NET.HostModel to use a 5.0 version.

Fix #35006

cc @jkotas 