### PR TITLE
JIT: add suppressed zero inits if we transform tail recursive call to…

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -1825,6 +1825,8 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     compFloatingPointUsed = false;
     compUnsafeCastUsed    = false;
 
+    compSuppressedZeroInit = false;
+
     compNeedsGSSecurityCookie = false;
     compGSReorderStackLayout  = false;
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -515,6 +515,8 @@ public:
     unsigned char lvImplicitlyReferenced : 1; // true if there are non-IR references to this local (prolog, epilog, gc,
                                               // eh)
 
+    unsigned char lvSuppressedZeroInit : 1; // local needs zero init if we transform tail call to loop
+
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
                                   // local.  For implicit byref parameters, this gets hijacked between
@@ -8415,6 +8417,7 @@ public:
     bool compHasBackwardJump;      // Does the method (or some inlinee) have a lexically backwards jump?
     bool compSwitchedToOptimized;  // Codegen initially was Tier0 but jit switched to FullOpts
     bool compSwitchedToMinOpts;    // Codegen initially was Tier1/FullOpts but jit switched to MinOpts
+    bool compSuppressedZeroInit;   // There are vars with lvSuppressedZeroInit set
 
 // NOTE: These values are only reliable after
 //       the importing is completely finished.

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -23649,14 +23649,12 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
             // If the local is used check whether we need to insert explicit zero initialization.
             if (tmpNum != BAD_VAR_NUM)
             {
-                if (!fgVarNeedsExplicitZeroInit(lvaGetDesc(tmpNum), bbInALoop, bbIsReturn))
+                LclVarDsc* const tmpDsc = lvaGetDesc(tmpNum);
+                if (!fgVarNeedsExplicitZeroInit(tmpDsc, bbInALoop, bbIsReturn))
                 {
-#ifdef DEBUG
-                    if (verbose)
-                    {
-                        printf("\nSkipping zero initialization of V%02u\n", tmpNum);
-                    }
-#endif // DEBUG
+                    JITDUMP("\nSuppressing zero-init for V%02u -- expect to zero in prolog\n", tmpNum);
+                    tmpDsc->lvSuppressedZeroInit = 1;
+                    compSuppressedZeroInit       = true;
                     continue;
                 }
 

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -13713,7 +13713,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             ((block->bbFlags & BBF_BACKWARD_JUMP) != 0);
                         bool bbIsReturn = (block->bbJumpKind == BBJ_RETURN) &&
                                           (!compIsForInlining() || (impInlineInfo->iciBlock->bbJumpKind == BBJ_RETURN));
-                        if (fgVarNeedsExplicitZeroInit(lvaGetDesc(lclNum), bbInALoop, bbIsReturn))
+                        LclVarDsc* const lclDsc = lvaGetDesc(lclNum);
+                        if (fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
                         {
                             // Append a tree to zero-out the temp
                             newObjThisPtr = gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet());
@@ -13723,6 +13724,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                                            false,            // isVolatile
                                                            false);           // not copyBlock
                             impAppendTree(newObjThisPtr, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
+                        }
+                        else
+                        {
+                            JITDUMP("\nSuppressing zero-init for V%02u -- expect to zero in prolog\n", lclNum);
+                            lclDsc->lvSuppressedZeroInit = 1;
+                            compSuppressedZeroInit       = true;
                         }
 
                         // Obtain the address of the temp

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8142,7 +8142,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     // but this loop can't include the prolog. Since we don't have liveness information, we insert zero-initialization
     // for all non-parameter IL locals as well as temp structs with GC fields.
     // Liveness phase will remove unnecessary initializations.
-    if (info.compInitMem)
+    if (info.compInitMem || compSuppressedZeroInit)
     {
         unsigned   varNum;
         LclVarDsc* varDsc;
@@ -8159,7 +8159,8 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
                 var_types lclType            = varDsc->TypeGet();
                 bool      isUserLocal        = (varNum < info.compLocalsCount);
                 bool      structWithGCFields = ((lclType == TYP_STRUCT) && varDsc->GetLayout()->HasGCPtr());
-                if (isUserLocal || structWithGCFields)
+                bool      hadSuppressedInit  = varDsc->lvSuppressedZeroInit;
+                if (isUserLocal || structWithGCFields || hadSuppressedInit)
                 {
                     GenTree* lcl  = gtNewLclvNode(varNum, lclType);
                     GenTree* init = nullptr;

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8160,7 +8160,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
                 bool      isUserLocal        = (varNum < info.compLocalsCount);
                 bool      structWithGCFields = ((lclType == TYP_STRUCT) && varDsc->GetLayout()->HasGCPtr());
                 bool      hadSuppressedInit  = varDsc->lvSuppressedZeroInit;
-                if (isUserLocal || structWithGCFields || hadSuppressedInit)
+                if ((info.compInitMem && (isUserLocal || structWithGCFields)) || hadSuppressedInit)
                 {
                     GenTree* lcl  = gtNewLclvNode(varNum, lclType);
                     GenTree* init = nullptr;

--- a/src/coreclr/src/jit/objectalloc.cpp
+++ b/src/coreclr/src/jit/objectalloc.cpp
@@ -518,9 +518,10 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
     comp->lvaSetStruct(lclNum, allocObj->gtAllocObjClsHnd, unsafeValueClsCheck);
 
     // Initialize the object memory if necessary.
-    bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
-    bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
-    if (comp->fgVarNeedsExplicitZeroInit(comp->lvaGetDesc(lclNum), bbInALoop, bbIsReturn))
+    bool             bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
+    bool             bbIsReturn = block->bbJumpKind == BBJ_RETURN;
+    LclVarDsc* const lclDsc     = comp->lvaGetDesc(lclNum);
+    if (comp->fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
     {
         //------------------------------------------------------------------------
         // STMTx (IL 0x... ???)
@@ -537,6 +538,12 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
         Statement* newStmt = comp->gtNewStmt(tree);
 
         comp->fgInsertStmtBefore(block, stmt, newStmt);
+    }
+    else
+    {
+        JITDUMP("\nSuppressing zero-init for V%02u -- expect to zero in prolog\n", lclNum);
+        lclDsc->lvSuppressedZeroInit = 1;
+        comp->compSuppressedZeroInit = true;
     }
 
     //------------------------------------------------------------------------

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_33529/Runtime_33529.il
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_33529/Runtime_33529.il
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly Runtime_33529 {}
+
+// Test case where the jit finds a tail call to loop opportunity after
+// suppressing zero initialization for a struct.
+
+// S is too large to enregister and has gc fields
+
+.class public sequential ansi sealed beforefieldinit S
+       extends [mscorlib]System.ValueType
+{
+  .field public static int32 s_i0
+  .field public int32 x
+  .field public int32 a
+  .field public int32 i0
+  .field public int32 i1
+  .field public string s
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(int32 _x,
+                               int32 _a) cil managed
+  {
+    // Code size       46 (0x2e)
+    .maxstack  8
+
+    // Modify S.ctor to read from i0 before initializing it        
+
+    ldarg.0
+    ldfld int32 S::i0
+
+    IL_0001:  stsfld     int32 S::s_i0
+    IL_0006:  ldarg.0
+    IL_0007:  ldarg.1
+    IL_0008:  stfld      int32 S::x
+    IL_000d:  ldarg.0
+    IL_000e:  ldarg.2
+    IL_000f:  stfld      int32 S::a
+    IL_0014:  ldarg.0
+    IL_0015:  ldc.i4.3
+    IL_0016:  stfld      int32 S::i0
+    IL_001b:  ldarg.0
+    IL_001c:  ldc.i4.4
+    IL_001d:  stfld      int32 S::i1
+    IL_0022:  ldarg.0
+    IL_0023:  ldstr      "a string"
+    IL_0028:  stfld      string S::s
+    IL_002d:  ret
+  } // end of method S::.ctor
+
+} // end of class S
+
+.class private auto ansi beforefieldinit X
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig static int32  F(int32 x,
+                                           int32 a) cil managed
+  {
+    // Code size       18 (0x12)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  brtrue.s   IL_0005
+
+    IL_0003:  ldarg.1
+    IL_0004:  ret
+
+    IL_0005:  ldarg.0
+    IL_0006:  ldarg.1
+
+    // This newobj will require a jit temp; the jit will suppress
+    // zero init assuming prolog zeroing will suffice.
+
+    IL_0007:  newobj     instance void S::.ctor(int32,int32)
+
+    // Inlining G will introduce a recursive tail call to F which
+    // the jit will optimize into a loop
+
+    IL_000c:  call       int32 X::G(valuetype S)
+    IL_0011:  ret
+  } // end of method X::F
+
+  .method public hidebysig static int32  G(valuetype S s) cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      int32 S::x
+    IL_0006:  ldc.i4.1
+    IL_0007:  sub
+    IL_0008:  ldarg.0
+    IL_0009:  ldfld      int32 S::a
+    IL_000e:  ldarg.0
+    IL_000f:  ldfld      int32 S::x
+    IL_0014:  mul
+    IL_0015:  call       int32 X::F(int32,
+                                    int32)
+    IL_001a:  ret
+  } // end of method X::G
+
+  .method public hidebysig static int32  H(int32 x) cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldc.i4.1
+    IL_0002:  call       int32 X::F(int32,
+                                    int32)
+    IL_0007:  ret
+  } // end of method X::H
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       78 (0x4e)
+    .maxstack  4
+    .locals init ([0] int32 r)
+    IL_0000:  ldc.i4.6
+    IL_0001:  call       int32 X::H(int32)
+    IL_0006:  stloc.0
+    IL_0007:  ldsfld     int32 S::s_i0
+    IL_000c:  brtrue.s   IL_0018
+
+    IL_000e:  ldloc.0
+    IL_000f:  ldc.i4     0x2d0
+    IL_0014:  ceq
+    IL_0016:  br.s       IL_0019
+
+    IL_0018:  ldc.i4.0
+    IL_0019:  dup
+    IL_001a:  brfalse.s  IL_0028
+
+    IL_001c:  ldstr      "Pass"
+    IL_0021:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0026:  br.s       IL_0047
+
+    IL_0028:  ldstr      "Fail, expected S.s_i0 == 0, got {0}, expected r =="
+    + " 720, got {1}"
+    IL_002d:  ldsfld     int32 S::s_i0
+    IL_0032:  box        [mscorlib]System.Int32
+    IL_0037:  ldloc.0
+    IL_0038:  box        [mscorlib]System.Int32
+    IL_003d:  call       string [mscorlib]System.String::Format(string,
+                                                                object,
+                                                                object)
+    IL_0042:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0047:  brtrue.s   IL_004b
+
+    IL_0049:  ldc.i4.m1
+    IL_004a:  ret
+
+    IL_004b:  ldc.i4.s   100
+    IL_004d:  ret
+  } // end of method X::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method X::.ctor
+
+} // end of class X
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// WARNING: Created Win32 resource file ixs.res

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_33529/Runtime_33529.ilproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_33529/Runtime_33529.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
… jump

Track whether the jit has suppressed in-body zero initialization for any locals
because at the time it appeared prolog initialization would be sufficient. If
the jit subsequently decides to change a tail recursive call into a loop, use
this information to add back the missing zero initializations.

Added a test case.

Addresses #33529.