### PR TITLE
Expose BinaryReader / BinaryWriter 7-bit encoding methods publicly

### DIFF
--- a/src/libraries/Common/src/System/Resources/ResourceWriter.cs
+++ b/src/libraries/Common/src/System/Resources/ResourceWriter.cs
@@ -325,7 +325,7 @@ namespace System.Resources
                     ResourceTypeCode typeCode = FindTypeCode(value, typeNames);
 
                     // Write out type code
-                    Write7BitEncodedInt(data, (int)typeCode);
+                    data.Write7BitEncodedInt((int)typeCode);
 
                     var userProvidedResource = value as PrecannedResource;
                     if (userProvidedResource != null)
@@ -415,20 +415,6 @@ namespace System.Resources
 
             // Indicate we've called Generate
             _resourceList = null;
-        }
-
-        private static void Write7BitEncodedInt(BinaryWriter store, int value)
-        {
-            Debug.Assert(store != null);
-            // Write out an int 7 bits at a time.  The high bit of the byte,
-            // when on, tells reader to continue reading more bytes.
-            uint v = (uint)value;   // support negative numbers
-            while (v >= 0x80)
-            {
-                store.Write((byte)(v | 0x80));
-                v >>= 7;
-            }
-            store.Write((byte)v);
         }
 
         // Finds the ResourceTypeCode for a type, or adds this type to the

--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.WriteTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.WriteTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-using System;
-using System.IO;
 using System.Text;
+using Xunit;
 
 namespace System.IO.Tests
 {
@@ -91,11 +89,35 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void BinaryWriter_Write7BitEncodedIntTest()
+        {
+            int[] i32arr = new int[]
+            {
+                int.MinValue, int.MaxValue, 0, -10000, 10000, -50, 50,
+                unchecked((int)uint.MinValue), unchecked((int)uint.MaxValue), unchecked((int)(uint.MaxValue - 100))
+            };
+
+            WriteTest(i32arr, (bw, s) => bw.Write7BitEncodedInt(s), (br) => br.Read7BitEncodedInt());
+        }
+
+        [Fact]
         public void BinaryWriter_WriteInt64Test()
         {
             long[] i64arr = new long[] { long.MinValue, long.MaxValue, 0, -10000, 10000, -50, 50 };
 
             WriteTest(i64arr, (bw, s) => bw.Write(s), (br) => br.ReadInt64());
+        }
+
+        [Fact]
+        public void BinaryWriter_Write7BitEncodedInt64Test()
+        {
+            long[] i64arr = new long[]
+            {
+                long.MinValue, long.MaxValue, 0, -10000, 10000, -50, 50,
+                unchecked((long)ulong.MinValue), unchecked((long)ulong.MaxValue), unchecked((long)(ulong.MaxValue - 100))
+            };
+
+            WriteTest(i64arr, (bw, s) => bw.Write7BitEncodedInt64(s), (br) => br.Read7BitEncodedInt64());
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2188,8 +2188,8 @@
   <data name="Format_AttributeUsage" xml:space="preserve">
     <value>Duplicate AttributeUsageAttribute found on attribute type {0}.</value>
   </data>
-  <data name="Format_Bad7BitInt32" xml:space="preserve">
-    <value>Too many bytes in what should have been a 7 bit encoded Int32.</value>
+  <data name="Format_Bad7BitInt" xml:space="preserve">
+    <value>Too many bytes in what should have been a 7-bit encoded integer.</value>
   </data>
   <data name="Format_BadBase" xml:space="preserve">
     <value>Invalid digits for the specified base.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryReader.cs
@@ -584,28 +584,88 @@ namespace System.IO
             } while (bytesRead < numBytes);
         }
 
-        protected internal int Read7BitEncodedInt()
+        public int Read7BitEncodedInt()
         {
-            // Read out an Int32 7 bits at a time.  The high bit
-            // of the byte when on means to continue reading more bytes.
-            int count = 0;
-            int shift = 0;
-            byte b;
-            do
-            {
-                // Check for a corrupted stream.  Read a max of 5 bytes.
-                // In a future version, add a DataFormatException.
-                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
-                {
-                    throw new FormatException(SR.Format_Bad7BitInt32);
-                }
+            // Unlike writing, we can't delegate to the 64-bit read on
+            // 64-bit platforms. The reason for this is that we want to
+            // stop consuming bytes if we encounter an integer overflow.
 
+            uint result = 0;
+            byte byteReadJustNow;
+
+            // Read the integer 7 bits at a time. The high bit
+            // of the byte when on means to continue reading more bytes.
+            //
+            // There are two failure cases: we've read more than 5 bytes,
+            // or the fifth byte is about to cause integer overflow.
+            // This means that we can read the first 4 bytes without
+            // worrying about integer overflow.
+
+            const int MaxBytesWithoutOverflow = 4;
+            for (int shift = 0; shift < MaxBytesWithoutOverflow * 7; shift += 7)
+            {
                 // ReadByte handles end of stream cases for us.
-                b = ReadByte();
-                count |= (b & 0x7F) << shift;
-                shift += 7;
-            } while ((b & 0x80) != 0);
-            return count;
+                byteReadJustNow = ReadByte();
+                result |= (byteReadJustNow & 0x7Fu) << shift;
+
+                if (byteReadJustNow <= 0x7Fu)
+                {
+                    return (int)result; // early exit
+                }
+            }
+
+            // Read the 5th byte. Since we already read 28 bits,
+            // the value of this byte must fit within 4 bits (32 - 28),
+            // and it must not have the high bit set.
+
+            byteReadJustNow = ReadByte();
+            if (byteReadJustNow > 0b_1111u)
+            {
+                throw new FormatException(SR.Format_Bad7BitInt);
+            }
+
+            result |= (uint)byteReadJustNow << (MaxBytesWithoutOverflow * 7);
+            return (int)result;
+        }
+
+        public long Read7BitEncodedInt64()
+        {
+            ulong result = 0;
+            byte byteReadJustNow;
+
+            // Read the integer 7 bits at a time. The high bit
+            // of the byte when on means to continue reading more bytes.
+            //
+            // There are two failure cases: we've read more than 10 bytes,
+            // or the tenth byte is about to cause integer overflow.
+            // This means that we can read the first 9 bytes without
+            // worrying about integer overflow.
+
+            const int MaxBytesWithoutOverflow = 9;
+            for (int shift = 0; shift < MaxBytesWithoutOverflow * 7; shift += 7)
+            {
+                // ReadByte handles end of stream cases for us.
+                byteReadJustNow = ReadByte();
+                result |= (byteReadJustNow & 0x7Ful) << shift;
+
+                if (byteReadJustNow <= 0x7Fu)
+                {
+                    return (long)result; // early exit
+                }
+            }
+
+            // Read the 10th byte. Since we already read 63 bits,
+            // the value of this byte must fit within 1 bit (64 - 63),
+            // and it must not have the high bit set.
+
+            byteReadJustNow = ReadByte();
+            if (byteReadJustNow > 0b_1u)
+            {
+                throw new FormatException(SR.Format_Bad7BitInt);
+            }
+
+            result |= (ulong)byteReadJustNow << (MaxBytesWithoutOverflow * 7);
+            return (long)result;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -453,21 +453,9 @@ namespace System.IO
             }
         }
 
-        public void Write7BitEncodedInt(int value) => Write7BitEncodedUInt32((uint)value);
-
-        public void Write7BitEncodedInt64(long value) => Write7BitEncodedUInt64((ulong)value);
-
-        private void Write7BitEncodedUInt32(uint value)
+        public void Write7BitEncodedInt(int value)
         {
-            // On 64-bit platforms, always use the 64-bit overload.
-            // It's just a small optimization that allows AOT compilers
-            // to eliminate this method implementation entirely.
-
-            if (IntPtr.Size >= 8)
-            {
-                Write7BitEncodedUInt64(value);
-                return;
-            }
+            uint uValue = (uint)value;
 
             // Write out an int 7 bits at a time. The high bit of the byte,
             // when on, tells reader to continue reading more bytes.
@@ -475,30 +463,32 @@ namespace System.IO
             // Using the constants 0x7F and ~0x7F below offers smaller
             // codegen than using the constant 0x80.
 
-            while (value > 0x7Fu)
+            while (uValue > 0x7Fu)
             {
-                Write((byte)(value | ~0x7Fu));
-                value >>= 7;
+                Write((byte)(uValue | ~0x7Fu));
+                uValue >>= 7;
             }
 
-            Write((byte)value);
+            Write((byte)uValue);
         }
 
-        private void Write7BitEncodedUInt64(ulong value)
+        public void Write7BitEncodedInt64(long value)
         {
+            ulong uValue = (ulong)value;
+
             // Write out an int 7 bits at a time. The high bit of the byte,
             // when on, tells reader to continue reading more bytes.
             //
             // Using the constants 0x7F and ~0x7F below offers smaller
             // codegen than using the constant 0x80.
 
-            while (value > 0x7Fu)
+            while (uValue > 0x7Fu)
             {
-                Write((byte)((uint)value | ~0x7Fu));
-                value >>= 7;
+                Write((byte)((uint)uValue | ~0x7Fu));
+                uValue >>= 7;
             }
 
-            Write((byte)value);
+            Write((byte)uValue);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryStaticData.cs
@@ -82,7 +82,7 @@ namespace System.Xml.Xsl.Runtime
             int length;
 
             // Read a format version
-            int formatVersion = dataReader.ReadInt32Encoded();
+            int formatVersion = dataReader.Read7BitEncodedInt();
 
             // Changes in the major part of version are not supported
             if ((formatVersion & ~0xff) > CurrentFormatVersion)
@@ -136,7 +136,7 @@ namespace System.Xml.Xsl.Runtime
                 _filters = new Int32Pair[length];
                 for (int idx = 0; idx < length; idx++)
                 {
-                    _filters[idx] = new Int32Pair(dataReader.ReadInt32Encoded(), dataReader.ReadInt32Encoded());
+                    _filters[idx] = new Int32Pair(dataReader.Read7BitEncodedInt(), dataReader.Read7BitEncodedInt());
                 }
             }
 
@@ -197,7 +197,7 @@ namespace System.Xml.Xsl.Runtime
             XmlQueryDataWriter dataWriter = new XmlQueryDataWriter(dataStream);
 
             // First put the format version
-            dataWriter.WriteInt32Encoded(CurrentFormatVersion);
+            dataWriter.Write7BitEncodedInt(CurrentFormatVersion);
 
             // XmlWriterSettings defaultWriterSettings;
             _defaultWriterSettings.GetObjectData(dataWriter);
@@ -259,8 +259,8 @@ namespace System.Xml.Xsl.Runtime
                 dataWriter.Write(_filters.Length);
                 foreach (Int32Pair filter in _filters)
                 {
-                    dataWriter.WriteInt32Encoded(filter.Left);
-                    dataWriter.WriteInt32Encoded(filter.Right);
+                    dataWriter.Write7BitEncodedInt(filter.Left);
+                    dataWriter.Write7BitEncodedInt(filter.Right);
                 }
             }
 
@@ -409,14 +409,6 @@ namespace System.Xml.Xsl.Runtime
         public XmlQueryDataReader(Stream input) : base(input) { }
 
         /// <summary>
-        /// Read in a 32-bit integer in compressed format.
-        /// </summary>
-        public int ReadInt32Encoded()
-        {
-            return Read7BitEncodedInt();
-        }
-
-        /// <summary>
         /// Read a string value from the stream. Value can be null.
         /// </summary>
         public string ReadStringQ()
@@ -445,14 +437,6 @@ namespace System.Xml.Xsl.Runtime
     internal class XmlQueryDataWriter : BinaryWriter
     {
         public XmlQueryDataWriter(Stream output) : base(output) { }
-
-        /// <summary>
-        /// Write a 32-bit integer in a compressed format.
-        /// </summary>
-        public void WriteInt32Encoded(int value)
-        {
-            Write7BitEncodedInt(value);
-        }
 
         /// <summary>
         /// Write a string value to the stream. Value can be null.

--- a/src/libraries/System.Resources.Extensions/src/BinaryWriterExtensions.cs
+++ b/src/libraries/System.Resources.Extensions/src/BinaryWriterExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    internal static class BinaryWriterExtensions
+    {
+        public static void Write7BitEncodedInt(this BinaryWriter writer, int value)
+        {
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint)value;   // support negative numbers
+            while (v >= 0x80)
+            {
+                writer.Write((byte)(v | 0x80));
+                v >>= 7;
+            }
+            writer.Write((byte)v);
+        }
+    }
+}

--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -15,6 +15,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Resources\ResourceTypeCode.cs" Link="System\Resources\ResourceTypeCode.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Resources\RuntimeResourceSet.cs" Link="System\Resources\Extensions\RuntimeResourceSet.cs" />
     <Compile Include="BinaryReaderExtensions.cs" />
+    <Compile Include="BinaryWriterExtensions.cs" />
     <Compile Include="System\Resources\Extensions\DeserializingResourceReader.cs" />
     <Compile Include="System\Resources\Extensions\PreserializedResourceWriter.cs" />
     <Compile Include="System\Resources\Extensions\SerializationFormat.cs" />

--- a/src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/PreserializedResourceWriter.cs
+++ b/src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/PreserializedResourceWriter.cs
@@ -213,7 +213,7 @@ namespace System.Resources.Extensions
             // Only write the format if we resources are in DeserializingResourceReader format
             if (_requiresDeserializingResourceReader)
             {
-                Write7BitEncodedInt(writer, (int)record.Format);
+                writer.Write7BitEncodedInt((int)record.Format);
             }
 
             try
@@ -228,7 +228,7 @@ namespace System.Resources.Extensions
                             // doesn't constrain binaryFormatter
                             if (_requiresDeserializingResourceReader)
                             {
-                                Write7BitEncodedInt(writer, data.Length);
+                                writer.Write7BitEncodedInt(data.Length);
                             }
 
                             writer.Write(data);
@@ -243,7 +243,7 @@ namespace System.Resources.Extensions
 
                             stream.Position = 0;
 
-                            Write7BitEncodedInt(writer, (int)stream.Length);
+                            writer.Write7BitEncodedInt((int)stream.Length);
 
                             stream.CopyTo(writer.BaseStream);
 
@@ -252,7 +252,7 @@ namespace System.Resources.Extensions
                     case SerializationFormat.TypeConverterByteArray:
                         {
                             byte[] data = (byte[])record.Data;
-                            Write7BitEncodedInt(writer, data.Length);
+                            writer.Write7BitEncodedInt(data.Length);
                             writer.Write(data);
                             break;
                         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6530,7 +6530,8 @@ namespace System.IO
         public virtual int Read(char[] buffer, int index, int count) { throw null; }
         public virtual int Read(System.Span<byte> buffer) { throw null; }
         public virtual int Read(System.Span<char> buffer) { throw null; }
-        protected internal int Read7BitEncodedInt() { throw null; }
+        public int Read7BitEncodedInt() { throw null; }
+        public long Read7BitEncodedInt64() { throw null; }
         public virtual bool ReadBoolean() { throw null; }
         public virtual byte ReadByte() { throw null; }
         public virtual byte[] ReadBytes(int count) { throw null; }
@@ -6591,7 +6592,8 @@ namespace System.IO
         public virtual void Write(uint value) { }
         [System.CLSCompliantAttribute(false)]
         public virtual void Write(ulong value) { }
-        protected void Write7BitEncodedInt(int value) { }
+        public void Write7BitEncodedInt(int value) { }
+        public void Write7BitEncodedInt64(long value) { }
     }
     public sealed partial class BufferedStream : System.IO.Stream
     {


### PR DESCRIPTION
Changes the visibility of `BinaryReader.Read7BitEncodedInt` and `BinaryWriter.Write7BitEncodedInt` from _protected_ to _public_. (Per API review this shouldn't be a breaking change.) Also adds 64-bit versions.

I also took this opportunity to tighten up the code paths a bit, including fixing the integer overflow checks in `Read7BitEncodedInt`. (It missed a few cases.) There's also increased unit test coverage.

Resolves https://github.com/dotnet/runtime/issues/24473.