### PR TITLE
Fix Http.Json serialization performance by using static options

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http.Json
             Debug.Assert(content.Headers.ContentType != null);
             Encoding? sourceEncoding = JsonContent.GetEncoding(content.Headers.ContentType.CharSet);
 
-            return ReadFromJsonAsyncCore(content, type, sourceEncoding, options ?? JsonContent.DefaultSerializerOptions, cancellationToken);
+            return ReadFromJsonAsyncCore(content, type, sourceEncoding, options, cancellationToken);
         }
 
         public static Task<T> ReadFromJsonAsync<T>(this HttpContent content, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
@@ -28,7 +28,7 @@ namespace System.Net.Http.Json
             Debug.Assert(content.Headers.ContentType != null);
             Encoding? sourceEncoding = JsonContent.GetEncoding(content.Headers.ContentType.CharSet);
 
-            return ReadFromJsonAsyncCore<T>(content, sourceEncoding, options ?? JsonContent.DefaultSerializerOptions, cancellationToken);
+            return ReadFromJsonAsyncCore<T>(content, sourceEncoding, options, cancellationToken);
         }
 
         private static async Task<object?> ReadFromJsonAsyncCore(HttpContent content, Type type, Encoding? sourceEncoding, JsonSerializerOptions? options, CancellationToken cancellationToken)
@@ -43,7 +43,7 @@ namespace System.Net.Http.Json
 
             using (contentStream)
             {
-                return await JsonSerializer.DeserializeAsync(contentStream, type, options, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync(contentStream, type, options ?? JsonContent.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -59,7 +59,7 @@ namespace System.Net.Http.Json
 
             using (contentStream)
             {
-                return await JsonSerializer.DeserializeAsync<T>(contentStream, options, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync<T>(contentStream, options ?? JsonContent.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -20,8 +20,8 @@ namespace System.Net.Http.Json
         private static MediaTypeHeaderValue DefaultMediaType
             => new MediaTypeHeaderValue(JsonMediaType) { CharSet = "utf-8" };
 
-        internal static JsonSerializerOptions DefaultSerializerOptions
-            => new JsonSerializerOptions { PropertyNameCaseInsensitive = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        internal static readonly JsonSerializerOptions s_defaultSerializerOptions
+            = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
         private readonly JsonSerializerOptions? _jsonSerializerOptions;
         public Type ObjectType { get; }
@@ -42,7 +42,7 @@ namespace System.Net.Http.Json
             Value = inputValue;
             ObjectType = inputType;
             Headers.ContentType = mediaType ?? DefaultMediaType;
-            _jsonSerializerOptions = options ?? DefaultSerializerOptions;
+            _jsonSerializerOptions = options ?? s_defaultSerializerOptions;
         }
 
         public static JsonContent Create<T>(T inputValue, MediaTypeHeaderValue? mediaType = null, JsonSerializerOptions? options = null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/34440

There was a considerable performance regression compared against `Microsoft.AspNetCore.Blazor.HttpClient` caused by always instantiating a `JsonSerializerOptions` object when not provided, which means that `System.Net.Http.Json` was not actively using the caching mechanism of the `JsonSerializer` for types and converters. 

I got the following results using the [aspnet/Benchmarks](https://github.com/aspnet/Benchmarks/tree/master/src/BenchmarksDriver2) repo to measure the amount of requests made to a simple WeatherForecast app that returns a `List<WeatherForecast>`.

The scenario keeps a thread sending Get requests for the specified duration (15s) after a specified warm-up time lapse (15s).

The benchmarks used can be found in https://github.com/Jozkee/HttpJsonBenchmarks.

I ran the scenarios 5 times each in order to get a larger sample.

I also ensured that the same version of System.Text.Json was being used (4.7.1 latest stable).

## Results
`Microsoft.AspNetCore.Blazor.HttpClient Version 3.2.0-preview3.20168.3`
  [client] 55458 iterations in 15s
  [client] 53794 iterations in 15s
  [client] 52779 iterations in 15s
  [client] 53429 iterations in 15s
  [client] 51582 iterations in 15s

`System.Net.Http.Json Version 3.2.0-preview3.20175.8` **Before fix** 
  [client] 13159 iterations in 15s
  [client] 12441 iterations in 15s

`System.Net.Http.Json 3.2.0-dev` (Private build) **After fix**
  [client] 55352 iterations in 15s
  [client] 51981 iterations in 15s
  [client] 53777 iterations in 15s
  [client] 52569 iterations in 15s
  [client] 52655 iterations in 15s

Note: There are further optimizations that can be made/be explored, specially on the Post/Put methods but those transcend the quick gain of using the static options for cache on serialization.

cc @ericstj  @joperezr @layomia 