### PR TITLE
Make URI Unc path recognition more consistent across platforms

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3638,15 +3638,13 @@ namespace System
             }
 
             // Unix: Unix path?
-            if (!IsWindowsSystem && idx < length && uriString[idx] == '/')
+            // A path starting with 2 / or \ (including mixed) is treated as UNC and will be matched below
+            if (!IsWindowsSystem && idx < length && uriString[idx] == '/' &&
+                (idx + 1 == length || (uriString[idx + 1] != '/' && uriString[idx + 1] != '\\')))
             {
-                // A path starting with 2 / or \ (including mixed) is treated as UNC and will be matched below
-                if (idx + 1 == length || (uriString[idx + 1] != '/' && uriString[idx + 1] != '\\'))
-                {
-                    flags |= (Flags.UnixPath | Flags.ImplicitFile | Flags.AuthorityFound);
-                    syntax = UriParser.UnixFileUri;
-                    return idx;
-                }
+                flags |= (Flags.UnixPath | Flags.ImplicitFile | Flags.AuthorityFound);
+                syntax = UriParser.UnixFileUri;
+                return idx;
             }
 
             // sets the recognizer for well known registered schemes

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3640,9 +3640,13 @@ namespace System
             // Unix: Unix path?
             if (!IsWindowsSystem && idx < length && uriString[idx] == '/')
             {
-                flags |= (Flags.UnixPath | Flags.ImplicitFile | Flags.AuthorityFound);
-                syntax = UriParser.UnixFileUri;
-                return idx;
+                // A path starting with 2 / or \ (including mixed) is treated as UNC and will be matched below
+                if (idx + 1 == length || (uriString[idx + 1] != '/' && uriString[idx + 1] != '\\'))
+                {
+                    flags |= (Flags.UnixPath | Flags.ImplicitFile | Flags.AuthorityFound);
+                    syntax = UriParser.UnixFileUri;
+                    return idx;
+                }
             }
 
             // sets the recognizer for well known registered schemes

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="IriEncodingDecodingTests.cs" />
     <Compile Include="IriRelativeFileResolutionTest.cs" />
     <Compile Include="IriTest.cs" />
+    <Compile Include="UncTest.cs" />
     <Compile Include="UriBuilderParameterTest.cs" />
     <Compile Include="UriBuilderRefreshTest.cs" />
     <Compile Include="UriBuilderTests.cs" />

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -117,5 +117,25 @@ namespace System.PrivateUri.Tests
             // Invalid as it's a relative Uri
             Assert.Throws<InvalidOperationException>(() => uri.IsUnc);
         }
+
+        [Theory]
+        [InlineData(@"\\host/share")]
+        [InlineData(@"\\host\share")]
+        [InlineData(@"//host/share")]
+        [InlineData(@"//host\share")]
+        [InlineData(@"\/host/share")]
+        [InlineData(@"\/host\share")]
+        [InlineData(@"/\host/share")]
+        [InlineData(@"/\host\share")]
+        public static void Uri_ImplicitToExplicitForm_StillRecognizedAsUnc(string uriString)
+        {
+            var uri = new Uri(uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("file://host/share", uri.AbsoluteUri);
+
+            uri = new Uri(uri.AbsoluteUri);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("file://host/share", uri.AbsoluteUri);
+        }
     }
 }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -90,5 +90,15 @@ namespace System.PrivateUri.Tests
             Assert.Equal(@"\\host\", uri.LocalPath);
             Assert.Equal("/", uri.AbsolutePath);
         }
+
+        [Theory]
+        [InlineData(@"\\host")]
+        [InlineData(@"//host")]
+        [InlineData(@"\/host")]
+        [InlineData(@"/\host")]
+        public static void Uri_UncPathEquality_IgnoresCase(string uncPath)
+        {
+            Assert.Equal(new Uri(uncPath), new Uri(uncPath.ToUpper()));
+        }
     }
 }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.PrivateUri.Tests
+{
+    public static class UncTest
+    {
+        [Fact]
+        public static void Uri_WithTwoForwardSlashes_IsUnc()
+        {
+            // Will be recognized as UNC - even on Unix
+            Assert.True(new Uri("//foo").IsUnc);
+        }
+
+        [Theory]
+        // / and \ can be mixed and will be recognized the same on all platforms
+        [InlineData(@"\\host")]
+        [InlineData(@"//host")]
+        [InlineData(@"\/host")]
+        [InlineData(@"/\host")]
+        public static void Uri_RecognizesUncPaths(string uriString)
+        {
+            var uri = new Uri(uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal("file://host/", uri.AbsoluteUri);
+            Assert.Equal(@"\\host", uri.LocalPath);
+
+            // Same for explicit file form
+            uri = new Uri("file://" + uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal("file://host/", uri.AbsoluteUri);
+            Assert.Equal(@"\\host", uri.LocalPath);
+        }
+
+        [Theory]
+        [InlineData(@"\\host/share")]
+        [InlineData(@"\\host\share")]
+        [InlineData(@"//host/share")]
+        [InlineData(@"//host\share")]
+        [InlineData(@"\/host/share")]
+        [InlineData(@"\/host\share")]
+        [InlineData(@"/\host/share")]
+        [InlineData(@"/\host\share")]
+        public static void Uri_UncLocalPath_ConvertsForwardSlashes(string uriString)
+        {
+            var uri = new Uri(uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal("file://host/share", uri.AbsoluteUri);
+            Assert.Equal(@"\\host\share", uri.LocalPath);
+            Assert.Equal(@"/share", uri.AbsolutePath);
+
+            // Same for explicit file form
+            uri = new Uri("file://" + uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal("file://host/share", uri.AbsoluteUri);
+            Assert.Equal(@"\\host\share", uri.LocalPath);
+            Assert.Equal(@"/share", uri.AbsolutePath);
+        }
+
+        [Theory]
+        [InlineData(@"\\host\..")]
+        [InlineData(@"\\host/..")]
+        [InlineData(@"//host\..")]
+        [InlineData(@"//host/..")]
+        [InlineData(@"\\host\foo\..\..")]
+        [InlineData(@"//host\foo\..\..")]
+        [InlineData(@"\/host\foo\..\..")]
+        [InlineData(@"/\host\foo\..\..")]
+        [InlineData(@"\\host/foo/../..")]
+        [InlineData(@"\\host/foo/../../")]
+        public static void Uri_UncPathEscaping_FixesOnHost(string uriString)
+        {
+            Uri uri = new Uri(uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal(@"\\host\", uri.LocalPath);
+            Assert.Equal("/", uri.AbsolutePath);
+
+            // Same for explicit file form
+            uri = new Uri("file://" + uriString);
+            Assert.True(uri.IsUnc);
+            Assert.Equal("host", uri.Host);
+            Assert.Equal(@"\\host\", uri.LocalPath);
+            Assert.Equal("/", uri.AbsolutePath);
+        }
+    }
+}

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -100,5 +100,22 @@ namespace System.PrivateUri.Tests
         {
             Assert.Equal(new Uri(uncPath), new Uri(uncPath.ToUpper()));
         }
+
+        [Theory]
+        [InlineData(@"\\")]
+        [InlineData(@"//")]
+        [InlineData(@"\/")]
+        [InlineData(@"/\")]
+        public static void Uri_ShortUnc_NotRecognizedAsAbsolute(string uriString)
+        {
+            Assert.False(Uri.TryCreate(uriString, UriKind.Absolute, out _));
+
+            Assert.Throws<UriFormatException>(() => new Uri(uriString));
+
+            Assert.True(Uri.TryCreate(uriString, UriKind.Relative, out Uri uri));
+
+            // Invalid as it's a relative Uri
+            Assert.Throws<InvalidOperationException>(() => uri.IsUnc);
+        }
     }
 }


### PR DESCRIPTION
Fixes #33049, fixes #33053, contributes to #33029.

While UNC is defined as starting with two backslashes, Windows does sometimes recognize the forward-slash form as well.

This PR makes Uri recognize strings starting with two forward slashes as UNC on Unix to make behavior consistent across platforms.

Previously:

Input | Windows | Unix
-- | -- | --
\\\\foo | UNC | UNC
//foo | UNC | Absolute file path
file://\\\\foo | UNC | UNC
file:////foo | UNC | UNC

Now, these are all treated as UNC (including when the two slashes are mixed - `"/\foo"` or `"\/foo"`).

This is a breaking change as paths starting with two forward slashes are no longer recognized as absolute file paths on Unix. Being recognized as UNC also changes their behavior to replace `/` with `\` when looking at the `LocalPath` property.