### PR TITLE
Issue 34817 db exception IsTransient property

### DIFF
--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -2170,6 +2170,10 @@ namespace System.Data.Common
     }
     public abstract partial class DbException : System.Runtime.InteropServices.ExternalException
     {
+        /// <summary>
+        /// When overriden in a derived class return true in all cases where a simple retry of the operation without any other change may be successful.
+        /// </summary>
+        public virtual bool IsTransient { get; protected set; }
         protected DbException() { }
         protected DbException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected DbException(string message) { }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
@@ -8,6 +8,11 @@ namespace System.Data.Common
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class DbException : System.Runtime.InteropServices.ExternalException
     {
+        /// <summary>
+        /// When overriden in a derived class return true in all cases where a simple retry of the operation without any other change may be successful.
+        /// </summary>
+        public bool IsTransient { get; protected set; } = false;
+
         protected DbException() : base() { }
 
         protected DbException(string message) : base(message) { }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
@@ -11,7 +11,7 @@ namespace System.Data.Common
         /// <summary>
         /// When overriden in a derived class return true in all cases where a simple retry of the operation without any other change may be successful.
         /// </summary>
-        public bool IsTransient { get; protected set; } = false;
+        public virtual bool IsTransient { get; protected set; } = false;
 
         protected DbException() : base() { }
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbException.cs
@@ -11,7 +11,7 @@ namespace System.Data.Common
         /// <summary>
         /// When overriden in a derived class return true in all cases where a simple retry of the operation without any other change may be successful.
         /// </summary>
-        public virtual bool IsTransient { get; protected set; } = false;
+        public virtual bool IsTransient { get; protected set; }
 
         protected DbException() : base() { }
 


### PR DESCRIPTION
Adding boolean property to DbException with a default implementation of false.  This property determines if the previously executed command is transient and could succeed if executed again without any changes.