### PR TITLE
Make MappingType more usable

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -134,7 +134,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 var entry = new DebugInfoBoundsEntry();
                 previousNativeOffset += reader.ReadUInt();
                 entry.NativeOffset = previousNativeOffset;
-                entry.ILOffset = (uint)(reader.ReadUInt() + (int)MappingTypes.MaxMappingValue);
+                entry.ILOffset = reader.ReadUInt() + (uint)DebugInfoBoundsType.MaxMappingValue;
                 entry.SourceTypes = (SourceTypes)reader.ReadUInt();
                 _boundsList.Add(entry);
             }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/DebugInfoTypes.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/DebugInfoTypes.cs
@@ -51,11 +51,11 @@ namespace ILCompiler.Reflection.ReadyToRun
         CallInstruction = 0x10
     }
 
-    public enum MappingTypes : int
+    public enum DebugInfoBoundsType : uint
     {
-        NoMapping = -1,
-        Prolog = -2,
-        Epilog = -3,
+        NoMapping = 0xffffffff,
+        Prolog = 0xfffffffe,
+        Epilog = 0xfffffffd,
         MaxMappingValue = Epilog
     }
 

--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -28,9 +28,23 @@ namespace R2RDump
                 {
                     writer.Write($"Native Offset: 0x{theThis.BoundsList[i].NativeOffset:X}, ");
                 }
-                writer.WriteLine($"IL Offset: 0x{theThis.BoundsList[i].ILOffset:X}, Source Types: {theThis.BoundsList[i].SourceTypes}");
+                if (theThis.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.NoMapping)
+                {
+                    writer.WriteLine($"NoMapping, Source Types: {theThis.BoundsList[i].SourceTypes}");
+                }
+                else if (theThis.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.Prolog)
+                {
+                    writer.WriteLine($"Prolog, Source Types: {theThis.BoundsList[i].SourceTypes}");
+                }
+                else if (theThis.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.Epilog)
+                {
+                    writer.WriteLine($"Epilog, Source Types: {theThis.BoundsList[i].SourceTypes}");
+                }
+                else
+                {
+                    writer.WriteLine($"IL Offset: 0x{theThis.BoundsList[i].ILOffset:x4}, Source Types: {theThis.BoundsList[i].SourceTypes}");
+                }
             }
-
             writer.WriteLine("");
 
             if (dumpOptions.Normalize)


### PR DESCRIPTION
I am proposing three changes in this PR:

- Rename `MappingType` to `DebugInfoBoundsType`, the former is very uninformative about what this type is about.
- Make `DebugInfoBoundsType` inherits from `uint` instead of `int`. It is always used in conjunction with the `ILOffset` property of `DebugInfoBoundsEntry`, which is currently an `uint`. Having the same type makes it easier.
- Update the R2RDump representation so that prolog and epilog are shown instead of those special values.