### PR TITLE
[installer] Add RuntimeSpecificFrameworkSuffix property

### DIFF
--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -26,14 +26,9 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Keep this isolated to desktop mono for now -->
-  <Target Name="MobileGetBuildRidSpecificPackageProps"
-          Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true' and '$(TargetsBrowser)' != 'true'"
-          AfterTargets="GetBuildRidSpecificPackageProps">
-    <PropertyGroup>
-      <RidSpecificPackProperties>BaseId=$(MSBuildProjectName)$(RuntimeSpecificFrameworkSuffix).Mono.$(PackageBuildRID);IdPrefix=</RidSpecificPackProperties>
-    </PropertyGroup>
-  </Target>
+  <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true' and '$(TargetsBrowser)' != 'true'">
+    <RuntimeSpecificFrameworkSuffix>.Mono</RuntimeSpecificFrameworkSuffix>
+  </PropertyGroup>
 
   <!--
     For any Dependency items with a VersionProp, set it to the property by that name given by the


### PR DESCRIPTION
This is a follow up to #34980 
This PR removes `MobileGetBuildRidSpecificPackageProps` target and create a property group `RuntimeSpecificFrameworkSuffix` with .Mono inside.
fixes #35107 