### PR TITLE
Http2LoopbackConnection properly handles stream termination

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -470,7 +470,7 @@ namespace System.Net.Test.Common
             }
         }
 
-        public async Task<byte[]> ReadBodyAsync()
+        public async Task<byte[]> ReadBodyAsync(bool expectEndOfStream = false)
         {
             byte[] body = null;
             Frame frame;
@@ -478,7 +478,11 @@ namespace System.Net.Test.Common
             do
             {
                 frame = await ReadFrameAsync(Timeout).ConfigureAwait(false);
-                if (frame == null || frame.Type == FrameType.RstStream)
+                if (frame == null && expectEndOfStream)
+                {
+                    break;
+                }
+                else if (frame == null || frame.Type == FrameType.RstStream)
                 {
                     throw new IOException( frame == null ? "End of stream" : "Got RST");
                 }

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -130,7 +130,7 @@ namespace System.Net.Http.Functional.Tests
             object socketsHttpHandler = socketsHttpHandlerField.GetValue(handler);
             Assert.NotNull(socketsHttpHandler);
 
-            EnableUncryptedHttp2((SocketsHttpHandler) socketsHttpHandler);
+            EnableUncryptedHttp2(socketsHttpHandler);
         }
 
 #if !NETFRAMEWORK

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -130,6 +130,21 @@ namespace System.Net.Http.Functional.Tests
             object socketsHttpHandler = socketsHttpHandlerField.GetValue(handler);
             Assert.NotNull(socketsHttpHandler);
 
+            EnableUncryptedHttp2((SocketsHttpHandler) socketsHttpHandler);
+        }
+
+        public static void EnableUnencryptedHttp2IfNecessary(SocketsHttpHandler socketsHttpHandler)
+        {
+            if (PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback())
+            {
+                return;
+            }
+
+            EnableUncryptedHttp2(socketsHttpHandler);
+        }
+
+        private static void EnableUncryptedHttp2(SocketsHttpHandler socketsHttpHandler)
+        {
             // Get HttpConnectionSettings object from SocketsHttpHandler.
             Type socketsHttpHandlerType = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.SocketsHttpHandler");
             FieldInfo settingsField = socketsHttpHandlerType.GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -133,6 +133,7 @@ namespace System.Net.Http.Functional.Tests
             EnableUncryptedHttp2((SocketsHttpHandler) socketsHttpHandler);
         }
 
+#if !NETFRAMEWORK
         public static void EnableUnencryptedHttp2IfNecessary(SocketsHttpHandler socketsHttpHandler)
         {
             if (PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback())
@@ -142,8 +143,9 @@ namespace System.Net.Http.Functional.Tests
 
             EnableUncryptedHttp2(socketsHttpHandler);
         }
+#endif
 
-        private static void EnableUncryptedHttp2(SocketsHttpHandler socketsHttpHandler)
+        private static void EnableUncryptedHttp2(object socketsHttpHandler)
         {
             // Get HttpConnectionSettings object from SocketsHttpHandler.
             Type socketsHttpHandlerType = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.SocketsHttpHandler");

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1862,7 +1862,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31220")]
         public async Task PostAsyncExpect100Continue_NonSuccessResponse_RequestBodyNotSent()
         {
             string responseContent = "no no!";
@@ -1870,7 +1869,7 @@ namespace System.Net.Http.Functional.Tests
             await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using (var handler = new SocketsHttpHandler())
-                using (HttpClient client = CreateHttpClient())
+                using (HttpClient client = CreateHttpClient(handler))
                 {
                     handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
                     // Increase default Expect: 100-continue timeout to ensure that we don't accidentally fire the timer and send the request body.
@@ -1899,7 +1898,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes(responseContent));
 
                 // Client should send empty request body
-                byte[] requestBody = await connection.ReadBodyAsync();
+                byte[] requestBody = await connection.ReadBodyAsync(expectEndOfStream:true);
                 Assert.Null(requestBody);
 
                 await connection.ShutdownIgnoringErrorsAsync(streamId);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1871,6 +1871,7 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = new SocketsHttpHandler())
                 using (HttpClient client = CreateHttpClient(handler))
                 {
+                    TestHelper.EnableUnencryptedHttp2IfNecessary(handler);
                     handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
                     // Increase default Expect: 100-continue timeout to ensure that we don't accidentally fire the timer and send the request body.
                     handler.Expect100ContinueTimeout = TimeSpan.FromSeconds(300);


### PR DESCRIPTION
PR adds an optional stream termination handling to `Http2LoopbackConnection.ReadBodyAsync` and fixes `HttpClient` construction missing the `SocketHttpHandler` created in the test.

Fixes #31220