### PR TITLE
Address some edge cases in EncoderNLS.GetBytes draining logic

### DIFF
--- a/src/libraries/System.Text.Encoding/tests/CustomEncoderReplacementFallback.cs
+++ b/src/libraries/System.Text.Encoding/tests/CustomEncoderReplacementFallback.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 
 namespace System.Text.Encodings.Tests
 {

--- a/src/libraries/System.Text.Encoding/tests/CustomEncoderReplacementFallback.cs
+++ b/src/libraries/System.Text.Encoding/tests/CustomEncoderReplacementFallback.cs
@@ -1,0 +1,55 @@
+﻿using Xunit;
+
+namespace System.Text.Encodings.Tests
+{
+    // A custom encoder fallback which substitutes unknown chars with "[xxxx]" (the code point as hex)
+    internal sealed class CustomEncoderReplacementFallback : EncoderFallback
+    {
+        public override int MaxCharCount => 8; // = "[10FFFF]".Length
+
+        public override EncoderFallbackBuffer CreateFallbackBuffer()
+        {
+            return new CustomEncoderFallbackBuffer();
+        }
+
+        private sealed class CustomEncoderFallbackBuffer : EncoderFallbackBuffer
+        {
+            private string _remaining = string.Empty;
+            private int _remainingIdx = 0;
+
+            public override int Remaining => _remaining.Length - _remainingIdx;
+
+            public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index)
+                => FallbackCommon((uint)char.ConvertToUtf32(charUnknownHigh, charUnknownLow));
+
+            public override bool Fallback(char charUnknown, int index)
+                => FallbackCommon(charUnknown);
+
+            private bool FallbackCommon(uint codePoint)
+            {
+                Assert.True(codePoint <= 0x10FFFF);
+                _remaining = FormattableString.Invariant($"[{codePoint:X4}]");
+                _remainingIdx = 0;
+                return true;
+            }
+
+            public override char GetNextChar()
+            {
+                return (_remainingIdx < _remaining.Length)
+                    ? _remaining[_remainingIdx++]
+                    : '\0' /* end of string reached */;
+            }
+
+            public override bool MovePrevious()
+            {
+                if (_remainingIdx == 0)
+                {
+                    return false;
+                }
+
+                _remainingIdx--;
+                return true;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
+++ b/src/libraries/System.Text.Encoding/tests/System.Text.Encoding.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="ASCIIEncoding\ASCIIEncodingGetMaxByteCount.cs" />
     <Compile Include="ASCIIEncoding\ASCIIEncodingGetMaxCharCount.cs" />
     <Compile Include="ASCIIEncoding\ASCIIEncodingTests.cs" />
+    <Compile Include="CustomEncoderReplacementFallback.cs" />
     <Compile Include="Decoder\DecoderSpanTests.cs" />
     <Compile Include="Decoder\DecoderConvert2.cs" />
     <Compile Include="Decoder\DecoderCtor.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33817.

There were two edge cases that weren't handled properly in the `EncoderNLS.GetBytes` draining logic. The first - as originally reported in https://github.com/dotnet/runtime/issues/415#issuecomment-601267431 - was triggered when a call to `EncoderNLS.GetBytes` was given a buffer which ended in a high surrogate character, and where the next call to `EncoderNLS.GetBytes` would not provide the low surrogate character at the start of the new input buffer.

The second edge case occurred where the first call to `EncoderNLS.GetBytes` ended with a high surrogate character, the second call began with the low surrogate character, _and_ the corresponding supplementary code point was not representable in the target encoding.

This fix addresses both edge cases. This code path is shared by `EncoderNLS.Convert`, so no separate fix was needed for that routine. The unit tests cover both `GetBytes` and `Convert` just to be safe.