### PR TITLE
Set fetch depth to 5 for stress tests on NanoServer

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -56,7 +56,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 1
+    fetchDepth: 5
     lfs: false
   
   - pwsh: |

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -57,7 +57,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 1
+    fetchDepth: 5
     lfs: false
 
   - pwsh: |


### PR DESCRIPTION
Increase git fetch depth for Windows NanoServer to avoid checkout failures
Fixes #33428