### PR TITLE
Add attributes to System.Drawing.Printing.PrintDocument

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -2719,6 +2719,8 @@ namespace System.Drawing.Printing
         public virtual System.Drawing.Graphics? OnStartPage(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintPageEventArgs e) { throw null; }
         public virtual void OnStartPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) { }
     }
+    [System.ComponentModel.DefaultPropertyAttribute("DocumentName")]
+    [System.ComponentModel.DefaultEventAttribute("PrintPage")]
     public partial class PrintDocument : System.ComponentModel.Component
     {
         public PrintDocument() { }

--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\System.Collections.NonGeneric\ref\System.Collections.NonGeneric.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel\ref\System.ComponentModel.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
+    <ProjectReference Include="..\..\System.ComponentModel.TypeConverter\ref\System.ComponentModel.TypeConverter.csproj" />
     <ProjectReference Include="..\..\System.Drawing.Primitives\ref\System.Drawing.Primitives.csproj" />
     <ProjectReference Include="..\..\System.ObjectModel\ref\System.ObjectModel.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
@@ -22,6 +23,7 @@
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
+    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Drawing.Primitives" />
     <Reference Include="System.ObjectModel" />

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -366,6 +366,7 @@
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
+    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Text.Encoding.Extensions" />

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.Unix.cs
@@ -40,6 +40,7 @@ using System.ComponentModel;
 
 namespace System.Drawing.Printing
 {
+    [DefaultProperty("DocumentName"), DefaultEvent("PrintPage")]
     public class PrintDocument : System.ComponentModel.Component
     {
         private PageSettings defaultpagesettings;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintDocument.Windows.cs
@@ -9,7 +9,7 @@ namespace System.Drawing.Printing
     /// <summary>
     /// Defines a reusable object that sends output to the printer.
     /// </summary>
-    [SRDescription(nameof(SR.PrintDocumentDesc))]
+    [DefaultProperty("DocumentName"), DefaultEvent("PrintPage"), SRDescription(nameof(SR.PrintDocumentDesc))]
     public class PrintDocument : Component
     {
         private string _documentName = "document";


### PR DESCRIPTION
Fixes #34696 

I added DefaultEventAttribute and DefaultPropertyAttribute on PrintDocument class in System.Drawing.Printing.PrintDocument, to be in sync with .NET Framework's [PrintDocument](https://referencesource.microsoft.com/#System.Drawing/commonui/System/Drawing/Printing/PrintDocument.cs,275c61df12f04804) as described in #34696 

@safern 
I mark this as WIP, because after I opened I System.Drawing.Common.sln and did build using Visual Studio on src\libraries\src\System.Drawing.Common.csproj on my machine, I got these errors:

```
Error occurred while restoring NuGet packages: Invalid restore input. Duplicate frameworks found: 'netcoreapp3.0, netcoreapp5.0, netcoreapp5.0, netcoreapp3.0'. Input files: D:\dotnetruntime\src\libraries\System.Drawing.Common\src\System.Drawing.Common.csproj.
1>------ Build started: Project: System.Drawing.Common (ref\System.Drawing.Common), Configuration: Debug Any CPU ------
1>System.Drawing.Common -> D:\dotnetruntime\artifacts\bin\System.Drawing.Common\ref\netcoreapp5.0-Debug\System.Drawing.Common.dll
2>------ Build started: Project: System.Drawing.Common (src\System.Drawing.Common), Configuration: Debug Any CPU ------
2>System.Drawing.Common -> D:\dotnetruntime\artifacts\bin\System.Drawing.Common\netcoreapp5.0-Windows_NT-Debug\System.Drawing.Common.dll
2>C:\Users\eriaw\.nuget\packages\microsoft.dotnet.apicompat\5.0.0-beta.20201.2\build\Microsoft.DotNet.ApiCompat.targets(82,5): error : CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultEventAttribute' exists on 'System.Drawing.Printing.PrintDocument' in the contract but not the implementation.
2>C:\Users\eriaw\.nuget\packages\microsoft.dotnet.apicompat\5.0.0-beta.20201.2\build\Microsoft.DotNet.ApiCompat.targets(82,5): error : CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultPropertyAttribute' exists on 'System.Drawing.Printing.PrintDocument' in the contract but not the implementation.
2>C:\Users\eriaw\.nuget\packages\microsoft.dotnet.apicompat\5.0.0-beta.20201.2\build\Microsoft.DotNet.ApiCompat.targets(96,5): error : ApiCompat failed for 'D:\GITHUB_REPO\dotnetruntime\artifacts\bin\System.Drawing.Common\netcoreapp5.0-Unix-Debug\System.Drawing.Common.dll'
2>Done building project "System.Drawing.Common.csproj" -- FAILED.
========== Build: 1 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
```

Is there I need to update on my side or do I miss something else? 

**UPDATE 1:**
I think I know what I've been missing! The attributes should also be added to PrintDocument class in PrintDocument.Unix.cs as well.

I have updated my commit.