### PR TITLE
Single-File Bundler: Add a FileSize test

### DIFF
--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -144,6 +144,17 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
+        public void TestFileSizes()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+            var bundler = BundleHelper.Bundle(fixture);
+            var publishPath = BundleHelper.GetPublishPath(fixture);
+
+            bundler.BundleManifest.Files.ForEach(file =>
+                Assert.True(file.Size == new FileInfo(Path.Combine(publishPath, file.RelativePath)).Length));
+        }
+
+        [Fact]
         public void TestAssemblyAlignment()
         {
             var fixture = sharedTestState.TestFixture.Copy();


### PR DESCRIPTION
Add a bundler consistency tests that verifies that the size of each embedded file (recorded in the bundle manifest) matches its original size of the file on disk.