### PR TITLE
Fix handling CoreClr profiler path for 32/64 bit flavors on ARM/ARM64

### DIFF
--- a/src/coreclr/src/vm/profilinghelper.cpp
+++ b/src/coreclr/src/vm/profilinghelper.cpp
@@ -702,9 +702,9 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
 
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER, &wszClsid));
 
-#if defined(TARGET_X86)
+#if defined(TARGET_X86) || defined(TARGET_ARM)
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_32, &wszProfilerDLL));
-#elif defined(TARGET_AMD64)
+#elif defined(TARGET_AMD64) || defined(TARGET_ARM64)
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_64, &wszProfilerDLL));
 #endif
     if(wszProfilerDLL == NULL)


### PR DESCRIPTION
We need to add handling of CORECLR_PROFILER_PATH_32/64 env variables on ARM64 systems also. Otherwise, profiler will not work in 32bit processes on such systems.

Similarl functionality for x86_64 was added in https://github.com/dotnet/coreclr/issues/601.