### PR TITLE
Use ReadOnlySpan<byte> instead of byte arrays

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptImportKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptImportKey.cs
@@ -10,9 +10,9 @@ internal partial class Interop
     internal partial class Advapi32
     {
         [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool CryptImportKey(
+        internal static extern unsafe bool CryptImportKey(
             SafeProvHandle hProv,
-            byte[] pbData,
+            byte* pbData,
             int dwDataLen,
             SafeKeyHandle hPubKey,
             int dwFlags,

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -20,7 +20,7 @@ namespace Internal.NativeCrypto
     /// </summary>
     internal static partial class CapiHelper
     {
-        private static readonly byte[] s_RgbPubKey =
+        private static ReadOnlySpan<byte> RgbPubKey => new byte[]
         {
                 0x06, 0x02, 0x00, 0x00, 0x00, 0xa4, 0x00, 0x00,
                 0x52, 0x53, 0x41, 0x31, 0x00, 0x02, 0x00, 0x00,
@@ -1330,7 +1330,7 @@ namespace Internal.NativeCrypto
             try
             {
                 // Import the public key
-                if (!CryptImportKey(hProv, s_RgbPubKey, s_RgbPubKey.Length, SafeKeyHandle.InvalidHandle, 0, out hPubKey))
+                if (!CryptImportKey(hProv, RgbPubKey, RgbPubKey.Length, SafeKeyHandle.InvalidHandle, 0, out hPubKey))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
                     throw hr.ToCryptographicException();
@@ -1469,19 +1469,22 @@ namespace Internal.NativeCrypto
             return response;
         }
 
-        public static bool CryptImportKey(
+        public static unsafe bool CryptImportKey(
             SafeProvHandle hProv,
-            byte[] pbData,
+            ReadOnlySpan<byte> pbData,
             int dwDataLen,
             SafeKeyHandle hPubKey,
             int dwFlags,
             out SafeKeyHandle phKey)
         {
-            bool response = Interop.Advapi32.CryptImportKey(hProv, pbData, dwDataLen, hPubKey, dwFlags, out phKey);
+            fixed (byte* pbDataPtr = pbData)
+            {
+                bool response = Interop.Advapi32.CryptImportKey(hProv, pbDataPtr, dwDataLen, hPubKey, dwFlags, out phKey);
 
-            phKey.SetParent(hProv);
+                phKey.SetParent(hProv);
 
-            return response;
+                return response;
+            }
         }
 
         public static bool CryptCreateHash(

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -1022,7 +1022,7 @@ namespace Internal.NativeCrypto
             }
 
             SafeKeyHandle hKey;
-            if (!CryptImportKey(saveProvHandle, keyBlob, keyBlob.Length, SafeKeyHandle.InvalidHandle, dwCapiFlags, out hKey))
+            if (!CryptImportKey(saveProvHandle, keyBlob, SafeKeyHandle.InvalidHandle, dwCapiFlags, out hKey))
             {
                 int hr = Marshal.GetHRForLastWin32Error();
 
@@ -1330,7 +1330,7 @@ namespace Internal.NativeCrypto
             try
             {
                 // Import the public key
-                if (!CryptImportKey(hProv, RgbPubKey, RgbPubKey.Length, SafeKeyHandle.InvalidHandle, 0, out hPubKey))
+                if (!CryptImportKey(hProv, RgbPubKey, SafeKeyHandle.InvalidHandle, 0, out hPubKey))
                 {
                     int hr = Marshal.GetHRForLastWin32Error();
                     throw hr.ToCryptographicException();
@@ -1472,14 +1472,13 @@ namespace Internal.NativeCrypto
         public static unsafe bool CryptImportKey(
             SafeProvHandle hProv,
             ReadOnlySpan<byte> pbData,
-            int dwDataLen,
             SafeKeyHandle hPubKey,
             int dwFlags,
             out SafeKeyHandle phKey)
         {
             fixed (byte* pbDataPtr = pbData)
             {
-                bool response = Interop.Advapi32.CryptImportKey(hProv, pbDataPtr, dwDataLen, hPubKey, dwFlags, out phKey);
+                bool response = Interop.Advapi32.CryptImportKey(hProv, pbDataPtr, pbData.Length, hPubKey, dwFlags, out phKey);
 
                 phKey.SetParent(hProv);
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -21,8 +21,6 @@ namespace Internal.Cryptography
 {
     internal static partial class PkcsHelpers
     {
-        private static readonly byte[] s_pSpecifiedDefaultParameters = { 0x04, 0x00 };
-
 #if !NETCOREAPP && !NETSTANDARD2_1
         // Compatibility API.
         internal static void AppendData(this IncrementalHash hasher, ReadOnlySpan<byte> data)
@@ -623,8 +621,10 @@ namespace Internal.Cryptography
                     return false;
                 }
 
+                ReadOnlySpan<byte> pSpecifiedDefaultParameters = new byte[] { 0x04, 0x00 };
+
                 if (oaepParameters.PSourceFunc.Parameters != null &&
-                    !oaepParameters.PSourceFunc.Parameters.Value.Span.SequenceEqual(s_pSpecifiedDefaultParameters))
+                    !oaepParameters.PSourceFunc.Parameters.Value.Span.SequenceEqual(pSpecifiedDefaultParameters))
                 {
                     exception = new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                     return false;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -532,8 +532,6 @@ namespace Internal.Cryptography
             }
         }
 
-        private static readonly byte[] s_invalidEmptyOid = { 0x06, 0x00 };
-
         public static byte[] EncodeUtcTime(DateTime utcTime)
         {
             const int maxLegalYear = 2049;
@@ -575,8 +573,10 @@ namespace Internal.Cryptography
 
         public static string DecodeOid(byte[] encodedOid)
         {
+            ReadOnlySpan<byte> invalidEmptyOid = new byte[] { 0x06, 0x00 };
+
             // Windows compat.
-            if (s_invalidEmptyOid.AsSpan().SequenceEqual(encodedOid))
+            if (invalidEmptyOid.SequenceEqual(encodedOid))
             {
                 return string.Empty;
             }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -569,18 +569,16 @@ namespace Internal.Cryptography
             return value.UtcDateTime;
         }
 
-        public static string DecodeOid(byte[] encodedOid)
+        public static string DecodeOid(ReadOnlySpan<byte> encodedOid)
         {
-            ReadOnlySpan<byte> invalidEmptyOid = new byte[] { 0x06, 0x00 };
-
-            // Windows compat.
-            if (invalidEmptyOid.SequenceEqual(encodedOid))
+            // Windows compat for a zero length OID.
+            if (encodedOid.Length == 2 && encodedOid[0] == 0x06 && encodedOid[1] == 0x00)
             {
                 return string.Empty;
             }
 
             // Read using BER because the CMS specification says the encoding is BER.
-            AsnReader reader = new AsnReader(encodedOid, AsnEncodingRules.BER);
+            AsnValueReader reader = new AsnValueReader(encodedOid, AsnEncodingRules.BER);
             string value = reader.ReadObjectIdentifierAsString();
             reader.ThrowIfNotEmpty();
             return value;


### PR DESCRIPTION
A few more changes to use the compiler's `ReadOnlySpan<byte>` optimization trick instead of static byte arrays.