### PR TITLE
fix ping on OSX when running as root

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -19,6 +19,8 @@ namespace System.Net.NetworkInformation
         private const int IcmpHeaderLengthInBytes = 8;
         private const int MinIpHeaderLengthInBytes = 20;
         private const int MaxIpHeaderLengthInBytes = 60;
+        private static bool _sendIpHeader = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        private static bool _needsConnect = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         [ThreadStatic]
         private static Random? t_idGenerator;
 
@@ -46,19 +48,36 @@ namespace System.Net.NetworkInformation
             return reply;
         }
 
-        private SocketConfig GetSocketConfig(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
+        private unsafe SocketConfig GetSocketConfig(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             // Use a random value as the identifier. This doesn't need to be perfectly random
             // or very unpredictable, rather just good enough to avoid unexpected conflicts.
             Random rand = t_idGenerator ??= new Random();
             ushort id = (ushort)rand.Next(ushort.MaxValue + 1);
+            IpHeader iph = default;
 
             bool ipv4 = address.AddressFamily == AddressFamily.InterNetwork;
+            bool sendIpHeader = ipv4 && options != null && _sendIpHeader;
+
+             if (sendIpHeader)
+             {
+                iph.VersionAndLength = 0x45;
+                // On OSX this strangely must be host byte order.
+                iph.TotalLength = (ushort)(sizeof(IpHeader) + sizeof(IcmpHeader) +  buffer.Length);
+                iph.Protocol = 1; // ICMP
+                iph.Ttl = (byte)options!.Ttl;
+                iph.Flags = (ushort)(options.DontFragment ? 0x4000 : 0);
+#pragma warning disable 618
+                iph.DestinationAddress = (uint)address.Address;
+#pragma warning restore 618
+                // No need to fill in SourceAddress or checksum.
+                // If left blank, kernel will fill it in - at least on OSX.
+             }
 
             return new SocketConfig(
                 new IPEndPoint(address, 0), timeout, options,
                 ipv4, ipv4 ? ProtocolType.Icmp : ProtocolType.IcmpV6, id,
-                CreateSendMessageBuffer(new IcmpHeader()
+                CreateSendMessageBuffer(iph, new IcmpHeader()
                 {
                     Type = ipv4 ? (byte)IcmpV4MessageType.EchoRequest : (byte)IcmpV6MessageType.EchoRequest,
                     Identifier = id,
@@ -68,12 +87,16 @@ namespace System.Net.NetworkInformation
         private Socket GetRawSocket(SocketConfig socketConfig)
         {
             IPEndPoint ep = (IPEndPoint)socketConfig.EndPoint;
-
-            // Setting Socket.DontFragment and .Ttl is not supported on Unix, so socketConfig.Options is ignored.
             AddressFamily addrFamily = ep.Address.AddressFamily;
+
             Socket socket = new Socket(addrFamily, SocketType.Raw, socketConfig.ProtocolType);
             socket.ReceiveTimeout = socketConfig.Timeout;
             socket.SendTimeout = socketConfig.Timeout;
+            if (addrFamily == AddressFamily.InterNetworkV6)
+            {
+                socket.DualMode = false;
+            }
+
             if (socketConfig.Options != null && socketConfig.Options.Ttl > 0)
             {
                 socket.Ttl = (short)socketConfig.Options.Ttl;
@@ -81,13 +104,21 @@ namespace System.Net.NetworkInformation
 
             if (socketConfig.Options != null && addrFamily == AddressFamily.InterNetwork)
             {
-                socket.DontFragment = socketConfig.Options.DontFragment;
+                if (_sendIpHeader)
+                {
+                    // some platforms like OSX don't support DontFragment so we construct IP header instead.
+                    socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.HeaderIncluded, 1);
+                }
+                else
+                {
+                    socket.DontFragment = socketConfig.Options.DontFragment;
+                }
             }
 
 #pragma warning disable 618
             // Disable warning about obsolete property. We could use GetAddressBytes but that allocates.
             // IPv4 multicast address starts with 1110 bits so mask rest and test if we get correct value e.g. 0xe0.
-            if (!ep.Address.IsIPv6Multicast && !(addrFamily == AddressFamily.InterNetwork && (ep.Address.Address & 0xf0) == 0xe0))
+            if (_needsConnect && !ep.Address.IsIPv6Multicast && !(addrFamily == AddressFamily.InterNetwork && (ep.Address.Address & 0xf0) == 0xe0))
             {
                 // If it is not multicast, use Connect to scope responses only to the target address.
                 socket.Connect(socketConfig.EndPoint);
@@ -359,6 +390,24 @@ namespace System.Net.NetworkInformation
         }
 #endif
 
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IpHeader
+        {
+            internal byte VersionAndLength;
+            internal byte Tos;
+            internal ushort TotalLength;
+
+            internal ushort Identifier;
+            internal ushort Flags;
+
+            internal byte Ttl;
+            internal byte Protocol;
+            internal ushort HeaderChecksum;
+
+            internal uint SourceAddress;
+            internal uint DestinationAddress;
+        };
+
         // Must be 8 bytes total.
         [StructLayout(LayoutKind.Sequential)]
         internal struct IcmpHeader
@@ -395,21 +444,34 @@ namespace System.Net.NetworkInformation
             public readonly byte[] SendBuffer;
         }
 
-        private static unsafe byte[] CreateSendMessageBuffer(IcmpHeader header, byte[] payload)
+        private static unsafe byte[] CreateSendMessageBuffer(IpHeader ipHeader, IcmpHeader icmpHeader, byte[] payload)
         {
-            int headerSize = sizeof(IcmpHeader);
-            byte[] result = new byte[headerSize + payload.Length];
-            Marshal.Copy(new IntPtr(&header), result, 0, headerSize);
-            payload.CopyTo(result, headerSize);
-            ushort checksum = ComputeBufferChecksum(result);
+            int icmpHeaderSize = sizeof(IcmpHeader);
+            int offset = 0;
+            int packetSize = ipHeader.TotalLength != 0 ? ipHeader.TotalLength : icmpHeaderSize + payload.Length;
+            byte[] result = new byte[packetSize];
+
+            if (ipHeader.TotalLength != 0)
+            {
+                int ipHeaderSize = sizeof(IpHeader);
+                Marshal.Copy(new IntPtr(&ipHeader), result, 0, ipHeaderSize);
+                offset = ipHeaderSize;
+            }
+
+            //byte[] result = new byte[headerSize + payload.Length];
+            Marshal.Copy(new IntPtr(&icmpHeader), result, offset, icmpHeaderSize);
+            payload.CopyTo(result, offset + icmpHeaderSize);
+
+            // offset now still points to beginning of ICMP header.
+            ushort checksum = ComputeBufferChecksum(result.AsSpan().Slice(offset));
             // Jam the checksum into the buffer.
-            result[2] = (byte)(checksum >> 8);
-            result[3] = (byte)(checksum & (0xFF));
+            result[offset + 2] = (byte)(checksum >> 8);
+            result[offset + 3] = (byte)(checksum & (0xFF));
 
             return result;
         }
 
-        private static ushort ComputeBufferChecksum(byte[] buffer)
+        private static ushort ComputeBufferChecksum(ReadOnlySpan<byte> buffer)
         {
             // This is using the "deferred carries" approach outlined in RFC 1071.
             uint sum = 0;

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -92,7 +92,7 @@ namespace System.Net.NetworkInformation
             Socket socket = new Socket(addrFamily, SocketType.Raw, socketConfig.ProtocolType);
             socket.ReceiveTimeout = socketConfig.Timeout;
             socket.SendTimeout = socketConfig.Timeout;
-            if (addrFamily == AddressFamily.InterNetworkV6 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            if (addrFamily == AddressFamily.InterNetworkV6 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 socket.DualMode = false;
             }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -92,7 +92,7 @@ namespace System.Net.NetworkInformation
             Socket socket = new Socket(addrFamily, SocketType.Raw, socketConfig.ProtocolType);
             socket.ReceiveTimeout = socketConfig.Timeout;
             socket.SendTimeout = socketConfig.Timeout;
-            if (addrFamily == AddressFamily.InterNetworkV6)
+            if (addrFamily == AddressFamily.InterNetworkV6 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
             {
                 socket.DualMode = false;
             }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -904,7 +904,7 @@ namespace System.Net.NetworkInformation.Tests
 
             _output.WriteLine($"pinging '{localIpAddress}'");
 
-            using (RemoteExecutor.Invoke(address  =>
+            RemoteExecutor.Invoke(address  =>
             {
                 byte[] buffer = TestSettings.PayloadAsBytes;
                 SendBatchPing(
@@ -914,9 +914,7 @@ namespace System.Net.NetworkInformation.Tests
                         PingResultValidator(pingReply, new IPAddress[] { IPAddress.Parse(address) }, null);
                         Assert.Equal(buffer, pingReply.Buffer);
                     });
-            }, localIpAddress.ToString(), new RemoteInvokeOptions { RunAsSudo = true }))
-            {
-            }
+            }, localIpAddress.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
     }
 }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -9,6 +9,7 @@ using System.Net.Test.Common;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 
 using Xunit;
 using Xunit.Abstractions;
@@ -46,10 +47,12 @@ namespace System.Net.NetworkInformation.Tests
 
         private void PingResultValidator(PingReply pingReply, IPAddress localIpAddress)
         {
-            PingResultValidator(pingReply, new IPAddress[] { localIpAddress });
+            PingResultValidator(pingReply, new IPAddress[] { localIpAddress },  _output);
         }
 
-        private void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses)
+        private void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses)  =>  PingResultValidator(pingReply, localIpAddresses, null);
+
+        private static void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses, ITestOutputHelper output)
         {
             if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsOSX)
             {
@@ -65,10 +68,13 @@ namespace System.Net.NetworkInformation.Tests
             }
             // We did not find response address in given list.
             // Test is going to fail. Collect some more info.
-            _output.WriteLine($"Reply address {pingReply.Address} is not expected local address.");
-            foreach (IPAddress address in localIpAddresses)
+            if (output != null)
             {
-                _output.WriteLine($"Local address {address}");
+                output.WriteLine($"Reply address {pingReply.Address} is not expected local address.");
+                foreach (IPAddress address in localIpAddresses)
+                {
+                    output.WriteLine($"Local address {address}");
+                }
             }
 
             Assert.Contains(pingReply.Address, localIpAddresses); ///, "Reply address {pingReply.Address} is not expected local address.");
@@ -879,6 +885,38 @@ namespace System.Net.NetworkInformation.Tests
             var sender = new Ping();
             PingReply reply = await sender.SendPingAsync(TestSettings.UnreachableAddress);
             Assert.Equal(IPStatus.TimedOut, reply.Status);
+        }
+
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [Theory]
+        [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        [OuterLoop] // Depends on sudo
+        public void SendPingWithIPAddressAndTimeoutAndBufferAndPingOptions_ElevatedUnix(AddressFamily addressFamily)
+        {
+            IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
+            if (localIpAddress == null)
+            {
+                // No local address for given address family.
+                return;
+            }
+
+            _output.WriteLine($"pinging '{localIpAddress}'");
+
+            using (RemoteExecutor.Invoke(address  =>
+            {
+                byte[] buffer = TestSettings.PayloadAsBytes;
+                SendBatchPing(
+                    (ping) => ping.Send(address, TestSettings.PingTimeout, buffer, new PingOptions()),
+                    (pingReply) =>
+                    {
+                        PingResultValidator(pingReply, new IPAddress[] { IPAddress.Parse(address) }, null);
+                        Assert.Equal(buffer, pingReply.Buffer);
+                    });
+            }, localIpAddress.ToString(), new RemoteInvokeOptions { RunAsSudo = true }))
+            {
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <!-- Test APIs introduced after 1.0 -->
   <ItemGroup>


### PR DESCRIPTION
This is fix for thee distance issues with current implementation.

first is regression on OSX caused by https://github.com/dotnet/corefx/pull/34084
It seems like OSX does connect behind the scenes and Send() files `System.Net.Sockets.SocketException (56): Socket is already connected` even if we call `Connect` just once. So I limit that to Linux only. 
fixes #33430

Second issues is when PingOptions is used. In that case we would always try to set ` socket.DontFragment = socketConfig.Options.DontFragment` and that fails on OSX because that is not supported by OS. Since we use RAW socket we have option too include IP header and set DF bit directly. I used Wireshark to verify that DF is properly set based on PingOptions.
fixes #34879

Third problem is with IPv6: (currently not tracked by any issue)
```

          Child exception:
            System.Net.NetworkInformation.PingException: An exception occurred during a Ping request.
           ---> System.PlatformNotSupportedException: This platform does not support packet information for dual-mode sockets.  If packet information is not required, use Socket.Receive.  If packet information is required set Socket.DualMode to false.
          /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs(40,0): at System.Net.Sockets.SocketPal.CheckDualModeReceiveSupport(Socket socket)
          /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(1744,0): at System.Net.Sockets.Socket.ReceiveFrom(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, EndPoint& remoteEP)
          /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs(1812,0): at System.Net.Sockets.Socket.ReceiveFrom(Byte[] buffer, SocketFlags socketFlags, EndPoint& remoteEP)
          /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs(206,0): at System.Net.NetworkInformation.Ping.SendIcmpEchoRequestOverRawSocket(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
```

Since we know what AF we need, the fix was to turn off DualMode on RAW socket. 
I don't think we really need "packet information" and that can be possibly future improvement. 

All this happened because we do not have any test coverage for RAW sockets in practice since CI runs as ordinary user. However, some other assemblies use RemoteExcetopr with RunAsSudo to get privileged access. It seems like we should be able to detect in CI. My prototype runs shows exactly the reported issues so it may be worth of getting at least some basic coverage. 
https://helix.dot.net/api/2019-06-17/jobs/353faf88-9320-4dfa-8215-534c515b3fa0/workitems/System.Net.Ping.Functional.Tests/console

Downside of this is that the test depends now on sudo for outer loop runs. It may asked for password if executed interactively or it may fail if given user is not in shudders group.
Given the history, it seems like this may be worth oof some hassle. 


