### PR TITLE
Module initializers spec proposal

### DIFF
--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -325,3 +325,19 @@ We propose the limit on #String and #Blob heap size is 2^29 (0.5 GB), that is an
 2) 0.5 GB is a very large heap. Having such a big PE file seems unreasonable and very rare scenario (if it exists at all).
 
 3) Having 3 spare bits available is very beneficial for the implementation. It allows to represent WinRT projected strings, namespaces, etc. in very efficient way. If we had to represent heap indices with all 32 bits it would bloat various structures and increase memory pressure. PE files over 0.5 GB of size are very rare, but the overhead would affect all compilers and tools working with the metadata reader.
+
+## Module Initializer
+
+All modules may have a module initializer. This method shall be static, a member of the module, take no parameters, return no value, be marked with **rtspecialname** and **specialname**, and be named `.cctor`.
+
+There are no limitations on what code is permitted in a module initializer. Module initializers are permitted to run and call both managed and unmanaged code.
+
+### Module Initialization Guarantees
+
+The CLI shall provide the following guarantees regarding module initialization:
+
+1. A module initializer is executed at, or sometime before, first access to any types, methods, or data defined in the module.
+
+2. A module initializer shall run exactly once for any given module unless explicitly called by user code.
+
+3. No method other than those called directly or indirectly from the module initializer will be able to access the types, methods, or data in a module before its initializer completes execution.

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -326,6 +326,31 @@ We propose the limit on #String and #Blob heap size is 2^29 (0.5 GB), that is an
 
 3) Having 3 spare bits available is very beneficial for the implementation. It allows to represent WinRT projected strings, namespaces, etc. in very efficient way. If we had to represent heap indices with all 32 bits it would bloat various structures and increase memory pressure. PE files over 0.5 GB of size are very rare, but the overhead would affect all compilers and tools working with the metadata reader.
 
+## Metadata merging
+
+The mention of metadata merging in § II.10.8 _Global fields and methods_ is a spec bug. The CLI does not merge metadata. Policies of static linkers that merge metadata may vary and do not concern the CLI.
+
+This text should be deleted, and the _metadata merging_ entry should be removed from the index:
+
+> ~~The only noticeable difference is in how definitions of this special class
+> are treated when multiple modules are combined together, as is done by a class loader. This process is
+> known as _metadata merging_.~~
+>
+> ~~For an ordinary type, if the metadata merges two definitions of the same type, it simply discards one
+> definition on the assumption they are equivalent, and that any anomaly will be discovered when the
+> type is used. For the special class that holds global members, however, members are unioned across all
+> modules at merge time. If the same name appears to be defined for cross-module use in multiple
+> modules then there is an error. In detail:~~
+>
+> * ~~If no member of the same kind (field or method), name, and signature exists, then
+>   add this member to the output class.~~
+>
+> * ~~If there are duplicates and no more than one has an accessibility other than
+>   **compilercontrolled**, then add them all to the output class.~~
+>
+> * ~~If there are duplicates and two or more have an accessibility other than
+>   **compilercontrolled**, an error has occurred.~~
+
 ## Module Initializer
 
 All modules may have a module initializer. This method shall be a global method, static, take no parameters, return no value, be marked with **rtspecialname** and **specialname**, and be named `.cctor`.

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -353,13 +353,13 @@ This text should be deleted, and the _metadata merging_ entry should be removed 
 
 ## Module Initializer
 
-All modules may have a module initializer. This method shall be a global method, static, take no parameters, return no value, be marked with **rtspecialname** and **specialname**, and be named `.cctor`.
+All modules may have a module initializer. A module initializer is defined as the type initializer (§ II.10.5.3) of the `<Module>` type (§ II.10.8).
 
 There are no limitations on what code is permitted in a module initializer. Module initializers are permitted to run and call both managed and unmanaged code.
 
 ### Module Initialization Guarantees
 
-The CLI shall provide the following guarantees regarding module initialization:
+In addition to the guarantees that apply to all type initializers, the CLI shall provide the following guarantees for module initializers:
 
 1. A module initializer is executed at, or sometime before, first access to any static field or first invocation of any method defined in the module.
 

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -336,7 +336,7 @@ There are no limitations on what code is permitted in a module initializer. Modu
 
 The CLI shall provide the following guarantees regarding module initialization:
 
-1. A module initializer is executed at, or sometime before, first access to any types, methods, or data defined in the module.
+1. A module initializer is executed at, or sometime before, first access to any static field or first invocation of any method defined in the module.
 
 2. A module initializer shall run exactly once for any given module unless explicitly called by user code.
 

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -328,7 +328,7 @@ We propose the limit on #String and #Blob heap size is 2^29 (0.5 GB), that is an
 
 ## Module Initializer
 
-All modules may have a module initializer. This method shall be static, a member of the module, take no parameters, return no value, be marked with **rtspecialname** and **specialname**, and be named `.cctor`.
+All modules may have a module initializer. This method shall be a global method, static, take no parameters, return no value, be marked with **rtspecialname** and **specialname**, and be named `.cctor`.
 
 There are no limitations on what code is permitted in a module initializer. Module initializers are permitted to run and call both managed and unmanaged code.
 


### PR DESCRIPTION
Requested by @AlekseyTs before proceeding with the [compiler feature](https://github.com/dotnet/csharplang/blob/master/meetings/2020/LDM-2020-04-08.md#module-initializers) that is designed on the premise of providing these guarantees.

The source for this spec is https://docs.microsoft.com/en-us/archive/blogs/junfeng/module-initializer-a-k-a-module-constructor. I edited a bit for clarity.

This probably explains why no mention of module initializers was added to ECMA-335:
(https://web.archive.org/web/20080309053655/http://msdn.microsoft.com/chats/transcripts/vstudio/vstudio_091604.aspx)

> Host: MartynL (Microsoft)
> **Q:** Is the "module constructor" a CLR feature or a CLI feature?
> **A:** Right now the module constructor has not been added to the CLI as I understand it. Generally our features for mixed mode are not part of the CLI.

/cc @jkotas 

Aleksey asked that this document explicitly mention what happens to module initializers during metadata merging as defined in ECMA 335 **II.10.8 Global fields and methods** (PDF page 180). Would that belong in the 'Guarantees' section or in the main section above?

ECMA 335 doesn't elaborate any further than to say "an error has occurred." To quote part of this section:

> For the special class that holds global members, however, members are unioned across all
modules at merge time. If the same name appears to be defined for cross-module use in multiple
modules then there is an error. In detail:
> - If no member of the same kind (field or method), name, and signature exists, then
add this member to the output class.
> - If there are duplicates and no more than one has an accessibility other than
`compilercontrolled`, then add them all to the output class.
> - If there are duplicates and two or more have an accessibility other than
`compilercontrolled`, an error has occurred.

When unioning between two or more `<Module>` types that have module initializers, module initializers will be members of the same kind (method) and same name (`.cctor`) and same signature (static parameterless void), and all will have an accessibility other than `compilercontrolled`. Therefore metadata merging between such modules would be an error. 

#### Proposed addition

Please suggest improvements and location within the existing text.

```
Metadata merging between two or more modules that each contain a module initializer is an
error. This is consistent with the treatment of duplicate members specified in ECMA 335 section
II.10.8.
```


