### PR TITLE
Fix for PInvoke behavior in composite mode

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -304,7 +304,8 @@ namespace ILCompiler
                 copiedCorHeader,
                 debugDirectory,
                 win32Resources: new Win32Resources.ResourceData(inputModule),
-                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_Component);
+                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_Component |
+                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs);
 
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer());
             DependencyAnalyzerBase<NodeFactory> componentGraph = new DependencyAnalyzer<NoLogStrategy<NodeFactory>, NodeFactory>(componentFactory, comparer);


### PR DESCRIPTION
Thanks to Fadi's help I finally identified the root problem with
Crossgen2 PInvokes in composite mode: we weren't setting the
READYTORUN_FLAG_NONSHARED_PINVOKE_STUBS flag on the component
assembly R2R headers and that's what the runtime is looking at.

I believe it's both easier and more general to fix this in the compiler
as it comes for free whereas redirecting the runtime to always look
at the composite header would require at least an additional
indirection. Also we could theoretically use different settings for
different component assemblies even though my impression from Fadi's
detailed explanation was that we basically always want to use
non-shared PInvokes in Crossgen2.

Thanks

Tomas