### PR TITLE
Remove verbose test output logging

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -101,6 +101,7 @@
     <!-- Invoke the run script with the test host as the runtime path. -->
     <Exec Command="$(RunTestsCommand)"
           ContinueOnError="true"
+          IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33926.

As we ContinueOnError and error by reading from the ExitCode property we can set IgnoreExitCode in the msbuild Exec invocation to avoid the following verbose output: `error MSB4132: The "Exec" task returned false but did not log an error.`

### Before
```
C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests>dotnet build /t:Test
Microsoft (R) Build Engine version 16.6.0-preview-20173-01+2d82e1a86 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  TestUtilities -> C:\git\runtime3\artifacts\bin\TestUtilities\netcoreapp5.0-Debug\TestUtilities.dll
  System.Text.RegularExpressions.Tests -> C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\System.Text.RegularExpressions.Tests.dll
  ----- start Fri 04/17/2020 16:16:21.69 ===============  To repro directly: =====================================================
  pushd C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\
  "C:\git\runtime3\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\dotnet.exe" exec --runtimeconfig System.Text.RegularExpressions.Tests.runtimeconfig.json --depsfile System.Text.RegularExpressions.Tests.deps.json xunit.console.dll System.Text.RegularExpressions.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing -notrait category=nonnetcoreapptests -notrait category=nonwindowstests
  popd
  ===========================================================================================================
    Discovering: System.Text.RegularExpressions.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Text.RegularExpressions.Tests (found 190 of 207 test cases)
    Starting:    System.Text.RegularExpressions.Tests (parallel test collections = on, max threads = 8)
      System.Text.RegularExpressions.Tests.GroupCollectionReadOnlyDictionaryTests.IReadOnlyDictionary_TryGetValueSuccess [FAIL]
        System.Exception : lskdfjkldsjf
        Stack Trace:
          C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\GroupCollectionReadOnlyDictionaryTests.cs(17,0): at System.Text.RegularExpressions.Tests.GroupCollectionReadOnlyDictionaryTests.IReadOnlyDictionary_TryGetValueSuccess()
    Finished:    System.Text.RegularExpressions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Text.RegularExpressions.Tests  Total: 7205, Errors: 0, Failed: 1, Skipped: 0, Time: 4.525s
  ----- end Fri 04/17/2020 16:16:27.25 ----- exit code 1 ----------------------------------------------------------
C:\git\runtime3\eng\testing\tests.targets(102,5): warning MSB3073: The command ""C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\RunTests.cmd" --runtime-path "C:\git\runtime3\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64"" exited with code 1. [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
C:\git\runtime3\eng\testing\tests.targets(102,5): warning MSB4132: The "Exec" task returned false but did not log an error. [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
C:\git\runtime3\eng\testing\tests.targets(114,5): error : One or more tests failed while running tests from 'System.Text.RegularExpressions.Tests'. Please check C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\testResults.xml for details! [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]

Build FAILED.

C:\git\runtime3\eng\testing\tests.targets(102,5): warning MSB3073: The command ""C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\RunTests.cmd" --runtime-path "C:\git\runtime3\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64"" exited with code 1. [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
C:\git\runtime3\eng\testing\tests.targets(102,5): warning MSB4132: The "Exec" task returned false but did not log an error. [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
C:\git\runtime3\eng\testing\tests.targets(114,5): error : One or more tests failed while running tests from 'System.Text.RegularExpressions.Tests'. Please check C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\testResults.xml for details! [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
    2 Warning(s)
    1 Error(s)
```

### After
```
C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests>dotnet build /t:Test
Microsoft (R) Build Engine version 16.6.0-preview-20173-01+2d82e1a86 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  TestUtilities -> C:\git\runtime3\artifacts\bin\TestUtilities\netcoreapp5.0-Debug\TestUtilities.dll
  System.Text.RegularExpressions.Tests -> C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\System.Text.RegularExpressions.Tests.dll
  ----- start Fri 04/17/2020 16:15:30.10 ===============  To repro directly: =====================================================
  pushd C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\
  "C:\git\runtime3\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\dotnet.exe" exec --runtimeconfig System.Text.RegularExpressions.Tests.runtimeconfig.json --depsfile System.Text.RegularExpressions.Tests.deps.json xunit.console.dll System.Text.RegularExpressions.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing -notrait category=nonnetcoreapptests -notrait category=nonwindowstests
  popd
  ===========================================================================================================
    Discovering: System.Text.RegularExpressions.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Text.RegularExpressions.Tests (found 190 of 207 test cases)
    Starting:    System.Text.RegularExpressions.Tests (parallel test collections = on, max threads = 8)
      System.Text.RegularExpressions.Tests.GroupCollectionReadOnlyDictionaryTests.IReadOnlyDictionary_TryGetValueSuccess [FAIL]
        System.Exception : lskdfjkldsjf
        Stack Trace:
          C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\GroupCollectionReadOnlyDictionaryTests.cs(17,0): at System.Text.RegularExpressions.Tests.GroupCollectionReadOnlyDictionaryTests.IReadOnlyDictionary_TryGetValueSuccess()
    Finished:    System.Text.RegularExpressions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Text.RegularExpressions.Tests  Total: 7205, Errors: 0, Failed: 1, Skipped: 0, Time: 4.913s
  ----- end Fri 04/17/2020 16:15:36.14 ----- exit code 1 ----------------------------------------------------------
C:\git\runtime3\eng\testing\tests.targets(115,5): error : One or more tests failed while running tests from 'System.Text.RegularExpressions.Tests'. Please check C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\testResults.xml for details! [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]

Build FAILED.

C:\git\runtime3\eng\testing\tests.targets(115,5): error : One or more tests failed while running tests from 'System.Text.RegularExpressions.Tests'. Please check C:\git\runtime3\artifacts\bin\System.Text.RegularExpressions.Tests\netcoreapp5.0-Debug\testResults.xml for details! [C:\git\runtime3\src\libraries\System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj]
    0 Warning(s)
    1 Error(s)
```