### PR TITLE
Fix collectible AssemblyLoadContext shutdown race

### DIFF
--- a/src/coreclr/src/binder/inc/clrprivbinderassemblyloadcontext.h
+++ b/src/coreclr/src/binder/inc/clrprivbinderassemblyloadcontext.h
@@ -78,7 +78,13 @@ private:
 
     CLRPrivBinderCoreCLR *m_pTPABinder;
 
+    // A long weak GC handle to the managed AssemblyLoadContext
     INT_PTR m_ptrManagedAssemblyLoadContext;
+    // A strong GC handle to the managed AssemblyLoadContext. This handle is set when the unload of the AssemblyLoadContext is initiated
+    // to keep the managed AssemblyLoadContext alive until the unload is finished.
+    // We still keep the weak handle pointing to the same managed AssemblyLoadContext so that native code can use the handle above 
+    // to refer to it during the whole lifetime of the AssemblyLoadContext.
+    INT_PTR m_ptrManagedStrongAssemblyLoadContext;
 
     LoaderAllocator* m_pAssemblyLoaderAllocator;
     void* m_loaderAllocatorHandle;


### PR DESCRIPTION
When the last reference to a collectible AssemblyLoadContext goes away,
its finalizer is called on the finalizer thread. It ends up calling the
native CLRPrivBinderAssemblyLoadContext::PrepareForLoadContextRelease
method which replaces a long weak GC handle to the managed
AssemblyLoadContext stored in the CLRPrivBinderAssemblyLoadContext by a
strong GC handle to the same AssemblyLoadContext and closes the original
weak handle.
The problem is that another thread may have read the weak handle pointer
and then try to use it to call into the resolving methods on the managed
AssemblyLoadContext. If that thread tries to resolve the related handle
after the finalizer thread has closed it, it fails as the handle doesn't
exist anymore. It could even get a completely different object if the
handle got reused in between. Or even worse, if the handle got reused by
another AssemblyLoadContext, the handle would resolve, but to the
different AssemblyLoadContext.

This change fixes the problem by keeping the weak handle open and
closing it after the AssemblyLoadContext shutdown completes (there are
no more assemblies that were loaded into that context and no instances
of types from those assemblies). The strong handle now serves only to
keep the managed AssemblyLoadContext alive.

Close #34838