### PR TITLE
fix endless loop in GetActiveUdpListeners

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -229,7 +229,8 @@ namespace System.Net.NetworkInformation
                 while (result == Interop.IpHlpApi.ERROR_INSUFFICIENT_BUFFER)
                 {
                     // Allocate the buffer and get the UDP table.
-                    IntPtr buffer = IntPtr.Zero;
+                    IntPtr buffer = Marshal.AllocHGlobal((int)size);
+
                     try
                     {
                         result = Interop.IpHlpApi.GetUdpTable(buffer, ref size, true);

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -28,7 +28,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_AccessAllMethods_NoErrors()
         {
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
@@ -54,7 +53,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
         [MemberData(nameof(Loopbacks))]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -80,7 +78,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
         [MemberData(nameof(Loopbacks))]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -110,7 +107,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void IPGlobalProperties_TcpActiveConnections_NotListening()
         {
             TcpConnectionInformation[] tcpCconnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();


### PR DESCRIPTION
Seems like regression caused by #1914. It removed `buffer = SafeLocalAllocHandle.LocalAlloc((int)size)` from SystemIPGlobalProperties.cs / GetActiveUdpListeners()  so when initial allocation fails we never allocate more bytes and we loop endlessly.

Tcp counterpart seems fine. 

I originally added some of the test as part of specific unix fixes. But they run fine on Windows as well and I checked and they would catch the regression. So I'm removing the Unix  restriction. 

fixes #35051
