### PR TITLE
Update VS minimum dependency

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -34,7 +34,7 @@ Visual Studio 2019 installation process:
 
 A `.vsconfig` file is included in the root of the dotnet/runtime repository that includes all components needed to build the dotnet/runtime repository. You can [import `.vsconfig` in your Visual Studio installer](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2019#import-a-configuration) to install all necessary components.
 
-The dotnet/runtime repository requires at least Visual Studio 2019 16.3.
+The dotnet/runtime repository requires at least Visual Studio 2019 16.6 Preview 2.
 
 ## CMake
 


### PR DESCRIPTION
With the net5.0 TFM change and the nuget static graph restore, we require VS >= 16.6 Preview2.

cc @danmosemsft @jaredpar 