### PR TITLE
Fix VSD stub null reference handling on amd64

### DIFF
--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -4132,24 +4132,6 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
 
     GenTree* result = nullptr;
 
-#ifdef TARGET_64BIT
-    // Non-tail calls: Jump Stubs are not taken into account by VM for mapping an AV into a NullRef
-    // exception. Therefore, JIT needs to emit an explicit null check.  Note that Jit64 too generates
-    // an explicit null check.
-    //
-    // Tail calls: fgMorphTailCall() materializes null check explicitly and hence no need to emit
-    // null check.
-
-    // Non-64-bit: No need to null check the this pointer - the dispatch code will deal with this.
-    // The VM considers exceptions that occur in stubs on 64-bit to be not managed exceptions and
-    // it would be difficult to change this in a way so that it affects only the right stubs.
-
-    if (!call->IsTailCallViaHelper())
-    {
-        call->gtFlags |= GTF_CALL_NULLCHECK;
-    }
-#endif
-
     // This is code to set up an indirect call to a stub address computed
     // via dictionary lookup.
     if (call->gtCallType == CT_INDIRECT)

--- a/src/coreclr/src/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/src/vm/amd64/virtualcallstubcpu.hpp
@@ -23,14 +23,14 @@
 #pragma pack(push, 1)
 // since we are placing code, we want byte packing of the structs
 
-// Four bytes starting at the instruction in the stub where the instruction
-// access violation is converted to NullReferenceException at the caller site.
+// Codes of the instruction in the stub where the instruction access violation
+// is converted to NullReferenceException at the caller site.
 #ifdef UNIX_AMD64_ABI
-#define X64_INSTR_CMP_IND_THIS_REG_RAX 0x013948
-#define X64_INSTR_MOV_RAX_IND_THIS_REG 0x018b48
-#else // UNIX_AMD64_ABI
 #define X64_INSTR_CMP_IND_THIS_REG_RAX 0x073948
 #define X64_INSTR_MOV_RAX_IND_THIS_REG 0x078b48
+#else // UNIX_AMD64_ABI
+#define X64_INSTR_CMP_IND_THIS_REG_RAX 0x013948
+#define X64_INSTR_MOV_RAX_IND_THIS_REG 0x018b48
 #endif // UNIX_AMD64_ABI
 
 #define USES_LOOKUP_STUBS       1

--- a/src/coreclr/src/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/src/vm/amd64/virtualcallstubcpu.hpp
@@ -23,6 +23,16 @@
 #pragma pack(push, 1)
 // since we are placing code, we want byte packing of the structs
 
+// Four bytes starting at the instruction in the stub where the instruction
+// access violation is converted to NullReferenceException at the caller site.
+#ifdef UNIX_AMD64_ABI
+#define X64_INSTR_CMP_IND_THIS_REG_RAX 0x013948
+#define X64_INSTR_MOV_RAX_IND_THIS_REG 0x018b48
+#else // UNIX_AMD64_ABI
+#define X64_INSTR_CMP_IND_THIS_REG_RAX 0x073948
+#define X64_INSTR_MOV_RAX_IND_THIS_REG 0x078b48
+#endif // UNIX_AMD64_ABI
+
 #define USES_LOOKUP_STUBS       1
 
 /*********************************************************************************************
@@ -594,13 +604,9 @@ void DispatchHolder::InitializeStatic()
     dispatchInit._entryPoint [0]      = 0x48;
     dispatchInit._entryPoint [1]      = 0xB8;
     dispatchInit._expectedMT          = 0xcccccccccccccccc;
-    dispatchInit.part1 [0]            = 0x48;
-    dispatchInit.part1 [1]            = 0x39;
-#ifdef UNIX_AMD64_ABI
-    dispatchInit.part1 [2]            = 0x07; // RDI
-#else
-    dispatchInit.part1 [2]            = 0x01; // RCX
-#endif
+    dispatchInit.part1 [0]            = X64_INSTR_CMP_IND_THIS_REG_RAX & 0xff;
+    dispatchInit.part1 [1]            = (X64_INSTR_CMP_IND_THIS_REG_RAX >> 8) & 0xff;
+    dispatchInit.part1 [2]            = (X64_INSTR_CMP_IND_THIS_REG_RAX >> 16) & 0xff;
     dispatchInit.nopOp                = 0x90;
 
     // Short dispatch stub initialization
@@ -686,13 +692,9 @@ void ResolveHolder::InitializeStatic()
     resolveInit._resolveEntryPoint [1] = 0x49;
     resolveInit._resolveEntryPoint [2] = 0xBA;
     resolveInit._cacheAddress          = 0xcccccccccccccccc;
-    resolveInit.part1 [ 0]             = 0x48;
-    resolveInit.part1 [ 1]             = 0x8B;
-#ifdef UNIX_AMD64_ABI
-    resolveInit.part1 [ 2]             = 0x07; // RDI
-#else
-    resolveInit.part1 [ 2]             = 0x01; // RCX
-#endif
+    resolveInit.part1 [ 0]             = X64_INSTR_MOV_RAX_IND_THIS_REG & 0xff;
+    resolveInit.part1 [ 1]             = (X64_INSTR_MOV_RAX_IND_THIS_REG >> 8) & 0xff;
+    resolveInit.part1 [ 2]             = (X64_INSTR_MOV_RAX_IND_THIS_REG >> 16) & 0xff;
     resolveInit.part1 [ 3]             = 0x48;
     resolveInit.part1 [ 4]             = 0x8B;
     resolveInit.part1 [ 5]             = 0xD0;

--- a/src/coreclr/src/vm/excep.cpp
+++ b/src/coreclr/src/vm/excep.cpp
@@ -6658,7 +6658,6 @@ EXTERN_C void JIT_WriteBarrier_Debug();
 EXTERN_C void JIT_WriteBarrier_Debug_End();
 #endif
 
-#ifdef VSD_STUB_CAN_THROW_AV
 //Return TRUE if pContext->Pc is in VirtualStub
 BOOL IsIPinVirtualStub(PCODE f_IP)
 {
@@ -6689,7 +6688,6 @@ BOOL IsIPinVirtualStub(PCODE f_IP)
         return FALSE;
     }
 }
-#endif // VSD_STUB_CAN_THROW_AV
 
 // Check if the passed in instruction pointer is in one of the
 // JIT helper functions.

--- a/src/coreclr/src/vm/excep.h
+++ b/src/coreclr/src/vm/excep.h
@@ -22,14 +22,8 @@ class Thread;
 #include <excepcpu.h>
 #include "interoputil.h"
 
-#if defined(TARGET_ARM) || defined(TARGET_X86)
-#define VSD_STUB_CAN_THROW_AV
-#endif // TARGET_ARM || TARGET_X86
-
 BOOL IsExceptionFromManagedCode(const EXCEPTION_RECORD * pExceptionRecord);
-#ifdef VSD_STUB_CAN_THROW_AV
 BOOL IsIPinVirtualStub(PCODE f_IP);
-#endif // VSD_STUB_CAN_THROW_AV
 bool IsIPInMarkedJitHelper(UINT_PTR uControlPc);
 
 BOOL AdjustContextForJITHelpers(EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pContext);

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -4684,9 +4684,8 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
         // Check whether we are crossing managed-to-native boundary
         while (!ExecutionManager::IsManagedCode(controlPc))
         {
-            if (IsIPinVirtualStub(controlPc))
+            if (AdjustContextForVirtualStub(NULL, frameContext))
             {
-                AdjustContextForVirtualStub(NULL, frameContext);
                 controlPc = GetIP(frameContext);
                 break;
             }
@@ -5288,9 +5287,9 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
                 PAL_VirtualUnwind(ex->GetContextRecord(), NULL);
                 ex->GetExceptionRecord()->ExceptionAddress = (PVOID)GetIP(ex->GetContextRecord());
             }
-            else if (IsIPinVirtualStub(controlPc))
+            else
             {
-                AdjustContextForVirtualStub(ex->GetExceptionRecord(), ex->GetContextRecord());
+                AdjustContextForVirtualStub(ex->GetExceptionRecord(), ex->GetContextRecord())
             }
             fef.InitAndLink(ex->GetContextRecord());
         }

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -5289,7 +5289,7 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
             }
             else
             {
-                AdjustContextForVirtualStub(ex->GetExceptionRecord(), ex->GetContextRecord())
+                AdjustContextForVirtualStub(ex->GetExceptionRecord(), ex->GetContextRecord());
             }
             fef.InitAndLink(ex->GetContextRecord());
         }

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -4684,14 +4684,12 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
         // Check whether we are crossing managed-to-native boundary
         while (!ExecutionManager::IsManagedCode(controlPc))
         {
-#ifdef VSD_STUB_CAN_THROW_AV
             if (IsIPinVirtualStub(controlPc))
             {
                 AdjustContextForVirtualStub(NULL, frameContext);
                 controlPc = GetIP(frameContext);
                 break;
             }
-#endif // VSD_STUB_CAN_THROW_AV
 
 #ifdef FEATURE_WRITEBARRIER_COPY
             if (IsIPInWriteBarrierCodeCopy(controlPc))
@@ -5201,9 +5199,7 @@ BOOL IsSafeToHandleHardwareException(PCONTEXT contextRecord, PEXCEPTION_RECORD e
         exceptionRecord->ExceptionCode == STATUS_BREAKPOINT ||
         exceptionRecord->ExceptionCode == STATUS_SINGLE_STEP ||
         (IsSafeToCallExecutionManager() && ExecutionManager::IsManagedCode(controlPc)) ||
-#ifdef VSD_STUB_CAN_THROW_AV
         IsIPinVirtualStub(controlPc) ||  // access violation comes from DispatchStub of Interface call
-#endif // VSD_STUB_CAN_THROW_AV
         IsIPInMarkedJitHelper(controlPc));
 }
 
@@ -5292,12 +5288,10 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
                 PAL_VirtualUnwind(ex->GetContextRecord(), NULL);
                 ex->GetExceptionRecord()->ExceptionAddress = (PVOID)GetIP(ex->GetContextRecord());
             }
-#ifdef VSD_STUB_CAN_THROW_AV
             else if (IsIPinVirtualStub(controlPc))
             {
                 AdjustContextForVirtualStub(ex->GetExceptionRecord(), ex->GetContextRecord());
             }
-#endif // VSD_STUB_CAN_THROW_AV
             fef.InitAndLink(ex->GetContextRecord());
         }
 

--- a/src/coreclr/src/vm/stackwalk.cpp
+++ b/src/coreclr/src/vm/stackwalk.cpp
@@ -727,9 +727,8 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
         uControlPc = VirtualUnwindCallFrame(pContext);
 #else // !TARGET_UNIX
 
-        if (IsIPinVirtualStub(uControlPc))
+        if (AdjustContextForVirtualStub(NULL, pContext))
         {
-            AdjustContextForVirtualStub(NULL, pContext);
             uControlPc = GetIP(pContext);
             break;
         }

--- a/src/coreclr/src/vm/stackwalk.cpp
+++ b/src/coreclr/src/vm/stackwalk.cpp
@@ -727,14 +727,12 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
         uControlPc = VirtualUnwindCallFrame(pContext);
 #else // !TARGET_UNIX
 
-#ifdef VSD_STUB_CAN_THROW_AV
         if (IsIPinVirtualStub(uControlPc))
         {
             AdjustContextForVirtualStub(NULL, pContext);
             uControlPc = GetIP(pContext);
             break;
         }
-#endif // VSD_STUB_CAN_THROW_AV
 
         BOOL success = PAL_VirtualUnwind(pContext, NULL);
         if (!success)

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_35000/test35000.cs
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_35000/test35000.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Reflection;
+
+public class TestData
+{
+    public virtual Guid InputGuid { get; set; }
+}
+
+class Test35000
+{
+    static int Main(string[] args)
+    {
+        bool success = false;
+
+        PropertyInfo property = typeof(TestData).GetProperty(nameof(TestData.InputGuid),
+            BindingFlags.Instance | BindingFlags.Public);
+
+        Func<object, object> func = GetFunc(property);
+
+        TestData data = new TestData();
+
+        data.InputGuid = Guid.NewGuid();
+
+        object value1 = func(data);
+        object value3 = func(data);
+
+        try
+        {
+            object value2 = func(null);
+        }
+        catch (NullReferenceException e)
+        {
+            Console.WriteLine(e);
+            success = true;
+        }
+
+        return success ? 100 : 101;
+    }
+
+    public static Func<object, object> GetFunc(PropertyInfo propertyInfo)
+    {
+        var method = typeof(Test35000).GetMethod(nameof(CreateFunc));
+
+        return (Func<object, object>)method
+            .MakeGenericMethod(propertyInfo.DeclaringType, propertyInfo.PropertyType)
+            .Invoke(null, new object[] { propertyInfo.GetMethod });
+    }
+
+    public static Func<object, object> CreateFunc<TTarget, TValue>(MethodInfo methodInfo)
+    {
+
+        var func = (Func<TTarget, TValue>)Delegate.CreateDelegate(typeof(Func<TTarget, TValue>), null, methodInfo);
+        return (object o) => func((TTarget)o);
+    }
+}

--- a/src/coreclr/tests/src/Regressions/coreclr/GitHub_35000/test35000.csproj
+++ b/src/coreclr/tests/src/Regressions/coreclr/GitHub_35000/test35000.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test35000.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When the VSD resolve or dispatch stub gets a null “this” reference on amd64, the resulting access violation is not converted to NullReferenceException and so we fail fast and tear down the process with AccessViolationException. The reason is that the amd64 version of the AdjustContextForVirtualStub always returns FALSE and doesn't do anything instead of manually unwinding to the managed caller of the stub.

This change fixes it by implementing the AdjustContextForVirtualStub the same way as on other architectures. While fixing it, I’ve also found that for arm64, we were not calling AdjustContextForVirtualStub in some code paths where we call it for x86 and arm. This code was under the VSD_STUB_CAN_THROW_AV define, which was defined only for x86 and arm for some reason.

In addition to the fix, I've noticed that at several places we call IsIPinVirtualStub and call the AdjustContextForVirtualStub only if that returns true. This is not necessary, as the AdjustContextForVirtualStub doesn't do anything and just returns false when the instruction pointer is not in VSD stub and we end up looking up the stub twice unnecessarily. So I've also fixed that.

This change also adds a regression test for the underlying issue.

Close #35000
Close #9027