### PR TITLE
[wasm][debugger] Implement `Runtime.callFunctionOn`, and support array expansion

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -845,7 +845,10 @@ static gboolean describe_value(MonoType * type, gpointer addr, gboolean expandVa
 			int obj_id = get_object_id (obj);
 
 			if (type-> type == MONO_TYPE_ARRAY || type->type == MONO_TYPE_SZARRAY) {
-				mono_wasm_add_typed_value ("array", class_name, obj_id);
+				MonoArray *array = (MonoArray *)obj;
+				EM_ASM ({
+					MONO.mono_wasm_add_typed_value ('array', $0, { objectId: $1, length: $2 });
+				}, class_name, obj_id, mono_array_length_internal (array));
 			} else if (m_class_is_delegate (klass) || (type->type == MONO_TYPE_GENERICINST && m_class_is_delegate (type->data.generic_class->container_class))) {
 				MonoMethod *method;
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19588,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>- This was prompted by vscode/vs requiring this for array expansion.
- It runs a given js function string, on a given object id.
- We handle the case for dotnet object ids.

Implementation:

- We build a proxy object that reflects the details of the real dotnet object/array
- And run the js function on that proxy object

- Then if `returnByValue` was requested, the result is returned as-is
- Else we cache that object, with a new special object id (`dotnet:cfo_res:..`),
  and return that id in the response.

- Subsequently, we would get `Runtime.getProperties` request on this new object id
- And a `Runtime.releaseObject` request, to free that function result.

- All this is handled currently

Tests:

- A few tests were added which invoke `callFunctionOn`, on JS objects, and checks the result
  - And the same checks are performed on equivalent dotnet objects, with the same js function
  - This should help stay in sync with what we think `callFunctionOn` should work as

  - These tests have an additional parameter - `roundtrip`, which calls a simple function
	`function () { return this; }`
    .. on a dotnet object, and gets the result object id. If `roundtrip == true`, then it
    runs that same function on the result object, and gets a new result object id. And the
    tests run their checks on that.

    - this helps to check that outside of the proxy, the result object behaves same as any
      other dotnet object.

- Also, most of the tests were modified to support an additional mode (`use_cfo`).
  - With this, whenever a test wants to run `Runtime.getProperties on an object, we pass that
    object through the earlier "identity" function, and then run `getProperties` on that
    resultant object.

  - This helps to take advantage most of the existing tests, and use them for `callFunctionOn`
    testing too, by ensuring that the results of CFO returns results same as any other object.

Fixes mono/mono#19229, mono/mono#19531