### PR TITLE
Support any dictionary types JsonExtensionData

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
@@ -42,6 +42,8 @@ namespace System.Text.Json.Serialization.Converters
             return creator((Dictionary<string, TValue>)value);
         }
 
+        internal override bool IsImmutableDictionary => true;
+
         protected internal override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
             IEnumerator<KeyValuePair<string, TValue>> enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
@@ -25,6 +25,11 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
         {
+            state.Current.ReturnValue = ConvertToDictionary(ref state, state.Current.ReturnValue!, options);
+        }
+
+        internal override object? ConvertToDictionary(ref ReadStack state, object value, JsonSerializerOptions options)
+        {
             JsonClassInfo classInfo = state.Current.JsonClassInfo;
 
             Func<IEnumerable<KeyValuePair<string, TValue>>, TCollection>? creator = (Func<IEnumerable<KeyValuePair<string, TValue>>, TCollection>?)classInfo.CreateObjectWithArgs;
@@ -34,7 +39,7 @@ namespace System.Text.Json.Serialization.Converters
                 classInfo.CreateObjectWithArgs = creator;
             }
 
-            state.Current.ReturnValue = creator((Dictionary<string, TValue>)state.Current.ReturnValue!);
+            return creator((Dictionary<string, TValue>)value);
         }
 
         protected internal override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -227,9 +227,13 @@ namespace System.Text.Json.Serialization.Converters
 
             if (state.Current.DataExtensionData != null)
             {
-                JsonPropertyInfo prop = state.Current.JsonClassInfo.DataExtensionProperty!;
-                object? converted = prop.ConverterBase.ConvertToDictionary(ref state, state.Current.DataExtensionData, options);
-                prop.SetValueAsObject(obj, converted);
+                JsonPropertyInfo dataExtProperty = state.Current.JsonClassInfo.DataExtensionProperty!;
+                object extData = state.Current.DataExtensionData;
+                if (dataExtProperty.ConverterBase.IsImmutableDictionary)
+                {
+                    extData = dataExtProperty.ConverterBase.ConvertToDictionary(ref state, extData, options)!;
+                }
+                dataExtProperty.SetValueAsObject(obj, extData);
             }
 
             value = (T)obj;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -205,7 +205,7 @@ namespace System.Text.Json.Serialization.Converters
                         }
                         else
                         {
-                            if (!jsonPropertyInfo.ReadJsonAndAddExtensionProperty(obj, ref state, ref reader))
+                            if (!jsonPropertyInfo.ReadJsonAndAddExtensionProperty(ref state, ref reader))
                             {
                                 // No need to set 'value' here since JsonElement must be read in full.
                                 state.Current.ReturnValue = obj;
@@ -223,6 +223,13 @@ namespace System.Text.Json.Serialization.Converters
             if (state.Current.PropertyRefCache != null)
             {
                 state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            }
+
+            if (state.Current.DataExtensionData != null)
+            {
+                JsonPropertyInfo prop = state.Current.JsonClassInfo.DataExtensionProperty!;
+                object? converted = prop.ConverterBase.ConvertToDictionary(ref state, state.Current.DataExtensionData, options);
+                prop.SetValueAsObject(obj, converted);
             }
 
             value = (T)obj;
@@ -380,7 +387,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
                 else
                 {
-                    jsonPropertyInfo.ReadJsonAndAddExtensionProperty(obj, ref state, ref reader);
+                    jsonPropertyInfo.ReadJsonAndAddExtensionProperty(ref state, ref reader);
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
                         {
                             Debug.Assert(jsonPropertyInfo == state.Current.JsonClassInfo.DataExtensionProperty);
                             state.Current.JsonPropertyNameAsString = dataExtKey;
-                            JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo);
+                            JsonSerializer.CreateDataExtensionProperty(ref state, jsonPropertyInfo);
                         }
 
                         ReadPropertyValue(obj, ref state, ref tempReader, jsonPropertyInfo, useExtensionProperty);
@@ -105,8 +105,8 @@ namespace System.Text.Json.Serialization.Converters
                         {
                             Debug.Assert(jsonPropertyInfo == state.Current.JsonClassInfo.DataExtensionProperty);
 
-                            JsonSerializer.CreateDataExtensionProperty(obj, jsonPropertyInfo);
-                            object extDictionary = jsonPropertyInfo.GetValueAsObject(obj)!;
+                            JsonSerializer.CreateDataExtensionProperty(ref state, jsonPropertyInfo);
+                            object extDictionary = state.Current.DataExtensionData!;
 
                             if (extDictionary is IDictionary<string, JsonElement> dict)
                             {
@@ -133,6 +133,13 @@ namespace System.Text.Json.Serialization.Converters
             if (state.Current.CtorArgumentState!.ParameterRefCache != null)
             {
                 state.Current.JsonClassInfo.UpdateSortedParameterCache(ref state.Current);
+            }
+
+            if (state.Current.DataExtensionData != null)
+            {
+                JsonPropertyInfo prop = state.Current.JsonClassInfo.DataExtensionProperty!;
+                object? converted = prop.ConverterBase.ConvertToDictionary(ref state, state.Current.DataExtensionData, options);
+                prop.SetValueAsObject(obj, converted);
             }
 
             value = (T)obj;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -276,8 +276,18 @@ namespace System.Text.Json
             if (jsonPropertyInfo != null)
             {
                 Type declaredPropertyType = jsonPropertyInfo.DeclaredPropertyType;
+
+                bool isImmutableReadOnly = declaredPropertyType.IsImmutableDictionaryType() &&
+                    (typeof(IReadOnlyDictionary<string, object>).IsAssignableFrom(declaredPropertyType) ||
+                     typeof(IReadOnlyDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType));
+
+                bool isReadOnlyDictionaryInterface = declaredPropertyType == typeof(IReadOnlyDictionary<string, object>) ||
+                     declaredPropertyType == typeof(IReadOnlyDictionary<string, JsonElement>);
+
                 if (typeof(IDictionary<string, object>).IsAssignableFrom(declaredPropertyType) ||
-                    typeof(IDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType))
+                    typeof(IDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType) ||
+                    isImmutableReadOnly||
+                    isReadOnlyDictionaryInterface)
                 {
                     JsonConverter converter = Options.GetConverter(declaredPropertyType);
                     Debug.Assert(converter != null);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -79,5 +79,8 @@ namespace System.Text.Json.Serialization
         internal virtual bool ConstructorIsParameterized => false;
 
         internal ConstructorInfo? ConstructorInfo { get; set; }
+
+        internal virtual object? ConvertToDictionary(ref ReadStack state, object value, JsonSerializerOptions options)
+            => value;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -38,6 +38,8 @@ namespace System.Text.Json.Serialization
 
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
 
+        internal abstract object CreateDictionaryOfStringT();
+
         internal abstract Type? ElementType { get; }
 
         /// <summary>
@@ -82,5 +84,7 @@ namespace System.Text.Json.Serialization
 
         internal virtual object? ConvertToDictionary(ref ReadStack state, object value, JsonSerializerOptions options)
             => value;
+
+        internal virtual bool IsImmutableDictionary { get; set; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -46,10 +46,7 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
-        internal override JsonParameterInfo CreateJsonParameterInfo()
-        {
-            throw new InvalidOperationException();
-        }
+        internal sealed override object CreateDictionaryOfStringT() => throw new InvalidOperationException();
 
         internal sealed override Type? ElementType => null;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -38,13 +38,9 @@ namespace System.Text.Json.Serialization
         /// </returns>
         public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
 
-        internal override JsonPropertyInfo CreateJsonPropertyInfo()
-        {
-            // We should never get here.
-            Debug.Assert(false);
+        internal sealed override JsonPropertyInfo CreateJsonPropertyInfo() => throw new InvalidOperationException();
 
-            throw new InvalidOperationException();
-        }
+        internal sealed override JsonParameterInfo CreateJsonParameterInfo() => throw new InvalidOperationException();
 
         internal sealed override object CreateDictionaryOfStringT() => throw new InvalidOperationException();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -51,6 +52,8 @@ namespace System.Text.Json.Serialization
         {
             return new JsonParameterInfo<T>();
         }
+
+        internal override object CreateDictionaryOfStringT() => new Dictionary<string, T>();
 
         internal override Type? ElementType => null;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -207,9 +207,9 @@ namespace System.Text.Json
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
         protected JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method
 
-        public bool ReadJsonAndAddExtensionProperty(object obj, ref ReadStack state, ref Utf8JsonReader reader)
+        public bool ReadJsonAndAddExtensionProperty(ref ReadStack state, ref Utf8JsonReader reader)
         {
-            object propValue = GetValueAsObject(obj)!;
+            object propValue = state.Current.DataExtensionData!;
 
             if (propValue is IDictionary<string, object?> dictionaryObject)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -232,13 +232,8 @@ namespace System.Text.Json
                     dictionaryObject[state.Current.JsonPropertyNameAsString!] = value;
                 }
             }
-            else
+            else if (propValue is IDictionary<string, JsonElement> dictionaryJsonElement)
             {
-                // Handle case where extension property is JsonElement-based.
-
-                Debug.Assert(propValue is IDictionary<string, JsonElement>);
-                IDictionary<string, JsonElement> dictionaryJsonElement = (IDictionary<string, JsonElement>)propValue;
-
                 JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverter(typeof(JsonElement));
 
                 if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out JsonElement value))
@@ -247,6 +242,10 @@ namespace System.Text.Json
                 }
 
                 dictionaryJsonElement[state.Current.JsonPropertyNameAsString!] = value;
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(DeclaredPropertyType);
             }
 
             return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -42,6 +42,9 @@ namespace System.Text.Json
         public int CtorArgumentStateIndex;
         public ArgumentState? CtorArgumentState;
 
+        // Holds properties that should be serialized into the data extension property
+        public object? DataExtensionData;
+
         public void EndConstructorParameter()
         {
             CtorArgumentState!.JsonParameterInfo = null;
@@ -65,6 +68,7 @@ namespace System.Text.Json
         {
             JsonPropertyNameAsString = null;
             PropertyState = StackFramePropertyState.None;
+            DataExtensionData = null;
         }
 
         public void InitializeReEntry(Type type, JsonSerializerOptions options, string? propertyName)
@@ -106,6 +110,7 @@ namespace System.Text.Json
             PropertyIndex = 0;
             PropertyRefCache = null;
             ReturnValue = null;
+            DataExtensionData = null;
 
             EndProperty();
         }

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -907,8 +907,8 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructor>("{\"hello\":\"world\"}"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyPrivateConstructorJsonElement>("{\"hello\":\"world\"}"));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutable>("{\"hello\":\"world\"}"));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutableJsonElement>("{\"hello\":\"world\"}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutable>("{\"hello\":\"world\"}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyCustomIImmutableJsonElement>("{\"hello\":\"world\"}"));
         }
 
         [Fact]


### PR DESCRIPTION
This changes the way that ExtensionData is gathered and assigned so that properties are added and assigned before finishing parsing an object.

This works for the following dictionary types
- `Dictionary<,>`
- `SortedDictionary<,>`
- `IDictionary<,>`
- `IReadOnlyDictionary<,>`
- `ImmutableDictionary<,>`
- `ImmutableSortedDictionary<,>`
- `IImmutableDictionary<,>`
- `ConcurrentDictionary<,>`

closes #31645 