### PR TITLE
Enable JIT/Regression/JitBlue/DevDiv_578214/DevDiv_578214 for mono.

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1499,9 +1499,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_545500/**">
             <Issue>https://github.com/dotnet/runtime/issues/34084</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_578214/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34382</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_578217/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
This passes now as a result of https://github.com/dotnet/runtime/pull/34949.

(See also: https://github.com/dotnet/runtime/issues/34382.)