### PR TITLE
Consolidate Microsoft.NETCore.App property usage

### DIFF
--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -22,6 +22,7 @@
     <NetCoreAppCurrentTargetFrameworkMoniker>.NETCoreApp,Version=v$(NETCoreAppCurrentVersion)</NetCoreAppCurrentTargetFrameworkMoniker>
     <NetCoreAppCurrent>netcoreapp$(NETCoreAppCurrentVersion)</NetCoreAppCurrent>
     <NetFrameworkCurrent>net472</NetFrameworkCurrent>
+    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
   </PropertyGroup>
 
   <!-- Honor the generic RuntimeConfiguration property. -->

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -34,7 +34,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
     <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
     <NETCoreAppFrameworkMoniker>$(NETCoreAppFrameworkIdentifier),Version=v$(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkMoniker>
     <NETCoreAppFrameworkBrandName>.NET $(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkBrandName>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
     <NETCoreAppFrameworkIdentifier>$(TargetFrameworkIdentifier)</NETCoreAppFrameworkIdentifier>
-    <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
   </PropertyGroup>
 
   <!-- Explicitly build the runtime.depproj project first to correctly set up the testhost. -->


### PR DESCRIPTION
This is a follow up to PR #34662 
This PR consolidates the usage of hardcoded `Microsoft.NETCore.App` properties in `src/installer` and `src/libraries` with one common single shared property. It also removes unused properties with hardcoded `Microsoft.NETCore.App` and replaces occurences in other locations.
#35023 